### PR TITLE
Connectome tool list

### DIFF
--- a/src/gui/mrview/tool/connectome/connectome.cpp
+++ b/src/gui/mrview/tool/connectome/connectome.cpp
@@ -1561,8 +1561,12 @@ namespace MR
         }
         void Connectome::node_colour_parameter_slot()
         {
+          node_colour_lower_button->blockSignals (true);
+          node_colour_upper_button->blockSignals (true);
           node_colour_lower_button->setMax (node_colour_upper_button->value());
           node_colour_upper_button->setMin (node_colour_lower_button->value());
+          node_colour_lower_button->blockSignals (false);
+          node_colour_upper_button->blockSignals (false);
           calculate_node_colours();
           window().updateGL();
         }
@@ -1585,8 +1589,12 @@ namespace MR
         }
         void Connectome::node_size_parameter_slot()
         {
+          node_size_lower_button->blockSignals (true);
+          node_size_upper_button->blockSignals (true);
           node_size_lower_button->setMax (node_size_upper_button->value());
           node_size_upper_button->setMin (node_size_lower_button->value());
+          node_size_lower_button->blockSignals (false);
+          node_size_upper_button->blockSignals (false);
           calculate_node_sizes();
           window().updateGL();
         }
@@ -1611,8 +1619,12 @@ namespace MR
         }
         void Connectome::node_alpha_parameter_slot()
         {
+          node_alpha_lower_button->blockSignals (true);
+          node_alpha_upper_button->blockSignals (true);
           node_alpha_lower_button->setMax (node_alpha_upper_button->value());
           node_alpha_upper_button->setMin (node_alpha_lower_button->value());
+          node_alpha_lower_button->blockSignals (false);
+          node_alpha_upper_button->blockSignals (false);
           calculate_node_alphas();
           window().updateGL();
         }
@@ -1960,6 +1972,12 @@ namespace MR
         }
         void Connectome::edge_colour_parameter_slot()
         {
+          edge_colour_lower_button->blockSignals (true);
+          edge_colour_upper_button->blockSignals (true);
+          edge_colour_lower_button->setMax (edge_colour_upper_button->value());
+          edge_colour_upper_button->setMin (edge_colour_lower_button->value());
+          edge_colour_lower_button->blockSignals (false);
+          edge_colour_upper_button->blockSignals (false);
           calculate_edge_colours();
           window().updateGL();
         }
@@ -1970,6 +1988,12 @@ namespace MR
         }
         void Connectome::edge_size_parameter_slot()
         {
+          edge_size_lower_button->blockSignals (true);
+          edge_size_upper_button->blockSignals (true);
+          edge_size_lower_button->setMax (edge_size_upper_button->value());
+          edge_size_upper_button->setMin (edge_size_lower_button->value());
+          edge_size_lower_button->blockSignals (false);
+          edge_size_upper_button->blockSignals (false);
           calculate_edge_sizes();
           window().updateGL();
         }
@@ -1980,6 +2004,12 @@ namespace MR
         }
         void Connectome::edge_alpha_parameter_slot()
         {
+          edge_alpha_lower_button->blockSignals (true);
+          edge_alpha_upper_button->blockSignals (true);
+          edge_alpha_lower_button->setMax (edge_alpha_upper_button->value());
+          edge_alpha_upper_button->setMin (edge_alpha_lower_button->value());
+          edge_alpha_lower_button->blockSignals (false);
+          edge_alpha_upper_button->blockSignals (false);
           calculate_edge_alphas();
           window().updateGL();
         }

--- a/src/gui/mrview/tool/connectome/connectome.cpp
+++ b/src/gui/mrview/tool/connectome/connectome.cpp
@@ -199,9 +199,11 @@ namespace MR
           hlayout->addWidget (node_visibility_warning_icon);
           gridlayout->addLayout (hlayout, 0, 3, 1, 2);
 
+          node_visibility_threshold_controls = new QWidget (this);
           hlayout = new HBoxLayout;
           hlayout->setContentsMargins (0, 0, 0, 0);
           hlayout->setSpacing (0);
+          node_visibility_threshold_controls->setLayout (hlayout);
           node_visibility_threshold_label = new QLabel ("Threshold: ");
           hlayout->addWidget (node_visibility_threshold_label);
           node_visibility_threshold_button = new AdjustButton (this);
@@ -214,10 +216,8 @@ namespace MR
           node_visibility_threshold_invert_checkbox->setTristate (false);
           connect (node_visibility_threshold_invert_checkbox, SIGNAL (stateChanged(int)), this, SLOT (node_visibility_parameter_slot()));
           hlayout->addWidget (node_visibility_threshold_invert_checkbox);
-          node_visibility_threshold_label->setVisible (false);
-          node_visibility_threshold_button->setVisible (false);
-          node_visibility_threshold_invert_checkbox->setVisible (false);
-          gridlayout->addLayout (hlayout, 1, 1, 1, 4);
+          node_visibility_threshold_controls->setVisible (false);
+          gridlayout->addWidget (node_visibility_threshold_controls, 1, 1, 1, 4);
 
           label = new QLabel ("Geometry: ");
           gridlayout->addWidget (label, 2, 0, 1, 2);
@@ -295,9 +295,11 @@ namespace MR
           hlayout->addWidget (node_colour_colourmap_button, 1);
           gridlayout->addLayout (hlayout, 3, 3, 1, 2);
 
+          node_colour_range_controls = new QWidget (this);
           hlayout = new HBoxLayout;
           hlayout->setContentsMargins (0, 0, 0, 0);
           hlayout->setSpacing (0);
+          node_colour_range_controls->setLayout (hlayout);
           node_colour_range_label = new QLabel ("Range: ");
           hlayout->addWidget (node_colour_range_label);
           node_colour_lower_button = new AdjustButton (this);
@@ -312,10 +314,8 @@ namespace MR
           node_colour_upper_button->setMax (std::numeric_limits<float>::max());
           connect (node_colour_upper_button, SIGNAL (valueChanged()), this, SLOT (node_colour_parameter_slot()));
           hlayout->addWidget (node_colour_upper_button);
-          node_colour_range_label->setVisible (false);
-          node_colour_lower_button->setVisible (false);
-          node_colour_upper_button->setVisible (false);
-          gridlayout->addLayout (hlayout, 4, 1, 1, 4);
+          node_colour_range_controls->setVisible (false);
+          gridlayout->addWidget (node_colour_range_controls, 4, 1, 1, 4);
 
           label = new QLabel ("Size scaling: ");
           gridlayout->addWidget (label, 5, 0, 1, 2);
@@ -353,9 +353,11 @@ namespace MR
           hlayout->addWidget (node_size_button, 1);
           gridlayout->addLayout (hlayout, 5, 3, 1, 2);
 
+          node_size_range_controls = new QWidget (this);
           hlayout = new HBoxLayout;
           hlayout->setContentsMargins (0, 0, 0, 0);
           hlayout->setSpacing (0);
+          node_size_range_controls->setLayout (hlayout);
           node_size_range_label = new QLabel ("Range: ");
           hlayout->addWidget (node_size_range_label);
           node_size_lower_button = new AdjustButton (this);
@@ -374,11 +376,8 @@ namespace MR
           node_size_invert_checkbox->setTristate (false);
           connect (node_size_invert_checkbox, SIGNAL (stateChanged(int)), this, SLOT (node_size_parameter_slot()));
           hlayout->addWidget (node_size_invert_checkbox);
-          node_size_range_label->setVisible (false);
-          node_size_lower_button->setVisible (false);
-          node_size_upper_button->setVisible (false);
-          node_size_invert_checkbox->setVisible (false);
-          gridlayout->addLayout (hlayout, 6, 1, 1, 4);
+          node_size_range_controls->setVisible (false);
+          gridlayout->addWidget (node_size_range_controls, 6, 1, 1, 4);
 
           label = new QLabel ("Transparency: ");
           gridlayout->addWidget (label, 7, 0, 1, 2);
@@ -415,9 +414,11 @@ namespace MR
           hlayout->addWidget (node_alpha_slider, 1);
           gridlayout->addLayout (hlayout, 7, 3, 1, 2);
 
+          node_alpha_range_controls = new QWidget (this);
           hlayout = new HBoxLayout;
           hlayout->setContentsMargins (0, 0, 0, 0);
           hlayout->setSpacing (0);
+          node_alpha_range_controls->setLayout (hlayout);
           node_alpha_range_label = new QLabel ("Range: ");
           hlayout->addWidget (node_alpha_range_label);
           node_alpha_lower_button = new AdjustButton (this);
@@ -436,11 +437,8 @@ namespace MR
           node_alpha_invert_checkbox->setTristate (false);
           connect (node_alpha_invert_checkbox, SIGNAL (stateChanged(int)), this, SLOT (node_alpha_parameter_slot()));
           hlayout->addWidget (node_alpha_invert_checkbox);
-          node_alpha_range_label->setVisible (false);
-          node_alpha_lower_button->setVisible (false);
-          node_alpha_upper_button->setVisible (false);
-          node_alpha_invert_checkbox->setVisible (false);
-          gridlayout->addLayout (hlayout, 8, 1, 1, 4);
+          node_alpha_range_controls->setVisible (false);
+          gridlayout->addWidget (node_alpha_range_controls, 8, 1, 1, 4);
 
           group_box = new QGroupBox ("Edge visualisation");
           main_box->addWidget (group_box);
@@ -465,9 +463,11 @@ namespace MR
           edge_visibility_warning_icon->setVisible (false);
           gridlayout->addWidget (edge_visibility_warning_icon, 0, 3);
 
+          edge_visibility_threshold_controls = new QWidget (this);
           hlayout = new HBoxLayout;
           hlayout->setContentsMargins (0, 0, 0, 0);
           hlayout->setSpacing (0);
+          edge_visibility_threshold_controls->setLayout (hlayout);
           edge_visibility_threshold_label = new QLabel ("Threshold: ");
           hlayout->addWidget (edge_visibility_threshold_label);
           edge_visibility_threshold_button = new AdjustButton (this);
@@ -480,7 +480,7 @@ namespace MR
           edge_visibility_threshold_invert_checkbox->setTristate (false);
           connect (edge_visibility_threshold_invert_checkbox, SIGNAL (stateChanged(int)), this, SLOT (edge_visibility_parameter_slot()));
           hlayout->addWidget (edge_visibility_threshold_invert_checkbox);
-          gridlayout->addLayout (hlayout, 1, 1, 1, 4);
+          gridlayout->addWidget (edge_visibility_threshold_controls, 1, 1, 1, 4);
 
           label = new QLabel ("Geometry: ");
           gridlayout->addWidget (label, 2, 0, 1, 2);
@@ -538,9 +538,11 @@ namespace MR
           hlayout->addWidget (edge_colour_colourmap_button, 1);
           gridlayout->addLayout (hlayout, 3, 3, 1, 2);
 
+          edge_colour_range_controls = new QWidget (this);
           hlayout = new HBoxLayout;
           hlayout->setContentsMargins (0, 0, 0, 0);
           hlayout->setSpacing (0);
+          edge_colour_range_controls->setLayout (hlayout);
           edge_colour_range_label = new QLabel ("Range: ");
           hlayout->addWidget (edge_colour_range_label);
           edge_colour_lower_button = new AdjustButton (this);
@@ -555,7 +557,7 @@ namespace MR
           edge_colour_upper_button->setMax (std::numeric_limits<float>::max());
           connect (edge_colour_upper_button, SIGNAL (valueChanged()), this, SLOT (edge_colour_parameter_slot()));
           hlayout->addWidget (edge_colour_upper_button);
-          gridlayout->addLayout (hlayout, 4, 1, 1, 4);
+          gridlayout->addWidget (edge_colour_range_controls, 4, 1, 1, 4);
 
           label = new QLabel ("Size scaling: ");
           gridlayout->addWidget (label, 5, 0, 1, 2);
@@ -576,9 +578,11 @@ namespace MR
           hlayout->addWidget (edge_size_button, 1);
           gridlayout->addLayout (hlayout, 5, 3, 1, 2);
 
+          edge_size_range_controls = new QWidget (this);
           hlayout = new HBoxLayout;
           hlayout->setContentsMargins (0, 0, 0, 0);
           hlayout->setSpacing (0);
+          edge_size_range_controls->setLayout (hlayout);
           edge_size_range_label = new QLabel ("Range: ");
           hlayout->addWidget (edge_size_range_label);
           edge_size_lower_button = new AdjustButton (this);
@@ -597,11 +601,8 @@ namespace MR
           edge_size_invert_checkbox->setTristate (false);
           connect (edge_size_invert_checkbox, SIGNAL (stateChanged(int)), this, SLOT (edge_size_parameter_slot()));
           hlayout->addWidget (edge_size_invert_checkbox);
-          edge_size_range_label->setVisible (false);
-          edge_size_lower_button->setVisible (false);
-          edge_size_upper_button->setVisible (false);
-          edge_size_invert_checkbox->setVisible (false);
-          gridlayout->addLayout (hlayout, 6, 1, 1, 4);
+          edge_size_range_controls->setVisible (false);
+          gridlayout->addWidget (edge_size_range_controls, 6, 1, 1, 4);
 
           label = new QLabel ("Transparency: ");
           gridlayout->addWidget (label, 7, 0, 1, 2);
@@ -622,9 +623,11 @@ namespace MR
           hlayout->addWidget (edge_alpha_slider, 1);
           gridlayout->addLayout (hlayout, 7, 3, 1, 2);
 
+          edge_alpha_range_controls = new QWidget (this);
           hlayout = new HBoxLayout;
           hlayout->setContentsMargins (0, 0, 0, 0);
           hlayout->setSpacing (0);
+          edge_alpha_range_controls->setLayout (hlayout);
           edge_alpha_range_label = new QLabel ("Range: ");
           hlayout->addWidget (edge_alpha_range_label);
           edge_alpha_lower_button = new AdjustButton (this);
