### PR TITLE
QOpenGLWidget and other OpenGL related issues

### DIFF
--- a/src/gui/dialog/opengl.cpp
+++ b/src/gui/dialog/opengl.cpp
@@ -32,7 +32,7 @@ namespace MR
     namespace Dialog
     {
 
-      OpenGL::OpenGL (QWidget* parent, const QGLFormat& format) : QDialog (parent)
+      OpenGL::OpenGL (QWidget* parent, const GL::Format& format) : QDialog (parent)
       {
         TreeModel* model = new TreeModel (this);
 
@@ -59,9 +59,14 @@ namespace MR
         bit_depths->appendChild (new TreeItem ("depth", str (format.depthBufferSize()), bit_depths));
         bit_depths->appendChild (new TreeItem ("stencil", str (format.stencilBufferSize()), bit_depths));
 
-        root->appendChild (new TreeItem ("Double buffering", format.doubleBuffer() ? "on" : "off", root));
+#if QT_VERSION >= 0x050400
+        root->appendChild (new TreeItem ("Buffering", format.swapBehavior() == QSurfaceFormat::SingleBuffer ? "single" :
+               ( format.swapBehavior() == QSurfaceFormat::DoubleBuffer ? "double" : "triple" ), root));
+#else
+        root->appendChild (new TreeItem ("Buffering", format.doubleBuffer() ? "double" : "single", root));
+#endif
         root->appendChild (new TreeItem ("VSync", format.swapInterval() ? "on" : "off", root));
-        root->appendChild (new TreeItem ("Multisample anti-aliasing", format.sampleBuffers() ? str(format.samples()).c_str() : "off", root));
+        root->appendChild (new TreeItem ("Multisample anti-aliasing", format.samples() ? str(format.samples()).c_str() : "off", root));
 
         gl::GetIntegerv (gl::MAX_TEXTURE_SIZE, &i);
         root->appendChild (new TreeItem ("Maximum texture size", str (i), root));

--- a/src/gui/dialog/opengl.h
+++ b/src/gui/dialog/opengl.h
@@ -35,7 +35,7 @@ namespace MR
       class OpenGL : public QDialog
       {
         public:
-          OpenGL (QWidget* parent, const QGLFormat& format);
+          OpenGL (QWidget* parent, const GL::Format& format);
       };
 
     }

--- a/src/gui/dwi/render_frame.cpp
+++ b/src/gui/dwi/render_frame.cpp
@@ -52,7 +52,7 @@ namespace MR
     {
 
       RenderFrame::RenderFrame (QWidget* parent) :
-        QGLWidget (parent),
+        GL::Area (parent),
         view_angle (40.0), distance (0.3), line_width (1.0), scale (1.0), 
         lmax_computed (0), lod_computed (0), recompute_mesh (true), recompute_amplitudes (true), 
         show_axes (true), hide_neg_lobes (true), color_by_dir (true), use_lighting (true), 

--- a/src/gui/dwi/render_frame.cpp
+++ b/src/gui/dwi/render_frame.cpp
@@ -88,7 +88,6 @@ namespace MR
       {
         GL::init();
         renderer.initGL();
-        gl::ClearColor (lighting->background_color[0], lighting->background_color[1], lighting->background_color[2], 0.0);
         gl::Enable (gl::DEPTH_TEST);
 
         axes_VB.gen();
@@ -147,6 +146,8 @@ namespace MR
 
       void RenderFrame::paintGL ()
       {
+        gl::ColorMask (true, true, true, true); 
+        gl::ClearColor (lighting->background_color[0], lighting->background_color[1], lighting->background_color[2], 0.0);
         gl::Clear (gl::COLOR_BUFFER_BIT | gl::DEPTH_BUFFER_BIT);
 
         float dist (1.0f / (distance * view_angle * D2R));
@@ -223,6 +224,14 @@ namespace MR
           gl::Disable (gl::BLEND);
           gl::Disable (gl::LINE_SMOOTH);
         }
+
+        // need to clear alpha channel when using QOpenGLWidget (Qt >= 5.4)
+        // otherwise we get transparent windows...
+#if QT_VERSION >= 0x050400
+        gl::ClearColor (0.0, 0.0, 0.0, 1.0);
+        gl::ColorMask (false, false, false, true); 
+        gl::Clear (GL_COLOR_BUFFER_BIT);
+#endif
 
         if (OS > 0) snapshot();
 

--- a/src/gui/dwi/render_frame.cpp
+++ b/src/gui/dwi/render_frame.cpp
@@ -57,23 +57,15 @@ namespace MR
         lmax_computed (0), lod_computed (0), recompute_mesh (true), recompute_amplitudes (true), 
         show_axes (true), hide_neg_lobes (true), color_by_dir (true), use_lighting (true), 
         normalise (false), font (parent->font()), projection (this, font),
-        focus (0.0, 0.0, 0.0), OS (0), OS_x (0), OS_y (0),
-        glrefresh_timer (new QTimer (this))
+        focus (0.0, 0.0, 0.0), OS (0), OS_x (0), OS_y (0)
       {
         setMinimumSize (128, 128);
         lighting = new GL::Lighting (this);
         lighting->set_background = true;
-        connect (lighting, SIGNAL (changed()), this, SLOT (updateGL()));
-        glrefresh_timer->setSingleShot (true);
-        connect (glrefresh_timer, SIGNAL (timeout()), this, SLOT (base_updateGL()));
+        connect (lighting, SIGNAL (changed()), this, SLOT (update()));
       }
 
 
-
-      RenderFrame::~RenderFrame()
-      {
-        delete glrefresh_timer;
-      }
 
 
 
@@ -85,17 +77,10 @@ namespace MR
         p[6] = rotation(0,2); p[7] = rotation(1,2); p[8] = rotation(2,2);
         Math::Matrix<float> M (p, 3, 3);
         orientation.from_matrix (M);
-        updateGL();
+        update();
       }
 
 
-
-      void RenderFrame::updateGL ()
-      {
-        if (glrefresh_timer->isActive())
-          return;
-        glrefresh_timer->start();
-      }
 
 
 
@@ -255,11 +240,11 @@ namespace MR
         if (event->modifiers() == Qt::NoModifier) {
           if (event->buttons() == Qt::LeftButton) {
             orientation = Math::Versor<float>();
-            updateGL();
+            update();
           }
           else if (event->buttons() == Qt::MidButton) {
             focus.set (0.0, 0.0, 0.0);
-            updateGL();
+            update();
           }
         }
       }
@@ -288,17 +273,17 @@ namespace MR
 
             Math::Versor<float> rot (angle, v);
             orientation = rot * orientation;
-            updateGL();
+            update();
           }
           else if (event->buttons() == Qt::MidButton) {
             focus += projection.screen_to_model_direction (QPoint (dx, -dy), focus);
-            updateGL();
+            update();
           }
           else if (event->buttons() == Qt::RightButton) {
             distance *= 1.0 - DIST_INC*dy;
             if (distance < DIST_MIN) distance = DIST_MIN;
             if (distance > DIST_MAX) distance = DIST_MAX;
-            updateGL();
+            update();
           }
         }
         else if (event->modifiers() == Qt::ControlModifier) {
@@ -306,7 +291,7 @@ namespace MR
             view_angle -= ANGLE_INC*dy;
             if (view_angle < ANGLE_MIN) view_angle = ANGLE_MIN;
             if (view_angle > ANGLE_MAX) view_angle = ANGLE_MAX;
-            updateGL();
+            update();
           }
         }
       }
