### PR TITLE
MRView: remove single ODF display from ODF tool

### DIFF
--- a/icons/odf_preview.svg
+++ b/icons/odf_preview.svg
@@ -1,0 +1,442 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   id="svg6430"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="odf_preview.svg">
+  <defs
+     id="defs6432">
+    <linearGradient
+       id="linearGradient4474">
+      <stop
+         id="stop4476"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop4478"
+         offset="1"
+         style="stop-color:#808080;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4253">
+      <stop
+         id="stop4255"
+         offset="0"
+         style="stop-color:#00ff00;stop-opacity:1" />
+      <stop
+         style="stop-color:#c0c000;stop-opacity:1"
+         offset="0.5"
+         id="stop4387" />
+      <stop
+         id="stop4257"
+         offset="1"
+         style="stop-color:#af0000;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3913">
+      <stop
+         style="stop-color:#00ff00;stop-opacity:1"
+         offset="0"
+         id="stop3915" />
+      <stop
+         style="stop-color:#ff0000;stop-opacity:1"
+         offset="1"
+         id="stop3917" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7550">
+      <stop
+         style="stop-color:#898989;stop-opacity:1;"
+         offset="0"
+         id="stop7552" />
+      <stop
+         style="stop-color:#f5f5f5;stop-opacity:1;"
+         offset="1"
+         id="stop7554" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5863-1">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop5865-9" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop5867-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5873-5">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop5875-5" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="1"
+         id="stop5877-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5863">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop5865" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop5867" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5873">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop5875" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="1"
+         id="stop5877" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5863-8"
+       id="linearGradient7238-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-57,1004.8621)"
+       x1="72"
+       y1="8"
+       x2="72"
+       y2="39" />
+    <linearGradient
+       id="linearGradient5863-8">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop5865-1" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop5867-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5873-8"
+       id="linearGradient7240-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-57,1004.8621)"
+       x1="76"
+       y1="8"
+       x2="76"
+       y2="39" />
+    <linearGradient
+       id="linearGradient5873-8">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop5875-7" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="1"
+         id="stop5877-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5863-1-8">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop5865-9-4" />
+      <stop
+         style="stop-color:#808080;stop-opacity:1"
+         offset="1"
+         id="stop5867-2-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5873-5-6">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop5875-5-2" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="1"
+         id="stop5877-9-6" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5873-9"
+       id="radialGradient6252"
+       cx="182.89905"
+       cy="24.915091"
+       fx="182.89905"
+       fy="24.915091"
+       r="13.693534"
+       gradientTransform="matrix(1,0,0,0.92467276,0,1.6584141)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient5873-9">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.26923078;"
+         offset="0"
+         id="stop5875-9" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.34615386;"
+         offset="1"
+         id="stop5877-1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5873-9"
+       id="radialGradient7510"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.92467276,0,1.6584141)"
+       cx="182.89905"
+       cy="24.915091"
+       fx="182.89905"
+       fy="24.915091"
+       r="13.693534" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5873-9-8"
+       id="radialGradient7510-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.92467276,0,1.6584141)"
+       cx="182.89905"
+       cy="24.915091"
+       fx="182.89905"
+       fy="24.915091"
+       r="13.693534" />
+    <linearGradient
+       id="linearGradient5873-9-8">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.76923078;"
+         offset="0"
+         id="stop5875-9-2" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.36923078;"
+         offset="1"
+         id="stop5877-1-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7550"
+       id="linearGradient7556"
+       x1="183.66415"
+       y1="31.13592"
+       x2="177.81732"
+       y2="11.923559"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5873-9-84"
+       id="radialGradient7510-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.92467276,0,1.6584141)"
+       cx="182.89905"
+       cy="24.915091"
+       fx="182.89905"
+       fy="24.915091"
+       r="13.693534" />
+    <linearGradient
+       id="linearGradient5873-9-84">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.26923078;"
+         offset="0"
+         id="stop5875-9-6" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.34615386;"
+         offset="1"
+         id="stop5877-1-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7550-3"
+       id="linearGradient7556-7"
+       x1="183.66415"
+       y1="31.13592"
+       x2="177.81732"
+       y2="11.923559"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient7550-3">
+      <stop
+         style="stop-color:#898989;stop-opacity:1;"
+         offset="0"
+         id="stop7552-5" />
+      <stop
+         style="stop-color:#f5f5f5;stop-opacity:1;"
+         offset="1"
+         id="stop7554-1" />
+    </linearGradient>
+    <radialGradient
+       r="13.693534"
+       fy="24.915091"
+       fx="182.89905"
+       cy="24.915091"
+       cx="182.89905"
+       gradientTransform="matrix(1,0,0,0.92467276,0,1.6584141)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient7581"
+       xlink:href="#linearGradient5873-9-84"
+       inkscape:collect="always" />
+    <radialGradient
+       r="13.693534"
+       fy="24.915091"
+       fx="182.89905"
+       cy="24.915091"
+       cx="182.89905"
+       gradientTransform="matrix(1,0,0,0.92467276,0,1.6584141)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient7581-9"
+       xlink:href="#linearGradient5873-9-84-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5873-9-84-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.26923078;"
+         offset="0"
+         id="stop5875-9-6-0" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.34615386;"
+         offset="1"
+         id="stop5877-1-1-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4253"
+       id="linearGradient4462"
+       x1="24.769655"
+       y1="1027.1742"
+       x2="50.899273"
+       y2="1038.0021"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4474"
+       id="linearGradient4470"
+       x1="48.192299"
+       y1="1044.5344"
+       x2="27.476627"
+       y2="1020.6418"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5863-1-8"
+       id="linearGradient4472"
+       gradientUnits="userSpaceOnUse"
+       x1="48.192299"
+       y1="1044.5344"
+       x2="27.476627"
+       y2="1020.6418" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="42.719229"
+     inkscape:cy="19.01886"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer2"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1140"
+     inkscape:window-x="1200"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true"
+       type="xygrid"
+       id="grid6438" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata6435">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="BG"
+     sodipodi:insensitive="true"
+     style="display:none">
+    <rect
+       style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4454"
+       width="48"
+       height="48"
+       x="0"
+       y="0" />
+  </g>
+  <g
+     inkscape:label="Axes"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1004.3622)">
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#00ff00;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 10,1042.3622 0,-20"
+       id="path3414"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#ff0000;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 30,1042.3622 -20,0"
+       id="path3416"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#0000ff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 10,1042.3622 -5,6"
+       id="path3412"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="FOD">
+    <g
+       id="g4433"
+       style="stroke:url(#linearGradient4470);stroke-width:1.5;stroke-miterlimit:4;stroke-dasharray:none;fill-opacity:1;fill:url(#linearGradient4462)"
+       transform="matrix(0.92393762,0.38254316,-0.38254316,0.92393762,380.05284,-940.52033)">
+      <path
+         sodipodi:nodetypes="czzzc"
+         inkscape:connector-curvature="0"
+         id="path4220-9-1"
+         d="m 40,1027.3622 c 0,0 4.970417,-5.0001 5,-13 0.02958,-8 -3.000014,-11.9927 -5,-12 -1.999987,-0.01 -4.970417,4 -5,12 -0.02958,8 5,13 5,13 z"
+         style="fill:url(#linearGradient4462);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4472);stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="czzzc"
+         inkscape:connector-curvature="0"
+         id="path4220-9-1-8"
+         d="m 40.000085,1027.3622 c 0,0 -4.970417,5.0001 -5,13 -0.02958,8 3.000014,11.9927 5,12 1.999987,0.01 4.970417,-4 5,-12 0.02958,-8 -5,-13 -5,-13 z"
+         style="fill:url(#linearGradient4462);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4470);stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/src/gui/dwi/renderer.cpp
+++ b/src/gui/dwi/renderer.cpp
@@ -298,6 +298,7 @@ namespace MR
             indices[n].set (index1, index2, index3);
           }
         }
+        edges.clear();
 
         update_transform (vertices, lmax);
 

--- a/src/gui/mrview/tool/base.cpp
+++ b/src/gui/mrview/tool/base.cpp
@@ -32,6 +32,8 @@ namespace MR
       namespace Tool
       {
 
+        void Dock::hideEvent (QHideEvent*) { assert (tool); tool->hide_event(); }
+
         Base::Base (Window& main_window, Dock* parent) : 
           QFrame (parent),
           window (main_window) { 

--- a/src/gui/mrview/tool/base.h
+++ b/src/gui/mrview/tool/base.h
@@ -53,6 +53,8 @@ namespace MR
             Dock (QWidget* parent, const QString& name) :
               QDockWidget (name, parent), tool (NULL) { }
 
+            void hideEvent (QHideEvent*) override;
+
             Base* tool;
         };
 
@@ -130,6 +132,7 @@ namespace MR
             virtual bool mouse_press_event ();
             virtual bool mouse_move_event ();
             virtual bool mouse_release_event ();
+            virtual void hide_event() { }
             virtual QCursor* get_cursor ();
             void update_cursor() { window.set_cursor(); }
         };

--- a/src/gui/mrview/tool/odf.cpp
+++ b/src/gui/mrview/tool/odf.cpp
@@ -169,7 +169,7 @@ namespace MR
             hide_all_button->setToolTip (tr ("Hide All"));
             hide_all_button->setIcon (QIcon (":/hide.svg"));
             hide_all_button->setCheckable (true);
-            connect (hide_all_button, SIGNAL (clicked()), this, SLOT (updateGL ()));
+            connect (hide_all_button, SIGNAL (clicked()), this, SLOT (hide_all_slot ()));
             layout->addWidget (hide_all_button, 1);
 
             main_box->addLayout (layout, 0);
@@ -449,6 +449,12 @@ namespace MR
           if (indexes.size())
             image_list_model->remove_item (indexes.first());
           updateGL();
+        }
+
+
+        void ODF::hide_all_slot ()
+        {
+          window.updateGL();
         }
 
 

--- a/src/gui/mrview/tool/odf.cpp
+++ b/src/gui/mrview/tool/odf.cpp
@@ -187,8 +187,9 @@ namespace MR
             image_list_model = new Model (this);
             image_list_view->setModel (image_list_model);
 
-
             main_box->addWidget (image_list_view, 1);
