### PR TITLE
ACT modifications

### DIFF
--- a/cmd/tckgen.cpp
+++ b/cmd/tckgen.cpp
@@ -52,7 +52,7 @@ using namespace App;
 
 
 
-const char* algorithms[] = { "fact", "ifod1", "ifod2", "nulldist", "sd_stream", "seedtest", "tensor_det", "tensor_prob", NULL };
+const char* algorithms[] = { "fact", "ifod1", "ifod2", "nulldist1", "nulldist2", "sd_stream", "seedtest", "tensor_det", "tensor_prob", NULL };
 
 
 void usage ()
@@ -81,7 +81,7 @@ void usage ()
    "Improved probabilistic streamlines tractography by 2nd order integration over fibre orientation distributions. "
    "Proceedings of the International Society for Magnetic Resonance in Medicine, 2010, 1670"
 
-   + "* Nulldist:\n"
+   + "* Nulldist1 / Nulldist2:\n"
    "Morris, D. M.; Embleton, K. V. & Parker, G. J. "
    "Probabilistic fibre tracking: Differentiation of connections from chance events. "
    "NeuroImage, 2008, 42, 1329-1339"
@@ -117,8 +117,8 @@ void usage ()
     + Argument ("source",
         "the image containing the source data. The type of data depends on the algorithm used:\n"
         "- FACT: the directions file (each triplet of volumes is the X,Y,Z direction of a fibre population).\n"
-        "- iFOD1/2 & SD_Stream: the SH image resulting from CSD.\n"
-        "- Nulldist & SeedTest: any image (will not be used).\n"
+        "- iFOD1/2, Nulldist2 & SD_Stream: the SH image resulting from CSD.\n"
+        "- Nulldist1 & SeedTest: any image (will not be used).\n"
         "- TensorDet / TensorProb: the DWI image.\n"
         ).type_image_in()
 
@@ -130,7 +130,7 @@ void usage ()
 
   + Option ("algorithm",
             "specify the tractography algorithm to use. Valid choices are: "
-              "FACT, iFOD1, iFOD2, Nulldist, SD_Stream, Seedtest, Tensor_Det, Tensor_Prob (default: iFOD2).")
+              "FACT, iFOD1, iFOD2, Nulldist1, Nulldist2, SD_Stream, Seedtest, Tensor_Det, Tensor_Prob (default: iFOD2).")
     + Argument ("name").type_choice (algorithms, 2)
 
   + DWI::Tractography::ROIOption
@@ -194,18 +194,21 @@ void run ()
       Exec<iFOD2>      ::run (argument[0], argument[1], properties);
       break;
     case 3:
-      Exec<NullDist>   ::run (argument[0], argument[1], properties);
+      Exec<NullDist1>   ::run (argument[0], argument[1], properties);
       break;
     case 4:
-      Exec<SDStream>   ::run (argument[0], argument[1], properties);
+      Exec<NullDist2>   ::run (argument[0], argument[1], properties);
       break;
     case 5:
-      Exec<Seedtest>   ::run (argument[0], argument[1], properties);
+      Exec<SDStream>   ::run (argument[0], argument[1], properties);
       break;
     case 6:
-      Exec<Tensor_Det> ::run (argument[0], argument[1], properties);
+      Exec<Seedtest>   ::run (argument[0], argument[1], properties);
       break;
     case 7:
+      Exec<Tensor_Det> ::run (argument[0], argument[1], properties);
+      break;
+    case 8:
       Exec<Tensor_Prob>::run (argument[0], argument[1], properties);
       break;
     default:

--- a/src/dwi/tractography/ACT/act.h
+++ b/src/dwi/tractography/ACT/act.h
@@ -35,6 +35,9 @@
 
 #define GMWMI_ACCURACY 0.01 // Absolute value of tissue proportion difference
 