@@ -318,7 +303,7 @@ namespace MR
         for (int n = 0; n > scroll; n--) scale /= SCALE_INC;
         if (scale > SCALE_MAX) scale = SCALE_MAX;
         if (scale < SCALE_MIN) scale = SCALE_MIN;
-        updateGL();
+        update();
       }
 
 
@@ -330,7 +315,7 @@ namespace MR
         OS_x = OS_y = 0;
         framebuffer.reset (new GLubyte [3*projection.width()*projection.height()]);
         pix.reset (new QImage (OS*projection.width(), OS*projection.height(), QImage::Format_RGB32));
-        updateGL();
+        update();
       }
 
 
@@ -366,7 +351,7 @@ namespace MR
           }
         }
 
-        updateGL();
+        update();
       }
 
 

--- a/src/gui/dwi/render_frame.cpp
+++ b/src/gui/dwi/render_frame.cpp
@@ -52,7 +52,7 @@ namespace MR
     {
 
       RenderFrame::RenderFrame (QWidget* parent) :
-        QGLWidget (GL::core_format(), parent),
+        QGLWidget (parent),
         view_angle (40.0), distance (0.3), line_width (1.0), scale (1.0), 
         lmax_computed (0), lod_computed (0), recompute_mesh (true), recompute_amplitudes (true), 
         show_axes (true), hide_neg_lobes (true), color_by_dir (true), use_lighting (true), 

--- a/src/gui/dwi/render_frame.h
+++ b/src/gui/dwi/render_frame.h
@@ -51,49 +51,48 @@ namespace MR
 
         public:
           RenderFrame (QWidget* parent);
-          ~RenderFrame();
 
           GL::Lighting* lighting;
 
           void set (const Math::Vector<float>& new_values) {
             values = new_values;
             recompute_amplitudes = true;
-            updateGL();
+            update();
           }
 
           void set_rotation (const GL::mat4& rotation);
 
           void set_show_axes (bool yesno = true) {
             show_axes = yesno;
-            updateGL();
+            update();
           }
           void set_hide_neg_lobes (bool yesno = true) {
             hide_neg_lobes = yesno;
-            updateGL();
+            update();
           }
           void set_color_by_dir (bool yesno = true) {
             color_by_dir = yesno;
-            updateGL();
+            update();
           }
           void set_use_lighting (bool yesno = true) {
             use_lighting = yesno;
-            updateGL();
+            update();
           }
           void set_normalise (bool yesno = true) {
             normalise = yesno;
-            updateGL();
+            update();
           }
           void set_lmax (int lmax) {
             if (lmax != lmax_computed) 
               recompute_mesh = recompute_amplitudes = true;
             lmax_computed = lmax;
-            updateGL();
+            update();
           }
           void set_LOD (int lod) {
             if (lod != lod_computed) 
               recompute_mesh = recompute_amplitudes = true;
             lod_computed = lod;
-            updateGL();
+            update();
           }
 
           int  get_LOD () const { return lod_computed; }
@@ -129,11 +128,6 @@ namespace MR
 
           Renderer renderer;
           Math::Vector<float> values;
-
-          QTimer* glrefresh_timer;
-        protected slots:
-          void base_updateGL() { QGLWidget::updateGL(); }
-          void updateGL();
 
         protected:
           virtual void initializeGL () override;

--- a/src/gui/dwi/render_frame.h
+++ b/src/gui/dwi/render_frame.h
@@ -45,7 +45,7 @@ namespace MR
     namespace DWI
     {
 
-      class RenderFrame : public QGLWidget
+      class RenderFrame : public GL::Area
       {
           Q_OBJECT
 
@@ -136,13 +136,13 @@ namespace MR
           void updateGL();
 
         protected:
-          virtual void initializeGL ();
-          virtual void resizeGL (int w, int h);
-          virtual void paintGL ();
-          void mouseDoubleClickEvent (QMouseEvent* event);
-          void mousePressEvent (QMouseEvent* event);
-          void mouseMoveEvent (QMouseEvent* event);
-          void wheelEvent (QWheelEvent* event);
+          virtual void initializeGL () override;
+          virtual void resizeGL (int w, int h) override;
+          virtual void paintGL () override;
+          void mouseDoubleClickEvent (QMouseEvent* event) override;
+          void mousePressEvent (QMouseEvent* event) override;
+          void mouseMoveEvent (QMouseEvent* event) override;
+          void wheelEvent (QWheelEvent* event) override;
 
           void snapshot ();
       };

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -48,6 +48,8 @@ namespace MR
           ::MR::Exception::display_func = Dialog::display_exception;
 
           ::MR::App::check_overwrite_files_func = Dialog::File::check_overwrite_files_func;
+
+          ::MR::GUI::GL::set_default_context ();
         }
 
         ~App () {

--- a/src/gui/mrview/tool/base.cpp
+++ b/src/gui/mrview/tool/base.cpp
@@ -32,7 +32,7 @@ namespace MR
       namespace Tool
       {
 
-        void Dock::hideEvent (QHideEvent*) { assert (tool); tool->hide_event(); }
+        void Dock::closeEvent (QCloseEvent*) { assert (tool); tool->close_event(); }
 
         Base::Base (Window& main_window, Dock* parent) : 
           QFrame (parent),

--- a/src/gui/mrview/tool/base.h
+++ b/src/gui/mrview/tool/base.h
@@ -53,7 +53,7 @@ namespace MR
             Dock (QWidget* parent, const QString& name) :
               QDockWidget (name, parent), tool (NULL) { }
 
-            void hideEvent (QHideEvent*) override;
+            void closeEvent (QCloseEvent*) override;
 
             Base* tool;
         };
@@ -133,7 +133,7 @@ namespace MR
             virtual bool mouse_press_event ();
             virtual bool mouse_move_event ();
             virtual bool mouse_release_event ();
-            virtual void hide_event() { }
+            virtual void close_event() { }
             virtual void reset_event () { }
             virtual QCursor* get_cursor ();
             void update_cursor() { window.set_cursor(); }

--- a/src/gui/mrview/tool/odf.cpp
+++ b/src/gui/mrview/tool/odf.cpp
@@ -145,11 +145,11 @@ namespace MR
 
         ODF::ODF (Window& main_window, Dock* parent) :
           Base (main_window, parent),
+          preview (nullptr),
           renderer (nullptr),
           lighting_dock (nullptr),
           lmax (0),
-          level_of_detail (0) { 
-
+          level_of_detail (0) {
             lighting = new GL::Lighting (this);
 
             VBoxLayout *main_box = new VBoxLayout (this);
@@ -284,14 +284,6 @@ namespace MR
             lmax_slot (0);
             adjust_scale_slot ();
 
-            preview = new Dock (&main_window,nullptr);
-            main_window.addDockWidget (Qt::RightDockWidgetArea, preview);
-            preview->tool = new ODF_Preview (window, preview, this);
-            preview->tool->adjustSize();
-            preview->setWidget (preview->tool);
-            preview->setFloating (true);
-            preview->hide();
-            connect (lighting, SIGNAL (changed()), preview->tool, SLOT (lighting_update_slot()));
           }
 
         ODF::~ODF()
@@ -506,6 +498,16 @@ namespace MR
 
         void ODF::show_preview_slot ()
         {
+          if (!preview) {
+            preview = new Dock (&window, nullptr);
+            window.addDockWidget (Qt::RightDockWidgetArea, preview);
+            preview->tool = new ODF_Preview (window, preview, this);
+            preview->tool->adjustSize();
+            preview->setWidget (preview->tool);
+            preview->setFloating (true);
+            connect (lighting, SIGNAL (changed()), preview->tool, SLOT (lighting_update_slot()));
+          }
+
           preview->show();
           preview->raise();
           update_preview();
@@ -525,9 +527,10 @@ namespace MR
           if (!settings)
             return;
           settings->color_by_direction = colour_by_direction_box->isChecked();
-          assert (preview);
-          assert (preview->tool);
-          dynamic_cast<ODF_Preview*>(preview->tool)->render_frame->set_color_by_dir (colour_by_direction_box->isChecked());
+          if (preview) {
+            assert (preview->tool);
+            dynamic_cast<ODF_Preview*>(preview->tool)->render_frame->set_color_by_dir (colour_by_direction_box->isChecked());
+          }
           updateGL();
         }
 
@@ -541,9 +544,10 @@ namespace MR
           if (!settings)
             return;
           settings->hide_negative_lobes = hide_negative_lobes_box->isChecked();
-          assert (preview);
-          assert (preview->tool);
-          dynamic_cast<ODF_Preview*>(preview->tool)->render_frame->set_hide_neg_lobes (hide_negative_lobes_box->isChecked());
+          if (preview) {
+            assert (preview->tool);
+            dynamic_cast<ODF_Preview*>(preview->tool)->render_frame->set_hide_neg_lobes (hide_negative_lobes_box->isChecked());
+          }
           updateGL();
         }
 
@@ -559,9 +563,10 @@ namespace MR
           if (!settings)
             return;
           settings->lmax = lmax_selector->value();
-          assert (preview);
-          assert (preview->tool);
-          dynamic_cast<ODF_Preview*>(preview->tool)->render_frame->set_lmax (lmax_selector->value());
+          if (preview) {
+            assert (preview->tool);
+            dynamic_cast<ODF_Preview*>(preview->tool)->render_frame->set_lmax (lmax_selector->value());
+          }
           updateGL();
         }
 
@@ -569,9 +574,10 @@ namespace MR
 
         void ODF::use_lighting_slot (int)
         {
-          assert (preview);
-          assert (preview->tool);
-          dynamic_cast<ODF_Preview*>(preview->tool)->render_frame->set_use_lighting (use_lighting_box->isChecked());
+          if (preview) {
+            assert (preview->tool);
+            dynamic_cast<ODF_Preview*>(preview->tool)->render_frame->set_use_lighting (use_lighting_box->isChecked());
+          }
           updateGL();
         }
 
@@ -598,16 +604,17 @@ namespace MR
           if (!settings)
             return;
           settings->scale = scale->value();
-          assert (preview);
-          assert (preview->tool);
-          dynamic_cast<ODF_Preview*>(preview->tool)->render_frame->set_scale (scale->value());
+          if (preview) {
+            assert (preview->tool);
+            dynamic_cast<ODF_Preview*>(preview->tool)->render_frame->set_scale (scale->value());
+          }
           updateGL();
         }
 
         void ODF::hide_event ()
         {
-          assert (preview);
-          preview->hide();
+          if (preview) 
+            preview->hide();
           if (lighting_dock)
             lighting_dock->hide();
         }