@@ -643,11 +646,8 @@ namespace MR
           edge_alpha_invert_checkbox->setTristate (false);
           connect (edge_alpha_invert_checkbox, SIGNAL (stateChanged(int)), this, SLOT (edge_alpha_parameter_slot()));
           hlayout->addWidget (edge_alpha_invert_checkbox);
-          edge_alpha_range_label->setVisible (false);
-          edge_alpha_lower_button->setVisible (false);
-          edge_alpha_upper_button->setVisible (false);
-          edge_alpha_invert_checkbox->setVisible (false);
-          gridlayout->addLayout (hlayout, 8, 1, 1, 4);
+          edge_alpha_range_controls->setVisible (false);
+          gridlayout->addWidget (edge_alpha_range_controls, 8, 1, 1, 4);
 
           group_box = new QGroupBox ("Miscellaneous options");
           main_box->addWidget (group_box);
@@ -942,18 +942,14 @@ namespace MR
               node_visibility = node_visibility_t::ALL;
               node_visibility_combobox->removeItem (6);
               node_visibility_matrix_operator_combobox->setVisible (false);
-              node_visibility_threshold_label->setVisible (false);
-              node_visibility_threshold_button->setVisible (false);
-              node_visibility_threshold_invert_checkbox->setVisible (false);
+              node_visibility_threshold_controls->setVisible (false);
               break;
             case 1:
               if (node_visibility == node_visibility_t::NONE) return;
               node_visibility = node_visibility_t::NONE;
               node_visibility_combobox->removeItem (6);
               node_visibility_matrix_operator_combobox->setVisible (false);
-              node_visibility_threshold_label->setVisible (false);
-              node_visibility_threshold_button->setVisible (false);
-              node_visibility_threshold_invert_checkbox->setVisible (false);
+              node_visibility_threshold_controls->setVisible (false);
               break;
             case 2:
               if (node_visibility == node_visibility_t::DEGREE) return;
@@ -970,9 +966,7 @@ namespace MR
               }
               node_visibility_combobox->removeItem (6);
               node_visibility_matrix_operator_combobox->setVisible (false);
-              node_visibility_threshold_label->setVisible (false);
-              node_visibility_threshold_button->setVisible (false);
-              node_visibility_threshold_invert_checkbox->setVisible (false);
+              node_visibility_threshold_controls->setVisible (false);
               break;
             case 3:
               if (node_visibility == node_visibility_t::CONNECTOME) return;
@@ -992,9 +986,7 @@ namespace MR
                 node_visibility_matrix_operator_combobox->setCurrentIndex (2);
                 node_visibility_matrix_operator_combobox->setEnabled (false);
               }
-              node_visibility_threshold_label->setVisible (true);
-              node_visibility_threshold_button->setVisible (true);
-              node_visibility_threshold_invert_checkbox->setVisible (true);
+              node_visibility_threshold_controls->setVisible (true);
               {
                 float min = 0.0f, mean = 0.0f, max = 0.0f;
                 QModelIndexList list = matrix_list_view->selectionModel()->selectedRows();
@@ -1023,9 +1015,7 @@ namespace MR
                 node_visibility_combobox->setItemText (6, node_values_from_file_visibility.get_name());
               node_visibility_combobox->setCurrentIndex (6);
               node_visibility_matrix_operator_combobox->setVisible (false);
-              node_visibility_threshold_label->setVisible (true);
-              node_visibility_threshold_button->setVisible (true);
-              node_visibility_threshold_invert_checkbox->setVisible (true);
+              node_visibility_threshold_controls->setVisible (true);
               update_controls_node_visibility (node_values_from_file_visibility.get_min(), node_values_from_file_visibility.get_mean(), node_values_from_file_visibility.get_max());
               break;
             case 5:
@@ -1059,9 +1049,7 @@ namespace MR
                 node_visibility_matrix_operator_combobox->setCurrentIndex (2);
                 node_visibility_matrix_operator_combobox->setEnabled (false);
               }
-              node_visibility_threshold_label->setVisible (true);
-              node_visibility_threshold_button->setVisible (true);
-              node_visibility_threshold_invert_checkbox->setVisible (true);
+              node_visibility_threshold_controls->setVisible (true);
               update_controls_node_visibility (node_values_from_file_visibility.get_min(), node_values_from_file_visibility.get_mean(), node_values_from_file_visibility.get_max());
               break;
             case 6:
@@ -1174,9 +1162,7 @@ namespace MR
               node_colour_fixedcolour_button->setVisible (true);
               node_colour_combobox->removeItem (6);
               node_colour_matrix_operator_combobox->setVisible (false);
-              node_colour_range_label->setVisible (false);
-              node_colour_lower_button->setVisible (false);
-              node_colour_upper_button->setVisible (false);
+              node_colour_range_controls->setVisible (false);
               break;
             case 1:
               // Regenerate random colours on repeat selection
@@ -1185,9 +1171,7 @@ namespace MR
               node_colour_fixedcolour_button->setVisible (false);
               node_colour_combobox->removeItem (6);
               node_colour_matrix_operator_combobox->setVisible (false);
-              node_colour_range_label->setVisible (false);
-              node_colour_lower_button->setVisible (false);
-              node_colour_upper_button->setVisible (false);
+              node_colour_range_controls->setVisible (false);
               break;
             case 2:
               if (node_colour == node_colour_t::FROM_LUT) return;
@@ -1196,9 +1180,7 @@ namespace MR
               node_colour_colourmap_button->setVisible (false);
               node_colour_combobox->removeItem (6);
               node_colour_matrix_operator_combobox->setVisible (false);
-              node_colour_range_label->setVisible (false);
-              node_colour_lower_button->setVisible (false);
-              node_colour_upper_button->setVisible (false);
+              node_colour_range_controls->setVisible (false);
               break;
             case 3:
               if (node_colour == node_colour_t::CONNECTOME) return;
@@ -1222,9 +1204,7 @@ namespace MR
                 node_colour_matrix_operator_combobox->setCurrentIndex (4);
                 node_colour_matrix_operator_combobox->setEnabled (false);
               }
-              node_colour_range_label->setVisible (true);
-              node_colour_lower_button->setVisible (true);
-              node_colour_upper_button->setVisible (true);
+              node_colour_range_controls->setVisible (true);
               {
                 float min = 0.0f, mean = 0.0f, max = 0.0f;
                 QModelIndexList list = matrix_list_view->selectionModel()->selectedRows();
@@ -1255,9 +1235,7 @@ namespace MR
                 node_colour_combobox->setItemText (6, node_values_from_file_colour.get_name());
               node_colour_combobox->setCurrentIndex (6);
               node_colour_matrix_operator_combobox->setVisible (false);
-              node_colour_range_label->setVisible (true);
-              node_colour_lower_button->setVisible (true);
-              node_colour_upper_button->setVisible (true);
+              node_colour_range_controls->setVisible (true);
               update_controls_node_colour (node_values_from_file_colour.get_min(), node_values_from_file_colour.get_mean(), node_values_from_file_colour.get_max());
               break;
             case 5:
@@ -1295,9 +1273,7 @@ namespace MR
                 node_colour_matrix_operator_combobox->setCurrentIndex (4);
                 node_colour_matrix_operator_combobox->setEnabled (false);
               }
-              node_colour_range_label->setVisible (true);
-              node_colour_lower_button->setVisible (true);
-              node_colour_upper_button->setVisible (true);
+              node_colour_range_controls->setVisible (true);
               update_controls_node_colour (node_values_from_file_colour.get_min(), node_values_from_file_colour.get_mean(), node_values_from_file_colour.get_max());
               break;
             case 6:
@@ -1319,20 +1295,14 @@ namespace MR
               node_size = node_size_t::FIXED;
               node_size_combobox->removeItem (5);
               node_size_matrix_operator_combobox->setVisible (false);
-              node_size_range_label->setVisible (false);
-              node_size_lower_button->setVisible (false);
-              node_size_upper_button->setVisible (false);
-              node_size_invert_checkbox->setVisible (false);
+              node_size_range_controls->setVisible (false);
               break;
             case 1:
               if (node_size == node_size_t::NODE_VOLUME) return;
               node_size = node_size_t::NODE_VOLUME;
               node_size_combobox->removeItem (5);
               node_size_matrix_operator_combobox->setVisible (false);
-              node_size_range_label->setVisible (false);
-              node_size_lower_button->setVisible (false);
-              node_size_upper_button->setVisible (false);
-              node_size_invert_checkbox->setVisible (false);
+              node_size_range_controls->setVisible (false);
               break;
             case 2:
               if (node_size == node_size_t::CONNECTOME) return;
@@ -1354,10 +1324,7 @@ namespace MR
                 node_size_matrix_operator_combobox->setCurrentIndex (4);
                 node_size_matrix_operator_combobox->setEnabled (false);
               }
-              node_size_range_label->setVisible (true);
-              node_size_lower_button->setVisible (true);
-              node_size_upper_button->setVisible (true);
-              node_size_invert_checkbox->setVisible (true);
+              node_size_range_controls->setVisible (true);
               {
                 float min = 0.0f, mean = 0.0f, max = 0.0f;
                 QModelIndexList list = matrix_list_view->selectionModel()->selectedRows();
@@ -1386,10 +1353,7 @@ namespace MR
                 node_size_combobox->setItemText (5, node_values_from_file_size.get_name());
               node_size_combobox->setCurrentIndex (5);
               node_size_matrix_operator_combobox->setVisible (false);
-              node_size_range_label->setVisible (true);
-              node_size_lower_button->setVisible (true);
-              node_size_upper_button->setVisible (true);
-              node_size_invert_checkbox->setVisible (true);
+              node_size_range_controls->setVisible (true);
               update_controls_node_size (node_values_from_file_size.get_min(), node_values_from_file_size.get_mean(), node_values_from_file_size.get_max());
               node_size_invert_checkbox->setChecked (false);
               break;
@@ -1425,10 +1389,7 @@ namespace MR
                 node_size_matrix_operator_combobox->setCurrentIndex (4);
                 node_size_matrix_operator_combobox->setEnabled (false);
               }
-              node_size_range_label->setVisible (true);
-              node_size_lower_button->setVisible (true);
-              node_size_upper_button->setVisible (true);
-              node_size_invert_checkbox->setVisible (true);
+              node_size_range_controls->setVisible (true);
               update_controls_node_size (node_values_from_file_size.get_min(), node_values_from_file_size.get_mean(), node_values_from_file_size.get_max());
               node_size_invert_checkbox->setChecked (false);
               break;
@@ -1450,10 +1411,7 @@ namespace MR
               node_alpha = node_alpha_t::FIXED;
               node_alpha_combobox->removeItem (4);
               node_alpha_matrix_operator_combobox->setVisible (false);
-              node_alpha_range_label->setVisible (false);
-              node_alpha_lower_button->setVisible (false);
-              node_alpha_upper_button->setVisible (false);
-              node_alpha_invert_checkbox->setVisible (false);
+              node_alpha_range_controls->setVisible (false);
               break;
             case 1:
               if (node_alpha == node_alpha_t::CONNECTOME) return;
@@ -1475,10 +1433,7 @@ namespace MR
                 node_alpha_matrix_operator_combobox->setCurrentIndex (4);
                 node_alpha_matrix_operator_combobox->setEnabled (false);
               }
-              node_alpha_range_label->setVisible (true);
-              node_alpha_lower_button->setVisible (true);
-              node_alpha_upper_button->setVisible (true);
-              node_alpha_invert_checkbox->setVisible (true);
+              node_alpha_range_controls->setVisible (true);
               {
                 float min = 0.0f, mean = 0.0f, max = 0.0f;
                 QModelIndexList list = matrix_list_view->selectionModel()->selectedRows();
@@ -1506,10 +1461,7 @@ namespace MR
                 node_alpha_combobox->setItemText (4, node_values_from_file_alpha.get_name());
               node_alpha_combobox->setCurrentIndex (4);
               node_alpha_matrix_operator_combobox->setVisible (false);
-              node_alpha_range_label->setVisible (true);
-              node_alpha_lower_button->setVisible (true);
-              node_alpha_upper_button->setVisible (true);
-              node_alpha_invert_checkbox->setVisible (true);
+              node_alpha_range_controls->setVisible (true);
               update_controls_node_alpha (node_values_from_file_alpha.get_min(), node_values_from_file_alpha.get_mean(), node_values_from_file_alpha.get_max());
               node_alpha_invert_checkbox->setChecked (false);
               break;
@@ -1544,10 +1496,7 @@ namespace MR
                 node_alpha_matrix_operator_combobox->setCurrentIndex (4);
                 node_alpha_matrix_operator_combobox->setEnabled (false);
               }
-              node_alpha_range_label->setVisible (true);
-              node_alpha_lower_button->setVisible (true);
-              node_alpha_upper_button->setVisible (true);
-              node_alpha_invert_checkbox->setVisible (true);
+              node_alpha_range_controls->setVisible (true);
               update_controls_node_alpha (node_values_from_file_alpha.get_min(), node_values_from_file_alpha.get_mean(), node_values_from_file_alpha.get_max());
               node_alpha_invert_checkbox->setChecked (false);
               break;
@@ -1682,17 +1631,13 @@ namespace MR
               if (edge_visibility == edge_visibility_t::ALL) return;
               edge_visibility = edge_visibility_t::ALL;
               edge_visibility_combobox->removeItem (5);
-              edge_visibility_threshold_label->setVisible (false);
-              edge_visibility_threshold_button->setVisible (false);
-              edge_visibility_threshold_invert_checkbox->setVisible (false);
+              edge_visibility_threshold_controls->setVisible (false);
               break;
             case 1:
               if (edge_visibility == edge_visibility_t::NONE) return;
               edge_visibility = edge_visibility_t::NONE;
               edge_visibility_combobox->removeItem (5);