+// Number of times a backtrack attempt will be made from a certain maximal track length before the length of truncation is increased
+#define ACT_BACKTRACK_ATTEMPTS 3
+
 
 namespace MR
 {

--- a/src/dwi/tractography/ACT/method.h
+++ b/src/dwi/tractography/ACT/method.h
@@ -155,7 +155,7 @@ namespace MR
             bool in_pathology() const { return (tissue_values.valid() && tissue_values.is_path()); }
 
 
-            unsigned int sgm_depth;
+            size_t sgm_depth;
             bool seed_in_sgm;
             bool sgm_seed_to_wm;
 

--- a/src/dwi/tractography/ACT/method.h
+++ b/src/dwi/tractography/ACT/method.h
@@ -154,6 +154,8 @@ namespace MR
 
             bool in_pathology() const { return (tissue_values.valid() && tissue_values.is_path()); }
 
+            void reverse_track() { sgm_depth = 0; }
+
 
             size_t sgm_depth;
             bool seed_in_sgm;

--- a/src/dwi/tractography/algorithms/iFOD1.h
+++ b/src/dwi/tractography/algorithms/iFOD1.h
@@ -175,17 +175,13 @@ namespace MR
           return EXIT_IMAGE;
 
         value_type max_val = 0.0;
-        size_t nan_count = 0;
         for (size_t i = 0; i < calibrate_list.size(); ++i) {
           value_type val = FOD (rotate_direction (dir, calibrate_list[i]));
           if (std::isnan (val))
-            ++nan_count;
+            return EXIT_IMAGE;
           else if (val > max_val)
             max_val = val;
         }
-
-        if (nan_count == calibrate_list.size())
-          return EXIT_IMAGE;
 
         if (max_val <= 0.0)
           return CALIBRATE_FAIL;

--- a/src/dwi/tractography/algorithms/iFOD2.h
+++ b/src/dwi/tractography/algorithms/iFOD2.h
@@ -125,7 +125,7 @@ namespace MR
                   ++num_proc;
                 }
 
-                float internal_step_size() const { return step_size / float(num_samples); }
+                float internal_step_size() const override { return step_size / float(num_samples); }
 
                 size_t lmax, num_samples, max_trials;
                 value_type sin_max_angle, fod_power;
@@ -289,10 +289,11 @@ end_init:
 
 
             // Restore proper probability from the FOD at the track seed point
-            void reverse_track()
+            void reverse_track() override
             {
               half_log_prob0 = half_log_prob0_seed;
               sample_idx = S.num_samples;
+              MethodBase::reverse_track();
             }
 
 

--- a/src/dwi/tractography/algorithms/iFOD2.h
+++ b/src/dwi/tractography/algorithms/iFOD2.h
@@ -405,7 +405,7 @@ end_init:
             }
 
 
-
+          protected:
             void get_path (std::vector< Point<value_type> >& positions, std::vector< Point<value_type> >& tangents, const Point<value_type>& end_dir) const
             {
               value_type cos_theta = end_dir.dot (dir);
@@ -445,7 +445,7 @@ end_init:
 
 
 
-
+          private:
             class Calibrate
             {
               public:

--- a/src/dwi/tractography/algorithms/iFOD2.h
+++ b/src/dwi/tractography/algorithms/iFOD2.h
@@ -312,7 +312,7 @@ end_init:
                 return;
               }
               const size_t new_size = length_to_revert_from - points_to_remove;
-              if (new_size == 1)
+              if (tck.size() == 2)
                 dir = (tck[1] - tck[0]).normalise();
               else if (new_size != tck.size())
                 dir = (tck[new_size] - tck[new_size - 2]).normalise();

--- a/src/dwi/tractography/algorithms/iFOD2.h
+++ b/src/dwi/tractography/algorithms/iFOD2.h
@@ -238,18 +238,14 @@ end_init:
               Point<value_type> next_pos, next_dir;
 
               value_type max_val = 0.0;
-              size_t nan_count = 0;
               for (size_t i = 0; i < calibrate_list.size(); ++i) {
                 get_path (calib_positions, calib_tangents, rotate_direction (dir, calibrate_list[i]));
                 value_type val = path_prob (calib_positions, calib_tangents);
                 if (std::isnan (val))
-                  ++nan_count;
+                  return EXIT_IMAGE;
                 else if (val > max_val)
                   max_val = val;
               }
-
-              if (nan_count == calibrate_list.size())
-                return EXIT_IMAGE;
 
               if (max_val <= 0.0)
                 return CALIBRATE_FAIL;
@@ -313,7 +309,7 @@ end_init:
                 return;
               }
               const size_t new_size = length_to_revert_from - points_to_remove;
