### PR TITLE
Header: preserve intensity scaling for integer types

### DIFF
--- a/cmd/mrconvert.cpp
+++ b/cmd/mrconvert.cpp
@@ -78,10 +78,9 @@ void usage ()
             "corresponding to offset & scale, with final intensity values being given by "
             "offset + scale * stored_value. "
             "By default, the values in the input image header are passed through to the "
-            "output image header when writing to an integer image; when writing to a "
-            "floating-point image, these values are reset to 0,1 (no scaling). To force "
-            "mrconvert to preserve the input image's scaling parameters even for "
-            "floating-point outputs, use '-scaling preserve'")
+            "output image header when writing to an integer image, and reset to 0,1 (no "
+            "scaling) for floating-point and binary images. Note that his option has no "
+            "effect for floating-point and binary images.")
   + Argument ("values").type_sequence_float()
 
   + Image::Stride::StrideOption
@@ -237,15 +236,15 @@ void run ()
 
   opt = get_options ("scaling");
   if (opt.size()) {
-    if (lowercase (opt[0][0]) == "preserve")
-      header_out.set_intensity_scaling (header_in);
-    else {
+    if (header_out.datatype().is_integer()) {
       std::vector<float> scaling = opt[0][0];
       if (scaling.size() != 2) 
         throw Exception ("-scaling option expects comma-separated 2-vector of floating-point values");
       header_out.intensity_offset() = scaling[0];
       header_out.intensity_scale() = scaling[1];
     }
+    else
+      WARN ("-scaling option has no effect for floating-point or binary images");
   }
 
 

--- a/cmd/mrconvert.cpp
+++ b/cmd/mrconvert.cpp
@@ -99,7 +99,7 @@ template <class InfoType>
 inline std::vector<int> set_header (Image::Header& header, const InfoType& input)
 {
   // need to preserve dataype, already parsed from command-line:
-  auto datatype = header.datatype();
+  DataType datatype = header.datatype();
   header.info() = input.info();
   header.datatype() = datatype;
 
@@ -195,8 +195,6 @@ void run ()
 
   Image::Header header_out (header_in);
   header_out.datatype() = DataType::from_command_line (header_out.datatype());
-  if (!header_out.datatype().is_floating_point())
-    header_out.set_intensity_scaling (header_in);
 
   if (header_in.datatype().is_complex() && !header_out.datatype().is_complex())
     WARN ("requested datatype is real but input datatype is complex - imaginary component will be ignored");
@@ -249,9 +247,6 @@ void run ()
       header_out.intensity_scale() = scaling[1];
     }
   }
-
-  if (!std::isfinite (header_out.intensity_offset()) || !std::isfinite (header_out.intensity_scale()) || header_out.intensity_scale() == 0.0)
-    WARN ("invalid scaling parameters (offset: " + str(header_out.intensity_offset()) + ", scale: " + str(header_out.intensity_scale()) + ")");
 
 
   if (header_out.intensity_offset() == 0.0 && header_out.intensity_scale() == 1.0 && !header_out.datatype().is_floating_point()) {

--- a/lib/datatype.h
+++ b/lib/datatype.h
@@ -42,9 +42,6 @@ namespace MR
       bool undefined () const {
         return dt == Undefined;
       }
-      uint8_t& operator() () {
-        return dt;
-      }
       const uint8_t& operator() () const {
         return dt;
       }

--- a/lib/image/format/mri.cpp
+++ b/lib/image/format/mri.cpp
@@ -155,7 +155,7 @@ namespace MR
           return { uint8_t (d | t) };
         }
 
-        uint8_t store_datatype (DataType& dt) {
+        uint8_t store_datatype (const DataType& dt) {
           uint8_t d = dt() & 0x07U;
           uint8_t t = dt() & ~(0x07U);
           if (d >= 0x05U) --d;


### PR DESCRIPTION
As discussed in #346.

Turned out to be a bit more complicated than anticipated due to the need to update the intensity scaling on datatype changes, which required `Header::datatype()` to return a proxy object. All seems to work OK, but I would really like someone to put this through its paces to see if I've missed something...