-              edge_visibility_threshold_label->setVisible (false);
-              edge_visibility_threshold_button->setVisible (false);
-              edge_visibility_threshold_invert_checkbox->setVisible (false);
+              edge_visibility_threshold_controls->setVisible (false);
               break;
             case 2:
               if (edge_visibility == edge_visibility_t::VISIBLE_NODES) return;
@@ -1708,17 +1653,13 @@ namespace MR
                 edge_visibility = edge_visibility_t::VISIBLE_NODES;
               }
               edge_visibility_combobox->removeItem (5);
-              edge_visibility_threshold_label->setVisible (false);
-              edge_visibility_threshold_button->setVisible (false);
-              edge_visibility_threshold_invert_checkbox->setVisible (false);
+              edge_visibility_threshold_controls->setVisible (false);
               break;
             case 3:
               if (edge_visibility == edge_visibility_t::CONNECTOME) return;
               edge_visibility = edge_visibility_t::CONNECTOME;
               edge_visibility_combobox->removeItem (5);
-              edge_visibility_threshold_label->setVisible (true);
-              edge_visibility_threshold_button->setVisible (true);
-              edge_visibility_threshold_invert_checkbox->setVisible (true);
+              edge_visibility_threshold_controls->setVisible (true);
               {
                 float min = 0.0f, mean = 0.0f, max = 0.0f;
                 QModelIndexList list = matrix_list_view->selectionModel()->selectedRows();
@@ -1745,9 +1686,7 @@ namespace MR
               else
                 edge_visibility_combobox->setItemText (5, edge_values_from_file_visibility.get_name());
               edge_visibility_combobox->setCurrentIndex (5);
-              edge_visibility_threshold_label->setVisible (true);
-              edge_visibility_threshold_button->setVisible (true);
-              edge_visibility_threshold_invert_checkbox->setVisible (true);
+              edge_visibility_threshold_controls->setVisible (true);
               update_controls_edge_visibility (edge_values_from_file_visibility.get_min(), edge_values_from_file_visibility.get_mean(), edge_values_from_file_visibility.get_max());
               break;
             case 5:
@@ -1837,9 +1776,7 @@ namespace MR
               edge_colour_colourmap_button->setVisible (false);
               edge_colour_fixedcolour_button->setVisible (true);
               edge_colour_combobox->removeItem (4);
-              edge_colour_range_label->setVisible (false);
-              edge_colour_lower_button->setVisible (false);
-              edge_colour_upper_button->setVisible (false);
+              edge_colour_range_controls->setVisible (false);
               break;
             case 1:
               if (edge_colour == edge_colour_t::DIRECTION) return;
@@ -1847,9 +1784,7 @@ namespace MR
               edge_colour_colourmap_button->setVisible (false);
               edge_colour_fixedcolour_button->setVisible (false);
               edge_colour_combobox->removeItem (4);
-              edge_colour_range_label->setVisible (false);
-              edge_colour_lower_button->setVisible (false);
-              edge_colour_upper_button->setVisible (false);
+              edge_colour_range_controls->setVisible (false);
               break;
             case 2:
               if (edge_colour == edge_colour_t::CONNECTOME) return;
@@ -1857,9 +1792,7 @@ namespace MR
               edge_colour_colourmap_button->setVisible (true);
               edge_colour_fixedcolour_button->setVisible (false);
               edge_colour_combobox->removeItem (4);
-              edge_colour_range_label->setVisible (true);
-              edge_colour_lower_button->setVisible (true);
-              edge_colour_upper_button->setVisible (true);
+              edge_colour_range_controls->setVisible (true);
               {
                 float min = 0.0f, mean = 0.0f, max = 0.0f;
                 QModelIndexList list = matrix_list_view->selectionModel()->selectedRows();
@@ -1887,9 +1820,7 @@ namespace MR
               else
                 edge_colour_combobox->setItemText (4, edge_values_from_file_colour.get_name());
               edge_colour_combobox->setCurrentIndex (4);
-              edge_colour_range_label->setVisible (true);
-              edge_colour_lower_button->setVisible (true);
-              edge_colour_upper_button->setVisible (true);
+              edge_colour_range_controls->setVisible (true);
               update_controls_edge_colour (edge_values_from_file_colour.get_min(), edge_values_from_file_colour.get_mean(), edge_values_from_file_colour.get_max());
               break;
             case 4:
@@ -1909,19 +1840,13 @@ namespace MR
               if (edge_size == edge_size_t::FIXED) return;
               edge_size = edge_size_t::FIXED;
               edge_size_combobox->removeItem (3);
-              edge_size_range_label->setVisible (false);
-              edge_size_lower_button->setVisible (false);
-              edge_size_upper_button->setVisible (false);
-              edge_size_invert_checkbox->setVisible (false);
+              edge_size_range_controls->setVisible (false);
               break;
             case 1:
               if (edge_size == edge_size_t::CONNECTOME) return;
               edge_size = edge_size_t::CONNECTOME;
               edge_size_combobox->removeItem (3);
-              edge_size_range_label->setVisible (true);
-              edge_size_lower_button->setVisible (true);
-              edge_size_upper_button->setVisible (true);
-              edge_size_invert_checkbox->setVisible (true);
+              edge_size_range_controls->setVisible (true);
               {
                 float min = 0.0f, mean = 0.0f, max = 0.0f;
                 QModelIndexList list = matrix_list_view->selectionModel()->selectedRows();
@@ -1946,10 +1871,7 @@ namespace MR
               else
                 edge_size_combobox->setItemText (3, edge_values_from_file_size.get_name());
               edge_size_combobox->setCurrentIndex (3);
-              edge_size_range_label->setVisible (true);
-              edge_size_lower_button->setVisible (true);
-              edge_size_upper_button->setVisible (true);
-              edge_size_invert_checkbox->setVisible (true);
+              edge_size_range_controls->setVisible (true);
               update_controls_edge_size (edge_values_from_file_size.get_min(), edge_values_from_file_size.get_mean(), edge_values_from_file_size.get_max());
               break;
             case 3:
@@ -1969,19 +1891,13 @@ namespace MR
               if (edge_alpha == edge_alpha_t::FIXED) return;
               edge_alpha = edge_alpha_t::FIXED;
               edge_alpha_combobox->removeItem (3);
-              edge_alpha_range_label->setVisible (false);
-              edge_alpha_lower_button->setVisible (false);
-              edge_alpha_upper_button->setVisible (false);
-              edge_alpha_invert_checkbox->setVisible (false);
+              edge_alpha_range_controls->setVisible (false);
               break;
             case 1:
               if (edge_alpha == edge_alpha_t::CONNECTOME) return;
               edge_alpha = edge_alpha_t::CONNECTOME;
               edge_alpha_combobox->removeItem (3);
-              edge_alpha_range_label->setVisible (true);
-              edge_alpha_lower_button->setVisible (true);
-              edge_alpha_upper_button->setVisible (true);
-              edge_alpha_invert_checkbox->setVisible (true);
+              edge_alpha_range_controls->setVisible (true);
               {
                 float min = 0.0f, mean = 0.0f, max = 0.0f;
                 QModelIndexList list = matrix_list_view->selectionModel()->selectedRows();
@@ -2006,10 +1922,7 @@ namespace MR
               else
                 edge_alpha_combobox->setItemText (3, edge_values_from_file_alpha.get_name());
               edge_alpha_combobox->setCurrentIndex (3);
-              edge_alpha_range_label->setVisible (true);
-              edge_alpha_lower_button->setVisible (true);
-              edge_alpha_upper_button->setVisible (true);
-              edge_alpha_invert_checkbox->setVisible (true);
+              edge_alpha_range_controls->setVisible (true);
               update_controls_edge_alpha (edge_values_from_file_alpha.get_min(), edge_values_from_file_alpha.get_mean(), edge_values_from_file_alpha.get_max());
               edge_alpha_invert_checkbox->setChecked (false);
               break;

--- a/src/gui/mrview/tool/connectome/connectome.cpp
+++ b/src/gui/mrview/tool/connectome/connectome.cpp
@@ -22,8 +22,6 @@
 
 #include "gui/mrview/tool/connectome/connectome.h"
 
-//#include "thread_queue.h"
-
 #include "file/path.h"
 #include "gui/dialog/file.h"
 #include "gui/mrview/colourmap.h"
@@ -131,62 +129,6 @@ namespace MR
           hlayout->addWidget (hide_all_button, 1);
           vlayout->addLayout (hlayout);
 
-          hlayout = new HBoxLayout;
-          hlayout->setContentsMargins (0, 0, 0, 0);
-          hlayout->setSpacing (0);
-          hlayout->addWidget (new QLabel ("Config: "));
-          config_button = new QPushButton (this);
-          config_button->setToolTip (tr ("Open connectome config file\n"
-                                         "Provide the connectome config file used at the labelconfig\n"
-                                         "step to access the proper node names in the node list."));
-          config_button->setText ("(none)");
-          connect (config_button, SIGNAL (clicked()), this, SLOT (config_open_slot ()));
-          hlayout->addWidget (config_button, 1);
-          vlayout->addLayout (hlayout);
-
-          group_box = new QGroupBox ("General display options");
-          main_box->addWidget (group_box);
-          GridLayout* gridlayout = new GridLayout();
-          group_box->setLayout (gridlayout);
-
-          lighting_checkbox = new QCheckBox ("Lighting");
-          lighting_checkbox->setTristate (false);
-          lighting_checkbox->setChecked (true);
-          lighting_checkbox->setToolTip (tr ("Toggle whether lighting should be applied to compatible elements"));
-          connect (lighting_checkbox, SIGNAL (stateChanged (int)), this, SLOT (lighting_change_slot (int)));
-          gridlayout->addWidget (lighting_checkbox, 0, 0);
-          lighting_settings_button = new QPushButton ("Settings...");
-          lighting_settings_button->setToolTip (tr ("Advanced lighting configuration"));
-          connect (lighting_settings_button, SIGNAL (clicked()), this, SLOT (lighting_settings_slot()));
-          gridlayout->addWidget (lighting_settings_button, 0, 1);
-          connect (&lighting, SIGNAL (changed()), SLOT (lighting_parameter_slot()));
-
-          crop_to_slab_checkbox = new QCheckBox ("Crop to slab");
-          crop_to_slab_checkbox->setTristate (false);
-          connect (crop_to_slab_checkbox, SIGNAL (stateChanged(int)), this, SLOT (crop_to_slab_toggle_slot (int)));
-          gridlayout->addWidget (crop_to_slab_checkbox, 1, 0);
-          hlayout = new HBoxLayout;
-          hlayout->setContentsMargins (0, 0, 0, 0);
-          hlayout->setSpacing (0);
-          crop_to_slab_label = new QLabel ("Thickness: ");
-          crop_to_slab_label->setEnabled (false);
-          hlayout->addWidget (crop_to_slab_label);
-          crop_to_slab_button = new AdjustButton (this);
-          crop_to_slab_button->setValue (0.0f);
-          crop_to_slab_button->setMin (0.0f);
-          crop_to_slab_button->setRate (0.1f);
-          crop_to_slab_button->setEnabled (false);
-          connect (crop_to_slab_button, SIGNAL (valueChanged()), this, SLOT (crop_to_slab_parameter_slot()));
-          hlayout->addWidget (crop_to_slab_button);
-          gridlayout->addLayout (hlayout, 1, 1);
-
-          show_node_list_label = new QLabel ("Node selection: ");
-          gridlayout->addWidget (show_node_list_label, 2, 0);
-          show_node_list_button = new QPushButton ("Show list");
-          show_node_list_button->setToolTip (tr ("Open window that displays list of nodes and enables their selection"));
-          connect (show_node_list_button, SIGNAL (clicked()), this, SLOT (show_node_list_slot()));
-          gridlayout->addWidget (show_node_list_button, 2, 1);
-
           group_box = new QGroupBox ("Connectome matrices");
           main_box->addWidget (group_box);
           vlayout = new VBoxLayout;
@@ -220,7 +162,7 @@ namespace MR
 
           group_box = new QGroupBox ("Node visualisation");
           main_box->addWidget (group_box);
-          gridlayout = new GridLayout();
+          GridLayout* gridlayout = new GridLayout();
           group_box->setLayout (gridlayout);
 
           QLabel* label = new QLabel ("Visibility: ");
@@ -356,19 +298,6 @@ namespace MR
           hlayout = new HBoxLayout;
           hlayout->setContentsMargins (0, 0, 0, 0);
           hlayout->setSpacing (0);
-          lut_label = new QLabel ("LUT file: ");
-          lut_label->setVisible (false);
-          hlayout->addWidget (lut_label);
-          lut_combobox = new QComboBox (this);
-          lut_combobox->setToolTip (tr ("Open lookup table file (must select appropriate format)\n"
-                                        "If the primary parcellation image has come from an atlas that\n"
-                                        "provides a look-up table, select that file here so that MRview \n"
-                                        "can access the appropriate node colours."));
-          for (size_t index = 0; MR::Connectome::lut_format_strings[index]; ++index)
-            lut_combobox->insertItem (index, MR::Connectome::lut_format_strings[index]);
-          lut_combobox->setVisible (false);
-          connect (lut_combobox, SIGNAL (activated(int)), this, SLOT (lut_open_slot (int)));
-          hlayout->addWidget (lut_combobox);
           node_colour_range_label = new QLabel ("Range: ");
           hlayout->addWidget (node_colour_range_label);
           node_colour_lower_button = new AdjustButton (this);
@@ -720,6 +649,69 @@ namespace MR
           edge_alpha_invert_checkbox->setVisible (false);
           gridlayout->addLayout (hlayout, 8, 1, 1, 4);
 
+          group_box = new QGroupBox ("Miscellaneous options");
+          main_box->addWidget (group_box);
+          gridlayout = new GridLayout();
+          group_box->setLayout (gridlayout);
+
+          gridlayout->addWidget (new QLabel ("Config: "), 0, 0);
+          config_button = new QPushButton (this);
+          config_button->setToolTip (tr ("Open connectome config file\n"
+                                         "Provide the connectome config file used at the labelconfig\n"
+                                         "step to access the proper node names in the node list."));
+          config_button->setText ("(none)");
+          connect (config_button, SIGNAL (clicked()), this, SLOT (config_open_slot ()));
+          gridlayout->addWidget (config_button, 0, 1);
+
+          gridlayout->addWidget (new QLabel ("LUT file: "), 1, 0);
+          lut_combobox = new QComboBox (this);
+          lut_combobox->setToolTip (tr ("Open lookup table file (must select appropriate format)\n"
+                                        "If the primary parcellation image has come from an atlas that\n"
+                                        "provides a look-up table, select that file here so that MRview \n"
+                                        "can access the appropriate node colours."));
+          for (size_t index = 0; MR::Connectome::lut_format_strings[index]; ++index)
+            lut_combobox->insertItem (index, MR::Connectome::lut_format_strings[index]);
+          connect (lut_combobox, SIGNAL (activated(int)), this, SLOT (lut_open_slot (int)));
+          gridlayout->addWidget (lut_combobox, 1, 1);
+
+          lighting_checkbox = new QCheckBox ("Lighting");
+          lighting_checkbox->setTristate (false);
+          lighting_checkbox->setChecked (true);
+          lighting_checkbox->setToolTip (tr ("Toggle whether lighting should be applied to compatible elements"));
+          connect (lighting_checkbox, SIGNAL (stateChanged (int)), this, SLOT (lighting_change_slot (int)));
+          gridlayout->addWidget (lighting_checkbox, 2, 0);
+          lighting_settings_button = new QPushButton ("Settings...");
+          lighting_settings_button->setToolTip (tr ("Advanced lighting configuration"));
+          connect (lighting_settings_button, SIGNAL (clicked()), this, SLOT (lighting_settings_slot()));
+          gridlayout->addWidget (lighting_settings_button, 2, 1);
+          connect (&lighting, SIGNAL (changed()), SLOT (lighting_parameter_slot()));
+
+          crop_to_slab_checkbox = new QCheckBox ("Crop to slab");
+          crop_to_slab_checkbox->setTristate (false);
+          connect (crop_to_slab_checkbox, SIGNAL (stateChanged(int)), this, SLOT (crop_to_slab_toggle_slot (int)));
+          gridlayout->addWidget (crop_to_slab_checkbox, 3, 0);
+          hlayout = new HBoxLayout;
+          hlayout->setContentsMargins (0, 0, 0, 0);
+          hlayout->setSpacing (0);
+          crop_to_slab_label = new QLabel ("Thickness: ");
+          crop_to_slab_label->setEnabled (false);
+          hlayout->addWidget (crop_to_slab_label);
+          crop_to_slab_button = new AdjustButton (this);
+          crop_to_slab_button->setValue (0.0f);
+          crop_to_slab_button->setMin (0.0f);
+          crop_to_slab_button->setRate (0.1f);
+          crop_to_slab_button->setEnabled (false);
+          connect (crop_to_slab_button, SIGNAL (valueChanged()), this, SLOT (crop_to_slab_parameter_slot()));
+          hlayout->addWidget (crop_to_slab_button);
+          gridlayout->addLayout (hlayout, 3, 1);
+
+          show_node_list_label = new QLabel ("Node selection: ");
+          gridlayout->addWidget (show_node_list_label, 4, 0);
+          show_node_list_button = new QPushButton ("Show list");
+          show_node_list_button->setToolTip (tr ("Open window that displays list of nodes and enables their selection"));
+          connect (show_node_list_button, SIGNAL (clicked()), this, SLOT (show_node_list_slot()));
+          gridlayout->addWidget (show_node_list_button, 4, 1);
+
           main_box->addWidget (node_list);
 
           main_box->addStretch ();
@@ -865,7 +857,6 @@ namespace MR
           return false;
         }
 
-
         void Connectome::image_open_slot()
         {
           const std::string path = Dialog::File::get_image (this, "Select connectome parcellation image");
@@ -886,75 +877,10 @@ namespace MR
         }
 
 
-        void Connectome::config_open_slot()
-        {
-          const std::string path = Dialog::File::get_file (this, "Select connectome configuration file", "Text files (*.txt)");
-          if (path.empty())
-            return;
-          config.clear();
-          lut_mapping.clear();
-          config_button->setText ("(none)");
-          try {
-            MR::Connectome::load_config (path, config);
-            config_button->setText (QString::fromStdString (Path::basename (path)));
-          } catch (Exception& e) {
-            e.display();
-            config.clear();
-          }
-          load_properties();
-          window().updateGL();
-        }
-
         void Connectome::hide_all_slot()
         {
           window().updateGL();
         }
-
-
-
-
-
-
-        void Connectome::lighting_change_slot (int /*value*/)
-        {
-          window().updateGL();
-        }
-        void Connectome::lighting_settings_slot()
-        {
-          if (!lighting_dock)
-            lighting_dock.reset (new LightingDock ("Connectome lighting", lighting, false));
-          lighting_dock->show();
-        }
-        void Connectome::lighting_parameter_slot()
-        {
-          if (use_lighting())
-            window().updateGL();
-        }
-        void Connectome::crop_to_slab_toggle_slot (int /*value*/)
-        {
-          crop_to_slab = crop_to_slab_checkbox->isChecked();
-          is_3D = !(crop_to_slab && !slab_thickness);
-          crop_to_slab_label->setEnabled (crop_to_slab);
-          crop_to_slab_button->setEnabled (crop_to_slab);
-          node_geometry_overlay_3D_warning_icon->setVisible (node_geometry == node_geometry_t::OVERLAY && is_3D);
-          window().updateGL();
-        }
-        void Connectome::crop_to_slab_parameter_slot()
-        {
-          slab_thickness = crop_to_slab_button->value();
-          is_3D = !(crop_to_slab && !slab_thickness);
-          node_geometry_overlay_3D_warning_icon->setVisible (node_geometry == node_geometry_t::OVERLAY && is_3D);
-          window().updateGL();
-        }
-        void Connectome::show_node_list_slot()
-        {
-          node_list->show();
-        }
-        void Connectome::node_selection_settings_changed_slot()
-        {
-          window().updateGL();
-        }
-
 
 
 
@@ -1248,8 +1174,6 @@ namespace MR
               node_colour_fixedcolour_button->setVisible (true);
               node_colour_combobox->removeItem (6);
               node_colour_matrix_operator_combobox->setVisible (false);
-              lut_label->setVisible (false);
-              lut_combobox->setVisible (false);
               node_colour_range_label->setVisible (false);
               node_colour_lower_button->setVisible (false);
               node_colour_upper_button->setVisible (false);
@@ -1261,8 +1185,6 @@ namespace MR
               node_colour_fixedcolour_button->setVisible (false);
               node_colour_combobox->removeItem (6);
               node_colour_matrix_operator_combobox->setVisible (false);
-              lut_label->setVisible (false);
-              lut_combobox->setVisible (false);
               node_colour_range_label->setVisible (false);
               node_colour_lower_button->setVisible (false);
               node_colour_upper_button->setVisible (false);
@@ -1274,8 +1196,6 @@ namespace MR
               node_colour_colourmap_button->setVisible (false);
               node_colour_combobox->removeItem (6);
               node_colour_matrix_operator_combobox->setVisible (false);
-              lut_label->setVisible (true);
-              lut_combobox->setVisible (true);
               node_colour_range_label->setVisible (false);
               node_colour_lower_button->setVisible (false);
               node_colour_upper_button->setVisible (false);
@@ -1302,8 +1222,6 @@ namespace MR
                 node_colour_matrix_operator_combobox->setCurrentIndex (4);
                 node_colour_matrix_operator_combobox->setEnabled (false);
               }
-              lut_label->setVisible (false);
-              lut_combobox->setVisible (false);
               node_colour_range_label->setVisible (true);
               node_colour_lower_button->setVisible (true);
               node_colour_upper_button->setVisible (true);
@@ -1337,8 +1255,6 @@ namespace MR
                 node_colour_combobox->setItemText (6, node_values_from_file_colour.get_name());
               node_colour_combobox->setCurrentIndex (6);
               node_colour_matrix_operator_combobox->setVisible (false);
-              lut_label->setVisible (false);
-              lut_combobox->setVisible (false);
               node_colour_range_label->setVisible (true);
               node_colour_lower_button->setVisible (true);
               node_colour_upper_button->setVisible (true);
@@ -1379,8 +1295,6 @@ namespace MR
                 node_colour_matrix_operator_combobox->setCurrentIndex (4);
                 node_colour_matrix_operator_combobox->setEnabled (false);
               }
-              lut_label->setVisible (false);
-              lut_combobox->setVisible (false);
               node_colour_range_label->setVisible (true);
               node_colour_lower_button->setVisible (true);
               node_colour_upper_button->setVisible (true);
@@ -1693,45 +1607,6 @@ namespace MR
           QColor c = node_colour_fixedcolour_button->color();
           node_fixed_colour.set (c.red() / 255.0f, c.green() / 255.0f, c.blue() / 255.0f);
           node_visibility_warning_icon->setVisible (node_visibility == node_visibility_t::NONE);
-          calculate_node_colours();
-          window().updateGL();
-        }
-        void Connectome::lut_open_slot (int index)
-        {
-          if (index == 5)
-            return; // Selected currently-open LUT; nothing to do
-          if (!index) {
-            lut.clear();
-            lut_mapping.clear();
-            lut_combobox->removeItem (5);
-          } else {
-            const std::string path = Dialog::File::get_file (this, std::string("Select lookup table file (in ") + MR::Connectome::lut_format_strings[index] + " format)", "Text files (*.txt)");
-            if (path.empty()) {
-              if (lut_combobox->count() == 6) {
-                lut_combobox->setCurrentIndex (5);
-              } else {
-                lut.clear();
-                lut_mapping.clear();
-                lut_combobox->setCurrentIndex (0);
-              }
-            } else {
-              lut.clear();
-              lut_mapping.clear();
-              lut_combobox->removeItem (5);
-              try {
-                switch (index) {
-                  case 1: lut.load (path, MR::Connectome::LUT_BASIC);      break;
-                  case 2: lut.load (path, MR::Connectome::LUT_FREESURFER); break;
-                  case 3: lut.load (path, MR::Connectome::LUT_AAL);        break;
-                  case 4: lut.load (path, MR::Connectome::LUT_ITKSNAP);    break;
-                  default: assert (0);
-                }
-                lut_combobox->insertItem (5, QString::fromStdString (Path::basename (path)));
-                lut_combobox->setCurrentIndex (5);
-              } catch (Exception& e) { e.display(); lut.clear(); lut_mapping.clear(); lut_combobox->setCurrentIndex (0); return; }
-            }
-          }
-          load_properties();
           calculate_node_colours();
           window().updateGL();
         }