@@ -622,7 +629,8 @@ namespace MR
 
         void ODF::update_preview()
         {
-          assert (preview);
+          if (!preview) 
+            return;
           if (!preview->isVisible())
             return;
           Image* settings = get_image();

--- a/src/gui/mrview/tool/odf.cpp
+++ b/src/gui/mrview/tool/odf.cpp
@@ -499,17 +499,11 @@ namespace MR
         void ODF::show_preview_slot ()
         {
           if (!preview) {
-            preview = new Dock (&window, nullptr);
-            window.addDockWidget (Qt::RightDockWidgetArea, preview);
-            preview->tool = new ODF_Preview (window, preview, this);
-            preview->tool->adjustSize();
-            preview->setWidget (preview->tool);
-            preview->setFloating (true);
-            connect (lighting, SIGNAL (changed()), preview->tool, SLOT (lighting_update_slot()));
+            preview = new Preview (window, this);
+            connect (lighting, SIGNAL (changed()), preview, SLOT (lighting_update_slot()));
           }
 
           preview->show();
-          preview->raise();
           update_preview();
         }
 
@@ -528,8 +522,7 @@ namespace MR
             return;
           settings->color_by_direction = colour_by_direction_box->isChecked();
           if (preview) {
-            assert (preview->tool);
-            dynamic_cast<ODF_Preview*>(preview->tool)->render_frame->set_color_by_dir (colour_by_direction_box->isChecked());
+            preview->render_frame->set_color_by_dir (colour_by_direction_box->isChecked());
           }
           updateGL();
         }
