### PR TITLE
tck2connectome: Fix length quantification

### DIFF
--- a/src/dwi/tractography/connectome/edge_metrics.h
+++ b/src/dwi/tractography/connectome/edge_metrics.h
@@ -100,7 +100,7 @@ class Metric_meanlength : public Metric_base {
 
     double operator() (const Streamline<>& tck, const NodePair& nodes) const override
     {
-      return (tck.size() - 1);
+      return tck.calc_length();
     }
 
     double operator() (const Streamline<>& tck, const std::vector<node_t>& nodes) const override
@@ -118,7 +118,7 @@ class Metric_invlength : public Metric_base {
 
     double operator() (const Streamline<>& tck, const NodePair& nodes) const override
     {
-      return (tck.size() > 1 ? (1.0 / (tck.size() - 1)) : 0);
+      return (tck.size() > 1 ? (1.0 / tck.calc_length()) : 0);
     }
 
     double operator() (const Streamline<>& tck, const std::vector<node_t>& nodes) const override
@@ -177,7 +177,7 @@ class Metric_invlength_invnodevolume : public Metric_invnodevolume {
 
     double operator() (const Streamline<>& tck, const NodePair& nodes) const override
     {
-      return (tck.size() > 1 ? (Metric_invnodevolume::operator() (tck, nodes) / (tck.size() - 1)) : 0);
+      return (tck.size() > 1 ? (Metric_invnodevolume::operator() (tck, nodes) / tck.calc_length()) : 0);
     }
 
     double operator() (const Streamline<>& tck, const std::vector<node_t>& nodes) const override

--- a/src/dwi/tractography/mapping/mapper.h
+++ b/src/dwi/tractography/mapping/mapper.h
@@ -305,7 +305,9 @@ void TrackMapperBase::voxelise_ends (const Streamline<>& tck, Cont& out) const
   for (size_t end = 0; end != 2; ++end) {
     const Point<int> vox = round (transform.scanner2voxel (end ? tck.back() : tck.front()));
     if (check (vox, info)) {
-      const Point<float> dir = (end ? (tck[tck.size()-1] - tck[tck.size()-2]) : (tck[0] - tck[1])).normalise();
+      Point<float> dir;
+      if (tck.size() > 1)
+        dir = (end ? (tck[tck.size()-1] - tck[tck.size()-2]) : (tck[0] - tck[1])).normalise();
       add_to_set (out, vox, dir, 1.0f);
     }
   }

--- a/src/dwi/tractography/seeding/basic.cpp
+++ b/src/dwi/tractography/seeding/basic.cpp
@@ -75,10 +75,10 @@ namespace MR
         bool Random_per_voxel::get_seed (Point<float>& p)
         {
 
+          std::lock_guard<std::mutex> lock (mutex);
+
           if (expired)
             return false;
-
-          std::lock_guard<std::mutex> lock (mutex);
 
           if (vox[2] < 0 || ++inc == num) {
             inc = 0;
@@ -114,10 +114,10 @@ namespace MR
         bool Grid_per_voxel::get_seed (Point<float>& p)
         {
 
+          std::lock_guard<std::mutex> lock (mutex);
+
           if (expired)
             return false;
-
-          std::lock_guard<std::mutex> lock (mutex);
 
           if (++pos[2] >= os) {
             pos[2] = 0;


### PR DESCRIPTION
This was fixed in 2cbfa942 but re-introduced in 7f70bbfc.