+
+
             show_preview_button = new QPushButton ("Inspect ODF at focus",this);
             show_preview_button->setToolTip (tr ("Inspect ODF at focus<br>(opens separate window)"));
             show_preview_button->setIcon (QIcon (":/odf_preview.svg"));
@@ -593,6 +594,9 @@ namespace MR
           if (!settings)
             return;
           settings->scale = scale->value();
+          assert (preview);
+          assert (preview->tool);
+          dynamic_cast<ODF_Preview*>(preview->tool)->render_frame->set_scale (scale->value());
           updateGL();
         }
 
@@ -635,10 +639,10 @@ namespace MR
           Image* settings = get_image();
           if (!settings)
             return;
+          scale->setValue (settings->scale);
           lmax_selector->setValue (settings->lmax);
           hide_negative_lobes_box->setChecked (settings->hide_negative_lobes);
           colour_by_direction_box->setChecked (settings->color_by_direction);
-          scale->setValue (settings->scale);
           updateGL();
           update_preview();
         }

--- a/src/gui/mrview/tool/odf.cpp
+++ b/src/gui/mrview/tool/odf.cpp
@@ -150,7 +150,13 @@ namespace MR
           lmax (0),
           level_of_detail (0) { 
 
-            preview = new ODF_Preview (window, this);
+            preview = new Dock (&main_window, "ODF preview pane");
+            main_window.addDockWidget (Qt::RightDockWidgetArea, preview);
+            preview->tool = new ODF_Preview (window, preview, this);
+            preview->tool->adjustSize();
+            preview->setWidget (preview->tool);
+            preview->setFloating (true);
+            preview->hide();
 
             lighting = new GL::Lighting (this);
             VBoxLayout *main_box = new VBoxLayout (this);
@@ -172,7 +178,6 @@ namespace MR
             show_preview_button = new QPushButton (this);
             show_preview_button->setToolTip (tr ("Show preview window"));
             show_preview_button->setIcon (QIcon (":/odf_preview.svg"));
-            show_preview_button->setCheckable (true);
             connect (show_preview_button, SIGNAL (clicked()), this, SLOT (show_preview_slot ()));
             layout->addWidget (show_preview_button, 1);
 
@@ -503,12 +508,9 @@ namespace MR
 
         void ODF::show_preview_slot ()
         {
-          if (show_preview_button->isChecked()) {
-            preview->show();
-            update_preview();
-          } else {
-            preview->hide();
-          }
+          preview->show();
+          preview->raise();
+          update_preview();
         }
 
 
@@ -581,7 +583,11 @@ namespace MR
           updateGL();
         }
 
-
+        void ODF::hide_event ()
+        {
+          assert (preview);
+          preview->hide();
+        }
 
 
 
@@ -600,9 +606,10 @@ namespace MR
           if (!settings)
             return;
           MRView::Image& image (settings->image);
-          Math::Vector<float> values (Math::SH::NforL (preview->lmax()));
-          get_values (values, image, window.focus(), preview->interpolate());
-          preview->set (values);
+          ODF_Preview* preview_tool = dynamic_cast<ODF_Preview*>(preview->tool);
+          Math::Vector<float> values (Math::SH::NforL (preview_tool->lmax()));
+          get_values (values, image, window.focus(), preview_tool->interpolate());
+          preview_tool->set (values);
         }
 
 

--- a/src/gui/mrview/tool/odf.cpp
+++ b/src/gui/mrview/tool/odf.cpp
@@ -168,12 +168,6 @@ namespace MR
             connect (button, SIGNAL (clicked()), this, SLOT (image_close_slot ()));
             layout->addWidget (button, 1);
 
-            show_preview_button = new QPushButton (this);
-            show_preview_button->setToolTip (tr ("Inspect ODF at focus (separate window)"));
-            show_preview_button->setIcon (QIcon (":/odf_preview.svg"));
-            connect (show_preview_button, SIGNAL (clicked()), this, SLOT (show_preview_slot ()));
-            layout->addWidget (show_preview_button, 1);
-
             hide_all_button = new QPushButton (this);
             hide_all_button->setToolTip (tr ("Hide all ODFs"));
             hide_all_button->setIcon (QIcon (":/hide.svg"));
@@ -182,6 +176,7 @@ namespace MR
             layout->addWidget (hide_all_button, 1);
 
             main_box->addLayout (layout, 0);
+
 
             image_list_view = new QListView (this);
             image_list_view->setSelectionMode (QAbstractItemView::SingleSelection);
@@ -192,14 +187,19 @@ namespace MR
             image_list_model = new Model (this);
             image_list_view->setModel (image_list_model);
 
-            main_box->addWidget (image_list_view, 1);
 
+            main_box->addWidget (image_list_view, 1);
+            show_preview_button = new QPushButton ("Inspect ODF at focus",this);
+            show_preview_button->setToolTip (tr ("Inspect ODF at focus<br>(opens separate window)"));
+            show_preview_button->setIcon (QIcon (":/odf_preview.svg"));
+            connect (show_preview_button, SIGNAL (clicked()), this, SLOT (show_preview_slot ()));
+            main_box->addWidget (show_preview_button, 1);
+            
 
             QGroupBox* group_box = new QGroupBox (tr("Display settings"));
             main_box->addWidget (group_box);
             GridLayout* box_layout = new GridLayout;
             group_box->setLayout (box_layout);
-
 
             QLabel* label = new QLabel ("scale");
             label->setAlignment (Qt::AlignHCenter);
@@ -208,66 +208,65 @@ namespace MR
             scale->setValue (1.0);
             scale->setMin (0.0);
             connect (scale, SIGNAL (valueChanged()), this, SLOT (adjust_scale_slot()));
-            box_layout->addWidget (scale, 0, 1);
+            box_layout->addWidget (scale, 0, 1, 1, 3);
 
             label = new QLabel ("detail");
             label->setAlignment (Qt::AlignHCenter);
-            box_layout->addWidget (label, 0, 2);
+            box_layout->addWidget (label, 1, 0);
             level_of_detail_selector = new QSpinBox (this);
             level_of_detail_selector->setMinimum (1);
             level_of_detail_selector->setMaximum (6);
             level_of_detail_selector->setSingleStep (1);
             level_of_detail_selector->setValue (3);
             connect (level_of_detail_selector, SIGNAL (valueChanged(int)), this, SLOT(updateGL()));
-            box_layout->addWidget (level_of_detail_selector, 0, 3);
-
+            box_layout->addWidget (level_of_detail_selector, 1, 1);
 
             label = new QLabel ("lmax");
             label->setAlignment (Qt::AlignHCenter);
-            box_layout->addWidget (label, 1, 0);
+            box_layout->addWidget (label, 1, 2);
             lmax_selector = new QSpinBox (this);
             lmax_selector->setMinimum (2);
             lmax_selector->setMaximum (16);
             lmax_selector->setSingleStep (2);
             lmax_selector->setValue (8);
             connect (lmax_selector, SIGNAL (valueChanged(int)), this, SLOT(lmax_slot(int)));
-            box_layout->addWidget (lmax_selector, 1, 1);
-
-            hide_negative_lobes_box = new QCheckBox ("hide negative lobes");
-            hide_negative_lobes_box->setChecked (true);
-            connect (hide_negative_lobes_box, SIGNAL (stateChanged(int)), this, SLOT (hide_negative_lobes_slot(int)));
-            box_layout->addWidget (hide_negative_lobes_box, 1, 2, 1, 2);
-
+            box_layout->addWidget (lmax_selector, 1, 3);
+            
             interpolation_box = new QCheckBox ("interpolation");
             interpolation_box->setChecked (true);
             connect (interpolation_box, SIGNAL (stateChanged(int)), this, SLOT (updateGL()));
             box_layout->addWidget (interpolation_box, 2, 0, 1, 2);
 
-
-            colour_by_direction_box = new QCheckBox ("colour by direction");
-            colour_by_direction_box->setChecked (true);
-            connect (colour_by_direction_box, SIGNAL (stateChanged(int)), this, SLOT (colour_by_direction_slot(int)));
-            box_layout->addWidget (colour_by_direction_box, 2, 2, 1, 2);
+            hide_negative_lobes_box = new QCheckBox ("hide negative lobes");
+            hide_negative_lobes_box->setChecked (true);
+            connect (hide_negative_lobes_box, SIGNAL (stateChanged(int)), this, SLOT (hide_negative_lobes_slot(int)));
+            box_layout->addWidget (hide_negative_lobes_box, 2, 2, 1, 2);
 
             lock_to_grid_box = new QCheckBox ("lock to grid");
             lock_to_grid_box->setChecked (true);
             connect (lock_to_grid_box, SIGNAL (stateChanged(int)), this, SLOT (updateGL()));
             box_layout->addWidget (lock_to_grid_box, 3, 0, 1, 2);
 
-            use_lighting_box = new QCheckBox ("use lighting");
-            use_lighting_box->setCheckable (true);
-            use_lighting_box->setChecked (true);
-            connect (use_lighting_box, SIGNAL (stateChanged(int)), this, SLOT (use_lighting_slot(int)));
-            box_layout->addWidget (use_lighting_box, 3, 2, 1, 2);
+            colour_by_direction_box = new QCheckBox ("colour by direction");
+            colour_by_direction_box->setChecked (true);
+            connect (colour_by_direction_box, SIGNAL (stateChanged(int)), this, SLOT (colour_by_direction_slot(int)));
+            box_layout->addWidget (colour_by_direction_box, 3, 2, 1, 2);
 
             main_grid_box = new QCheckBox ("use main grid");
+            main_grid_box->setToolTip (tr ("Show individual ODFs using the grid of the main image instead of the ODF image's own grid"));
             main_grid_box->setChecked (false);
             connect (main_grid_box, SIGNAL (stateChanged(int)), this, SLOT (updateGL()));
             box_layout->addWidget (main_grid_box, 4, 0, 1, 2);
 
-            QPushButton *lighting_settings_button = new QPushButton ("adjust lighting...", this);
+            use_lighting_box = new QCheckBox ("use lighting");
+            use_lighting_box->setCheckable (true);
+            use_lighting_box->setChecked (true);
+            connect (use_lighting_box, SIGNAL (stateChanged(int)), this, SLOT (use_lighting_slot(int)));
+            box_layout->addWidget (use_lighting_box, 4, 2, 1, 2);
+
+            QPushButton *lighting_settings_button = new QPushButton ("ODF colour and lighting...", this);
             connect (lighting_settings_button, SIGNAL(clicked(bool)), this, SLOT (lighting_settings_slot (bool)));
