### PR TITLE
Fix opengl dealloc

### DIFF
--- a/src/gui/mrview/mode/ortho.cpp
+++ b/src/gui/mrview/mode/ortho.cpp
@@ -70,7 +70,6 @@ namespace MR
           projection.set (MV, P);
 
           gl::Disable (gl::DEPTH_TEST);
-          gl::LineWidth (2.0);
 
           if (!frame_VB || !frame_VAO) {
             frame_VB.gen();

--- a/src/gui/mrview/tool/base.h
+++ b/src/gui/mrview/tool/base.h
@@ -46,17 +46,26 @@ namespace MR
     {
       namespace Tool
       {
+        class Base;
+
+
+
 
         class Dock : public QDockWidget
         {
           public:
             Dock (const QString& name) :
               QDockWidget (name, Window::main), tool (nullptr) { }
+            ~Dock (); 
 
             void closeEvent (QCloseEvent*) override;
 
             Base* tool;
         };
+
+
+
+
 
 
         class Base : public QFrame {
@@ -141,7 +150,16 @@ namespace MR
 
 
 
+
+
+
+
         //! \cond skip
+        
+        inline Dock::~Dock () { delete tool; }
+
+
+
         class __Action__ : public QAction
         {
           public:
@@ -155,6 +173,8 @@ namespace MR
               setShortcut (tr (std::string ("Ctrl+F" + str (index)).c_str()));
               setStatusTip (tr (description));
             }
+
+            virtual ~__Action__ () { delete dock; }
 
             virtual Dock* create () = 0;
             Dock* dock;

--- a/src/gui/mrview/tool/odf.cpp
+++ b/src/gui/mrview/tool/odf.cpp
@@ -289,6 +289,10 @@ namespace MR
             delete renderer;
             renderer = nullptr;
           }
+          if (preview) {
+            delete preview;
+            preview = nullptr;
+          }
           if (lighting_dock) {
             delete lighting_dock;
             lighting_dock = nullptr;

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -675,8 +675,14 @@ namespace MR
 
       Window::~Window ()
       {
-        mode = nullptr;
-        delete glarea;
+        glarea->makeCurrent();
+        QList<QAction*> tools = tool_group->actions();
+        for (QAction* action : tools) 
+          delete action;
+        mode.reset();
+        QList<QAction*> images = image_group->actions();
+        for (QAction* action : images) 
+          delete action;
       }
 
 
@@ -796,6 +802,7 @@ namespace MR
 
       void Window::select_mode_slot (QAction* action)
       {
+        glarea->makeCurrent();
         mode.reset (dynamic_cast<GUI::MRView::Mode::__Action__*> (action)->create());
         mode->set_visible(! image_hide_action->isChecked());
         set_mode_features();

--- a/src/gui/mrview/window.h
+++ b/src/gui/mrview/window.h
@@ -36,6 +36,30 @@ namespace MR
       {
           Q_OBJECT
 
+        private:
+          Cursor cursors_do_not_use;
+
+          class GLArea : public GL::Area {
+            public:
+              GLArea (Window& parent);
+              QSize sizeHint () const override;
+
+            protected:
+              void dragEnterEvent (QDragEnterEvent* event) override;
+              void dragMoveEvent (QDragMoveEvent* event) override;
+              void dragLeaveEvent (QDragLeaveEvent* event) override;
+              void dropEvent (QDropEvent* event) override;
+              bool event (QEvent* event) override;
+            private:
+              void initializeGL () override;
+              void paintGL () override;
+              void mousePressEvent (QMouseEvent* event) override;
+              void mouseMoveEvent (QMouseEvent* event) override;
+              void mouseReleaseEvent (QMouseEvent* event) override;
+              void wheelEvent (QWheelEvent* event) override;
+          };
+          GLArea* glarea;
+
         public:
           Window();
           ~Window();
@@ -178,30 +202,9 @@ namespace MR
 
 
         private:
-          Cursor cursors_do_not_use;
           QPoint mouse_position_, mouse_displacement_;
           Qt::MouseButtons buttons_;
           Qt::KeyboardModifiers modifiers_;
-
-          class GLArea : public GL::Area {
-            public:
-              GLArea (Window& parent);
-              QSize sizeHint () const override;
-
-            protected:
-              void dragEnterEvent (QDragEnterEvent* event) override;
-              void dragMoveEvent (QDragMoveEvent* event) override;
-              void dragLeaveEvent (QDragLeaveEvent* event) override;
-              void dropEvent (QDropEvent* event) override;
-              bool event (QEvent* event) override;
-            private:
-              void initializeGL () override;
-              void paintGL () override;
-              void mousePressEvent (QMouseEvent* event) override;
-              void mouseMoveEvent (QMouseEvent* event) override;
-              void mouseReleaseEvent (QMouseEvent* event) override;
-              void wheelEvent (QWheelEvent* event) override;
-          };
 
           enum MouseAction {
             NoAction,
@@ -213,7 +216,6 @@ namespace MR
             Rotate
           };
 
-          GLArea* glarea;
           std::unique_ptr<Mode::Base> mode;
           GL::Lighting* lighting_;
           GL::Font font;


### PR DESCRIPTION
An attempt at addressing #299 and potentially #21. This introduces more thorough checks in debug mode to verify that the original OpenGL context is current when resources are deleted. These were used to ensure that all deallocation happen in the right order, and under the right context. It seems to fix most issues, but there is still a problem with the ODF tool failing an assert at exit if used, I'll investigate further before merging. 