-              if (tck.size() == 2)
+              if (tck.size() == 2 || new_size == 1)
                 dir = (tck[1] - tck[0]).normalise();
               else if (new_size != tck.size())
                 dir = (tck[new_size] - tck[new_size - 2]).normalise();

--- a/src/dwi/tractography/algorithms/iFOD2.h
+++ b/src/dwi/tractography/algorithms/iFOD2.h
@@ -452,6 +452,7 @@ end_init:
                 Calibrate (iFOD2& method) :
                   P (method),
                   fod (&P.values[0], P.source.dim(3)),
+                  vox (P.S.vox()),
                   positions (P.S.num_samples),
                   tangents (P.S.num_samples)
               {
@@ -461,11 +462,12 @@ end_init:
 
                 value_type operator() (value_type el)
                 {
+                  P.pos.set (0.0f, 0.0f, 0.0f);
                   P.get_path (positions, tangents, Point<value_type> (std::sin (el), 0.0, std::cos(el)));
 
                   value_type log_prob = init_log_prob;
                   for (size_t i = 0; i < P.S.num_samples; ++i) {
-                    value_type prob = Math::SH::value (P.values, tangents[i], P.S.lmax);
+                    value_type prob = Math::SH::value (P.values, tangents[i], P.S.lmax) * (1.0 - (positions[i][0] / vox));
                     if (prob <= 0.0)
                       return 0.0;
                     prob = std::log (prob);
@@ -481,6 +483,7 @@ end_init:
               private:
                 iFOD2& P;
                 Math::Vector<value_type> fod;
+                const value_type vox;
                 value_type init_log_prob;
                 std::vector< Point<value_type> > positions, tangents;
             };

--- a/src/dwi/tractography/algorithms/nulldist.h
+++ b/src/dwi/tractography/algorithms/nulldist.h
@@ -24,6 +24,7 @@
 #define __dwi_tractography_algorithms_nulldist_h__
 
 #include "point.h"
+#include "dwi/tractography/algorithms/iFOD2.h"
 #include "dwi/tractography/tracking/method.h"
 #include "dwi/tractography/tracking/shared.h"
 #include "dwi/tractography/tracking/types.h"
@@ -41,7 +42,7 @@ namespace MR
 
     using namespace MR::DWI::Tractography::Tracking;
 
-    class NullDist : public MethodBase {
+    class NullDist1 : public MethodBase {
       public:
 
       class Shared : public SharedBase {
@@ -51,12 +52,12 @@ namespace MR
         {
           set_step_size (0.1);
           sin_max_angle = std::sin (max_angle);
-          properties["method"] = "Nulldist";
+          properties["method"] = "Nulldist1";
         }
         value_type sin_max_angle;
       };
 
-      NullDist (const Shared& shared) :
+      NullDist1 (const Shared& shared) :
         MethodBase (shared),
         S (shared),
         source (S.source_voxel) { }
@@ -86,6 +87,86 @@ namespace MR
       Interpolator<SourceBufferType::voxel_type>::type source;
 
       Point<value_type> rand_dir (const Point<value_type>& d) { return (random_direction (d, S.max_angle, S.sin_max_angle)); }
+
+    };
+
+    class NullDist2 : public iFOD2 {
+      public:
+
+      class Shared : public iFOD2::Shared {
+        public:
+        Shared (const std::string& diff_path, DWI::Tractography::Properties& property_set) :
+          iFOD2::Shared (diff_path, property_set)
+        {
+          properties["method"] = "Nulldist2";
+        }
+      };
+
+      NullDist2 (const Shared& shared) :
+        iFOD2 (shared),
+        S (shared),
+        source (S.source_voxel),
+        positions (S.num_samples),
+        tangents (S.num_samples),
+        sample_idx (S.num_samples) { }
+
+      NullDist2 (const NullDist2& that) :
+        iFOD2 (that),
+        S (that.S),
+        source (S.source_voxel),
+        positions (S.num_samples),
+        tangents (S.num_samples),
+        sample_idx (S.num_samples) { }
+
+      bool init() {
+        if (!get_data (source))
+          return false;
+        dir = S.init_dir.valid() ? S.init_dir : random_direction();
+        sample_idx = S.num_samples;
+        return true;
+      }
+
+      term_t next () {
+
+        if (++sample_idx < S.num_samples) {
+          pos = positions[sample_idx];
+          dir = tangents [sample_idx];
+          return CONTINUE;
+        }
+
+        iFOD2::get_path (positions, tangents, iFOD2::rand_dir (dir));
+        if (S.is_act()) {
+          if (!act().fetch_tissue_data (positions[S.num_samples - 1]))
+            return EXIT_IMAGE;
+        }
+        pos = positions[0];
+        dir = tangents[0];
+        sample_idx = 0;
+        return CONTINUE;
+
+      }
+
+      void reverse_track() override
+      {
+        sample_idx = S.num_samples;
+        MethodBase::reverse_track();
+      }
+
+      void truncate_track (GeneratedTrack& tck, const size_t length_to_revert_from, const size_t revert_step)
+      {
+        iFOD2::truncate_track (tck, length_to_revert_from, revert_step);
+        sample_idx = S.num_samples;
+      }
+
+      float get_metric() { return uniform_rng(); }
+
+
+      protected:
+      const Shared& S;
+      Interpolator<SourceBufferType::voxel_type>::type source;
+
+      std::vector< Point<value_type> > positions, tangents;
+      size_t sample_idx;
 
     };
 

--- a/src/dwi/tractography/algorithms/tensor_prob.h
+++ b/src/dwi/tractography/algorithms/tensor_prob.h
@@ -134,7 +134,7 @@ namespace MR
 
           }
 */
-        void truncate_track (std::vector< Point<value_type> >& tck, const int revert_step) {}
+        void truncate_track (std::vector< Point<value_type> >& tck, const size_t length_to_revert_from, const int revert_step) { }
 
 
         protected:

--- a/src/dwi/tractography/tracking/exec.h
+++ b/src/dwi/tractography/tracking/exec.h
@@ -418,6 +418,9 @@ namespace MR
               // If using the Seed_test algorithm (indicated by max_num_points == 2), don't want to execute this check
               if (S.max_num_points == 2)
                 return true;
+              // If the seed was in SGM, need to confirm that one side of the track actually made it to WM
+              if (method.act().seed_in_sgm && !method.act().sgm_seed_to_wm)
+                return false;
               // Used these in the ACT paper, but wasn't entirely happy with the method; can change these #defines to re-enable
               // ACT instead now defaults to a 2-voxel minimum length
               if (!ACT_WM_INT_REQ && !ACT_WM_ABS_REQ)

--- a/src/dwi/tractography/tracking/exec.h
+++ b/src/dwi/tractography/tracking/exec.h
@@ -239,6 +239,7 @@ namespace MR
               if (S.is_act() && S.act().backtrack()) {
 
                 size_t revert_step = 0;
+                size_t max_size_at_backtrack = tck.size();
 
                 do {
                   termination = iterate();
@@ -247,7 +248,14 @@ namespace MR
                   if (termination) {
                     apply_priors (termination);
                     if (track_excluded && termination != ENTER_EXCLUDE) {
-                      method.truncate_track (tck, ++revert_step);
+                      if (tck.size() > max_size_at_backtrack) {
+                        max_size_at_backtrack = tck.size();
+                        revert_step = 1;
+                      } else {
+                        ++revert_step;
+                        tck.resize (max_size_at_backtrack, Point<float>());
+                      }
+                      method.truncate_track (tck, revert_step);
                       if (tck.size() > tck.get_seed_index() + 1) {
                         track_excluded = false;
                         termination = CONTINUE;

--- a/src/dwi/tractography/tracking/exec.h
+++ b/src/dwi/tractography/tracking/exec.h
@@ -260,11 +260,9 @@ namespace MR
                         }
                       }
                       method.truncate_track (tck, max_size_at_backtrack, revert_step);
-                      if (tck.size() > tck.get_seed_index() + 1) {
+                      if (method.pos.valid()) {
                         track_excluded = false;
                         termination = CONTINUE;
-                        method.pos = tck.back();
-                        method.dir = (tck.back() - tck[tck.size() - 2]).normalise();
                       }
                     }
                   } else if (tck.size() >= S.max_num_points) {

--- a/src/dwi/tractography/tracking/exec.h
+++ b/src/dwi/tractography/tracking/exec.h
@@ -238,8 +238,9 @@ namespace MR
 
               if (S.is_act() && S.act().backtrack()) {
 
-                size_t revert_step = 0;
+                size_t revert_step = 1;
                 size_t max_size_at_backtrack = tck.size();
+                unsigned int revert_count = 0;
 
                 do {
                   termination = iterate();
@@ -251,11 +252,14 @@ namespace MR
                       if (tck.size() > max_size_at_backtrack) {
                         max_size_at_backtrack = tck.size();
                         revert_step = 1;
+                        revert_count = 1;
                       } else {
-                        ++revert_step;
-                        tck.resize (max_size_at_backtrack, Point<float>());
+                        if (revert_count++ == ACT_BACKTRACK_ATTEMPTS) {
+                          revert_count = 1;
+                          ++revert_step;
+                        }
                       }
-                      method.truncate_track (tck, revert_step);
+                      method.truncate_track (tck, max_size_at_backtrack, revert_step);
                       if (tck.size() > tck.get_seed_index() + 1) {
                         track_excluded = false;
                         termination = CONTINUE;

--- a/src/dwi/tractography/tracking/exec.h
+++ b/src/dwi/tractography/tracking/exec.h
@@ -231,9 +231,6 @@ namespace MR
             void gen_track_unidir (GeneratedTrack& tck)
             {
 
-              if (S.is_act())
-                method.act().sgm_depth = 0;
-
               term_t termination = CONTINUE;
 
               if (S.is_act() && S.act().backtrack()) {

--- a/src/dwi/tractography/tracking/method.h
+++ b/src/dwi/tractography/tracking/method.h
@@ -104,12 +104,17 @@ namespace MR
         float get_metric() { return NAN; }
 
 
-        void truncate_track (std::vector< Point<value_type> >& tck, const size_t revert_step)
+        void truncate_track (GeneratedTrack& tck, const size_t length_to_revert_from, const size_t revert_step)
         {
-          for (size_t i = revert_step; i && tck.size(); --i)
-            tck.pop_back();
+          if (tck.get_seed_index() + revert_step >= length_to_revert_from) {
+            tck.clear();
+            pos.invalidate();
+            dir.invalidate();
+            return;
+          }
+          tck.resize (length_to_revert_from - revert_step);
           if (S.is_act())
-            act().sgm_depth = MAX (0, act().sgm_depth - int(revert_step));
+            act().sgm_depth = (act().sgm_depth > revert_step) ? act().sgm_depth - revert_step : 0;
         }
 
 

--- a/src/dwi/tractography/tracking/method.h
+++ b/src/dwi/tractography/tracking/method.h
@@ -113,7 +113,7 @@ namespace MR
             return;
           }
           const size_t new_size = length_to_revert_from - revert_step;
-          if (tck.size() == 2)
+          if (tck.size() == 2 || new_size == 1)
             dir = (tck[1] - tck[0]).normalise();
           else
             dir = (tck[new_size] - tck[new_size - 2]).normalise();

--- a/src/dwi/tractography/tracking/method.h
+++ b/src/dwi/tractography/tracking/method.h
@@ -112,7 +112,13 @@ namespace MR
             dir.invalidate();
             return;
           }
+          const size_t new_size = length_to_revert_from - revert_step;
+          if (tck.size() == 2)
+            dir = (tck[1] - tck[0]).normalise();
+          else
+            dir = (tck[new_size] - tck[new_size - 2]).normalise();
           tck.resize (length_to_revert_from - revert_step);
+          pos = tck.back();
           if (S.is_act())
             act().sgm_depth = (act().sgm_depth > revert_step) ? act().sgm_depth - revert_step : 0;
         }

--- a/src/dwi/tractography/tracking/method.h
+++ b/src/dwi/tractography/tracking/method.h
@@ -98,7 +98,7 @@ namespace MR
         }
 
 
-        void reverse_track() { }
+        virtual void reverse_track() { if (act_method_additions) act().reverse_track(); }
         bool init() { return false; }
         term_t next() { return term_t(); }
         float get_metric() { return NAN; }

--- a/src/dwi/tractography/tracking/tractography.cpp
+++ b/src/dwi/tractography/tracking/tractography.cpp
@@ -26,14 +26,15 @@ namespace MR
       + Option ("number",
             "set the desired number of tracks. The program will continue to "
             "generate tracks until this number of tracks have been selected "
-            "and written to the output file.")
+            "and written to the output file; set to 0 to ignore limit.")
           + Argument ("tracks").type_integer (0, 0, std::numeric_limits<int>::max())
 
       + Option ("maxnum",
             "set the maximum number of tracks to generate. The program will "
             "not generate more tracks than this number, even if the desired "
-            "number of tracks hasn't yet been reached (default is 100 x number).")
-          + Argument ("tracks").type_integer (1, 1, INT_MAX)
+            "number of tracks hasn't yet been reached (default is 100 x number); "
+            "set to 0 to ignore limit.")
+          + Argument ("tracks").type_integer (0, 0, INT_MAX)
 
       + Option ("maxlength",
             "set the maximum length of any track in mm (default is 100 x voxelsize).")

--- a/src/dwi/tractography/tracking/write_kernel.cpp
+++ b/src/dwi/tractography/tracking/write_kernel.cpp
@@ -43,7 +43,7 @@ namespace MR
               (*seeds) << str(writer.count) << "," << str(tck.get_seed_index()) << "," << str(p[0]) << "," << str(p[1]) << "," << str(p[2]) << ",\n";
             }
             writer (tck);
-            progress.update ([&](){ return printf ("%8" PRIu64 " generated, %8" PRIu64 " selected", writer.total_count, writer.count); }, finite_seeds ? true : tck.size());
+            progress.update ([&](){ return printf ("%8" PRIu64 " generated, %8" PRIu64 " selected", writer.total_count, writer.count); }, always_increment ? true : tck.size());
             return true;
           }
 

--- a/src/dwi/tractography/tracking/write_kernel.h
+++ b/src/dwi/tractography/tracking/write_kernel.h
@@ -59,8 +59,8 @@ namespace MR
               const DWI::Tractography::Properties& properties) :
                 S (shared),
                 writer (output_file, properties),
-                finite_seeds (S.properties.seeds.is_finite()),
-                progress (printf ("       0 generated,        0 selected", 0, 0), finite_seeds ? S.max_num_attempts : S.max_num_tracks)
+                always_increment (S.properties.seeds.is_finite() || !S.max_num_tracks),
+                progress (printf ("       0 generated,        0 selected", 0, 0), always_increment ? S.max_num_attempts : S.max_num_tracks)
           {
             DWI::Tractography::Properties::const_iterator seed_output = properties.find ("seed_output");
             if (seed_output != properties.end()) {
@@ -85,13 +85,13 @@ namespace MR
 
           bool operator() (const GeneratedTrack&);
 
-          bool complete() const { return (writer.count >= S.max_num_tracks || writer.total_count >= S.max_num_attempts); }
+          bool complete() const { return ((S.max_num_tracks && writer.count >= S.max_num_tracks) || (S.max_num_attempts && writer.total_count >= S.max_num_attempts)); }
 
 
         protected:
           const SharedBase& S;
           Writer<value_type> writer;
-          const bool finite_seeds;
+          const bool always_increment;
           std::unique_ptr<File::OFStream> seeds;
           ProgressBar progress;
       };


### PR DESCRIPTION
Need to make sure this isn't going to break something, kind of a crucial functionality...

* The original back-tracking algorithm was a bit naive: each time a bad termination was encountered, an integer was incremented, and the streamline was truncated with length according to that integer. This meant that if back-tracking was used to traverse one problematic region, but then another was encountered, the length of truncation would immediately be high. Now, the behaviour is as follows:

  * The length of truncation is 'reset' if the streamline length exceeds that at the previous back-tracking event, i.e. the first problematic area has been passed.

  * If a truncation has occurred, but the streamline has not reached the same maximum length before back-tracking is again invoked, the truncation length is with reference to the _maximal_ streamline length, not the current length.

  * Each length of truncation is repeated for three back-tracking attempts before the length of truncation is increased (trade-off between effectiveness and speed).

* It is now possible to seed streamlines within sub-cortical grey matter. The streamline must reach white matter for it to be accepted. If tracking bi-directionally, only one of the unidirectional streamline projections may enter the WM; if both attempt to do so, the second is treated as exiting the SGM as per the normal ACT priors.

* When approaching the edge of the image, iFOD2 will now terminate with EXIT_IMAGE flag if _any_ calibrator path exits the image, rather than requiring that they all exit the image.