@@ -2193,6 +2068,110 @@ namespace MR
         void Connectome::edge_alpha_parameter_slot()
         {
           calculate_edge_alphas();
+          window().updateGL();
+        }
+
+
+
+
+
+
+
+
+        void Connectome::config_open_slot()
+        {
+          const std::string path = Dialog::File::get_file (this, "Select connectome configuration file", "Text files (*.txt)");
+          if (path.empty())
+            return;
+          config.clear();
+          lut_mapping.clear();
+          config_button->setText ("(none)");
+          try {
+            MR::Connectome::load_config (path, config);
+            config_button->setText (QString::fromStdString (Path::basename (path)));
+          } catch (Exception& e) {
+            e.display();
+            config.clear();
+          }
+          load_properties();
+          window().updateGL();
+        }
+        void Connectome::lut_open_slot (int index)
+        {
+          if (index == 5)
+            return; // Selected currently-open LUT; nothing to do
+          if (!index) {
+            lut.clear();
+            lut_mapping.clear();
+            lut_combobox->removeItem (5);
+          } else {
+            const std::string path = Dialog::File::get_file (this, std::string("Select lookup table file (in ") + MR::Connectome::lut_format_strings[index] + " format)", "Text files (*.txt)");
+            if (path.empty()) {
+              if (lut_combobox->count() == 6) {
+                lut_combobox->setCurrentIndex (5);
+              } else {
+                lut.clear();
+                lut_mapping.clear();
+                lut_combobox->setCurrentIndex (0);
+              }
+            } else {
+              lut.clear();
+              lut_mapping.clear();
+              lut_combobox->removeItem (5);
+              try {
+                switch (index) {
+                  case 1: lut.load (path, MR::Connectome::LUT_BASIC);      break;
+                  case 2: lut.load (path, MR::Connectome::LUT_FREESURFER); break;
+                  case 3: lut.load (path, MR::Connectome::LUT_AAL);        break;
+                  case 4: lut.load (path, MR::Connectome::LUT_ITKSNAP);    break;
+                  default: assert (0);
+                }
+                lut_combobox->insertItem (5, QString::fromStdString (Path::basename (path)));
+                lut_combobox->setCurrentIndex (5);
+              } catch (Exception& e) { e.display(); lut.clear(); lut_mapping.clear(); lut_combobox->setCurrentIndex (0); return; }
+            }
+          }
+          load_properties();
+          calculate_node_colours();
+          window().updateGL();
+        }
+        void Connectome::lighting_change_slot (int /*value*/)
+        {
+          window().updateGL();
+        }
+        void Connectome::lighting_settings_slot()
+        {
+          if (!lighting_dock)
+            lighting_dock.reset (new LightingDock ("Connectome lighting", lighting, false));
+          lighting_dock->show();
+        }
+        void Connectome::lighting_parameter_slot()
+        {
+          if (use_lighting())
+            window().updateGL();
+        }
+        void Connectome::crop_to_slab_toggle_slot (int /*value*/)
+        {
+          crop_to_slab = crop_to_slab_checkbox->isChecked();
+          is_3D = !(crop_to_slab && !slab_thickness);
+          crop_to_slab_label->setEnabled (crop_to_slab);
+          crop_to_slab_button->setEnabled (crop_to_slab);
+          node_geometry_overlay_3D_warning_icon->setVisible (node_geometry == node_geometry_t::OVERLAY && is_3D);
+          window().updateGL();
+        }
+        void Connectome::crop_to_slab_parameter_slot()
+        {
+          slab_thickness = crop_to_slab_button->value();
+          is_3D = !(crop_to_slab && !slab_thickness);
+          node_geometry_overlay_3D_warning_icon->setVisible (node_geometry == node_geometry_t::OVERLAY && is_3D);
+          window().updateGL();
+        }
+        void Connectome::show_node_list_slot()
+        {
+          node_list->show();
+        }
+        void Connectome::node_selection_settings_changed_slot()
+        {
           window().updateGL();
         }
 

