### PR TITLE
mrconvert scaling issue

### DIFF
--- a/cmd/mrconvert.cpp
+++ b/cmd/mrconvert.cpp
@@ -72,6 +72,14 @@ void usage ()
             "-1 at the corresponding position in the list.")
   + Argument ("axes").type_sequence_int()
 
+  + Option ("scaling",
+            "specify the data scaling parameters used to rescale the intensity values. "
+            "These take the form of a comma-separated 2-vector of floating-point values, "
+            "corresponding to offset & scale, with final intensity values being given by "
+            "offset + scale * stored_value. By default, the values in the original header "
+            "are preserved.")
+  + Argument ("values").type_sequence_float()
+
   + Image::Stride::StrideOption
 
   + DataType::options()
@@ -91,10 +99,19 @@ inline std::vector<int> set_header (Image::Header& header, const InfoType& input
   header.info() = input.info();
   header.datatype() = datatype;
 
+  Options opt = get_options ("scaling");
+  if (opt.size()) {
+    std::vector<float> scaling = opt[0][0];
+    if (scaling.size() != 2) 
+      throw Exception ("-scaling option expects comma-separated 2-vector of floating-point values");
+    header.intensity_offset() = scaling[0];
+    header.intensity_scale() = scaling[1];
+  }
+
   if (get_options ("grad").size() || get_options ("fslgrad").size())
     header.DW_scheme() = DWI::get_DW_scheme<float> (header);
 
-  Options opt = get_options ("axes");
+  opt = get_options ("axes");
   std::vector<int> axes;
   if (opt.size()) {
     axes = opt[0][0];

--- a/cmd/mrconvert.cpp
+++ b/cmd/mrconvert.cpp
@@ -76,8 +76,11 @@ void usage ()
             "specify the data scaling parameters used to rescale the intensity values. "
             "These take the form of a comma-separated 2-vector of floating-point values, "
             "corresponding to offset & scale, with final intensity values being given by "
-            "offset + scale * stored_value. By default, the values in the original header "
-            "are preserved.")
+            "offset + scale * stored_value. "
+            "By default, the values in the input image header are preserved when writing to "
+            "an integer image; when writing to a floating-point image, any scaling present "
+            "in the input image header is applied to the raw image data, such that the "
+            "output image header contains standard (non-influential) scaling only.")
   + Argument ("values").type_sequence_float()
 
   + Image::Stride::StrideOption

--- a/cmd/mrconvert.cpp
+++ b/cmd/mrconvert.cpp
@@ -191,7 +191,8 @@ void run ()
 
   Image::Header header_out (header_in);
   header_out.datatype() = DataType::from_command_line (header_out.datatype());
-  header_out.set_intensity_scaling (header_in);
+  if (!header_out.datatype().is_floating_point())
+    header_out.set_intensity_scaling (header_in);
 
   if (header_in.datatype().is_complex() && !header_out.datatype().is_complex())
     WARN ("requested datatype is real but input datatype is complex - imaginary component will be ignored");

--- a/cmd/mrconvert.cpp
+++ b/cmd/mrconvert.cpp
@@ -91,9 +91,6 @@ inline std::vector<int> set_header (Image::Header& header, const InfoType& input
   header.info() = input.info();
   header.datatype() = datatype;
 
-  header.intensity_offset() = 0.0;
-  header.intensity_scale() = 1.0;
-
   if (get_options ("grad").size() || get_options ("fslgrad").size())
     header.DW_scheme() = DWI::get_DW_scheme<float> (header);
 
@@ -186,6 +183,7 @@ void run ()
 
   Image::Header header_out (header_in);
   header_out.datatype() = DataType::from_command_line (header_out.datatype());
+  header_out.set_intensity_scaling (header_in);
 
   if (header_in.datatype().is_complex() && !header_out.datatype().is_complex())
     WARN ("requested datatype is real but input datatype is complex - imaginary component will be ignored");


### PR DESCRIPTION
As discussed on [this MRtrix3 forum post](https://plus.google.com/102850892380704369664/posts/JjvrqdwRCts), the header entries specifying the intensity scaling were not being preserved by mrconvert, when they were in version 0.2.x. This fixes this to preserve these values by default.

It also introduces an option to manually specify these values if needed. For example, `-scaling 0,1` would give the same answer as it does currently.

Note that this did not affect the values read - only how they were stored. And these values would be correct given the scaling parameters that were actually used (i.e. 0,1) - within the precision of the data type. Where this would be problematic is for e.g. an FA map stored using an integer type and rescaled between 0 and 1 using these header parameters: this would convert fine to floating-point, but mrconvert would previously have produced a map of zeros when converting to the same or another integer type. This should fix that problem.