@@ -544,10 +537,8 @@ namespace MR
           if (!settings)
             return;
           settings->hide_negative_lobes = hide_negative_lobes_box->isChecked();
-          if (preview) {
-            assert (preview->tool);
-            dynamic_cast<ODF_Preview*>(preview->tool)->render_frame->set_hide_neg_lobes (hide_negative_lobes_box->isChecked());
-          }
+          if (preview) 
+            preview->render_frame->set_hide_neg_lobes (hide_negative_lobes_box->isChecked());
           updateGL();
         }
 
@@ -563,10 +554,8 @@ namespace MR
           if (!settings)
             return;
           settings->lmax = lmax_selector->value();
-          if (preview) {
-            assert (preview->tool);
-            dynamic_cast<ODF_Preview*>(preview->tool)->render_frame->set_lmax (lmax_selector->value());
-          }
+          if (preview) 
+            preview->render_frame->set_lmax (lmax_selector->value());
           updateGL();
         }
 
@@ -574,10 +563,8 @@ namespace MR
 
         void ODF::use_lighting_slot (int)
         {
-          if (preview) {
-            assert (preview->tool);
-            dynamic_cast<ODF_Preview*>(preview->tool)->render_frame->set_use_lighting (use_lighting_box->isChecked());
-          }
+          if (preview) 
+            preview->render_frame->set_use_lighting (use_lighting_box->isChecked());
           updateGL();
         }
 
@@ -604,10 +591,8 @@ namespace MR
           if (!settings)
             return;
           settings->scale = scale->value();
-          if (preview) {
-            assert (preview->tool);
-            dynamic_cast<ODF_Preview*>(preview->tool)->render_frame->set_scale (scale->value());
-          }
+          if (preview) 
+            preview->render_frame->set_scale (scale->value());
           updateGL();
         }
 
@@ -637,10 +622,9 @@ namespace MR
           if (!settings)
             return;
           MRView::Image& image (settings->image);
-          ODF_Preview* preview_tool = dynamic_cast<ODF_Preview*>(preview->tool);
           Math::Vector<float> values (Math::SH::NforL (lmax_selector->value()));
-          get_values (values, image, window.focus(), preview_tool->interpolate());
-          preview_tool->set (values);
+          get_values (values, image, window.focus(), preview->interpolate());
+          preview->set (values);
         }
 
 

--- a/src/gui/mrview/tool/odf.cpp
+++ b/src/gui/mrview/tool/odf.cpp
@@ -596,7 +596,7 @@ namespace MR
           updateGL();
         }
 