--- a/src/gui/mrview/tool/connectome/connectome.cpp
+++ b/src/gui/mrview/tool/connectome/connectome.cpp
@@ -811,12 +811,12 @@ namespace MR
         void Connectome::draw_colourbars()
         {
           if (hide_all_button->isChecked()) return;
-          if ((node_colour == node_colour_t::VECTOR_FILE || node_colour == node_colour_t::MATRIX_FILE) && show_node_colour_bar)
+          if ((node_colour == node_colour_t::CONNECTOME || node_colour == node_colour_t::VECTOR_FILE || node_colour == node_colour_t::MATRIX_FILE) && show_node_colour_bar)
             window().colourbar_renderer.render (node_colourmap_index, node_colourmap_invert,
                                               node_colour_lower_button->value(), node_colour_upper_button->value(),
                                               node_colour_lower_button->value(), node_colour_upper_button->value() - node_colour_lower_button->value(),
                                               node_fixed_colour);
-          if (edge_colour == edge_colour_t::MATRIX_FILE && show_edge_colour_bar)
+          if ((edge_colour == edge_colour_t::CONNECTOME || edge_colour == edge_colour_t::MATRIX_FILE) && show_edge_colour_bar)
             window().colourbar_renderer.render (edge_colourmap_index, edge_colourmap_invert,
                                               edge_colour_lower_button->value(), edge_colour_upper_button->value(),
                                               edge_colour_lower_button->value(), edge_colour_upper_button->value() - edge_colour_lower_button->value(),
@@ -826,8 +826,8 @@ namespace MR
 
         size_t Connectome::visible_number_colourbars()
         {
-          return ((((node_colour == node_colour_t::VECTOR_FILE || node_colour == node_colour_t::MATRIX_FILE) && show_node_colour_bar) ? 1 : 0)
-                  + ((edge_colour == edge_colour_t::MATRIX_FILE && show_edge_colour_bar) ? 1 : 0));
+          return ((((node_colour == node_colour_t::CONNECTOME || node_colour == node_colour_t::VECTOR_FILE || node_colour == node_colour_t::MATRIX_FILE) && show_node_colour_bar) ? 1 : 0)
+                  + (((edge_colour == edge_colour_t::CONNECTOME || edge_colour == edge_colour_t::MATRIX_FILE) && show_edge_colour_bar) ? 1 : 0));
         }
 
 
@@ -1127,8 +1127,8 @@ namespace MR
                   case node_visibility_t::NONE:        node_visibility_combobox->setCurrentIndex (1); return;
                   case node_visibility_t::DEGREE:      node_visibility_combobox->setCurrentIndex (2); return;
                   case node_visibility_t::CONNECTOME:  node_visibility_combobox->setCurrentIndex (3); return;
-                  case node_visibility_t::VECTOR_FILE: node_visibility_combobox->setCurrentIndex (5); return;
-                  case node_visibility_t::MATRIX_FILE: node_visibility_combobox->setCurrentIndex (5); return;
+                  case node_visibility_t::VECTOR_FILE: node_visibility_combobox->setCurrentIndex (6); return;
+                  case node_visibility_t::MATRIX_FILE: node_visibility_combobox->setCurrentIndex (6); return;
                 }
               }
               node_visibility = node_visibility_t::VECTOR_FILE;
@@ -2241,22 +2241,22 @@ namespace MR
           matrix_list_model->clear();
           selected_nodes.resize (0);
           selected_node_count = 0;
