### PR TITLE
Fix configure to support building with msys2 on windows.

### DIFF
--- a/configure
+++ b/configure
@@ -366,6 +366,8 @@ exe_suffix = ''
 lib_prefix = 'lib'
 
 system = platform.system().lower()
+if system.startswith('mingw'):
+  system = 'windows'
 report ('Detecting OS: ' + system + '\n')
 if system == 'linux':
   cpp_flags += [ '-pthread', '-fPIC' ]
@@ -876,8 +878,6 @@ int main() { Foo f; }
       f.close();
 
       qmake_cmd = [ qmake ]
-      if system == 'windows':
-        qmake_cmd += [ '-spec', 'win32-g++' ]
 
       try: 
          (retcode, stdout, stderr) = execute (qmake_cmd, QMakeError, raise_on_non_zero_exit_code = False, cwd=qt_dir.name)
@@ -914,6 +914,9 @@ int main() { Foo f; }
         elif line.startswith ('LFLAGS'):
           qt_ldflags = shlex.split (line[line.find('=')+1:].strip())
 
+      for index, entry in enumerate(qt_includes):
+        if entry[2:].startswith('..'):
+          qt_includes[index] = '-I' + os.path.abspath(qt_dir.name + '/' + entry[2:])
       
       qt = qt_cflags + qt_defines + qt_includes
       qt_cflags = []

--- a/src/gui/dwi/render_frame.cpp
+++ b/src/gui/dwi/render_frame.cpp
@@ -230,7 +230,7 @@ namespace MR
 #if QT_VERSION >= 0x050400
         gl::ClearColor (0.0, 0.0, 0.0, 1.0);
         gl::ColorMask (false, false, false, true); 
-        gl::Clear (GL_COLOR_BUFFER_BIT);
+        gl::Clear (gl::COLOR_BUFFER_BIT);
 #endif
 
         if (OS > 0) snapshot();

--- a/src/gui/mrview/tool/connectome/connectome.cpp
+++ b/src/gui/mrview/tool/connectome/connectome.cpp
@@ -732,8 +732,8 @@ namespace MR
 
           Edge::set_streamtube_LOD (3);
 
-          glGetIntegerv (GL_ALIASED_LINE_WIDTH_RANGE, line_thickness_range_aliased);
-          glGetIntegerv (GL_SMOOTH_LINE_WIDTH_RANGE, line_thickness_range_smooth);
+          glGetIntegerv (gl::ALIASED_LINE_WIDTH_RANGE, line_thickness_range_aliased);
+          glGetIntegerv (gl::SMOOTH_LINE_WIDTH_RANGE, line_thickness_range_smooth);
           GL_CHECK_ERROR;
 
           enable_all (false);
@@ -2416,7 +2416,7 @@ namespace MR
             }
 
             if ((edge_geometry == edge_geometry_t::LINE || edge_geometry == edge_geometry_t::STREAMLINE) && edge_geometry_line_smooth_checkbox->isChecked())
-              gl::Enable (GL_LINE_SMOOTH);
+              gl::Enable (gl::LINE_SMOOTH);
 
             GLuint node_centre_one_ID = 0, node_centre_two_ID = 0, rot_matrix_ID = 0;
             if (edge_geometry == edge_geometry_t::CYLINDER) {
@@ -2518,7 +2518,7 @@ namespace MR
             if (edge_geometry == edge_geometry_t::LINE || edge_geometry == edge_geometry_t::STREAMLINE) {
               gl::LineWidth (1.0f);
               if (edge_geometry_line_smooth_checkbox->isChecked())
-                gl::Disable (GL_LINE_SMOOTH);
+                gl::Disable (gl::LINE_SMOOTH);
             }
 
             edge_shader.stop();

--- a/src/gui/mrview/tool/roi_editor/roi.cpp
+++ b/src/gui/mrview/tool/roi_editor/roi.cpp
@@ -319,7 +319,7 @@ namespace MR
             Window::GrabContext context; 
             roi->texture().bind();
             gl::PixelStorei (gl::PACK_ALIGNMENT, 1);
-            gl::GetTexImage (gl::TEXTURE_3D, 0, GL_RED, GL_UNSIGNED_BYTE, (void*) (&data[0]));
+            gl::GetTexImage (gl::TEXTURE_3D, 0, gl::RED, gl::UNSIGNED_BYTE, (void*) (&data[0]));
           }
 
           try {

--- a/src/gui/mrview/tool/roi_editor/undoentry.cpp
+++ b/src/gui/mrview/tool/roi_editor/undoentry.cpp
@@ -138,7 +138,7 @@ namespace MR
           tex.bind();
           gl::PixelStorei (gl::PACK_ALIGNMENT, 1);
 
-          gl::GetTexImage (gl::TEXTURE_2D, 0, GL_RED, GL_UNSIGNED_BYTE, (void*)(&before[0]));
+          gl::GetTexImage (gl::TEXTURE_2D, 0, gl::RED, gl::UNSIGNED_BYTE, (void*)(&before[0]));
           after = before;
           GL_CHECK_ERROR;
         }