-        void ODF::hide_event ()
+        void ODF::close_event ()
         {
           if (preview) 
             preview->hide();

--- a/src/gui/mrview/tool/odf.h
+++ b/src/gui/mrview/tool/odf.h
@@ -74,7 +74,7 @@ namespace MR
             void updateGL ();
             void update_preview();
 
-            void hide_event() override;
+            void close_event() override;
 
           protected:
              class Model;

--- a/src/gui/mrview/tool/odf.h
+++ b/src/gui/mrview/tool/odf.h
@@ -79,8 +79,9 @@ namespace MR
           protected:
              class Model;
              class Image;
+             class Preview;
 
-             Dock *preview;
+             Preview *preview;
 
              DWI::Renderer *renderer;
 

--- a/src/gui/mrview/tool/odf_preview.cpp
+++ b/src/gui/mrview/tool/odf_preview.cpp
@@ -38,13 +38,13 @@ namespace MR
 
 
 
-        ODF_Preview::RenderFrame::RenderFrame (QWidget* parent, Window& window) :
+        ODF::Preview::RenderFrame::RenderFrame (QWidget* parent, Window& window) :
             DWI::RenderFrame (parent),
             window (window) {
           setMinimumSize (300, 300);    
         }
 
-        void ODF_Preview::RenderFrame::wheelEvent (QWheelEvent*) {
+        void ODF::Preview::RenderFrame::wheelEvent (QWheelEvent*) {
           //Talk to the hand, 'cause the scroll wheel ain't listening.      
         }
 
@@ -52,8 +52,8 @@ namespace MR
 
 
 
-        ODF_Preview::ODF_Preview (Window& main_window, Dock* dock, ODF* parent) :
-            Base (main_window, dock),
+        ODF::Preview::Preview (Window& main_window, ODF* parent) :
+            QWidget (&main_window, Qt::Tool),
             parent (parent),
             render_frame (new RenderFrame (this, main_window))
         {
@@ -113,37 +113,37 @@ namespace MR
 
 
 
-        void ODF_Preview::set (const Math::Vector<float>& data)
+        void ODF::Preview::set (const Math::Vector<float>& data)
         {
           render_frame->set (data);
           lock_orientation_to_image_slot (0);
         }
 
-        void ODF_Preview::lock_orientation_to_image_slot (int)
+        void ODF::Preview::lock_orientation_to_image_slot (int)
         {
           if (lock_orientation_to_image_box->isChecked()) {
-            const Projection* proj = window.get_current_mode()->get_current_projection();
+            const Projection* proj = parent->window.get_current_mode()->get_current_projection();
             if (!proj) return;
             render_frame->set_rotation (proj->modelview());
           }
         }
 
-        void ODF_Preview::interpolation_slot (int)
+        void ODF::Preview::interpolation_slot (int)
         {
           parent->update_preview();
         }
 
-        void ODF_Preview::show_axes_slot (int)
+        void ODF::Preview::show_axes_slot (int)
         {
           render_frame->set_show_axes (show_axes_box->isChecked());
         }
 
-        void ODF_Preview::level_of_detail_slot (int)
+        void ODF::Preview::level_of_detail_slot (int)
         {
           render_frame->set_LOD (level_of_detail_selector->value());
         }
 
-        void ODF_Preview::lighting_update_slot()
+        void ODF::Preview::lighting_update_slot()
         {
           // Use a dummy call that won't actually change anything, but will call updateGL() (which is protected)
           render_frame->set_LOD (level_of_detail_selector->value());

--- a/src/gui/mrview/tool/odf_preview.cpp
+++ b/src/gui/mrview/tool/odf_preview.cpp
@@ -44,24 +44,6 @@ namespace MR
           setMinimumSize (300, 300);    
         }
 
-        void ODF_Preview::RenderFrame::resizeGL (const int w, const int h) {
-          makeCurrent();
-            DWI::RenderFrame::resizeGL (w,h);
-          window.makeGLcurrent();
-        }
-
-        void ODF_Preview::RenderFrame::initializeGL () {
-          makeCurrent();
-          DWI::RenderFrame::initializeGL();
-          window.makeGLcurrent();
-        }
-
-        void ODF_Preview::RenderFrame::paintGL () {
-          makeCurrent();
-          DWI::RenderFrame::paintGL();
-          window.makeGLcurrent();
-        }
-
         void ODF_Preview::RenderFrame::wheelEvent (QWheelEvent*) {
           //Talk to the hand, 'cause the scroll wheel ain't listening.      
         }

--- a/src/gui/mrview/tool/odf_preview.h
+++ b/src/gui/mrview/tool/odf_preview.h
@@ -25,7 +25,7 @@
 
 #include "gui/dwi/render_frame.h"
 
-#include "gui/mrview/tool/base.h"
+#include "gui/mrview/tool/odf.h"
 #include "gui/mrview/window.h"
 
 namespace MR
@@ -37,9 +37,7 @@ namespace MR
       namespace Tool
       {
 
-        class ODF;
-
-        class ODF_Preview : public Base
+        class ODF::Preview : public QWidget
         {
             Q_OBJECT
 
@@ -59,7 +57,7 @@ namespace MR
             };
 
           public:
-            ODF_Preview (Window&, Dock*, ODF*);
+            Preview (Window&, ODF*);
             void set (const Math::Vector<float>&);
             bool interpolate() const { return interpolation_box->isChecked(); }
           private slots:

--- a/src/gui/mrview/tool/odf_preview.h
+++ b/src/gui/mrview/tool/odf_preview.h
@@ -55,9 +55,6 @@ namespace MR
                 
               protected:
                 Window& window;
-                virtual void resizeGL (const int w, const int h);
-                virtual void initializeGL();
-                virtual void paintGL();
                 virtual void wheelEvent (QWheelEvent*);
             };
 

--- a/src/gui/mrview/tool/odf_preview.h
+++ b/src/gui/mrview/tool/odf_preview.h
@@ -50,7 +50,7 @@ namespace MR
                 
                 void set_scale (float sc) {
                   scale = sc;
-                  updateGL();
+                  update();
                 }
                 
               protected:

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -638,7 +638,7 @@ namespace MR
           WARN ("invalid specifier \"" + cbar_pos + "\" for config file entry \"MRViewToolsColourBarPosition\"");
 
         glrefresh_timer->setSingleShot (true);
-        connect (glrefresh_timer, SIGNAL (timeout()), glarea, SLOT (updateGL()));
+        connect (glrefresh_timer, SIGNAL (timeout()), glarea, SLOT (update()));
       }
 
 

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -1246,6 +1246,7 @@ namespace MR
 
       void Window::paintGL ()
       {
+        glColorMask (true, true, true, true);
         gl::ClearColor (background_colour[0], background_colour[1], background_colour[2], 1.0);
         gl::Enable (gl::MULTISAMPLE);
         if (mode->in_paint())
@@ -1253,6 +1254,13 @@ namespace MR
 
         gl::DrawBuffer (gl::BACK);
         mode->paintGL();
+        
+        // need to clear alpha channel when using QOpenGLWidget (Qt >= 5.4)
+        // otherwise we get transparent windows...
+#if QT_VERSION >= 0x050400
+        gl::ColorMask (false, false, false, true); 
+        gl::Clear (GL_COLOR_BUFFER_BIT);
+#endif
       }
 
 

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -186,7 +186,6 @@ namespace MR
 
       Window::Window() :
         glarea (new GLArea (*this)),
-        glrefresh_timer (new QTimer (this)),
         mode (nullptr),
         font (glarea->font()),
 #ifdef MRTRIX_MACOSX
@@ -436,32 +435,32 @@ namespace MR
         action->setShortcut (tr("Space"));
         addAction (action);
 
-        show_crosshairs_action = menu->addAction (tr ("Show focus"), this, SLOT (updateGL()));
+        show_crosshairs_action = menu->addAction (tr ("Show focus"), glarea, SLOT (update()));
         show_crosshairs_action->setShortcut (tr("F"));
         show_crosshairs_action->setCheckable (true);
         show_crosshairs_action->setChecked (true);
         addAction (show_crosshairs_action);
 
-        show_comments_action = menu->addAction (tr ("Show comments"), this, SLOT (updateGL()));
+        show_comments_action = menu->addAction (tr ("Show comments"), glarea, SLOT (update()));
         show_comments_action->setToolTip (tr ("Show/hide image comments\n\nShortcut: H"));
         show_comments_action->setShortcut (tr("H"));
         show_comments_action->setCheckable (true);
         show_comments_action->setChecked (true);
         addAction (show_comments_action);
 
-        show_voxel_info_action = menu->addAction (tr ("Show voxel information"), this, SLOT (updateGL()));
+        show_voxel_info_action = menu->addAction (tr ("Show voxel information"), glarea, SLOT (update()));
         show_voxel_info_action->setShortcut (tr("V"));
         show_voxel_info_action->setCheckable (true);
         show_voxel_info_action->setChecked (true);
         addAction (show_voxel_info_action);
 
-        show_orientation_labels_action = menu->addAction (tr ("Show orientation labels"), this, SLOT (updateGL()));
+        show_orientation_labels_action = menu->addAction (tr ("Show orientation labels"), glarea, SLOT (update()));
         show_orientation_labels_action->setShortcut (tr("O"));
         show_orientation_labels_action->setCheckable (true);
         show_orientation_labels_action->setChecked (true);
         addAction (show_orientation_labels_action);
 
-        show_colourbar_action = menu->addAction (tr ("Show colour bar"), this, SLOT (updateGL()));
+        show_colourbar_action = menu->addAction (tr ("Show colour bar"), glarea, SLOT (update()));
         show_colourbar_action->setShortcut (tr("B"));
         show_colourbar_action->setCheckable (true);
         show_colourbar_action->setChecked (true);
@@ -615,7 +614,7 @@ namespace MR
 
 
         lighting_ = new GL::Lighting (this);
-        connect (lighting_, SIGNAL (changed()), this, SLOT (updateGL()));
+        connect (lighting_, SIGNAL (changed()), glarea, SLOT (update()));
 
         set_image_menu ();
 
@@ -636,9 +635,6 @@ namespace MR
         tools_colourbar_position = parse_colourmap_position_str(cbar_pos);
         if(!tools_colourbar_position)
           WARN ("invalid specifier \"" + cbar_pos + "\" for config file entry \"MRViewToolsColourBarPosition\"");
-
-        glrefresh_timer->setSingleShot (true);
-        connect (glrefresh_timer, SIGNAL (timeout()), glarea, SLOT (update()));
       }
 
 
@@ -665,7 +661,6 @@ namespace MR
       {
         mode = nullptr;
         delete glarea;
-        delete glrefresh_timer;
       }
 
 
@@ -781,7 +776,7 @@ namespace MR
         mode->set_visible(image_visible_action->isChecked());
         set_mode_features();
         emit modeChanged();
-        updateGL();
+        glarea->update();
       }
 
 