-          if (node_visibility == node_visibility_t::VECTOR_FILE || node_visibility == node_visibility_t::MATRIX_FILE) {
+          if (node_visibility == node_visibility_t::CONNECTOME || node_visibility == node_visibility_t::VECTOR_FILE || node_visibility == node_visibility_t::MATRIX_FILE) {
             node_visibility_combobox->removeItem (6);
             node_visibility_combobox->setCurrentIndex (0);
             node_visibility = node_visibility_t::ALL;
           }
-          if (node_colour == node_colour_t::VECTOR_FILE || node_colour == node_colour_t::MATRIX_FILE) {
+          if (node_colour == node_colour_t::CONNECTOME || node_colour == node_colour_t::VECTOR_FILE || node_colour == node_colour_t::MATRIX_FILE) {
             node_colour_combobox->removeItem (6);
             node_colour_combobox->setCurrentIndex (0);
             node_colour = node_colour_t::FIXED;
           }
-          if (node_size == node_size_t::VECTOR_FILE || node_size == node_size_t::MATRIX_FILE) {
+          if (node_size == node_size_t::CONNECTOME || node_size == node_size_t::VECTOR_FILE || node_size == node_size_t::MATRIX_FILE) {
             node_size_combobox->removeItem (5);
             node_size_combobox->setCurrentIndex (0);
             node_size = node_size_t::FIXED;
           }
-          if (node_alpha == node_alpha_t::VECTOR_FILE || node_alpha == node_alpha_t::MATRIX_FILE) {
+          if (node_alpha == node_alpha_t::CONNECTOME || node_alpha == node_alpha_t::VECTOR_FILE || node_alpha == node_alpha_t::MATRIX_FILE) {
             node_alpha_combobox->removeItem (5);
             node_alpha_combobox->setCurrentIndex (0);
             node_alpha = node_alpha_t::FIXED;
@@ -2767,7 +2767,7 @@ namespace MR
             if (alpha)
               edge_alpha_ID = gl::GetUniformLocation (edge_shader, "edge_alpha");
 
-            if (edge_colour == edge_colour_t::MATRIX_FILE && ColourMap::maps[edge_colourmap_index].is_colour)
+            if ((edge_colour == edge_colour_t::CONNECTOME || edge_colour == edge_colour_t::MATRIX_FILE) && ColourMap::maps[edge_colourmap_index].is_colour)
               gl::Uniform3fv (gl::GetUniformLocation (edge_shader, "colourmap_colour"), 1, &edge_fixed_colour[0]);
 
             std::map<float, size_t> edge_ordering;
@@ -3649,7 +3649,7 @@ namespace MR
           selected_node_count = list.size();
           for (std::vector<node_t>::const_iterator n = list.begin(); n != list.end(); ++n)
             selected_nodes[*n] = true;
-          if (node_visibility == node_visibility_t::MATRIX_FILE) {
+          if (node_visibility == node_visibility_t::CONNECTOME || node_visibility == node_visibility_t::MATRIX_FILE) {
             if (selected_node_count >= 2) {
               node_visibility_matrix_operator_combobox->removeItem (2);
               switch (node_visibility_matrix_operator) {
@@ -3665,7 +3665,7 @@ namespace MR
             }
             calculate_node_visibility();
           }
-          if (node_colour == node_colour_t::MATRIX_FILE) {
+          if (node_colour == node_colour_t::CONNECTOME || node_colour == node_colour_t::MATRIX_FILE) {
             if (selected_node_count >= 2) {
               node_colour_matrix_operator_combobox->removeItem (4);
               switch (node_colour_matrix_operator) {
@@ -3683,7 +3683,7 @@ namespace MR
             }
             calculate_node_colours();
           }
-          if (node_size == node_size_t::MATRIX_FILE) {
+          if (node_size == node_size_t::CONNECTOME || node_size == node_size_t::MATRIX_FILE) {
             if (selected_node_count >= 2) {
               node_size_matrix_operator_combobox->removeItem (4);
               switch (node_size_matrix_operator) {
@@ -3701,7 +3701,7 @@ namespace MR
             }
             calculate_node_sizes();
           }
-          if (node_alpha == node_alpha_t::MATRIX_FILE) {
+          if (node_alpha == node_alpha_t::CONNECTOME || node_alpha == node_alpha_t::MATRIX_FILE) {
             if (selected_node_count >= 2) {
               node_alpha_matrix_operator_combobox->removeItem (4);
               switch (node_alpha_matrix_operator) {

--- a/src/gui/mrview/tool/connectome/connectome.cpp
+++ b/src/gui/mrview/tool/connectome/connectome.cpp
@@ -193,7 +193,8 @@ namespace MR
           connect (node_visibility_matrix_operator_combobox, SIGNAL (activated(int)), this, SLOT (node_visibility_matrix_operator_slot (int)));
           hlayout->addWidget (node_visibility_matrix_operator_combobox);
           node_visibility_warning_icon = new QLabel();
-          node_visibility_warning_icon->setPixmap (warning_icon.pixmap (node_visibility_combobox->height()));
+          node_visibility_warning_icon->setPixmap (warning_icon.pixmap (node_visibility_combobox->height(), Qt::KeepAspectRatio));
+          node_visibility_warning_icon->setScaledContents (true);
           node_visibility_warning_icon->setToolTip ("Changes to node visualisation will have no apparent effect if node visibility is set to \'none\'");
           node_visibility_warning_icon->setVisible (false);
           hlayout->addWidget (node_visibility_warning_icon);
@@ -249,7 +250,8 @@ namespace MR
           connect (node_geometry_overlay_interp_checkbox, SIGNAL (stateChanged(int)), this, SLOT(overlay_interp_slot(int)));
           hlayout->addWidget (node_geometry_overlay_interp_checkbox, 1);
           node_geometry_overlay_3D_warning_icon = new QLabel();
-          node_geometry_overlay_3D_warning_icon->setPixmap (warning_icon.pixmap (node_geometry_combobox->height()));
+          node_geometry_overlay_3D_warning_icon->setPixmap (warning_icon.pixmap (node_geometry_combobox->height(), Qt::KeepAspectRatio));
+          node_geometry_overlay_3D_warning_icon->setScaledContents (true);
           node_geometry_overlay_3D_warning_icon->setToolTip ("The node overlay image can only be displayed in pure 2D mode (slab thickness of zero)");
           node_geometry_overlay_3D_warning_icon->setVisible (false);
           hlayout->addWidget (node_geometry_overlay_3D_warning_icon, 1);
@@ -458,7 +460,8 @@ namespace MR
           connect (edge_visibility_combobox, SIGNAL (activated(int)), this, SLOT (edge_visibility_selection_slot (int)));
           gridlayout->addWidget (edge_visibility_combobox, 0, 2);
           edge_visibility_warning_icon = new QLabel();
-          edge_visibility_warning_icon->setPixmap (warning_icon.pixmap (edge_visibility_combobox->height()));
+          edge_visibility_warning_icon->setPixmap (warning_icon.pixmap (edge_visibility_combobox->height(), Qt::KeepAspectRatio));
+          edge_visibility_warning_icon->setScaledContents (true);
           edge_visibility_warning_icon->setToolTip ("Changes to edge visualisation will have no apparent effect if edge visibility is set to \'none\'");
           edge_visibility_warning_icon->setVisible (false);
           gridlayout->addWidget (edge_visibility_warning_icon, 0, 3);
@@ -723,6 +726,15 @@ namespace MR
           node_list->setFeatures (QDockWidget::DockWidgetClosable | QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetFloatable);
           window().addDockWidget (Qt::RightDockWidgetArea, node_list);
           connect (&node_selection_settings, SIGNAL(dataChanged()), this, SLOT (node_selection_settings_changed_slot()));
+
+          const int height = node_visibility_combobox->sizeHint().height();
+          node_visibility_warning_icon         ->setFixedSize   (height, height);
+          node_geometry_overlay_3D_warning_icon->setFixedSize   (height, height);
+          node_colour_fixedcolour_button       ->setFixedHeight (height);
+          node_colour_colourmap_button         ->setFixedHeight (height);
+          edge_visibility_warning_icon         ->setFixedSize   (height, height);
+          edge_colour_fixedcolour_button       ->setFixedHeight (height);
+          edge_colour_colourmap_button         ->setFixedHeight (height);
 
           Window::GrabContext context;
 

--- a/src/gui/mrview/tool/connectome/connectome.cpp
+++ b/src/gui/mrview/tool/connectome/connectome.cpp
@@ -1111,13 +1111,13 @@ namespace MR
               node_visibility_threshold_button->setVisible (true);
               node_visibility_threshold_invert_checkbox->setVisible (true);
               {
-                float min = 0.0f, max = 0.0f;
+                float min = 0.0f, mean = 0.0f, max = 0.0f;
                 QModelIndexList list = matrix_list_view->selectionModel()->selectedRows();
                 if (list.size()) {
                   const FileDataVector& data (matrix_list_model->get (list[0]));
-                  min = data.get_min(); max = data.get_max();
+                  min = data.get_min(); mean = data.get_mean(); max = data.get_max();
                 }
-                update_controls_node_visibility (min, max);
+                update_controls_node_visibility (min, mean, max);
               }
               break;
             case 4:
@@ -1141,7 +1141,7 @@ namespace MR
               node_visibility_threshold_label->setVisible (true);
               node_visibility_threshold_button->setVisible (true);
               node_visibility_threshold_invert_checkbox->setVisible (true);
-              update_controls_node_visibility (node_values_from_file_visibility.get_min(), node_values_from_file_visibility.get_max());
+              update_controls_node_visibility (node_values_from_file_visibility.get_min(), node_values_from_file_visibility.get_mean(), node_values_from_file_visibility.get_max());
               break;
             case 5:
               if (!import_matrix_file (node_values_from_file_visibility, "node visibility")) {
@@ -1177,7 +1177,7 @@ namespace MR
               node_visibility_threshold_label->setVisible (true);
               node_visibility_threshold_button->setVisible (true);
               node_visibility_threshold_invert_checkbox->setVisible (true);
-              update_controls_node_visibility (node_values_from_file_visibility.get_min(), node_values_from_file_visibility.get_max());
+              update_controls_node_visibility (node_values_from_file_visibility.get_min(), node_values_from_file_visibility.get_mean(), node_values_from_file_visibility.get_max());
               break;
             case 6:
               return;
@@ -1354,13 +1354,13 @@ namespace MR
               node_colour_lower_button->setVisible (true);
               node_colour_upper_button->setVisible (true);
               {
-                float min = 0.0f, max = 0.0f;
+                float min = 0.0f, mean = 0.0f, max = 0.0f;
                 QModelIndexList list = matrix_list_view->selectionModel()->selectedRows();
                 if (list.size()) {
                   const FileDataVector& data (matrix_list_model->get (list[0]));
-                  min = data.get_min(); max = data.get_max();
+                  min = data.get_min(); mean = data.get_mean(); max = data.get_max();
                 }
-                update_controls_node_colour (min, max);
+                update_controls_node_colour (min, mean, max);
               }
               break;
             case 4:
@@ -1386,7 +1386,7 @@ namespace MR
               node_colour_range_label->setVisible (true);
               node_colour_lower_button->setVisible (true);
               node_colour_upper_button->setVisible (true);
-              update_controls_node_colour (node_values_from_file_colour.get_min(), node_values_from_file_colour.get_max());
+              update_controls_node_colour (node_values_from_file_colour.get_min(), node_values_from_file_colour.get_mean(), node_values_from_file_colour.get_max());
               break;
             case 5:
               if (!import_matrix_file (node_values_from_file_colour, "node colours")) {
@@ -1426,7 +1426,7 @@ namespace MR
               node_colour_range_label->setVisible (true);
               node_colour_lower_button->setVisible (true);
               node_colour_upper_button->setVisible (true);
-              update_controls_node_colour (node_values_from_file_colour.get_min(), node_values_from_file_colour.get_max());
+              update_controls_node_colour (node_values_from_file_colour.get_min(), node_values_from_file_colour.get_mean(), node_values_from_file_colour.get_max());
               break;
             case 6:
               return;
@@ -1487,13 +1487,13 @@ namespace MR
               node_size_upper_button->setVisible (true);
               node_size_invert_checkbox->setVisible (true);
               {
-                float min = 0.0f, max = 0.0f;
+                float min = 0.0f, mean = 0.0f, max = 0.0f;
                 QModelIndexList list = matrix_list_view->selectionModel()->selectedRows();
                 if (list.size()) {
                   const FileDataVector& data (matrix_list_model->get (list[0]));
-                  min = data.get_min(); max = data.get_max();
+                  min = data.get_min(); mean = data.get_mean(); max = data.get_max();
                 }
-                update_controls_node_size (min, max);
+                update_controls_node_size (min, mean, max);
               }
               node_size_invert_checkbox->setChecked (false);
               break;
@@ -1518,7 +1518,7 @@ namespace MR
               node_size_lower_button->setVisible (true);
               node_size_upper_button->setVisible (true);
               node_size_invert_checkbox->setVisible (true);
-              update_controls_node_size (node_values_from_file_size.get_min(), node_values_from_file_size.get_max());
+              update_controls_node_size (node_values_from_file_size.get_min(), node_values_from_file_size.get_mean(), node_values_from_file_size.get_max());
               node_size_invert_checkbox->setChecked (false);
               break;
             case 4:
@@ -1557,7 +1557,7 @@ namespace MR
               node_size_lower_button->setVisible (true);
               node_size_upper_button->setVisible (true);
               node_size_invert_checkbox->setVisible (true);
-              update_controls_node_size (node_values_from_file_size.get_min(), node_values_from_file_size.get_max());
+              update_controls_node_size (node_values_from_file_size.get_min(), node_values_from_file_size.get_mean(), node_values_from_file_size.get_max());
               node_size_invert_checkbox->setChecked (false);
               break;
             case 5:
@@ -1630,13 +1630,13 @@ namespace MR
               node_alpha_upper_button->setVisible (true);
               node_alpha_invert_checkbox->setVisible (true);
               {
-                float min = 0.0f, max = 0.0f;
+                float min = 0.0f, mean = 0.0f, max = 0.0f;
                 QModelIndexList list = matrix_list_view->selectionModel()->selectedRows();
                 if (list.size()) {
                   const FileDataVector& data (matrix_list_model->get (list[0]));
-                  min = data.get_min(); max = data.get_max();
+                  min = data.get_min(); mean = data.get_mean(); max = data.get_max();
                 }
-                update_controls_node_alpha (min, max);
+                update_controls_node_alpha (min, mean, max);
               }
               node_alpha_invert_checkbox->setChecked (false);
               break;
@@ -1661,7 +1661,7 @@ namespace MR
               node_alpha_lower_button->setVisible (true);
               node_alpha_upper_button->setVisible (true);
               node_alpha_invert_checkbox->setVisible (true);
-              update_controls_node_alpha (node_values_from_file_alpha.get_min(), node_values_from_file_alpha.get_max());
+              update_controls_node_alpha (node_values_from_file_alpha.get_min(), node_values_from_file_alpha.get_mean(), node_values_from_file_alpha.get_max());
               node_alpha_invert_checkbox->setChecked (false);
               break;
             case 4:
@@ -1700,7 +1700,7 @@ namespace MR
               node_alpha_lower_button->setVisible (true);
               node_alpha_upper_button->setVisible (true);
               node_alpha_invert_checkbox->setVisible (true);
-              update_controls_node_alpha (node_values_from_file_alpha.get_min(), node_values_from_file_alpha.get_max());
+              update_controls_node_alpha (node_values_from_file_alpha.get_min(), node_values_from_file_alpha.get_mean(), node_values_from_file_alpha.get_max());
               node_alpha_invert_checkbox->setChecked (false);
               break;
             case 5:
@@ -1872,13 +1872,13 @@ namespace MR
               edge_visibility_threshold_button->setVisible (true);
               edge_visibility_threshold_invert_checkbox->setVisible (true);
               {
-                float min = 0.0f, max = 0.0f;
+                float min = 0.0f, mean = 0.0f, max = 0.0f;
                 QModelIndexList list = matrix_list_view->selectionModel()->selectedRows();
                 if (list.size()) {
                   const FileDataVector& data (matrix_list_model->get (list[0]));
-                  min = data.get_min(); max = data.get_max();
+                  min = data.get_min(); mean = data.get_mean(); max = data.get_max();
                 }
-                update_controls_edge_visibility (min, max);
+                update_controls_edge_visibility (min, mean, max);
               }
               break;
             case 4:
@@ -1900,7 +1900,7 @@ namespace MR
               edge_visibility_threshold_label->setVisible (true);
               edge_visibility_threshold_button->setVisible (true);
               edge_visibility_threshold_invert_checkbox->setVisible (true);
-              update_controls_edge_visibility (edge_values_from_file_visibility.get_min(), edge_values_from_file_visibility.get_max());
+              update_controls_edge_visibility (edge_values_from_file_visibility.get_min(), edge_values_from_file_visibility.get_mean(), edge_values_from_file_visibility.get_max());
               break;
             case 5:
               return;
@@ -2013,13 +2013,13 @@ namespace MR
               edge_colour_lower_button->setVisible (true);
               edge_colour_upper_button->setVisible (true);
               {
-                float min = 0.0f, max = 0.0f;
+                float min = 0.0f, mean = 0.0f, max = 0.0f;
                 QModelIndexList list = matrix_list_view->selectionModel()->selectedRows();
                 if (list.size()) {
                   const FileDataVector& data (matrix_list_model->get (list[0]));
-                  min = data.get_min(); max = data.get_max();
+                  min = data.get_min(); mean = data.get_mean(); max = data.get_max();
                 }
-                update_controls_edge_colour (min, max);
+                update_controls_edge_colour (min, mean, max);
               }
               break;
             case 3:
@@ -2042,7 +2042,7 @@ namespace MR
               edge_colour_range_label->setVisible (true);
               edge_colour_lower_button->setVisible (true);
               edge_colour_upper_button->setVisible (true);
-              update_controls_edge_colour (edge_values_from_file_colour.get_min(), edge_values_from_file_colour.get_max());
+              update_controls_edge_colour (edge_values_from_file_colour.get_min(), edge_values_from_file_colour.get_mean(), edge_values_from_file_colour.get_max());
               break;
             case 4:
               return;
@@ -2075,13 +2075,13 @@ namespace MR
               edge_size_upper_button->setVisible (true);
               edge_size_invert_checkbox->setVisible (true);
               {
-                float min = 0.0f, max = 0.0f;
+                float min = 0.0f, mean = 0.0f, max = 0.0f;
                 QModelIndexList list = matrix_list_view->selectionModel()->selectedRows();
                 if (list.size()) {
                   const FileDataVector& data (matrix_list_model->get (list[0]));
-                  min = data.get_min(); max = data.get_max();
+                  min = data.get_min(); mean = data.get_mean(); max = data.get_max();
                 }
-                update_controls_edge_size (min, max);
+                update_controls_edge_size (min, mean, max);
               }
               break;
             case 2:
@@ -2102,7 +2102,7 @@ namespace MR
               edge_size_lower_button->setVisible (true);
               edge_size_upper_button->setVisible (true);
               edge_size_invert_checkbox->setVisible (true);
-              update_controls_edge_size (edge_values_from_file_size.get_min(), edge_values_from_file_size.get_max());
+              update_controls_edge_size (edge_values_from_file_size.get_min(), edge_values_from_file_size.get_mean(), edge_values_from_file_size.get_max());
               break;
             case 3:
               return;
@@ -2135,13 +2135,13 @@ namespace MR
               edge_alpha_upper_button->setVisible (true);
               edge_alpha_invert_checkbox->setVisible (true);
               {
-                float min = 0.0f, max = 0.0f;
+                float min = 0.0f, mean = 0.0f, max = 0.0f;
                 QModelIndexList list = matrix_list_view->selectionModel()->selectedRows();
                 if (list.size()) {
                   const FileDataVector& data (matrix_list_model->get (list[0]));
-                  min = data.get_min(); max = data.get_max();
+                  min = data.get_min(); mean = data.get_mean(); max = data.get_max();
                 }
-                update_controls_edge_alpha (min, max);
+                update_controls_edge_alpha (min, mean, max);
               }
               break;
             case 2:
@@ -2162,7 +2162,7 @@ namespace MR
               edge_alpha_lower_button->setVisible (true);
               edge_alpha_upper_button->setVisible (true);
               edge_alpha_invert_checkbox->setVisible (true);
-              update_controls_edge_alpha (edge_values_from_file_alpha.get_min(), edge_values_from_file_alpha.get_max());
+              update_controls_edge_alpha (edge_values_from_file_alpha.get_min(), edge_values_from_file_alpha.get_mean(), edge_values_from_file_alpha.get_max());
               edge_alpha_invert_checkbox->setChecked (false);
               break;
             case 3:
@@ -2485,7 +2485,7 @@ namespace MR
               MR::Connectome::verify_matrix (matrix, num_nodes());
               FileDataVector temp;
               mat2vec (matrix, temp);
-              temp.calc_minmax();
+              temp.calc_stats();
               temp.set_name (list[i]);
               data.push_back (std::move (temp));
             }
@@ -2504,21 +2504,21 @@ namespace MR
             if (!previous_size) {
               const FileDataVector& data (matrix_list_model->get (previous_size));
               if (node_visibility == node_visibility_t::CONNECTOME)
-                update_controls_node_visibility (data.get_min(), data.get_max());
+                update_controls_node_visibility (data.get_min(), data.get_mean(), data.get_max());
               if (node_colour == node_colour_t::CONNECTOME)
-                update_controls_node_colour (data.get_min(), data.get_max());
+                update_controls_node_colour (data.get_min(), data.get_mean(), data.get_max());
               if (node_size == node_size_t::CONNECTOME)
-                update_controls_node_size (data.get_min(), data.get_max());
+                update_controls_node_size (data.get_min(), data.get_mean(), data.get_max());
               if (node_alpha == node_alpha_t::CONNECTOME)
-                update_controls_node_alpha (data.get_min(), data.get_max());
+                update_controls_node_alpha (data.get_min(), data.get_mean(), data.get_max());
               if (edge_visibility == edge_visibility_t::CONNECTOME)
-                update_controls_edge_visibility (data.get_min(), data.get_max());
+                update_controls_edge_visibility (data.get_min(), data.get_mean(), data.get_max());
               if (edge_colour == edge_colour_t::CONNECTOME)
-                update_controls_edge_colour (data.get_min(), data.get_max());
+                update_controls_edge_colour (data.get_min(), data.get_mean(), data.get_max());
               if (edge_size == edge_size_t::CONNECTOME)
-                update_controls_edge_size (data.get_min(), data.get_max());
+                update_controls_edge_size (data.get_min(), data.get_mean(), data.get_max());
               if (edge_alpha == edge_alpha_t::CONNECTOME)
-                update_controls_edge_alpha (data.get_min(), data.get_max());
+                update_controls_edge_alpha (data.get_min(), data.get_mean(), data.get_max());
             }
 
             // Force re-calculation of any visual properties that are based on connectome data
@@ -2877,7 +2877,7 @@ namespace MR
           }
           data.clear();
           mat2vec (temp, data);
-          data.calc_minmax();
+          data.calc_stats();
           data.set_name (Path::basename (path));
           return true;
         }
@@ -3858,73 +3858,73 @@ namespace MR
 
 
 
-        void Connectome::update_controls_node_visibility (const float min, const float max)
+        void Connectome::update_controls_node_visibility (const float min, const float mean, const float max)
         {
           node_visibility_threshold_button->setRate (0.001 * (max - min));
           node_visibility_threshold_button->setMin (min);
           node_visibility_threshold_button->setMax (max);
-          node_visibility_threshold_button->setValue (0.5 * (min + max));
+          node_visibility_threshold_button->setValue (mean);
         }
-        void Connectome::update_controls_node_colour     (const float min, const float max)
+        void Connectome::update_controls_node_colour     (const float min, const float mean, const float max)
         {
           node_colour_lower_button->setValue (min);
           node_colour_upper_button->setValue (max);
           node_colour_lower_button->setMax (max);
           node_colour_upper_button->setMin (min);
-          node_colour_lower_button->setRate (0.01 * (max - min));
-          node_colour_upper_button->setRate (0.01 * (max - min));
+          node_colour_lower_button->setRate (0.01f * (mean - min));
+          node_colour_upper_button->setRate (0.01f * (max - mean));
         }
-        void Connectome::update_controls_node_size       (const float min, const float max)
+        void Connectome::update_controls_node_size       (const float min, const float mean, const float max)
         {
           node_size_lower_button->setValue (min);
           node_size_upper_button->setValue (max);
           node_size_lower_button->setMax (max);
           node_size_upper_button->setMin (min);
-          node_size_lower_button->setRate (0.01 * (max - min));
-          node_size_upper_button->setRate (0.01 * (max - min));
+          node_size_lower_button->setRate (0.01f * (mean - min));
+          node_size_upper_button->setRate (0.01f * (max - mean));
         }
-        void Connectome::update_controls_node_alpha      (const float min, const float max)
+        void Connectome::update_controls_node_alpha      (const float min, const float mean, const float max)
         {
           node_alpha_lower_button->setValue (min);
           node_alpha_upper_button->setValue (max);
           node_alpha_lower_button->setMax (max);
           node_alpha_upper_button->setMin (min);
-          node_alpha_lower_button->setRate (0.01 * (max - min));
-          node_alpha_upper_button->setRate (0.01 * (max - min));
+          node_alpha_lower_button->setRate (0.01f * (mean - min));
+          node_alpha_upper_button->setRate (0.01f * (max - mean));
         }
-        void Connectome::update_controls_edge_visibility (const float min, const float max)
+        void Connectome::update_controls_edge_visibility (const float min, const float mean, const float max)
         {
           edge_visibility_threshold_button->setRate (0.001 * (max - min));
           edge_visibility_threshold_button->setMin (min);
           edge_visibility_threshold_button->setMax (max);
-          edge_visibility_threshold_button->setValue (0.5 * (min + max));
+          edge_visibility_threshold_button->setValue (mean);
         }
-        void Connectome::update_controls_edge_colour     (const float min, const float max)
+        void Connectome::update_controls_edge_colour     (const float min, const float mean, const float max)
         {
           edge_colour_lower_button->setValue (min);
           edge_colour_upper_button->setValue (max);
           edge_colour_lower_button->setMax (max);
           edge_colour_upper_button->setMin (min);
-          edge_colour_lower_button->setRate (0.01 * (max - min));
-          edge_colour_upper_button->setRate (0.01 * (max - min));
+          edge_colour_lower_button->setRate (0.01f * (mean - min));
+          edge_colour_upper_button->setRate (0.01f * (max - mean));
         }
-        void Connectome::update_controls_edge_size       (const float min, const float max)
+        void Connectome::update_controls_edge_size       (const float min, const float mean, const float max)
         {
           edge_size_lower_button->setValue (min);
           edge_size_upper_button->setValue (max);
           edge_size_lower_button->setMax (max);
           edge_size_upper_button->setMin (min);
-          edge_size_lower_button->setRate (0.01 * (max - min));
-          edge_size_upper_button->setRate (0.01 * (max - min));
+          edge_size_lower_button->setRate (0.01f * (mean - min));
+          edge_size_upper_button->setRate (0.01f * (max - mean));
         }
-        void Connectome::update_controls_edge_alpha      (const float min, const float max)
+        void Connectome::update_controls_edge_alpha      (const float min, const float mean, const float max)
         {
           edge_alpha_lower_button->setValue (min);
           edge_alpha_upper_button->setValue (max);
           edge_alpha_lower_button->setMax (max);
           edge_alpha_upper_button->setMin (min);
-          edge_alpha_lower_button->setRate (0.01 * (max - min));
-          edge_alpha_upper_button->setRate (0.01 * (max - min));
+          edge_alpha_lower_button->setRate (0.01f * (mean - min));
+          edge_alpha_upper_button->setRate (0.01f * (max - mean));
         }
 
 

--- a/src/gui/mrview/tool/connectome/connectome.h
+++ b/src/gui/mrview/tool/connectome/connectome.h
@@ -400,14 +400,14 @@ namespace MR
             float        edge_alpha_given_selection      (const Edge&);
 
             // Helper functions to update the min / max / value / rate of parameter controls
-            void update_controls_node_visibility (const float, const float);
-            void update_controls_node_colour     (const float, const float);
-            void update_controls_node_size       (const float, const float);
-            void update_controls_node_alpha      (const float, const float);
-            void update_controls_edge_visibility (const float, const float);
-            void update_controls_edge_colour     (const float, const float);
-            void update_controls_edge_size       (const float, const float);
-            void update_controls_edge_alpha      (const float, const float);
+            void update_controls_node_visibility (const float, const float, const float);
+            void update_controls_node_colour     (const float, const float, const float);
+            void update_controls_node_size       (const float, const float, const float);
+            void update_controls_node_alpha      (const float, const float, const float);
+            void update_controls_edge_visibility (const float, const float, const float);
+            void update_controls_edge_colour     (const float, const float, const float);
+            void update_controls_edge_size       (const float, const float, const float);
+            void update_controls_edge_alpha      (const float, const float, const float);
 
             void get_meshes();
             void get_exemplars();

--- a/src/gui/mrview/tool/connectome/connectome.h
+++ b/src/gui/mrview/tool/connectome/connectome.h
@@ -100,17 +100,9 @@ namespace MR
             virtual bool process_commandline_option (const MR::App::ParsedOption& opt) override;
 
           private slots:
-            void image_open_slot();
-            void config_open_slot();
-            void hide_all_slot();
 
-            void lighting_change_slot (int);
-            void lighting_settings_slot();
-            void lighting_parameter_slot();
-            void crop_to_slab_toggle_slot (int);
-            void crop_to_slab_parameter_slot();
-            void show_node_list_slot();
-            void node_selection_settings_changed_slot();
+            void image_open_slot();
+            void hide_all_slot();
 
             void matrix_open_slot();
             void matrix_close_slot();
@@ -128,7 +120,6 @@ namespace MR
             void overlay_interp_slot (int);
             void node_colour_matrix_operator_slot (int);
             void node_fixed_colour_change_slot();
-            void lut_open_slot (int);
             void node_colour_parameter_slot();
             void node_size_matrix_operator_slot (int);
             void node_size_value_slot();
@@ -152,18 +143,19 @@ namespace MR
             void edge_alpha_value_slot (int);
             void edge_alpha_parameter_slot();
 
+            void config_open_slot();
+            void lut_open_slot (int);
+            void lighting_change_slot (int);
+            void lighting_settings_slot();
+            void lighting_parameter_slot();
+            void crop_to_slab_toggle_slot (int);
+            void crop_to_slab_parameter_slot();
+            void show_node_list_slot();
+            void node_selection_settings_changed_slot();
+
           protected:
 
             QPushButton *image_button, *hide_all_button;
-            QPushButton *config_button;
-
-            QCheckBox *lighting_checkbox;
-            QPushButton *lighting_settings_button;
-            QCheckBox *crop_to_slab_checkbox;
-            QLabel *crop_to_slab_label;
-            AdjustButton *crop_to_slab_button;
-            QLabel *show_node_list_label;
-            QPushButton *show_node_list_button;
 
             QPushButton *matrix_open_button, *matrix_close_button;
             QListView *matrix_list_view;
@@ -185,8 +177,7 @@ namespace MR
             QComboBox *node_colour_matrix_operator_combobox;
             QColorButton *node_colour_fixedcolour_button;
             ColourMapButton *node_colour_colourmap_button;
-            QLabel *lut_label;
-            QComboBox *lut_combobox;
+
             QLabel *node_colour_range_label;
             AdjustButton *node_colour_lower_button, *node_colour_upper_button;
 
@@ -232,6 +223,16 @@ namespace MR
             QLabel *edge_alpha_range_label;
             AdjustButton *edge_alpha_lower_button, *edge_alpha_upper_button;
             QCheckBox *edge_alpha_invert_checkbox;
+
+            QPushButton *config_button;
+            QComboBox *lut_combobox;
+            QCheckBox *lighting_checkbox;
+            QPushButton *lighting_settings_button;
+            QCheckBox *crop_to_slab_checkbox;
+            QLabel *crop_to_slab_label;
+            AdjustButton *crop_to_slab_button;
+            QLabel *show_node_list_label;
+            QPushButton *show_node_list_button;
 
           private:
 

--- a/src/gui/mrview/tool/connectome/connectome.h
+++ b/src/gui/mrview/tool/connectome/connectome.h
@@ -163,6 +163,7 @@ namespace MR
             QComboBox *node_visibility_combobox;
             QComboBox *node_visibility_matrix_operator_combobox;
             QLabel *node_visibility_warning_icon;
+            QWidget *node_visibility_threshold_controls;
             QLabel *node_visibility_threshold_label;
             AdjustButton *node_visibility_threshold_button;
             QCheckBox *node_visibility_threshold_invert_checkbox;
@@ -177,13 +178,14 @@ namespace MR
             QComboBox *node_colour_matrix_operator_combobox;
             QColorButton *node_colour_fixedcolour_button;
             ColourMapButton *node_colour_colourmap_button;
-
+            QWidget *node_colour_range_controls;
             QLabel *node_colour_range_label;
             AdjustButton *node_colour_lower_button, *node_colour_upper_button;
 
             QComboBox *node_size_combobox;
             QComboBox *node_size_matrix_operator_combobox;
             AdjustButton *node_size_button;
+            QWidget *node_size_range_controls;
             QLabel *node_size_range_label;
             AdjustButton *node_size_lower_button, *node_size_upper_button;
             QCheckBox *node_size_invert_checkbox;
@@ -191,12 +193,14 @@ namespace MR
             QComboBox *node_alpha_combobox;
             QComboBox *node_alpha_matrix_operator_combobox;
             QSlider *node_alpha_slider;
+            QWidget *node_alpha_range_controls;
             QLabel *node_alpha_range_label;
             AdjustButton *node_alpha_lower_button, *node_alpha_upper_button;
             QCheckBox *node_alpha_invert_checkbox;
 
             QComboBox *edge_visibility_combobox;
             QLabel *edge_visibility_warning_icon;
+            QWidget *edge_visibility_threshold_controls;
             QLabel *edge_visibility_threshold_label;
             AdjustButton *edge_visibility_threshold_button;
             QCheckBox *edge_visibility_threshold_invert_checkbox;
@@ -209,17 +213,20 @@ namespace MR
             QComboBox *edge_colour_combobox;
             QColorButton *edge_colour_fixedcolour_button;
             ColourMapButton *edge_colour_colourmap_button;
+            QWidget *edge_colour_range_controls;
             QLabel *edge_colour_range_label;
             AdjustButton *edge_colour_lower_button, *edge_colour_upper_button;
 
             QComboBox *edge_size_combobox;
             AdjustButton *edge_size_button;
+            QWidget *edge_size_range_controls;
             QLabel *edge_size_range_label;
             AdjustButton *edge_size_lower_button, *edge_size_upper_button;
             QCheckBox *edge_size_invert_checkbox;
 
             QComboBox *edge_alpha_combobox;
             QSlider *edge_alpha_slider;
+            QWidget *edge_alpha_range_controls;
             QLabel *edge_alpha_range_label;
             AdjustButton *edge_alpha_lower_button, *edge_alpha_upper_button;
             QCheckBox *edge_alpha_invert_checkbox;

--- a/src/gui/mrview/tool/connectome/connectome.h
+++ b/src/gui/mrview/tool/connectome/connectome.h
@@ -101,7 +101,6 @@ namespace MR
 
           private slots:
             void image_open_slot();
-            void lut_open_slot (int);
             void config_open_slot();
             void hide_all_slot();
 
@@ -129,6 +128,7 @@ namespace MR
             void overlay_interp_slot (int);
             void node_colour_matrix_operator_slot (int);
             void node_fixed_colour_change_slot();
+            void lut_open_slot (int);
             void node_colour_parameter_slot();
             void node_size_matrix_operator_slot (int);
             void node_size_value_slot();
@@ -155,7 +155,6 @@ namespace MR
           protected:
 
             QPushButton *image_button, *hide_all_button;
-            QComboBox *lut_combobox;
             QPushButton *config_button;
 
             QCheckBox *lighting_checkbox;
@@ -186,6 +185,8 @@ namespace MR
             QComboBox *node_colour_matrix_operator_combobox;
             QColorButton *node_colour_fixedcolour_button;
             ColourMapButton *node_colour_colourmap_button;
+            QLabel *lut_label;
+            QComboBox *lut_combobox;
             QLabel *node_colour_range_label;
             AdjustButton *node_colour_lower_button, *node_colour_upper_button;
 

--- a/src/gui/mrview/tool/connectome/connectome.h
+++ b/src/gui/mrview/tool/connectome/connectome.h
@@ -56,6 +56,7 @@
 #include "gui/mrview/tool/connectome/colourmap_observers.h"
 #include "gui/mrview/tool/connectome/edge.h"
 #include "gui/mrview/tool/connectome/file_data_vector.h"
+#include "gui/mrview/tool/connectome/matrix_list.h"
 #include "gui/mrview/tool/connectome/node.h"
 #include "gui/mrview/tool/connectome/node_list.h"
 #include "gui/mrview/tool/connectome/node_overlay.h"
@@ -112,6 +113,10 @@ namespace MR
             void show_node_list_slot();
             void node_selection_settings_changed_slot();
 
+            void matrix_open_slot();
+            void matrix_close_slot();
+            void connectome_selection_changed_slot (const QItemSelection&, const QItemSelection&);
+
             void node_visibility_selection_slot (int);
             void node_geometry_selection_slot (int);
             void node_colour_selection_slot (int);
@@ -160,6 +165,9 @@ namespace MR
             AdjustButton *crop_to_slab_button;
             QLabel *show_node_list_label;
             QPushButton *show_node_list_button;
+
+            QPushButton *matrix_open_button, *matrix_close_button;
+            QListView *matrix_list_view;
 
             QComboBox *node_visibility_combobox;
             QComboBox *node_visibility_matrix_operator_combobox;
@@ -263,6 +271,10 @@ namespace MR
             std::unique_ptr<LightingDock> lighting_dock;
 
 
+            // Model for selecting connectome matrices
+            Matrix_list_model* matrix_list_model;
+
+
             // Node selection
             Tool::Dock* node_list;
 
@@ -353,6 +365,7 @@ namespace MR
             void clear_all();
             void enable_all (const bool);
             void initialise (const std::string&);
+            void add_matrices (const std::vector<std::string>&);
 
             void draw_nodes (const Projection&);
             void draw_edges (const Projection&);
@@ -377,7 +390,6 @@ namespace MR
             // Helper functions for determining actual node / edge visual properties
             //   given current selection status
             void node_selection_changed (const std::vector<node_t>&);
-
             bool         node_visibility_given_selection (const node_t);
             Point<float> node_colour_given_selection     (const node_t);
             float        node_size_given_selection       (const node_t);
@@ -386,6 +398,16 @@ namespace MR
             Point<float> edge_colour_given_selection     (const Edge&);
             float        edge_size_given_selection       (const Edge&);
             float        edge_alpha_given_selection      (const Edge&);
+
+            // Helper functions to update the min / max / value / rate of parameter controls
+            void update_controls_node_visibility (const float, const float);
+            void update_controls_node_colour     (const float, const float);
+            void update_controls_node_size       (const float, const float);
+            void update_controls_node_alpha      (const float, const float);
+            void update_controls_edge_visibility (const float, const float);
+            void update_controls_edge_colour     (const float, const float);
+            void update_controls_edge_size       (const float, const float);
+            void update_controls_edge_alpha      (const float, const float);
 
             void get_meshes();
             void get_exemplars();

--- a/src/gui/mrview/tool/connectome/file_data_vector.cpp
+++ b/src/gui/mrview/tool/connectome/file_data_vector.cpp
@@ -39,36 +39,41 @@ namespace MR
         FileDataVector::FileDataVector () :
             Math::Vector<float>(),
             min (NAN),
+            mean (NAN),
             max (NAN) { }
 
         FileDataVector::FileDataVector (const FileDataVector& V) :
             Math::Vector<float> (V),
             name (V.name),
             min (V.min),
+            mean (V.mean),
             max (V.max) { }
 
         FileDataVector::FileDataVector (FileDataVector&& V) :
             Math::Vector<float> (std::move (V)),
             name (V.name),
             min (V.min),
+            mean (V.mean),
             max (V.max)
         {
           V.name.clear();
-          V.min = V.max = NAN;
+          V.min = V.mean = V.max = NAN;
         }
 
         FileDataVector::FileDataVector (size_t nelements) :
             Math::Vector<float> (nelements),
             min (NAN),
+            mean (NAN),
             max (NAN) { }
 
         FileDataVector::FileDataVector (const std::string& file) :
             Math::Vector<float> (file),
             name (Path::basename (file).c_str()),
             min (NAN),
+            mean (NAN),
             max (NAN)
         {
-          calc_minmax();
+          calc_stats();
         }
 
 
@@ -79,6 +84,7 @@ namespace MR
           Math::Vector<float>::operator= (that);
           name = that.name;
           min = that.min;
+          mean = that.mean;
           max = that.max;
           return *this;
         }
@@ -87,9 +93,10 @@ namespace MR
           Math::Vector<float>::operator= (std::move (that));
           name = that.name;
           min = that.min;
+          mean = that.mean;
           max = that.max;
           that.name.clear();
-          that.min = that.max = NAN;
+          that.min = that.mean = that.max = NAN;
           return *this;
         }
 
@@ -99,7 +106,7 @@ namespace MR
         FileDataVector& FileDataVector::load (const std::string& filename) {
           Math::Vector<float>::load (filename);
           name = Path::basename (filename).c_str();
-          calc_minmax();
+          calc_stats();
           return *this;
         }
 
@@ -107,18 +114,21 @@ namespace MR
         {
           Math::Vector<float>::clear();
           name.clear();
-          min = max = NAN;
+          min = mean = max = NAN;
           return *this;
         }
 
-        void FileDataVector::calc_minmax()
+        void FileDataVector::calc_stats()
         {
           min = std::numeric_limits<float>::max();
+          mean = 0.0f;
           max = -std::numeric_limits<float>::max();
           for (size_t i = 0; i != size(); ++i) {
             min = std::min (min, operator[] (i));
+            mean += operator[] (i);
             max = std::max (max, operator[] (i));
           }
+          mean /= float(size());
         }
 
 

--- a/src/gui/mrview/tool/connectome/file_data_vector.h
+++ b/src/gui/mrview/tool/connectome/file_data_vector.h
@@ -56,14 +56,15 @@ namespace MR
           const QString& get_name() const { return name; }
           void set_name (const std::string& s) { name = s.c_str(); }
 
-          float get_min() const { return min; }
-          float get_max() const { return max; }
+          float get_min()  const { return min; }
+          float get_mean() const { return mean; }
+          float get_max()  const { return max; }
 
-          void calc_minmax();
+          void calc_stats();
 
         private:
           QString name;
-          float min, max;
+          float min, mean, max;
 
       };
 

--- a/src/gui/mrview/tool/connectome/matrix_list.cpp
+++ b/src/gui/mrview/tool/connectome/matrix_list.cpp
@@ -1,0 +1,65 @@
+/*
+   Copyright 2009 Brain Research Institute, Melbourne, Australia
+
+   Written by Robert E. Smith, 2015.
+
+   This file is part of MRtrix.
+
+   MRtrix is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   MRtrix is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with MRtrix.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+#include "gui/mrview/tool/connectome/matrix_list.h"
+
+#include "gui/mrview/tool/connectome/connectome.h"
+
+
+namespace MR
+{
+  namespace GUI
+  {
+    namespace MRView
+    {
+      namespace Tool
+      {
+
+
+
+      Matrix_list_model::Matrix_list_model (Connectome* parent) :
+          QAbstractItemModel (dynamic_cast<QObject*>(parent)) { }
+
+
+
+
+
+
+      void Matrix_list_model::add_items (std::vector<FileDataVector>& list) {
+        beginInsertRows (QModelIndex(), items.size(), items.size() + list.size());
+        items.reserve (items.size() + list.size());
+        std::move (std::begin (list), std::end (list), std::back_inserter (items));
+        list.clear();
+        endInsertRows();
+      }
+
+
+
+
+
+      }
+    }
+  }
+}
+
+
+

--- a/src/gui/mrview/tool/connectome/matrix_list.h
+++ b/src/gui/mrview/tool/connectome/matrix_list.h
@@ -1,0 +1,116 @@
+/*
+   Copyright 2009 Brain Research Institute, Melbourne, Australia
+
+   Written by Robert E. Smith, 2015.
+
+   This file is part of MRtrix.
+
+   MRtrix is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   MRtrix is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with MRtrix.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+#ifndef __gui_mrview_tool_connectome_matrix_list_h__
+#define __gui_mrview_tool_connectome_matrix_list_h__
+
+#include <memory>
+
+#include <QAbstractItemModel>
+
+#include "gui/mrview/tool/connectome/file_data_vector.h"
+
+
+namespace MR
+{
+  namespace GUI
+  {
+    namespace MRView
+    {
+
+      class Window;
+
+      namespace Tool
+      {
+
+
+        class Connectome;
+
+
+        class Matrix_list_model : public QAbstractItemModel
+        {
+          public:
+
+            Matrix_list_model (Connectome* parent);
+
+            QVariant data (const QModelIndex& index, int role) const override {
+              if (!index.isValid()) return QVariant();
+              if (role != Qt::DisplayRole) return QVariant();
+              return shorten (items[index.row()].get_name().toStdString(), 35, 0).c_str();
+            }
+
+            Qt::ItemFlags flags (const QModelIndex& index) const override {
+              if (!index.isValid()) return 0;
+              return Qt::ItemIsEnabled | Qt::ItemIsSelectable;
+            }
+
+            QModelIndex parent (const QModelIndex&) const override {
+              return QModelIndex(); 
+            }
+
+            int rowCount (const QModelIndex& parent = QModelIndex()) const override {
+              (void) parent; // to suppress warnings about unused parameters
+              return items.size();
+            }
+
+            int columnCount (const QModelIndex& parent = QModelIndex()) const override {
+              (void) parent;
+              return 1;
+            }
+
+            QModelIndex index (int row, int column, const QModelIndex& parent = QModelIndex()) const override {
+              (void ) parent;
+              return createIndex (row, column);
+            }
+
+            void remove_item (QModelIndex& index) {
+              beginRemoveRows (QModelIndex(), index.row(), index.row());
+              items.erase (items.begin() + index.row());
+              endRemoveRows();
+            }
+
+            void clear() {
+              beginRemoveRows (QModelIndex(), 0, items.size());
+              items.clear();
+              endRemoveRows();
+            }
+
+            void add_items (std::vector<FileDataVector>&);
+
+            const FileDataVector& get (const size_t index) { assert (index < items.size()); return items[index]; }
+            const FileDataVector& get (QModelIndex& index) { assert (size_t(index.row()) < items.size()); return items[index.row()]; }
+
+          protected:
+            std::vector<FileDataVector> items;
+
+        };
+
+
+      }
+    }
+  }
+}
+
+#endif
+
+
+

--- a/src/gui/mrview/tool/connectome/types.h
+++ b/src/gui/mrview/tool/connectome/types.h
@@ -39,17 +39,17 @@ namespace MR
       typedef MR::Connectome::Node_info Node_info;
       typedef MR::Connectome::Node_map  Node_map;
 
-      enum class node_visibility_t { ALL, NONE, DEGREE, VECTOR_FILE, MATRIX_FILE };
+      enum class node_visibility_t { ALL, NONE, DEGREE, CONNECTOME, VECTOR_FILE, MATRIX_FILE };
       enum class node_geometry_t   { SPHERE, CUBE, OVERLAY, MESH };
-      enum class node_colour_t     { FIXED, RANDOM, FROM_LUT, VECTOR_FILE, MATRIX_FILE };
-      enum class node_size_t       { FIXED, NODE_VOLUME, VECTOR_FILE, MATRIX_FILE };
-      enum class node_alpha_t      { FIXED, FROM_LUT, VECTOR_FILE, MATRIX_FILE };
+      enum class node_colour_t     { FIXED, RANDOM, FROM_LUT, CONNECTOME, VECTOR_FILE, MATRIX_FILE };
+      enum class node_size_t       { FIXED, NODE_VOLUME, CONNECTOME, VECTOR_FILE, MATRIX_FILE };
+      enum class node_alpha_t      { FIXED, FROM_LUT, CONNECTOME, VECTOR_FILE, MATRIX_FILE };
 
-      enum class edge_visibility_t { ALL, NONE, VISIBLE_NODES, MATRIX_FILE };
+      enum class edge_visibility_t { ALL, NONE, VISIBLE_NODES, CONNECTOME, MATRIX_FILE };
       enum class edge_geometry_t   { LINE, CYLINDER, STREAMLINE, STREAMTUBE };
-      enum class edge_colour_t     { FIXED, DIRECTION, MATRIX_FILE };
-      enum class edge_size_t       { FIXED, MATRIX_FILE };
-      enum class edge_alpha_t      { FIXED, MATRIX_FILE };
+      enum class edge_colour_t     { FIXED, DIRECTION, CONNECTOME, MATRIX_FILE };
+      enum class edge_size_t       { FIXED, CONNECTOME, MATRIX_FILE };
+      enum class edge_alpha_t      { FIXED, CONNECTOME, MATRIX_FILE };
 
       }
     }

--- a/src/gui/mrview/tool/connectome/types.h
+++ b/src/gui/mrview/tool/connectome/types.h
@@ -43,7 +43,7 @@ namespace MR
       enum class node_geometry_t   { SPHERE, CUBE, OVERLAY, MESH };
       enum class node_colour_t     { FIXED, RANDOM, FROM_LUT, CONNECTOME, VECTOR_FILE, MATRIX_FILE };
       enum class node_size_t       { FIXED, NODE_VOLUME, CONNECTOME, VECTOR_FILE, MATRIX_FILE };
-      enum class node_alpha_t      { FIXED, FROM_LUT, CONNECTOME, VECTOR_FILE, MATRIX_FILE };
+      enum class node_alpha_t      { FIXED, CONNECTOME, VECTOR_FILE, MATRIX_FILE };
 
       enum class edge_visibility_t { ALL, NONE, VISIBLE_NODES, CONNECTOME, MATRIX_FILE };
       enum class edge_geometry_t   { LINE, CYLINDER, STREAMLINE, STREAMTUBE };


### PR DESCRIPTION
Enhancing the connectome tool to hopefully make the initial entry point a bit easier for users: Initialise using the parcellation image, load a connectome, and you can see the connectome (with somewhat sensible defaults). Also gives the possibility of scrolling through a set of connectomes (though I still need to enable use of the keyboard arrows in the QListView).

But throwing it up here now in case someone wants to take up the challenge of breaking it, or has any other comments about the UI design, e.g. in #320.

Closes #320.