-            box_layout->addWidget (lighting_settings_button, 4, 2, 1, 2);
+            box_layout->addWidget (lighting_settings_button, 5, 0, 1, 4);
 
 
             connect (image_list_view->selectionModel(),
@@ -275,6 +274,7 @@ namespace MR
                 SLOT (selection_changed_slot(const QItemSelection &, const QItemSelection &)) );
 
             connect (lighting, SIGNAL (changed()), this, SLOT (updateGL()));
+
 
             hide_negative_lobes_slot (0);
             colour_by_direction_slot (0);

--- a/src/gui/mrview/tool/odf.cpp
+++ b/src/gui/mrview/tool/odf.cpp
@@ -129,62 +129,27 @@ namespace MR
             }
 
             Image* get_image (QModelIndex& index) {
-              return index.isValid() ? dynamic_cast<Image*>(items[index.row()]) : NULL;
+              return index.isValid() ? dynamic_cast<Image*>(items[index.row()]) : nullptr;
             }
 
             VecPtr<Image> items;
         };
 
 
-        class ODF::RenderFrame : public DWI::RenderFrame 
-        {
-          public:
-            RenderFrame (QWidget* parent, Window& window) :
-              DWI::RenderFrame (parent),
-              window (window) { }
-          protected:
-            Window& window;
 
-            virtual void resizeGL (int w, int h) {
-              makeCurrent();
-              DWI::RenderFrame::resizeGL (w,h);
-              window.makeGLcurrent();
-            }
 
-            virtual void initializeGL () {
-              makeCurrent();
-              DWI::RenderFrame::initializeGL();
-              window.makeGLcurrent();
-            }
-            virtual void paintGL () {
-              makeCurrent();
-              DWI::RenderFrame::paintGL();
-              window.makeGLcurrent();
-            }
-        };
+
+
 
 
         ODF::ODF (Window& main_window, Dock* parent) :
           Base (main_window, parent),