@@ -831,7 +826,7 @@ namespace MR
         } else {
           tool->close();
         }
-        updateGL();
+        glarea->update();
       }
 
 
@@ -840,7 +835,7 @@ namespace MR
           Image* imagep = image();
           if (imagep) {
             imagep->set_colourmap (colourmap);
-            updateGL();
+            glarea->update();
           }
       }
 
@@ -852,7 +847,7 @@ namespace MR
           if (imagep) {
             std::array<GLubyte, 3> c_colour{{GLubyte(colour.red()), GLubyte(colour.green()), GLubyte(colour.blue())}};
             imagep->set_colour(c_colour);
-            updateGL();
+            glarea->update();
           }
       }
 
@@ -862,7 +857,7 @@ namespace MR
       {
         if (image()) {
           image()->set_invert_scale (invert_scale_action->isChecked());
-          updateGL();
+          glarea->update();
         }
       }
 
@@ -874,7 +869,7 @@ namespace MR
           snap_to_image_axes_and_voxel = snap_to_image_action->isChecked();
           if (snap_to_image_axes_and_voxel) 
             mode->reset_orientation();
-          updateGL();
+          glarea->update();
         }
       }
 
@@ -891,10 +886,7 @@ namespace MR
 
       void Window::updateGL () 
       { 
-        if (glrefresh_timer->isActive())
-          return;
-
-        glrefresh_timer->start();
+        glarea->update();
       }
 
 
@@ -905,7 +897,7 @@ namespace MR
         if (imagep) {
           imagep->reset_windowing();
           on_scaling_changed();
-          updateGL();
+          glarea->update();
         }
       }
 
@@ -916,7 +908,7 @@ namespace MR
         Image* imagep = image();
         if (imagep) {
           imagep->set_interpolate (image_interpolate_action->isChecked());
-          updateGL();
+          glarea->update();
         }
       }
 
@@ -935,7 +927,7 @@ namespace MR
         else if (action == sagittal_action) set_plane (0);
         else if (action == coronal_action) set_plane (1);
         else assert (0);
-        updateGL();
+        glarea->update();
       }
 
 
@@ -962,7 +954,7 @@ namespace MR
           background_colour[0] = GLubyte(colour.red()) / 255.0f;
           background_colour[1] = GLubyte(colour.green()) / 255.0f;
           background_colour[2] = GLubyte(colour.blue()) / 255.0f;
-          updateGL();
+          glarea->update();
         }
 
       }
@@ -1072,7 +1064,7 @@ namespace MR
             mode->features & Mode::ShaderTransparency,
             mode->features & Mode::ShaderLighting);
         emit imageChanged();
-        updateGL();
+        glarea->update();
       }
 
 
@@ -1102,7 +1094,7 @@ namespace MR
           show_orientation_labels_action->setChecked (annotations & 0x00000008);
           show_colourbar_action->setChecked (annotations & 0x00000010);
         }
-        updateGL();
+        glarea->update();
       }
 
 
@@ -1117,7 +1109,7 @@ namespace MR
         close_action->setEnabled (N>0);
         properties_action->setEnabled (N>0);
         set_image_navigation_menu();
-        updateGL();
+        glarea->update();
       }
 
       int Window::get_mouse_mode ()
@@ -1253,7 +1245,7 @@ namespace MR
 
 
       void Window::paintGL ()
-      {  
+      {
         gl::ClearColor (background_colour[0], background_colour[1], background_colour[2], 1.0);
         gl::Enable (gl::MULTISAMPLE);
         if (mode->in_paint())
@@ -1420,7 +1412,7 @@ namespace MR
 
               if (modifiers_ == Qt::ControlModifier) {
                 set_FOV (FOV() * std::exp (-event->delta()/1200.0));
-                updateGL();
+                glarea->update();
                 event->accept();
                 return;
               }
@@ -1495,7 +1487,7 @@ namespace MR
           } \
           ++tool_id;
             
-        updateGL();
+        glarea->update();
         qApp->processEvents();
 
         try {
@@ -1538,7 +1530,7 @@ namespace MR
             else if (opt.opt->is ("fov")) { 
               float fov = opt[0];
               set_FOV (fov);
-              updateGL();
+              glarea->update();
               continue;
             }
 
@@ -1547,7 +1539,7 @@ namespace MR
               if (pos.size() != 3) 
                 throw Exception ("-focus option expects a comma-separated list of 3 floating-point values");
               set_focus (Point<> (pos[0], pos[1], pos[2]));
-              updateGL();
+              glarea->update();
               continue;
             }
 
@@ -1557,7 +1549,7 @@ namespace MR
                 if (pos.size() != 3) 
                   throw Exception ("-voxel option expects a comma-separated list of 3 floating-point values");
                 set_focus (image()->interp.voxel2scanner (Point<> (pos[0], pos[1], pos[2])));
-                updateGL();
+                glarea->update();
               }
               continue;
             }
@@ -1565,14 +1557,14 @@ namespace MR
             if (opt.opt->is ("fov")) { 
               float fov = opt[0];
               set_FOV (fov);
-              updateGL();
+              glarea->update();
               continue;
             }
 
             if (opt.opt->is ("plane")) { 
               int n = opt[0];
               set_plane (n);
-              updateGL();
+              glarea->update();
               continue;
             }
 
@@ -1618,7 +1610,7 @@ namespace MR
                 if (param.size() != 2) 
                   throw Exception ("-intensity_range options expects comma-separated list of two floating-point values");
                 image()->set_windowing (param[0], param[1]);
-                updateGL();
+                glarea->update();
               }
               continue;
             }

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -82,7 +82,7 @@ namespace MR
       // GLArea definitions:
       
       Window::GLArea::GLArea (Window& parent) :