@@ -179,7 +179,7 @@ namespace MR
 
           Window::GrabContext context;
           roi.texture().bind();
-          gl::TexSubImage3D (GL_TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], GL_RED, GL_UNSIGNED_BYTE, (void*) (&after[0]));
+          gl::TexSubImage3D (gl::TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], gl::RED, gl::UNSIGNED_BYTE, (void*) (&after[0]));
         }
 
 
@@ -223,7 +223,7 @@ namespace MR
 
           Window::GrabContext context;
           roi.texture().bind();
-          gl::TexSubImage3D (GL_TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], GL_RED, GL_UNSIGNED_BYTE, (void*) (&after[0]));
+          gl::TexSubImage3D (gl::TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], gl::RED, gl::UNSIGNED_BYTE, (void*) (&after[0]));
         }
 
 
@@ -256,7 +256,7 @@ namespace MR
 
           Window::GrabContext context;
           roi.texture().bind();
-          gl::TexSubImage3D (GL_TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], GL_RED, GL_UNSIGNED_BYTE, (void*) (&after[0]));
+          gl::TexSubImage3D (gl::TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], gl::RED, gl::UNSIGNED_BYTE, (void*) (&after[0]));
         }
 
 
@@ -287,7 +287,7 @@ namespace MR
 
           Window::GrabContext context;
           roi.texture().bind();
-          gl::TexSubImage3D (GL_TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], GL_RED, GL_UNSIGNED_BYTE, (void*) (&after[0]));
+          gl::TexSubImage3D (gl::TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], gl::RED, gl::UNSIGNED_BYTE, (void*) (&after[0]));
         }
 
 
@@ -330,7 +330,7 @@ namespace MR
           }
           Window::GrabContext context;
           roi.texture().bind();
-          gl::TexSubImage3D (GL_TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], GL_RED, GL_UNSIGNED_BYTE, (void*) (&after[0]));
+          gl::TexSubImage3D (gl::TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], gl::RED, gl::UNSIGNED_BYTE, (void*) (&after[0]));
         }
 
 
@@ -341,13 +341,13 @@ namespace MR
         {
           Window::GrabContext context;
           roi.texture().bind();
-          gl::TexSubImage3D (GL_TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], GL_RED, GL_UNSIGNED_BYTE, (void*) (&before[0]));
+          gl::TexSubImage3D (gl::TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], gl::RED, gl::UNSIGNED_BYTE, (void*) (&before[0]));
         }
 
         void ROI_UndoEntry::redo (ROI_Item& roi) 
         {
           roi.texture().bind();
-          gl::TexSubImage3D (GL_TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], GL_RED, GL_UNSIGNED_BYTE, (void*) (&after[0]));
+          gl::TexSubImage3D (gl::TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], gl::RED, gl::UNSIGNED_BYTE, (void*) (&after[0]));
         }
 
         void ROI_UndoEntry::copy (ROI_Item& roi, ROI_UndoEntry& source) 
@@ -355,7 +355,7 @@ namespace MR
           Window::GrabContext context;
           after = source.before;
           roi.texture().bind();
-          gl::TexSubImage3D (GL_TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], GL_RED, GL_UNSIGNED_BYTE, (void*) (&after[0]));
+          gl::TexSubImage3D (gl::TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], gl::RED, gl::UNSIGNED_BYTE, (void*) (&after[0]));
         }
 
 

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -1315,7 +1315,7 @@ namespace MR
         // otherwise we get transparent windows...
 #if QT_VERSION >= 0x050400
         gl::ColorMask (false, false, false, true); 
-        gl::Clear (GL_COLOR_BUFFER_BIT);
+        gl::Clear (gl::COLOR_BUFFER_BIT);
         glColorMask (true, true, true, true);
 #endif
         GL_CHECK_ERROR;


### PR DESCRIPTION
Fix OS being reported as mingw_* instead of windows on msys2.
Fix configure to handle include paths relative to tmp.
Replace GL_ with gl:: to make OpenGL related stuff compile with Qt 4.