-          overlay_renderer (NULL),
-          lighting_dialog (NULL),
-          overlay_lmax (0),
-          overlay_level_of_detail (0) { 
+          renderer (nullptr),
+          lighting_dialog (nullptr),
+          lmax (0),
+          level_of_detail (0) { 
+            lighting = new GL::Lighting (this);
             VBoxLayout *main_box = new VBoxLayout (this);
-
-            QSplitter* splitter = new QSplitter (Qt::Vertical, parent);
-            main_box->addWidget (splitter);
-
-            render_frame = new RenderFrame (this, window);
-            splitter->addWidget (render_frame);
-
-
-
-            QFrame* frame = new QFrame (this);
-            frame->setFrameStyle (QFrame::NoFrame);
-            splitter->addWidget (frame);
-
-            main_box = new VBoxLayout (frame);
 
             HBoxLayout* layout = new HBoxLayout;
 
@@ -199,6 +164,13 @@ namespace MR
             button->setIcon (QIcon (":/close.svg"));
             connect (button, SIGNAL (clicked()), this, SLOT (image_close_slot ()));
             layout->addWidget (button, 1);
+
+            hide_all_button = new QPushButton (this);
+            hide_all_button->setToolTip (tr ("Hide All"));
+            hide_all_button->setIcon (QIcon (":/hide.svg"));
+            hide_all_button->setCheckable (true);
+            connect (hide_all_button, SIGNAL (clicked()), this, SLOT (updateGL ()));
+            layout->addWidget (hide_all_button, 1);
 
             main_box->addLayout (layout, 0);
 
@@ -219,32 +191,49 @@ namespace MR
             GridLayout* box_layout = new GridLayout;
             group_box->setLayout (box_layout);
 
-            lock_orientation_to_image_box = new QCheckBox ("auto align");
-            lock_orientation_to_image_box->setChecked (true);
-            connect (lock_orientation_to_image_box, SIGNAL (stateChanged(int)), this, SLOT (lock_orientation_to_image_slot(int)));
-            box_layout->addWidget (lock_orientation_to_image_box, 0, 0, 1, 2);
 
-            interpolation_box = new QCheckBox ("interpolation");
-            interpolation_box->setChecked (true);
-            connect (interpolation_box, SIGNAL (stateChanged(int)), this, SLOT (interpolation_slot(int)));
-            box_layout->addWidget (interpolation_box, 0, 2, 1, 2);
+            QLabel* label = new QLabel ("scale");
+            label->setAlignment (Qt::AlignHCenter);
+            box_layout->addWidget (label, 0, 0);
+            scale = new AdjustButton (this, 1.0);
+            scale->setValue (1.0);
+            scale->setMin (0.0);
+            connect (scale, SIGNAL (valueChanged()), this, SLOT (adjust_scale_slot()));
+            box_layout->addWidget (scale, 0, 1);
 
-            show_axes_box = new QCheckBox ("show axes");
-            show_axes_box->setChecked (true);
-            connect (show_axes_box, SIGNAL (stateChanged(int)), this, SLOT (show_axes_slot(int)));
-            box_layout->addWidget (show_axes_box, 1, 0, 1, 2);
+            label = new QLabel ("detail");
+            label->setAlignment (Qt::AlignHCenter);
+            box_layout->addWidget (label, 0, 2);
+            level_of_detail_selector = new QSpinBox (this);
+            level_of_detail_selector->setMinimum (1);
+            level_of_detail_selector->setMaximum (6);
+            level_of_detail_selector->setSingleStep (1);
+            level_of_detail_selector->setValue (3);
+            connect (level_of_detail_selector, SIGNAL (valueChanged(int)), this, SLOT(updateGL()));
+            box_layout->addWidget (level_of_detail_selector, 0, 3);
+
+
+            label = new QLabel ("lmax");
+            label->setAlignment (Qt::AlignHCenter);
+            box_layout->addWidget (label, 1, 0);
+            lmax_selector = new QSpinBox (this);
+            lmax_selector->setMinimum (2);
+            lmax_selector->setMaximum (16);
+            lmax_selector->setSingleStep (2);
+            lmax_selector->setValue (8);
+            connect (lmax_selector, SIGNAL (valueChanged(int)), this, SLOT(lmax_slot(int)));
+            box_layout->addWidget (lmax_selector, 1, 1);
 
             colour_by_direction_box = new QCheckBox ("colour by direction");
             colour_by_direction_box->setChecked (true);
             connect (colour_by_direction_box, SIGNAL (stateChanged(int)), this, SLOT (colour_by_direction_slot(int)));
             box_layout->addWidget (colour_by_direction_box, 1, 2, 1, 2);
 
-            use_lighting_box = new QCheckBox ("use lighting");
-            use_lighting_box->setCheckable (true);
-            use_lighting_box->setChecked (true);
-            connect (use_lighting_box, SIGNAL (stateChanged(int)), this, SLOT (use_lighting_slot(int)));
-            box_layout->addWidget (use_lighting_box, 2, 0, 1, 2);
 
+            interpolation_box = new QCheckBox ("interpolation");
+            interpolation_box->setChecked (true);
+            connect (interpolation_box, SIGNAL (stateChanged(int)), this, SLOT (updateGL()));
+            box_layout->addWidget (interpolation_box, 2, 0, 1, 2);
 
 
             hide_negative_lobes_box = new QCheckBox ("hide negative lobes");
@@ -253,95 +242,46 @@ namespace MR
             box_layout->addWidget (hide_negative_lobes_box, 2, 2, 1, 2);
 
 
-            QLabel* label = new QLabel ("lmax");
-            label->setAlignment (Qt::AlignHCenter);
-            box_layout->addWidget (label, 3, 0);
-            lmax_selector = new QSpinBox (this);
-            lmax_selector->setMinimum (2);
-            lmax_selector->setMaximum (16);
-            lmax_selector->setSingleStep (2);
-            lmax_selector->setValue (8);
-            connect (lmax_selector, SIGNAL (valueChanged(int)), this, SLOT(lmax_slot(int)));
-            box_layout->addWidget (lmax_selector, 3, 1);
 
-            label = new QLabel ("detail");
-            label->setAlignment (Qt::AlignHCenter);
-            box_layout->addWidget (label, 3, 2);
-            level_of_detail_selector = new QSpinBox (this);
-            level_of_detail_selector->setMinimum (1);
-            level_of_detail_selector->setMaximum (7);
-            level_of_detail_selector->setSingleStep (1);
-            level_of_detail_selector->setValue (4);
-            connect (level_of_detail_selector, SIGNAL (valueChanged(int)), this, SLOT(level_of_detail_slot(int)));
-            box_layout->addWidget (level_of_detail_selector, 3, 3);
+            use_lighting_box = new QCheckBox ("use lighting");
+            use_lighting_box->setCheckable (true);
+            use_lighting_box->setChecked (true);
+            connect (use_lighting_box, SIGNAL (stateChanged(int)), this, SLOT (updateGL()));
+            box_layout->addWidget (use_lighting_box, 3, 0, 1, 2);
 
 
-            QPushButton *lighting_settings_button = new QPushButton ("lighting...", this);
+            QPushButton *lighting_settings_button = new QPushButton ("adjust lighting...", this);
             connect (lighting_settings_button, SIGNAL(clicked(bool)), this, SLOT (lighting_settings_slot (bool)));
-            box_layout->addWidget (lighting_settings_button, 5, 0, 1, 4);
+            box_layout->addWidget (lighting_settings_button, 3, 2, 1, 2);
 
 
 
-            overlay_frame = new QGroupBox (tr("Overlay"));
-            overlay_frame->setCheckable (true);
-            overlay_frame->setChecked (false);
-            connect (overlay_frame, SIGNAL (clicked()), this, SLOT(overlay_toggled_slot()));
-            main_box->addWidget (overlay_frame);
-            box_layout = new GridLayout;
-            overlay_frame->setLayout (box_layout);
-
-            label = new QLabel ("scale");
-            label->setAlignment (Qt::AlignHCenter);
-            box_layout->addWidget (label, 0, 0);
-            overlay_scale = new AdjustButton (this, 1.0);
-            overlay_scale->setValue (1.0);
-            overlay_scale->setMin (0.0);
-            connect (overlay_scale, SIGNAL (valueChanged()), this, SLOT (overlay_scale_slot()));
-            box_layout->addWidget (overlay_scale, 0, 1);
-
-            label = new QLabel ("detail");
-            label->setAlignment (Qt::AlignHCenter);
-            box_layout->addWidget (label, 0, 2);
-            overlay_level_of_detail_selector = new QSpinBox (this);
-            overlay_level_of_detail_selector->setMinimum (1);
-            overlay_level_of_detail_selector->setMaximum (6);
-            overlay_level_of_detail_selector->setSingleStep (1);
-            overlay_level_of_detail_selector->setValue (3);
-            connect (overlay_level_of_detail_selector, SIGNAL (valueChanged(int)), this, SLOT(overlay_update_slot(int)));
-            box_layout->addWidget (overlay_level_of_detail_selector, 0, 3);
-
-            overlay_lock_to_grid_box = new QCheckBox ("lock to grid");
-            overlay_lock_to_grid_box->setChecked (true);
-            connect (overlay_lock_to_grid_box, SIGNAL (stateChanged(int)), this, SLOT (overlay_update_slot(int)));
-            box_layout->addWidget (overlay_lock_to_grid_box, 1, 0, 1, 2);
+            lock_to_grid_box = new QCheckBox ("lock to grid");
+            lock_to_grid_box->setChecked (true);
+            connect (lock_to_grid_box, SIGNAL (stateChanged(int)), this, SLOT (updateGL()));
+            box_layout->addWidget (lock_to_grid_box, 4, 0, 1, 2);
 
             label = new QLabel ("grid");
             label->setAlignment (Qt::AlignHCenter);
-            box_layout->addWidget (label, 1, 2);
-            overlay_grid_selector = new QComboBox (this);
-            overlay_grid_selector->addItem ("overlay");
-            overlay_grid_selector->addItem ("main");
-            connect (overlay_grid_selector, SIGNAL (activated(int)), this, SLOT(overlay_update_slot(int)));
-            box_layout->addWidget (overlay_grid_selector, 1, 3);
+            box_layout->addWidget (label, 4, 2);
+            grid_selector = new QComboBox (this);
+            grid_selector->addItem ("overlay");
+            grid_selector->addItem ("main");
+            connect (grid_selector, SIGNAL (activated(int)), this, SLOT(updateGL()));
+            box_layout->addWidget (grid_selector, 4, 3);
 
-            splitter->setStretchFactor (0, 1);
-            splitter->setStretchFactor (1, 0);
+
 
             connect (image_list_view->selectionModel(),
                 SIGNAL(selectionChanged(const QItemSelection &, const QItemSelection &)),
                 SLOT (selection_changed_slot(const QItemSelection &, const QItemSelection &)) );
 
-            connect (render_frame->lighting, SIGNAL (changed()), this, SLOT (overlay_update_slot()));
+            connect (lighting, SIGNAL (changed()), this, SLOT (updateGL()));
 
             hide_negative_lobes_slot (0);
-            show_axes_slot (0);
             colour_by_direction_slot (0);
-            use_lighting_slot (0);
             lmax_slot (0);
-            level_of_detail_slot (0);
-            lock_orientation_to_image_slot (0);
-
-            overlay_scale_slot ();
+            adjust_scale_slot ();
           }
 
 
@@ -354,29 +294,28 @@ namespace MR
           if (is_3D) 
             return;
 
-          lock_orientation_to_image_slot(0);
 
           Image* settings = get_image();
           if (!settings)
             return;
 
-          MRView::Image& image (overlay_grid_selector->currentIndex() ? *window.image() : settings->image);
+          MRView::Image& image (grid_selector->currentIndex() ? *window.image() : settings->image);
 
-          if (overlay_frame->isChecked()) {
+          if (!hide_all_button->isChecked()) {
 
-            if (!overlay_renderer) {
-              overlay_renderer = new DWI::Renderer;
-              overlay_renderer->initGL();
+            if (!renderer) {
+              renderer = new DWI::Renderer;
+              renderer->initGL();
             }
 
-            if (overlay_lmax != settings->lmax || 
-                overlay_level_of_detail != overlay_level_of_detail_selector->value()) {
-              overlay_lmax = settings->lmax;
-              overlay_level_of_detail = overlay_level_of_detail_selector->value();
-              overlay_renderer->update_mesh (overlay_level_of_detail, overlay_lmax);
+            if (lmax != settings->lmax || 
+                level_of_detail != level_of_detail_selector->value()) {
+              lmax = settings->lmax;
+              level_of_detail = level_of_detail_selector->value();
+              renderer->update_mesh (level_of_detail, lmax);
             }
 
-            overlay_renderer->start (projection, *render_frame->lighting, settings->scale, 
+            renderer->start (projection, *lighting, settings->scale, 
                 use_lighting_box->isChecked(), settings->color_by_direction, settings->hide_negative_lobes, true);
 
             gl::Enable (gl::DEPTH_TEST);
@@ -384,7 +323,7 @@ namespace MR
 
             Point<> pos (window.target());
             pos += projection.screen_normal() * (projection.screen_normal().dot (window.focus() - window.target()));
-            if (overlay_lock_to_grid_box->isChecked()) {
+            if (lock_to_grid_box->isChecked()) {
               Point<> p = image.interp.scanner2voxel (pos);
               p[0] = std::round (p[0]);
               p[1] = std::round (p[1]);
@@ -422,13 +361,13 @@ namespace MR
                 get_values (values, settings->image, p);
                 if (!std::isfinite (values[0])) continue;
                 if (values[0] == 0.0) continue;
-                overlay_renderer->compute_r_del_daz (r_del_daz, values.sub (0, Math::SH::NforL (overlay_lmax)));
-                overlay_renderer->set_data (r_del_daz);
-                overlay_renderer->draw (p);
+                renderer->compute_r_del_daz (r_del_daz, values.sub (0, Math::SH::NforL (lmax)));
+                renderer->set_data (r_del_daz);
+                renderer->draw (p);
               }
             }
 
-            overlay_renderer->stop();
+            renderer->stop();
 
             gl::Disable (gl::DEPTH_TEST);
             gl::DepthMask (gl::FALSE_);
@@ -439,40 +378,20 @@ namespace MR
 
 
 
-        void ODF::showEvent (QShowEvent*) 
-        {
-          connect (&window, SIGNAL (focusChanged()), this, SLOT (onFocusChanged()));
-          onFocusChanged();
-        }
 
-
-        void ODF::closeEvent (QCloseEvent*) {
-          window.disconnect (this); 
-        }
-
-        void ODF::onFocusChanged () 
-        {
-          if (!isVisible())
-            return;
-
-          Image* settings = get_image();
-          if (!settings)
-            return;
-
-          MRView::Image& image (settings->image);
-
-          Math::Vector<float> values (Math::SH::NforL (lmax_selector->value()));
-          get_values (values, image, window.focus());
-          render_frame->set (values);
-        }
 
         inline ODF::Image* ODF::get_image () 
         {
           QModelIndexList list = image_list_view->selectionModel()->selectedRows();
           if (!list.size())
-            return NULL;
+            return nullptr;
           return image_list_model->get_image (list[0]);
         }
+
+
+
+
+
 
         void ODF::get_values (Math::Vector<float>& values, MRView::Image& image, const Point<>& pos)
         {
@@ -490,25 +409,37 @@ namespace MR
 
 
 
+
+
+        void ODF::add_images (std::vector<std::string>& list)
+        {
+          size_t previous_size = image_list_model->rowCount();
+          if (!image_list_model->add_items (list,
+                lmax_selector->value(), 
+                colour_by_direction_box->isChecked(), 
+                hide_negative_lobes_box->isChecked(), 
+                scale->value())) 
+            return;
+          QModelIndex first = image_list_model->index (previous_size, 0, QModelIndex());
+          image_list_view->selectionModel()->select (first, QItemSelectionModel::ClearAndSelect);
+          updateGL();
+        }
+
+
+
+
+
         void ODF::image_open_slot ()
         {
           std::vector<std::string> list = Dialog::File::get_images (&window, "Select overlay images to open");
           if (list.empty())
             return;
 
-          size_t previous_size = image_list_model->rowCount();
-          if (!image_list_model->add_items (list,
-                lmax_selector->value(), 
-                colour_by_direction_box->isChecked(), 
-                hide_negative_lobes_box->isChecked(), 
-                overlay_scale->value())) 
-            return;
-          QModelIndex first = image_list_model->index (previous_size, 0, QModelIndex());
-          image_list_view->selectionModel()->select (first, QItemSelectionModel::ClearAndSelect);
-          onFocusChanged();
-          if (overlay_frame->isChecked())
-            window.updateGL();
+          add_images (list);
         }
+
+
+
 
 
 
@@ -517,133 +448,133 @@ namespace MR
           QModelIndexList indexes = image_list_view->selectionModel()->selectedIndexes();
           if (indexes.size())
             image_list_model->remove_item (indexes.first());
-          onFocusChanged();
-          if (overlay_frame->isChecked())
-            window.updateGL();
+          updateGL();
         }
 
 
-
-        void ODF::lock_orientation_to_image_slot (int)
-        {
-          if (lock_orientation_to_image_box->isChecked()) {
-            const Projection* proj = window.get_current_mode()->get_current_projection();
-            if (!proj) return;
-            render_frame->set_rotation (proj->modelview());
-          }
-        }
 
         void ODF::colour_by_direction_slot (int) 
         { 
-          render_frame->set_color_by_dir (colour_by_direction_box->isChecked()); 
           Image* settings = get_image();
           if (!settings)
             return;
           settings->color_by_direction = colour_by_direction_box->isChecked();
-          if (overlay_frame->isChecked())
-            window.updateGL();
+          updateGL();
         }
+
+
+
+
 
         void ODF::hide_negative_lobes_slot (int) 
         {
-          render_frame->set_hide_neg_lobes (hide_negative_lobes_box->isChecked()); 
           Image* settings = get_image();
           if (!settings)
             return;
           settings->hide_negative_lobes = hide_negative_lobes_box->isChecked();
-          if (overlay_frame->isChecked())
-            window.updateGL();
-        }
-
-        void ODF::use_lighting_slot (int) 
-        { 
-          render_frame->set_use_lighting (use_lighting_box->isChecked()); 
-          if (overlay_frame->isChecked())
-            window.updateGL();
-        }
-
-        void ODF::interpolation_slot (int) 
-        { 
-          onFocusChanged();
-          if (overlay_frame->isChecked())
-            window.updateGL();
+          updateGL();
         }
 
 
-        void ODF::show_axes_slot (int) 
-        {
-          render_frame->set_show_axes (show_axes_box->isChecked()); 
-        }
 
-        void ODF::level_of_detail_slot (int) 
-        { 
-          render_frame->set_LOD (level_of_detail_selector->value());
-        }
+
+
+
 
         void ODF::lmax_slot (int) 
         { 
-          render_frame->set_lmax (lmax_selector->value()); 
           Image* settings = get_image();
           if (!settings)
             return;
           settings->lmax = lmax_selector->value();
-          if (overlay_frame->isChecked())
-            window.updateGL();
+          updateGL();
         }
 
-        void ODF::update_slot (int) 
-        {
-          window.updateGL();
-        }
+
+
+
 
         void ODF::lighting_settings_slot (bool)
         {
           if (!lighting_dialog)
-            lighting_dialog = new Dialog::Lighting (&window, "Advanced Lighting", *render_frame->lighting);
+            lighting_dialog = new Dialog::Lighting (&window, "Advanced Lighting", *lighting);
           lighting_dialog->show();
         }
 
 
 
-        void ODF::overlay_toggled_slot () { window.updateGL(); }
 
 
-        void ODF::overlay_scale_slot () 
+        void ODF::adjust_scale_slot () 
         { 
-          overlay_scale->setRate (0.01 * overlay_scale->value());
+          scale->setRate (0.01 * scale->value());
           Image* settings = get_image();
           if (!settings)
             return;
-          settings->scale = overlay_scale->value();
-          if (overlay_frame->isChecked())
+          settings->scale = scale->value();
+          updateGL();
+        }
+
+
+
+
+
+        void ODF::updateGL () 
+        {
+          if (!hide_all_button->isChecked())
             window.updateGL();
         }
 
-        void ODF::overlay_update_slot () 
-        {
-          if (overlay_frame->isChecked()) 
-            window.updateGL();
-        }
 
-        void ODF::overlay_update_slot (int) 
-        {
-          if (overlay_frame->isChecked()) 
-            window.updateGL();
-        }
+
 
         void ODF::selection_changed_slot (const QItemSelection &, const QItemSelection &)
         {
-          onFocusChanged();
           Image* settings = get_image();
           if (!settings)
             return;
           lmax_selector->setValue (settings->lmax);
           hide_negative_lobes_box->setChecked (settings->hide_negative_lobes);
           colour_by_direction_box->setChecked (settings->color_by_direction);
-          overlay_scale->setValue (settings->scale);
-          if (overlay_frame->isChecked())
-            window.updateGL();
+          scale->setValue (settings->scale);
+          updateGL();
         }
+
+
+
+
+
+        void ODF::add_commandline_options (MR::App::OptionList& options) 
+        { 
+          using namespace MR::App;
+          options
+            + OptionGroup ("ODF tool options")
+
+            + Option ("odf.load", "Loads the specified image on the ODF tool.")
+            +   Argument ("image").type_image_in();
+            
+        }
+
+
+
+
+
+        bool ODF::process_commandline_option (const MR::App::ParsedOption& opt) 
+        {
+          if (opt.opt->is ("odf.load")) {
+            try {
+              std::vector<std::string> list (1, opt[0]);
+              add_images (list);
+            }
+            catch (Exception& e) {
+              e.display();
+            }
+            return true;
+          }
+
+          return false;
+        }
+
 
 
       }

--- a/src/gui/mrview/tool/odf.h
+++ b/src/gui/mrview/tool/odf.h
@@ -52,57 +52,43 @@ namespace MR
 
             void draw (const Projection& projection, bool is_3D, int axis, int slice);
 
+            static void add_commandline_options (MR::App::OptionList& options);
+            virtual bool process_commandline_option (const MR::App::ParsedOption& opt);
 
           private slots:
-            void onFocusChanged ();
             void image_open_slot ();
             void image_close_slot ();
-            // void toggle_shown_slot (const QModelIndex& index);
             void selection_changed_slot (const QItemSelection &, const QItemSelection &);
-            void update_slot (int unused);
-            void lock_orientation_to_image_slot (int unused);
             void colour_by_direction_slot (int unused);
             void hide_negative_lobes_slot (int unused);
-            void use_lighting_slot (int unused);
-            void interpolation_slot (int unused);
-            void show_axes_slot (int unused);
             void lmax_slot (int value);
-            void level_of_detail_slot (int value);
             void lighting_settings_slot (bool unused);
 
-            void overlay_toggled_slot ();
-            void overlay_scale_slot ();
-            void overlay_update_slot ();
-            void overlay_update_slot (int value);
-
-            // void values_changed ();
-            // void colourmap_changed (int index);
+            void updateGL ();
+            void adjust_scale_slot ();
 
           protected:
              class Model;
              class Image;
-             class RenderFrame;
+
+             DWI::Renderer *renderer;
 
              Model* image_list_model;
-             RenderFrame *render_frame;
              QListView* image_list_view;
-             QCheckBox *lock_orientation_to_image_box, *use_lighting_box, *hide_negative_lobes_box;
-             QCheckBox *colour_by_direction_box, *interpolation_box, *show_axes_box;
+             QPushButton* hide_all_button;
+             QCheckBox *use_lighting_box, *hide_negative_lobes_box, *lock_to_grid_box;
+             QCheckBox *colour_by_direction_box, *interpolation_box;
              QSpinBox *lmax_selector, *level_of_detail_selector;
 
-             DWI::Renderer *overlay_renderer;
-             QGroupBox *overlay_frame;
-             AdjustButton *overlay_scale;
-             QSpinBox *overlay_level_of_detail_selector;
-             QComboBox *overlay_grid_selector;
-             QCheckBox *overlay_lock_to_grid_box;
+             AdjustButton *scale;
+             QComboBox *grid_selector;
 
              Dialog::Lighting *lighting_dialog;
+             GL::Lighting* lighting;
 
-             int overlay_lmax, overlay_level_of_detail;
+             int lmax, level_of_detail;
              
-             virtual void showEvent (QShowEvent* event);
-             virtual void closeEvent (QCloseEvent* event);
+             void add_images (std::vector<std::string>& list);
 
              Image* get_image ();
              void get_values (Math::Vector<float>& SH, MRView::Image& image, const Point<>& pos);

--- a/src/gui/mrview/tool/odf.h
+++ b/src/gui/mrview/tool/odf.h
@@ -88,12 +88,11 @@ namespace MR
              Model* image_list_model;
              QListView* image_list_view;
              QPushButton *show_preview_button, *hide_all_button;
-             QCheckBox *use_lighting_box, *hide_negative_lobes_box, *lock_to_grid_box;
+             QCheckBox *use_lighting_box, *hide_negative_lobes_box, *lock_to_grid_box, *main_grid_box;
              QCheckBox *colour_by_direction_box, *interpolation_box;
              QSpinBox *lmax_selector, *level_of_detail_selector;
 
              AdjustButton *scale;
-             QComboBox *grid_selector;
 
              Dialog::Lighting *lighting_dialog;
              GL::Lighting* lighting;

--- a/src/gui/mrview/tool/odf.h
+++ b/src/gui/mrview/tool/odf.h
@@ -32,6 +32,7 @@ namespace MR
   {
     namespace DWI {
       class Renderer;
+      class RenderFrame;
     }
     namespace Dialog {
       class Lighting;
@@ -42,6 +43,8 @@ namespace MR
       namespace Tool
       {
 
+        class ODF_Preview;
+
         class ODF : public Base
         {
             Q_OBJECT
@@ -49,6 +52,7 @@ namespace MR
           public:
 
             ODF (Window& main_window, Dock* parent);
+            ~ODF();
 
             void draw (const Projection& projection, bool is_3D, int axis, int slice);
 
@@ -56,8 +60,11 @@ namespace MR
             virtual bool process_commandline_option (const MR::App::ParsedOption& opt);
 
           private slots:
+            void onWindowChange ();
+            void onPreviewClosed ();
             void image_open_slot ();
             void image_close_slot ();
+            void show_preview_slot ();
             void hide_all_slot ();
             void selection_changed_slot (const QItemSelection &, const QItemSelection &);
             void colour_by_direction_slot (int unused);
@@ -66,17 +73,20 @@ namespace MR
             void lighting_settings_slot (bool unused);
 
             void updateGL ();
+            void update_preview();
             void adjust_scale_slot ();
 
           protected:
              class Model;
              class Image;
 
+             ODF_Preview *preview;
+
              DWI::Renderer *renderer;
 
              Model* image_list_model;
              QListView* image_list_view;
-             QPushButton* hide_all_button;
+             QPushButton *show_preview_button, *hide_all_button;
              QCheckBox *use_lighting_box, *hide_negative_lobes_box, *lock_to_grid_box;
              QCheckBox *colour_by_direction_box, *interpolation_box;
              QSpinBox *lmax_selector, *level_of_detail_selector;
@@ -91,8 +101,14 @@ namespace MR
              
              void add_images (std::vector<std::string>& list);
 
+             virtual void showEvent (QShowEvent* event);
+             virtual void closeEvent (QCloseEvent* event);
+
              Image* get_image ();
-             void get_values (Math::Vector<float>& SH, MRView::Image& image, const Point<>& pos);
+             void get_values (Math::Vector<float>& SH, MRView::Image& image, const Point<>& pos, const bool interp);
+
+             friend class ODF_Preview;
+
         };
 
       }

--- a/src/gui/mrview/tool/odf.h
+++ b/src/gui/mrview/tool/odf.h
@@ -68,6 +68,7 @@ namespace MR
             void colour_by_direction_slot (int unused);
             void hide_negative_lobes_slot (int unused);
             void lmax_slot (int value);
+            void use_lighting_slot (int unused);
             void lighting_settings_slot (bool unused);
 
             void updateGL ();

--- a/src/gui/mrview/tool/odf.h
+++ b/src/gui/mrview/tool/odf.h
@@ -65,15 +65,14 @@ namespace MR
             void show_preview_slot ();
             void hide_all_slot ();
             void selection_changed_slot (const QItemSelection &, const QItemSelection &);
+            void adjust_scale_slot ();
             void colour_by_direction_slot (int unused);
             void hide_negative_lobes_slot (int unused);
             void lmax_slot (int value);
             void use_lighting_slot (int unused);
             void lighting_settings_slot (bool unused);
-
             void updateGL ();
             void update_preview();
-            void adjust_scale_slot ();
 
             void hide_event() override;
 

--- a/src/gui/mrview/tool/odf.h
+++ b/src/gui/mrview/tool/odf.h
@@ -43,8 +43,6 @@ namespace MR
       namespace Tool
       {
 
-        class ODF_Preview;
-
         class ODF : public Base
         {
             Q_OBJECT
@@ -76,11 +74,13 @@ namespace MR
             void update_preview();
             void adjust_scale_slot ();
 
+            void hide_event() override;
+
           protected:
              class Model;
              class Image;
 
-             ODF_Preview *preview;
+             Dock *preview;
 
              DWI::Renderer *renderer;
 

--- a/src/gui/mrview/tool/odf.h
+++ b/src/gui/mrview/tool/odf.h
@@ -58,6 +58,7 @@ namespace MR
           private slots:
             void image_open_slot ();
             void image_close_slot ();
+            void hide_all_slot ();
             void selection_changed_slot (const QItemSelection &, const QItemSelection &);
             void colour_by_direction_slot (int unused);
             void hide_negative_lobes_slot (int unused);

--- a/src/gui/mrview/tool/odf_preview.cpp
+++ b/src/gui/mrview/tool/odf_preview.cpp
@@ -1,0 +1,266 @@
+/*
+   Copyright 2009 Brain Research Institute, Melbourne, Australia
+
+   Written by J-Donald Tournier and Robert E. Smith, 2015.
+
+   This file is part of MRtrix.
+
+   MRtrix is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   MRtrix is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with MRtrix.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+#include "gui/mrview/tool/odf_preview.h"
+#include "gui/dialog/lighting.h"
+#include "gui/dwi/render_frame.h"
+#include "gui/mrview/window.h"
+#include "gui/mrview/tool/odf.h"
+#include "gui/mrview/mode/base.h"
+
+namespace MR
+{
+  namespace GUI
+  {
+    namespace MRView
+    {
+      namespace Tool
+      {
+
+
+
+
+        class ODF_Preview::RenderFrame : public DWI::RenderFrame
+        {
+          public:
+            RenderFrame (QWidget* parent, Window& window) :
+              DWI::RenderFrame (parent),
+              window (window) { }
+          protected:
+            Window& window;
+
+            virtual void resizeGL (int w, int h) {
+              makeCurrent();
+              DWI::RenderFrame::resizeGL (w,h);
+              window.makeGLcurrent();
+            }
+
+            virtual void initializeGL () {
+              makeCurrent();
+              DWI::RenderFrame::initializeGL();
+              window.makeGLcurrent();
+            }
+            virtual void paintGL () {
+              makeCurrent();
+              DWI::RenderFrame::paintGL();
+              window.makeGLcurrent();
+            }
+        };
+
+
+
+
+
+        ODF_Preview::ODF_Preview (Window& main_window, ODF* parent) :
+            QDialog (parent),
+            window (main_window),
+            parent (parent),
+            render_frame (new RenderFrame (this, main_window)),
+            lighting_dialog (nullptr)
+        {
+          setWindowTitle ("ODF preview pane");
+          setModal (false);
+          setSizeGripEnabled (true);
+
+          Tool::Base::VBoxLayout *main_box = new Tool::Base::VBoxLayout (this);
+
+          QSplitter* splitter = new QSplitter (Qt::Vertical, parent);
+          main_box->addWidget (splitter);
+          splitter->addWidget (render_frame);
+
+          QGroupBox* group_box = new QGroupBox (tr("Display settings"));
+          splitter->addWidget (group_box);
+          Tool::Base::GridLayout* box_layout = new Tool::Base::GridLayout;
+          group_box->setLayout (box_layout);
+
+          lock_orientation_to_image_box = new QCheckBox ("auto align");
+          lock_orientation_to_image_box->setChecked (true);
+          connect (lock_orientation_to_image_box, SIGNAL (stateChanged(int)), this, SLOT (lock_orientation_to_image_slot(int)));
+          box_layout->addWidget (lock_orientation_to_image_box, 0, 0, 1, 2);
+
+          interpolation_box = new QCheckBox ("interpolation");
+          interpolation_box->setChecked (false);
+          connect (interpolation_box, SIGNAL (stateChanged(int)), this, SLOT (interpolation_slot(int)));
+          box_layout->addWidget (interpolation_box, 0, 2, 1, 2);
+
+          show_axes_box = new QCheckBox ("show axes");
+          show_axes_box->setChecked (true);
+          connect (show_axes_box, SIGNAL (stateChanged(int)), this, SLOT (show_axes_slot(int)));
+          box_layout->addWidget (show_axes_box, 1, 0, 1, 2);
+
+          colour_by_direction_box = new QCheckBox ("colour by direction");
+          colour_by_direction_box->setChecked (true);
+          connect (colour_by_direction_box, SIGNAL (stateChanged(int)), this, SLOT (colour_by_direction_slot(int)));
+          box_layout->addWidget (colour_by_direction_box, 1, 2, 1, 2);
+
+          hide_negative_lobes_box = new QCheckBox ("hide negative lobes");
+          hide_negative_lobes_box->setChecked (true);
+          connect (hide_negative_lobes_box, SIGNAL (stateChanged(int)), this, SLOT (hide_negative_lobes_slot(int)));
+          box_layout->addWidget (hide_negative_lobes_box, 2, 2, 1, 2);
+
+          QLabel* label = new QLabel ("lmax");
+          label->setAlignment (Qt::AlignHCenter);
+          box_layout->addWidget (label, 3, 0);
+          lmax_selector = new QSpinBox (this);
+          lmax_selector->setMinimum (2);
+          lmax_selector->setMaximum (16);
+          lmax_selector->setSingleStep (2);
+          lmax_selector->setValue (8);
+          connect (lmax_selector, SIGNAL (valueChanged(int)), this, SLOT(lmax_slot(int)));
+          box_layout->addWidget (lmax_selector, 3, 1);
+
+          label = new QLabel ("detail");
+          label->setAlignment (Qt::AlignHCenter);
+          box_layout->addWidget (label, 3, 2);
+          level_of_detail_selector = new QSpinBox (this);
+          level_of_detail_selector->setMinimum (1);
+          level_of_detail_selector->setMaximum (7);
+          level_of_detail_selector->setSingleStep (1);
+          level_of_detail_selector->setValue (4);
+          connect (level_of_detail_selector, SIGNAL (valueChanged(int)), this, SLOT(level_of_detail_slot(int)));
+          box_layout->addWidget (level_of_detail_selector, 3, 3);
+
+          use_lighting_box = new QCheckBox ("use lighting");
+          use_lighting_box->setCheckable (true);
+          use_lighting_box->setChecked (true);
+          connect (use_lighting_box, SIGNAL (stateChanged(int)), this, SLOT (use_lighting_slot(int)));
+          box_layout->addWidget (use_lighting_box, 2, 0, 1, 2);
+
+          QPushButton *lighting_settings_button = new QPushButton ("lighting...", this);
+          connect (lighting_settings_button, SIGNAL(clicked(bool)), this, SLOT (lighting_settings_slot (bool)));
+          box_layout->addWidget (lighting_settings_button, 5, 0, 1, 4);
+
+          splitter->setStretchFactor (0, 1);
+          splitter->setStretchFactor (1, 0);
+
+          hide_negative_lobes_slot (0);
+          show_axes_slot (0);
+          colour_by_direction_slot (0);
+          use_lighting_slot (0);
+          lmax_slot (0);
+          level_of_detail_slot (0);
+          lock_orientation_to_image_slot (0);
+        }
+
+
+
+
+        void ODF_Preview::set (const Math::Vector<float>& data)
+        {
+          render_frame->set (data);
+          lock_orientation_to_image_slot (0);
+        }
+
+        void ODF_Preview::hide()
+        {
+          parent->show_preview_button->setChecked (false);
+          if (lighting_dialog)
+            lighting_dialog->hide();
+          QDialog::hide();
+        }
+
+        void ODF_Preview::lock_orientation_to_image_slot (int)
+        {
+          if (lock_orientation_to_image_box->isChecked()) {
+            const Projection* proj = window.get_current_mode()->get_current_projection();
+            if (!proj) return;
+            render_frame->set_rotation (proj->modelview());
+          }
+        }
+
+        void ODF_Preview::hide_negative_lobes_slot (int)
+        {
+          render_frame->set_hide_neg_lobes (hide_negative_lobes_box->isChecked());
+        }
+
+        void ODF_Preview::colour_by_direction_slot (int)
+        {
+          render_frame->set_color_by_dir (colour_by_direction_box->isChecked());
+        }
+
+        void ODF_Preview::interpolation_slot (int)
+        {
+          parent->update_preview();
+        }
+
+        void ODF_Preview::show_axes_slot (int)
+        {
+          render_frame->set_show_axes (show_axes_box->isChecked());
+        }
+
+        void ODF_Preview::lmax_slot (int)
+        {
+          render_frame->set_lmax (lmax_selector->value());
+        }
+
+        void ODF_Preview::level_of_detail_slot (int)
+        {
+          render_frame->set_LOD (level_of_detail_selector->value());
+        }
+
+        void ODF_Preview::use_lighting_slot (int)
+        {
+          render_frame->set_use_lighting (use_lighting_box->isChecked());
+        }
+
+        void ODF_Preview::lighting_settings_slot (bool)
+        {
+          assert (render_frame);
+          if (!lighting_dialog)
+            lighting_dialog = new Dialog::Lighting (&window, "Lighting for ODF preview", *render_frame->lighting);
+          lighting_dialog->show();
+        }
+
+        void ODF_Preview::closeEvent (QCloseEvent*)
+        {
+          hide();
+        }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+      }
+    }
+  }
+}
+
+
+
+
+

--- a/src/gui/mrview/tool/odf_preview.cpp
+++ b/src/gui/mrview/tool/odf_preview.cpp
@@ -84,12 +84,10 @@ namespace MR
 
           Tool::Base::VBoxLayout *main_box = new Tool::Base::VBoxLayout (this);
 
-          QSplitter* splitter = new QSplitter (Qt::Vertical, parent);
-          main_box->addWidget (splitter);
-          splitter->addWidget (render_frame);
+          main_box->addWidget (render_frame);
 
           QGroupBox* group_box = new QGroupBox (tr("Display settings"));
-          splitter->addWidget (group_box);
+          main_box->addWidget (group_box);
           Tool::Base::GridLayout* box_layout = new Tool::Base::GridLayout;
           group_box->setLayout (box_layout);
 
@@ -150,8 +148,8 @@ namespace MR
           connect (lighting_settings_button, SIGNAL(clicked(bool)), this, SLOT (lighting_settings_slot (bool)));
           box_layout->addWidget (lighting_settings_button, 5, 0, 1, 4);
 
-          splitter->setStretchFactor (0, 1);
-          splitter->setStretchFactor (1, 0);
+          main_box->setStretchFactor (render_frame, 1);
+          main_box->setStretchFactor (group_box, 0);
 
           hide_negative_lobes_slot (0);
           show_axes_slot (0);

--- a/src/gui/mrview/tool/odf_preview.cpp
+++ b/src/gui/mrview/tool/odf_preview.cpp
@@ -80,6 +80,7 @@ namespace MR
           setWindowTitle ("ODF preview pane");
           setModal (false);
           setSizeGripEnabled (true);
+          setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
 
           Tool::Base::VBoxLayout *main_box = new Tool::Base::VBoxLayout (this);
 

--- a/src/gui/mrview/tool/odf_preview.cpp
+++ b/src/gui/mrview/tool/odf_preview.cpp
@@ -39,32 +39,30 @@ namespace MR
 
 
 
-        class ODF_Preview::RenderFrame : public DWI::RenderFrame
-        {
-          public:
-            RenderFrame (QWidget* parent, Window& window) :
-              DWI::RenderFrame (parent),
-              window (window) { }
-          protected:
-            Window& window;
+        ODF_Preview::RenderFrame::RenderFrame (QWidget* parent, Window& window) :
+            DWI::RenderFrame (parent),
+            window (window) { }
 
-            virtual void resizeGL (int w, int h) {
-              makeCurrent();
-              DWI::RenderFrame::resizeGL (w,h);
-              window.makeGLcurrent();
-            }
+        void ODF_Preview::RenderFrame::resizeGL (const int w, const int h) {
+          makeCurrent();
+            DWI::RenderFrame::resizeGL (w,h);
+          window.makeGLcurrent();
+        }
 
-            virtual void initializeGL () {
-              makeCurrent();
-              DWI::RenderFrame::initializeGL();
-              window.makeGLcurrent();
-            }
-            virtual void paintGL () {
-              makeCurrent();
-              DWI::RenderFrame::paintGL();
-              window.makeGLcurrent();
-            }
-        };
+        void ODF_Preview::RenderFrame::initializeGL () {
+          makeCurrent();
+          DWI::RenderFrame::initializeGL();
+          window.makeGLcurrent();
+        }
+
+        void ODF_Preview::RenderFrame::paintGL () {
+          makeCurrent();
+          DWI::RenderFrame::paintGL();
+          window.makeGLcurrent();
+        }
+
+
+
 
 
 
@@ -72,9 +70,11 @@ namespace MR
         ODF_Preview::ODF_Preview (Window& main_window, Dock* dock, ODF* parent) :
             Base (main_window, dock),
             parent (parent),
-            render_frame (new RenderFrame (this, main_window)),
-            lighting_dialog (nullptr)
+            render_frame (new RenderFrame (this, main_window))
         {
+          delete render_frame->lighting;
+          render_frame->lighting = parent->lighting;
+
           Tool::Base::VBoxLayout *main_box = new Tool::Base::VBoxLayout (this);
 
           main_box->addWidget (render_frame);
@@ -99,58 +99,29 @@ namespace MR
           connect (show_axes_box, SIGNAL (stateChanged(int)), this, SLOT (show_axes_slot(int)));
           box_layout->addWidget (show_axes_box, 1, 0, 1, 2);
 
-          colour_by_direction_box = new QCheckBox ("colour by direction");
-          colour_by_direction_box->setChecked (true);
-          connect (colour_by_direction_box, SIGNAL (stateChanged(int)), this, SLOT (colour_by_direction_slot(int)));
-          box_layout->addWidget (colour_by_direction_box, 1, 2, 1, 2);
-
-          hide_negative_lobes_box = new QCheckBox ("hide negative lobes");
-          hide_negative_lobes_box->setChecked (true);
-          connect (hide_negative_lobes_box, SIGNAL (stateChanged(int)), this, SLOT (hide_negative_lobes_slot(int)));
-          box_layout->addWidget (hide_negative_lobes_box, 2, 2, 1, 2);
-
-          QLabel* label = new QLabel ("lmax");
+          QLabel* label = new QLabel ("detail");
           label->setAlignment (Qt::AlignHCenter);
-          box_layout->addWidget (label, 3, 0);
-          lmax_selector = new QSpinBox (this);
-          lmax_selector->setMinimum (2);
-          lmax_selector->setMaximum (16);
-          lmax_selector->setSingleStep (2);
-          lmax_selector->setValue (8);
-          connect (lmax_selector, SIGNAL (valueChanged(int)), this, SLOT(lmax_slot(int)));
-          box_layout->addWidget (lmax_selector, 3, 1);
-
-          label = new QLabel ("detail");
-          label->setAlignment (Qt::AlignHCenter);
-          box_layout->addWidget (label, 3, 2);
+          box_layout->addWidget (label, 1, 2, 1, 1);
           level_of_detail_selector = new QSpinBox (this);
           level_of_detail_selector->setMinimum (1);
           level_of_detail_selector->setMaximum (7);
           level_of_detail_selector->setSingleStep (1);
           level_of_detail_selector->setValue (4);
           connect (level_of_detail_selector, SIGNAL (valueChanged(int)), this, SLOT(level_of_detail_slot(int)));
-          box_layout->addWidget (level_of_detail_selector, 3, 3);
-
-          use_lighting_box = new QCheckBox ("use lighting");
-          use_lighting_box->setCheckable (true);
-          use_lighting_box->setChecked (true);
-          connect (use_lighting_box, SIGNAL (stateChanged(int)), this, SLOT (use_lighting_slot(int)));
-          box_layout->addWidget (use_lighting_box, 2, 0, 1, 2);
-
-          QPushButton *lighting_settings_button = new QPushButton ("lighting...", this);
-          connect (lighting_settings_button, SIGNAL(clicked(bool)), this, SLOT (lighting_settings_slot (bool)));
-          box_layout->addWidget (lighting_settings_button, 5, 0, 1, 4);
+          box_layout->addWidget (level_of_detail_selector, 1, 3, 1, 1);
 
           main_box->setStretchFactor (render_frame, 1);
           main_box->setStretchFactor (group_box, 0);
 
-          hide_negative_lobes_slot (0);
-          show_axes_slot (0);
-          colour_by_direction_slot (0);
-          use_lighting_slot (0);
-          lmax_slot (0);
-          level_of_detail_slot (0);
-          lock_orientation_to_image_slot (0);
+          render_frame->set_color_by_dir (parent->colour_by_direction_box->isChecked());
+          render_frame->set_hide_neg_lobes (parent->hide_negative_lobes_box->isChecked());
+          render_frame->set_use_lighting (parent->use_lighting_box->isChecked());
+          render_frame->set_lmax (parent->lmax_selector->value());
+          lock_orientation_to_image_slot (1);
+          interpolation_slot (0);
+          show_axes_slot (1);
+          level_of_detail_slot (4);
+
         }
 
 
@@ -171,16 +142,6 @@ namespace MR
           }
         }
 
-        void ODF_Preview::hide_negative_lobes_slot (int)
-        {
-          render_frame->set_hide_neg_lobes (hide_negative_lobes_box->isChecked());
-        }
-
-        void ODF_Preview::colour_by_direction_slot (int)
-        {
-          render_frame->set_color_by_dir (colour_by_direction_box->isChecked());
-        }
-
         void ODF_Preview::interpolation_slot (int)
         {
           parent->update_preview();
@@ -191,51 +152,16 @@ namespace MR
           render_frame->set_show_axes (show_axes_box->isChecked());
         }
 
-        void ODF_Preview::lmax_slot (int)
-        {
-          render_frame->set_lmax (lmax_selector->value());
-        }
-
         void ODF_Preview::level_of_detail_slot (int)
         {
           render_frame->set_LOD (level_of_detail_selector->value());
         }
 
-        void ODF_Preview::use_lighting_slot (int)
+        void ODF_Preview::lighting_update_slot()
         {
-          render_frame->set_use_lighting (use_lighting_box->isChecked());
+          // Use a dummy call that won't actually change anything, but will call updateGL() (which is protected)
+          render_frame->set_LOD (level_of_detail_selector->value());
         }
-
-        void ODF_Preview::lighting_settings_slot (bool)
-        {
-          assert (render_frame);
-          if (!lighting_dialog)
-            lighting_dialog = new Dialog::Lighting (&window, "Lighting for ODF preview", *render_frame->lighting);
-          lighting_dialog->show();
-        }
-
-        void ODF_Preview::hide_event ()
-        {
-          if (lighting_dialog)
-            lighting_dialog->hide();
-        }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/src/gui/mrview/tool/odf_preview.cpp
+++ b/src/gui/mrview/tool/odf_preview.cpp
@@ -41,7 +41,9 @@ namespace MR
 
         ODF_Preview::RenderFrame::RenderFrame (QWidget* parent, Window& window) :
             DWI::RenderFrame (parent),
-            window (window) { }
+            window (window) {
+          setMinimumSize (300, 300);    
+        }
 
         void ODF_Preview::RenderFrame::resizeGL (const int w, const int h) {
           makeCurrent();

--- a/src/gui/mrview/tool/odf_preview.cpp
+++ b/src/gui/mrview/tool/odf_preview.cpp
@@ -106,7 +106,7 @@ namespace MR
           level_of_detail_selector->setMinimum (1);
           level_of_detail_selector->setMaximum (7);
           level_of_detail_selector->setSingleStep (1);
-          level_of_detail_selector->setValue (4);
+          level_of_detail_selector->setValue (5);
           connect (level_of_detail_selector, SIGNAL (valueChanged(int)), this, SLOT(level_of_detail_slot(int)));
           box_layout->addWidget (level_of_detail_selector, 1, 3, 1, 1);
 
@@ -120,7 +120,7 @@ namespace MR
           lock_orientation_to_image_slot (1);
           interpolation_slot (0);
           show_axes_slot (1);
-          level_of_detail_slot (4);
+          level_of_detail_slot (5);
 
         }
 

--- a/src/gui/mrview/tool/odf_preview.cpp
+++ b/src/gui/mrview/tool/odf_preview.cpp
@@ -69,19 +69,12 @@ namespace MR
 
 
 
-
-        ODF_Preview::ODF_Preview (Window& main_window, ODF* parent) :
-            QDialog (parent),
-            window (main_window),
+        ODF_Preview::ODF_Preview (Window& main_window, Dock* dock, ODF* parent) :
+            Base (main_window, dock),
             parent (parent),
             render_frame (new RenderFrame (this, main_window)),
             lighting_dialog (nullptr)
         {
-          setWindowTitle ("ODF preview pane");
-          setModal (false);
-          setSizeGripEnabled (true);
-          setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
-
           Tool::Base::VBoxLayout *main_box = new Tool::Base::VBoxLayout (this);
 
           main_box->addWidget (render_frame);
@@ -169,14 +162,6 @@ namespace MR
           lock_orientation_to_image_slot (0);
         }
 
-        void ODF_Preview::hide()
-        {
-          parent->show_preview_button->setChecked (false);
-          if (lighting_dialog)
-            lighting_dialog->hide();
-          QDialog::hide();
-        }
-
         void ODF_Preview::lock_orientation_to_image_slot (int)
         {
           if (lock_orientation_to_image_box->isChecked()) {
@@ -229,9 +214,10 @@ namespace MR
           lighting_dialog->show();
         }
 
-        void ODF_Preview::closeEvent (QCloseEvent*)
+        void ODF_Preview::hide_event ()
         {
-          hide();
+          if (lighting_dialog)
+            lighting_dialog->hide();
         }
 
 

--- a/src/gui/mrview/tool/odf_preview.cpp
+++ b/src/gui/mrview/tool/odf_preview.cpp
@@ -61,7 +61,9 @@ namespace MR
           window.makeGLcurrent();
         }
 
-
+        void ODF_Preview::RenderFrame::wheelEvent (QWheelEvent*) {
+          //Talk to the hand, 'cause the scroll wheel ain't listening.      
+        }
 
 
 
@@ -90,7 +92,7 @@ namespace MR
           box_layout->addWidget (lock_orientation_to_image_box, 0, 0, 1, 2);
 
           interpolation_box = new QCheckBox ("interpolation");
-          interpolation_box->setChecked (false);
+          interpolation_box->setChecked (true);
           connect (interpolation_box, SIGNAL (stateChanged(int)), this, SLOT (interpolation_slot(int)));
           box_layout->addWidget (interpolation_box, 0, 2, 1, 2);
 
@@ -113,12 +115,13 @@ namespace MR
           main_box->setStretchFactor (render_frame, 1);
           main_box->setStretchFactor (group_box, 0);
 
+          render_frame->set_scale (parent->scale->value());
           render_frame->set_color_by_dir (parent->colour_by_direction_box->isChecked());
           render_frame->set_hide_neg_lobes (parent->hide_negative_lobes_box->isChecked());
           render_frame->set_use_lighting (parent->use_lighting_box->isChecked());
           render_frame->set_lmax (parent->lmax_selector->value());
           lock_orientation_to_image_slot (1);
-          interpolation_slot (0);
+          interpolation_slot (1);
           show_axes_slot (1);
           level_of_detail_slot (5);
 

--- a/src/gui/mrview/tool/odf_preview.h
+++ b/src/gui/mrview/tool/odf_preview.h
@@ -47,11 +47,18 @@ namespace MR
             {
               public:
                 RenderFrame (QWidget* parent, Window& window);
+                
+                void set_scale (float sc) {
+                  scale = sc;
+                  updateGL();
+                }
+                
               protected:
                 Window& window;
                 virtual void resizeGL (const int w, const int h);
                 virtual void initializeGL();
                 virtual void paintGL();
+                virtual void wheelEvent (QWheelEvent*);
             };
 
           public:

--- a/src/gui/mrview/tool/odf_preview.h
+++ b/src/gui/mrview/tool/odf_preview.h
@@ -23,6 +23,8 @@
 #ifndef __gui_mrview_tool_odf_preview_h__
 #define __gui_mrview_tool_odf_preview_h__
 
+#include "gui/dwi/render_frame.h"
+
 #include "gui/mrview/tool/base.h"
 #include "gui/mrview/window.h"
 
@@ -30,17 +32,6 @@ namespace MR
 {
   namespace GUI
   {
-    namespace DWI {
-      class Renderer;
-      class RenderFrame;
-    }
-    namespace Dialog {
-      class Lighting;
-    }
-    namespace GL {
-      class Lighting;
-    }
-
     namespace MRView
     {
       namespace Tool
@@ -51,31 +42,35 @@ namespace MR
         class ODF_Preview : public Base
         {
             Q_OBJECT
+
+            class RenderFrame : public DWI::RenderFrame
+            {
+              public:
+                RenderFrame (QWidget* parent, Window& window);
+              protected:
+                Window& window;
+                virtual void resizeGL (const int w, const int h);
+                virtual void initializeGL();
+                virtual void paintGL();
+            };
+
           public:
             ODF_Preview (Window&, Dock*, ODF*);
             void set (const Math::Vector<float>&);
             bool interpolate() const { return interpolation_box->isChecked(); }
-            size_t lmax() const { return lmax_selector->value(); }
           private slots:
             void lock_orientation_to_image_slot (int);
-            void hide_negative_lobes_slot (int);
-            void colour_by_direction_slot (int);
             void interpolation_slot (int);
             void show_axes_slot (int);
-            void lmax_slot (int);
             void level_of_detail_slot (int);
-            void use_lighting_slot (int);
-            void lighting_settings_slot (bool);
-            void hide_event ();
+            void lighting_update_slot();
           protected:
             ODF* parent;
-            class RenderFrame;
             RenderFrame* render_frame;
-            QCheckBox *lock_orientation_to_image_box, *hide_negative_lobes_box;
-            QCheckBox *colour_by_direction_box, *interpolation_box, *show_axes_box;
-            QSpinBox *lmax_selector, *level_of_detail_selector;
-            QCheckBox *use_lighting_box;
-            Dialog::Lighting *lighting_dialog;
+            QCheckBox *lock_orientation_to_image_box;
+            QCheckBox *interpolation_box, *show_axes_box;
+            QSpinBox *level_of_detail_selector;
+            friend class ODF;
         };
 
       }

--- a/src/gui/mrview/tool/odf_preview.h
+++ b/src/gui/mrview/tool/odf_preview.h
@@ -23,6 +23,7 @@
 #ifndef __gui_mrview_tool_odf_preview_h__
 #define __gui_mrview_tool_odf_preview_h__
 
+#include "gui/mrview/tool/base.h"
 #include "gui/mrview/window.h"
 
 namespace MR
@@ -47,15 +48,14 @@ namespace MR
 
         class ODF;
 
-        class ODF_Preview : public QDialog
+        class ODF_Preview : public Base
         {
             Q_OBJECT
           public:
-            ODF_Preview (Window&, ODF*);
+            ODF_Preview (Window&, Dock*, ODF*);
             void set (const Math::Vector<float>&);
             bool interpolate() const { return interpolation_box->isChecked(); }
             size_t lmax() const { return lmax_selector->value(); }
-            void hide();
           private slots:
             void lock_orientation_to_image_slot (int);
             void hide_negative_lobes_slot (int);
@@ -66,9 +66,8 @@ namespace MR
             void level_of_detail_slot (int);
             void use_lighting_slot (int);
             void lighting_settings_slot (bool);
-            void closeEvent (QCloseEvent*);
+            void hide_event ();
           protected:
-            Window& window;
             ODF* parent;
             class RenderFrame;
             RenderFrame* render_frame;

--- a/src/gui/mrview/tool/odf_preview.h
+++ b/src/gui/mrview/tool/odf_preview.h
@@ -1,0 +1,92 @@
+/*
+   Copyright 2009 Brain Research Institute, Melbourne, Australia
+
+   Written by J-Donald Tournier and Robert E. Smith, 2015.
+
+   This file is part of MRtrix.
+
+   MRtrix is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   MRtrix is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with MRtrix.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+#ifndef __gui_mrview_tool_odf_preview_h__
+#define __gui_mrview_tool_odf_preview_h__
+
+#include "gui/mrview/window.h"
+
+namespace MR
+{
+  namespace GUI
+  {
+    namespace DWI {
+      class Renderer;
+      class RenderFrame;
+    }
+    namespace Dialog {
+      class Lighting;
+    }
+    namespace GL {
+      class Lighting;
+    }
+
+    namespace MRView
+    {
+      namespace Tool
+      {
+
+        class ODF;
+
+        class ODF_Preview : public QDialog
+        {
+            Q_OBJECT
+          public:
+            ODF_Preview (Window&, ODF*);
+            void set (const Math::Vector<float>&);
+            bool interpolate() const { return interpolation_box->isChecked(); }
+            size_t lmax() const { return lmax_selector->value(); }
+            void hide();
+          private slots:
+            void lock_orientation_to_image_slot (int);
+            void hide_negative_lobes_slot (int);
+            void colour_by_direction_slot (int);
+            void interpolation_slot (int);
+            void show_axes_slot (int);
+            void lmax_slot (int);
+            void level_of_detail_slot (int);
+            void use_lighting_slot (int);
+            void lighting_settings_slot (bool);
+            void closeEvent (QCloseEvent*);
+          protected:
+            Window& window;
+            ODF* parent;
+            class RenderFrame;
+            RenderFrame* render_frame;
+            QCheckBox *lock_orientation_to_image_box, *hide_negative_lobes_box;
+            QCheckBox *colour_by_direction_box, *interpolation_box, *show_axes_box;
+            QSpinBox *lmax_selector, *level_of_detail_selector;
+            QCheckBox *use_lighting_box;
+            Dialog::Lighting *lighting_dialog;
+        };
+
+      }
+    }
+  }
+}
+
+#endif
+
+
+
+
+


### PR DESCRIPTION
This remove the ODF display pane from the ODF tool, as discussed in issue #194.
Feedback welcome.