-        QGLWidget (&parent),
+        GL::Area (&parent),
         main (parent) {
           setCursor (Cursor::crosshair);
           setMouseTracking (true);

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -82,7 +82,7 @@ namespace MR
       // GLArea definitions:
       
       Window::GLArea::GLArea (Window& parent) :
-        QGLWidget (GL::core_format(), &parent),
+        QGLWidget (&parent),
         main (parent) {
           setCursor (Cursor::crosshair);
           setMouseTracking (true);

--- a/src/gui/mrview/window.h
+++ b/src/gui/mrview/window.h
@@ -180,25 +180,25 @@ namespace MR
           Qt::KeyboardModifiers modifiers_;
 
 
-          class GLArea : public QGLWidget {
+          class GLArea : public GL::Area {
             public:
               GLArea (Window& parent);
-              QSize sizeHint () const;
+              QSize sizeHint () const override;
 
             protected:
-              void dragEnterEvent (QDragEnterEvent* event);
-              void dragMoveEvent (QDragMoveEvent* event);
-              void dragLeaveEvent (QDragLeaveEvent* event);
-              void dropEvent (QDropEvent* event);
+              void dragEnterEvent (QDragEnterEvent* event) override;
+              void dragMoveEvent (QDragMoveEvent* event) override;
+              void dragLeaveEvent (QDragLeaveEvent* event) override;
+              void dropEvent (QDropEvent* event) override;
             private:
               Window& main;
 
-              void initializeGL ();
-              void paintGL ();
-              void mousePressEvent (QMouseEvent* event);
-              void mouseMoveEvent (QMouseEvent* event);
-              void mouseReleaseEvent (QMouseEvent* event);
-              void wheelEvent (QWheelEvent* event);
+              void initializeGL () override;
+              void paintGL () override;
+              void mousePressEvent (QMouseEvent* event) override;
+              void mouseMoveEvent (QMouseEvent* event) override;
+              void mouseReleaseEvent (QMouseEvent* event) override;
+              void wheelEvent (QWheelEvent* event) override;
           };
 
           enum MouseAction {

--- a/src/gui/mrview/window.h
+++ b/src/gui/mrview/window.h
@@ -106,7 +106,7 @@ namespace MR
           void makeGLcurrent () { glarea->makeCurrent(); }
 
           void captureGL (std::string filename) {
-            QImage image (glarea->grabFrameBuffer());
+            QImage image (glarea->grabFramebuffer());
             image.save (filename.c_str());
           }
 

--- a/src/gui/mrview/window.h
+++ b/src/gui/mrview/window.h
@@ -212,7 +212,6 @@ namespace MR
           };
 
           GLArea* glarea;
-          QTimer* glrefresh_timer;
           std::unique_ptr<Mode::Base> mode;
           GL::Lighting* lighting_;
           GL::Font font;

--- a/src/gui/opengl/gl.cpp
+++ b/src/gui/opengl/gl.cpp
@@ -82,7 +82,7 @@ namespace MR
         INFO ("GL version:   " + std::string ( (const char*) gl::GetString (gl::VERSION)));
         INFO ("GL vendor:    " + std::string ( (const char*) gl::GetString (gl::VENDOR)));
         GL_CHECK_ERROR;
-        GLint gl_version, gl_version_major;
+        GLint gl_version (0), gl_version_major (0);
         gl::GetIntegerv (gl::MAJOR_VERSION, &gl_version_major);
         GL_CHECK_ERROR;
         gl::GetIntegerv (gl::MINOR_VERSION, &gl_version);

--- a/src/gui/opengl/gl.cpp
+++ b/src/gui/opengl/gl.cpp
@@ -48,27 +48,32 @@ namespace MR
         //CONF How many samples to use for multi-sample anti-aliasing (to
         //CONF improve display quality). 
 
-        int nsamples = File::Config::get_int ("MSAA", 0);
-        int swap_interval = MR::File::Config::get_int ("VSync", 0);
+        GL::Format f;
+#if QT_VERSION >= 0x050400
+        f.setSwapBehavior (GL::Format::DoubleBuffer);
+        f.setRenderableType (GL::Format::OpenGL);
+#else
+        f.setDoubleBuffer (true);
+#endif
 
-        QGLFormat f (QGL::DoubleBuffer | QGL::DepthBuffer | QGL::Rgba);
-        f.setSwapInterval (swap_interval);
-        if (File::Config::get_bool ("NeedOpenGLCoreProfile", true)) {
-          f.setVersion (3,3);
-          f.setProfile (QGLFormat::CoreProfile);
-        }
-        if (nsamples > 1) {
-          f.setSampleBuffers (true);
-          f.setSamples (nsamples);
-        }
-
+        f.setVersion (3,3);
+        if (File::Config::get_bool ("NeedOpenGLCoreProfile", true))
+          f.setProfile (GL::Format::CoreProfile);
+        
         f.setDepthBufferSize (24);
         f.setRedBufferSize (8);
         f.setGreenBufferSize (8);
         f.setBlueBufferSize (8);
         f.setAlphaBufferSize (8);
 
-        QGLFormat::setDefaultFormat (f);
+        int swap_interval = MR::File::Config::get_int ("VSync", 0);
+        f.setSwapInterval (swap_interval);
+
+        int nsamples = File::Config::get_int ("MSAA", 0);
+        if (nsamples > 1) 
+          f.setSamples (nsamples);
+
+        GL::Format::setDefaultFormat (f);
       }
 
 

--- a/src/gui/opengl/gl.cpp
+++ b/src/gui/opengl/gl.cpp
@@ -88,8 +88,10 @@ namespace MR
         gl::GetIntegerv (gl::MINOR_VERSION, &gl_version);
         GL_CHECK_ERROR;
         gl_version += 10*gl_version_major;
-        if (gl_version < 33)
+        if (gl_version < 33) {
           FAIL ("your OpenGL implementation is not sufficient to run MRView - need version 3.3 or higher");
+          FAIL ("    operation is likely to be unstable");
+        }
 /*
         GLenum status = gl::CheckFramebufferStatus (gl::FRAMEBUFFER);
         switch (status) {

--- a/src/gui/opengl/gl.cpp
+++ b/src/gui/opengl/gl.cpp
@@ -30,6 +30,52 @@ namespace MR
     namespace GL
     {
 
+
+      void set_default_context () {
+        //CONF option: VSync
+        //CONF default: 0 (false)
+        //CONF Whether the screen update should synchronise with the monitor's
+        //CONF vertical refresh (to avoid tearing artefacts). 
+        
+        //CONF option: NeedOpenGLCoreProfile
+        //CONF default: 1 (true)
+        //CONF Whether the creation of an OpenGL 3.3 context requires it to be
+        //CONF a core profile (needed on newer versions of the ATI drivers on
+        //CONF Linux, for instance).
+
+        //CONF option: MSAA
+        //CONF default: 0 (false)
+        //CONF How many samples to use for multi-sample anti-aliasing (to
+        //CONF improve display quality). 
+
+        int nsamples = File::Config::get_int ("MSAA", 0);
+        int swap_interval = MR::File::Config::get_int ("VSync", 0);
+
+        QGLFormat f (QGL::DoubleBuffer | QGL::DepthBuffer | QGL::Rgba);
+        f.setSwapInterval (swap_interval);
+        if (File::Config::get_bool ("NeedOpenGLCoreProfile", true)) {
+          f.setVersion (3,3);
+          f.setProfile (QGLFormat::CoreProfile);
+        }
+        if (nsamples > 1) {
+          f.setSampleBuffers (true);
+          f.setSamples (nsamples);
+        }
+
+        f.setDepthBufferSize (24);
+        f.setRedBufferSize (8);
+        f.setGreenBufferSize (8);
+        f.setBlueBufferSize (8);
+        f.setAlphaBufferSize (8);
+
+        QGLFormat::setDefaultFormat (f);
+      }
+
+
+
+
+
+
       void init ()
       {
         INFO ("GL renderer:  " + std::string ( (const char*) gl::GetString (gl::RENDERER)));
@@ -73,41 +119,6 @@ namespace MR
 
 
 
-
-      QGLFormat core_format () {
-        QGLFormat f (QGL::DoubleBuffer | QGL::DepthBuffer | QGL::Rgba);
-        //CONF option: VSync
-        //CONF default: 0 (false)
-        //CONF Whether the screen update should synchronise with the monitor's
-        //CONF vertical refresh (to avoid tearing artefacts). 
-        int swap_interval = MR::File::Config::get_int ("VSync", 0);
-        f.setSwapInterval (swap_interval);
-        bool need_core_profile = 
-#ifdef MRTRIX_MACOSX
-        true;
-#else
-        false;
-#endif
-        //CONF option: NeedOpenGLCoreProfile
-        //CONF default: 0 (true on MacOSX, false otherwise)
-        //CONF Whether the creation of an OpenGL 3.3 context requires it to be
-        //CONF a core profile (needed on newer versions of the ATI drivers on
-        //CONF Linux, for instance).
-        if (File::Config::get_bool ("NeedOpenGLCoreProfile", need_core_profile)) {
-          f.setVersion (3,3);
-          f.setProfile (QGLFormat::CoreProfile);
-        }
-        //CONF option: MSAA
-        //CONF default: 0 (false)
-        //CONF How many samples to use for multi-sample anti-aliasing (to
-        //CONF improve display quality). 
-        int nsamples = File::Config::get_int ("MSAA", 0);
-        if (nsamples > 1) {
-          f.setSampleBuffers (true);
-          f.setSamples (nsamples);
-        }
-        return f;
-      }
 
     }
   }

--- a/src/gui/opengl/gl.h
+++ b/src/gui/opengl/gl.h
@@ -63,7 +63,17 @@ namespace MR
     namespace GL
     {
 
-      typedef QGLWidget Area;
+#if QT_VERSION >= 0x050400
+      typedef QOpenGLWidget Area;
+      typedef QSurfaceFormat Format;
+#else
+      class Area : public QGLWidget {
+        public:
+          using QGLWidget::QGLWidget;
+          QImage grabFramebuffer () { return QGLWidget::grabFrameBuffer(); }
+      };
+      typedef QGLFormat Format;
+#endif
  
       void init ();
       void set_default_context ();

--- a/src/gui/opengl/gl.h
+++ b/src/gui/opengl/gl.h
@@ -63,6 +63,8 @@ namespace MR
     namespace GL
     {
 
+      typedef QGLWidget Area;
+ 
       void init ();
       void set_default_context ();
 

--- a/src/gui/opengl/gl.h
+++ b/src/gui/opengl/gl.h
@@ -64,6 +64,7 @@ namespace MR
     {
 
       void init ();
+      void set_default_context ();
 
       const char* ErrorString (GLenum errorcode);
 
@@ -244,7 +245,6 @@ namespace MR
       };
 
 
-      QGLFormat core_format ();
 
     }
   }

--- a/src/gui/projection.h
+++ b/src/gui/projection.h
@@ -36,7 +36,7 @@ namespace MR
 
 #if QT_VERSION >= 0x050100
         void set_viewport (const QWidget& frame) const {
-          int m = frame.windowHandle()->devicePixelRatio();
+          int m = frame.window()->devicePixelRatio();
           gl::Viewport (m*viewport[0], m*viewport[1], m*viewport[2], m*viewport[3]);
         }
 #else

--- a/src/gui/projection.h
+++ b/src/gui/projection.h
@@ -22,7 +22,7 @@ namespace MR
     class Projection
     {
       public:
-        Projection (QGLWidget* parent, const GL::Font& font) : 
+        Projection (GL::Area* parent, const GL::Font& font) : 
           glarea (parent), 
           font (font) { } 
 
@@ -230,7 +230,7 @@ namespace MR
         }
 
       protected:
-        QGLWidget* glarea;
+        GL::Area* glarea;
         const GL::Font& font;
         GL::mat4 MV, iMV, P, iP, MVP, iMVP;
         GLint viewport[4];


### PR DESCRIPTION
This branch introduces a few changes to the OpenGL backend. I've tried to test most use cases on my system, but I'd prefer to have as many people try it out before I commit something that might very well screw up - especially now that we've publicised it at the ISMRM...

I'd like confirmation that this works on all platforms and for all common combinations (especially Windows, I'll test MacOSX tomorrow), for both Qt4.8, 5.2/3 & 5.4 (where applicable), on as many different hardware combinations as possible. So far, I've only tested on Arch Linux 64-bit with the nvidia drivers, for Qt 4.8.6 and 5.4.2. Feedback appreciated before a merge to master.

As to the changes themselves, in a nutshell: 

- This branch replaces the `QGLWidget` (deprecated with Qt 5.4) with its replacement `QOpenGLWidget` when compiling with Qt >= 5.4. This would close issue #191, and seems to fix issue #192.

- It also removes the glrefresh timer trick that we'd introduced to get around delayed even handling when the render was slow. This was due to the fact that calls to `updateGL()` were immediate, so further events in the event loop would get queued up and processed in turn much later. The new `QOpenGLWidget` class no longer has this function, relying instead on the generic `QWidget::update()`, which _schedules_ a repaint (exactly what we were trying to achieve with the refresh timer) - and it's available in Qt 4 as well... 

- This also now forces a core OpenGL profile by default on all platforms. Previously, this was only the case on MacOSX (can't get OpenGL 3.3 at all otherwise), but since people have been having issues with their ATI cards, and it seems to work fine on NVidia too, I guess we might as well switch over completely. This will also help sort out issues lile #222.