### PR TITLE
Streamline length

### DIFF
--- a/cmd/tckedit.cpp
+++ b/cmd/tckedit.cpp
@@ -117,7 +117,6 @@ void run ()
   // Make sure configuration is sensible
   if (get_options("tck_weights_in").size() && num_inputs > 1)
     throw Exception ("Cannot use per-streamline weighting with multiple input files");
-  // TODO Anything else?
 
   // Get the consensus streamline properties from among the multiple input files
   Tractography::Properties properties;

--- a/cmd/tckstats.cpp
+++ b/cmd/tckstats.cpp
@@ -174,7 +174,7 @@ void run ()
   double stdev = 0.0;
   for (std::vector<LW>::const_iterator i = all_lengths.begin(); i != all_lengths.end(); ++i)
     stdev += i->get_weight() * Math::pow2 (i->get_length() - mean_length);
-  stdev /= sum_weights;
+  stdev = std::sqrt (stdev / (((count - 1) / float(count)) * sum_weights));
 
   const size_t width = 12;
 
@@ -194,7 +194,9 @@ void run ()
 
   Options opt = get_options ("histogram");
   if (opt.size()) {
-    File::OFStream out (argument[1], std::ios_base::out | std::ios_base::trunc);
+    File::OFStream out (opt[0][0], std::ios_base::out | std::ios_base::trunc);
+    if (!std::isfinite (step_size))
+      step_size = 1.0f;
     if (weights_provided) {
       out << "Length,Sum_weights\n";
       for (size_t i = 0; i != histogram.size(); ++i)

--- a/src/dwi/tractography/connectomics/edge_metrics.h
+++ b/src/dwi/tractography/connectomics/edge_metrics.h
@@ -88,7 +88,7 @@ class Metric_meanlength : public Metric_base {
 
     double operator() (const Streamline<>& tck, const NodePair& nodes) const
     {
-      return (tck.size() - 1);
+      return tck.calc_length();
     }
 
 };
@@ -101,7 +101,7 @@ class Metric_invlength : public Metric_base {
 
     double operator() (const Streamline<>& tck, const NodePair& nodes) const
     {
-      return (tck.size() > 1 ? (1.0 / (tck.size() - 1)) : 0);
+      return (tck.size() > 1 ? (1.0 / tck.calc_length()) : 0);
     }
 
 };
@@ -144,7 +144,7 @@ class Metric_invlength_invnodevolume : public Metric_invnodevolume {
 
     double operator() (const Streamline<>& tck, const NodePair& nodes) const
     {
-      return (tck.size() > 1 ? (Metric_invnodevolume::operator() (tck, nodes) / (tck.size() - 1)) : 0);
+      return (tck.size() > 1 ? (Metric_invnodevolume::operator() (tck, nodes) / tck.calc_length()) : 0);
     }
 
 };

--- a/src/dwi/tractography/editing/worker.cpp
+++ b/src/dwi/tractography/editing/worker.cpp
@@ -160,10 +160,11 @@ namespace MR {
 
 
         Worker::Thresholds::Thresholds (Tractography::Properties& properties) :
-          max_num_points (std::numeric_limits<size_t>::max()),
-          min_num_points (0),
+          max_length (std::numeric_limits<float>::infinity()),
+          min_length (0.0f),
           max_weight (std::numeric_limits<float>::infinity()),
-          min_weight (0.0)
+          min_weight (0.0f),
+          step_size (NAN)
         {
 
           std::string step_size_string;
@@ -172,30 +173,25 @@ namespace MR {
           else
             step_size_string = properties["output_step_size"];
 
-          float maxlength = 0.0, minlength = 0.0;
           if (properties.find ("max_dist") != properties.end()) {
             try {
-              maxlength = to<float>(properties["max_dist"]);
+              max_length = to<float>(properties["max_dist"]);
             } catch (...) { }
           }
           if (properties.find ("min_dist") != properties.end()) {
             try {
-              minlength = to<float>(properties["min_dist"]);
+              min_length = to<float>(properties["min_dist"]);
             } catch (...) { }
           }
 
-          if (step_size_string == "variable" && (maxlength || minlength))
-            throw Exception ("Cannot apply length threshold; step size is inconsistent between input track files");
-
-          const float step_size = to<float>(step_size_string);
-
-          if ((!step_size || !std::isfinite (step_size)) && (maxlength || minlength))
-            throw Exception ("Cannot apply length threshold; step size information is incomplete");
-
-          if (maxlength)
-            max_num_points = std::round (maxlength / step_size) + 1;
-          if (minlength)
-            min_num_points = std::max (2, round (minlength/step_size) + 1);
+          try {
+            step_size = to<float>(step_size_string);
+            // User may set these values to a precise value, which may then fail due to floating-point
+            //   calculation of streamline length
+            // Therefore throw a bit of error margin in here
+            max_length += 0.1 * step_size;
+            min_length -= 0.1 * step_size;
+          } catch (...) { }
 
           if (properties.find ("max_weight") != properties.end())
             max_weight = to<float>(properties["max_weight"]);
@@ -209,18 +205,20 @@ namespace MR {
 
 
         Worker::Thresholds::Thresholds (const Worker::Thresholds& that) :
-          max_num_points (that.max_num_points),
-          min_num_points (that.min_num_points),
+          max_length (that.max_length),
+          min_length (that.min_length),
           max_weight (that.max_weight),
-          min_weight (that.min_weight) { }
+          min_weight (that.min_weight),
+          step_size  (that.step_size) { }
 
 
 
 
         bool Worker::Thresholds::operator() (const Tractography::Streamline<>& in) const
         {
-          return ((in.size() <= max_num_points) &&
-              (in.size() >= min_num_points) &&
+          const float length = (std::isfinite (step_size) ? in.calc_length (step_size) : in.calc_length());
+          return ((length <= max_length) &&
+              (length >= min_length) &&
               (in.weight <= max_weight) &&
               (in.weight >= min_weight));
         }

--- a/src/dwi/tractography/editing/worker.cpp
+++ b/src/dwi/tractography/editing/worker.cpp
@@ -189,8 +189,11 @@ namespace MR {
             // User may set these values to a precise value, which may then fail due to floating-point
             //   calculation of streamline length
             // Therefore throw a bit of error margin in here
-            max_length += 0.1 * step_size;
-            min_length -= 0.1 * step_size;
+            float error_margin = 0.1;
+            if (properties.find ("downsample_factor") != properties.end())
+              error_margin = 0.5 / to<float>(properties["downsample_factor"]);
+            max_length += error_margin * step_size;
+            min_length -= error_margin * step_size;
           } catch (...) { }
 
           if (properties.find ("max_weight") != properties.end())

--- a/src/dwi/tractography/editing/worker.h
+++ b/src/dwi/tractography/editing/worker.h
@@ -82,8 +82,9 @@ namespace MR {
                 Thresholds (const Thresholds&);
                 bool operator() (const Tractography::Streamline<>&) const;
               private:
-                size_t max_num_points, min_num_points;
+                float max_length, min_length;
                 float max_weight, min_weight;
+                float step_size;
             } thresholds;
 
             mutable std::vector<bool> include_visited;

--- a/src/dwi/tractography/mapping/mapper.cpp
+++ b/src/dwi/tractography/mapping/mapper.cpp
@@ -54,15 +54,8 @@ void TrackMapperTWI::set_factor (const Streamline<>& tck, SetVoxelExtras& out) c
   switch (contrast) {
 
     case TDI: out.factor = 1.0; break;
-
-    case LENGTH:
-    case INVLENGTH:
-      out.factor = 0.0;
-      for (size_t i = 1; i != tck.size(); ++i)
-        out.factor += dist(tck[i], tck[i-1]);
-      if (contrast == INVLENGTH)
-        out.factor = 1.0f / out.factor;
-      break;
+    case LENGTH: out.factor = tck.calc_length(); break;
+    case INVLENGTH: out.factor = 1.0f / tck.calc_length(); break;
 
     case SCALAR_MAP:
     case SCALAR_MAP_COUNT:

--- a/src/dwi/tractography/streamline.h
+++ b/src/dwi/tractography/streamline.h
@@ -66,9 +66,43 @@ namespace MR
             weight = 1.0;
           }
 
+          float calc_length() const;
+          float calc_length (const float step_size) const;
+
           size_t index;
           value_type weight;
       };
+
+
+
+
+      template <typename T>
+      float Streamline<T>::calc_length() const
+      {
+        switch (size()) {
+          case 0: return NAN;
+          case 1: return 0.0;
+          case 2: return dist (front(), back());
+          case 3: return (dist ((*this)[1], (*this)[0]) + dist ((*this)[2], (*this)[1]));
+          default: break;
+        }
+        const size_t midpoint = size() / 2;
+        const float step_size = dist ((*this)[midpoint-1], (*this)[midpoint]);
+        return calc_length (step_size);
+      }
+
+      template <typename T>
+      float Streamline<T>::calc_length (const float step_size) const
+      {
+        switch (size()) {
+          case 0: return NAN;
+          case 1: return 0.0;
+          case 2: return dist (front(), back());
+          case 3: return (dist ((*this)[1], (*this)[0]) + dist ((*this)[2], (*this)[1]));
+          default: break;
+        }
+        return (((size()-3) * step_size) + dist ((*this)[1], (*this)[0]) + dist ((*this)[size()-1], (*this)[size()-2]));
+      }
 
 
 

--- a/src/dwi/tractography/streamline.h
+++ b/src/dwi/tractography/streamline.h
@@ -79,14 +79,14 @@ namespace MR
       template <typename T>
       float Streamline<T>::calc_length() const
       {
-        switch (size()) {
+        switch (Streamline<T>::size()) {
           case 0: return NAN;
           case 1: return 0.0;
-          case 2: return dist (front(), back());
+          case 2: return dist ((*this)[0], (*this)[1]);
           case 3: return (dist ((*this)[1], (*this)[0]) + dist ((*this)[2], (*this)[1]));
           default: break;
         }
-        const size_t midpoint = size() / 2;
+        const size_t midpoint = Streamline<T>::size() / 2;
         const float step_size = dist ((*this)[midpoint-1], (*this)[midpoint]);
         return calc_length (step_size);
       }
@@ -94,14 +94,15 @@ namespace MR
       template <typename T>
       float Streamline<T>::calc_length (const float step_size) const
       {
-        switch (size()) {
+        switch (Streamline<T>::size()) {
           case 0: return NAN;
           case 1: return 0.0;
-          case 2: return dist (front(), back());
+          case 2: return dist ((*this)[0], (*this)[1]);
           case 3: return (dist ((*this)[1], (*this)[0]) + dist ((*this)[2], (*this)[1]));
           default: break;
         }
-        return (((size()-3) * step_size) + dist ((*this)[1], (*this)[0]) + dist ((*this)[size()-1], (*this)[size()-2]));
+        const size_t size = Streamline<T>::size();
+        return (((size-3) * step_size) + dist ((*this)[1], (*this)[0]) + dist ((*this)[size-1], (*this)[size-2]));
       }
 
 


### PR DESCRIPTION
Would like some independent eyes on this one. See commit message of 6fc76f5 for particular details.

Main point of contention is src/dwi/tractography/editing/worker.cpp, line 190ish: Because streamline lengths are now dealt with in floating-point lengths rather than point counts, it introduces a floating-point comparison problem. Ie. You don't want the user to request streamlines with a maximum length of 25mm, only to have it reject streamlines with a length calculated as 25.01mm. So I've thrown a bit of a fudge factor in there.

Also: `tckgen` code is _unchanged_. Mostly these changes are to deal with the down-sampling that occurs by default with iFOD2, so aren't applicable while the streamlines are being generated. Disadvantage of not changing the `tckgen` code is the rare use case where `-act -crop_at_gmwmi` is used: if the streamline has a short segment at either end caused by the interface cropping, it may be under the maximum length but get rejected because of the number of points. But I'm not too concerned about this.