### PR TITLE
Fixes to dwibiascorrect script

### DIFF
--- a/scripts/dwibiascorrect
+++ b/scripts/dwibiascorrect
@@ -9,6 +9,7 @@ import lib.app
 
 from lib.binaryInPath  import binaryInPath
 from lib.errorMessage  import errorMessage
+from lib.getFSLSuffix  import getFSLSuffix
 from lib.getHeaderInfo import getHeaderInfo
 from lib.runCommand    import runCommand
 
@@ -26,10 +27,24 @@ if not binaryInPath(fast_cmd):
   fast_cmd = 'fsl5.0-fast'
   if not binaryInPath(fast_cmd):
     errorMessage('Could not find FSL program fast; please verify FSL install')
+    
+fsl_suffix = getFSLSuffix()
+if fast_cmd == 'fast':
+  fast_suffix = fsl_suffix
+else:
+  fast_suffix = '.nii.gz'
 
 runCommand('mrconvert ' + lib.app.args.input + ' ' + os.path.join(lib.app.tempDir, 'in.mif'))
 
 lib.app.gotoTempDir()
+
+# Make sure it's actually a DWI that's been passed
+dims = getHeaderInfo('in.mif', 'dim').split()
+if len(dims) != 4:
+  errorMessage('Input image must be a 4D image')
+DW_scheme = getHeaderInfo('in.mif', 'dwgrad').split('\n')
+if len(DW_scheme) != int(dims[3]):
+  errorMessage('Input image does not contain valid DW gradient scheme')
 
 # Generate a brain mask
 runCommand('dwi2mask in.mif mask.mif')
@@ -42,10 +57,10 @@ if len(bzero_dim) == 4:
 else:
   runCommand('mrconvert bzeros.mif mean_bzero.nii -stride +1,+2,+3')
 
-runCommand('fast -t 2 -o fast -n 3 -b mean_bzero.nii')
+runCommand(fast_cmd + ' -t 2 -o fast -n 3 -b mean_bzero.nii')
 
 result_path = 'result' + os.path.splitext(lib.app.args.output)[1]
-runCommand('mrcalc in.mif fast_bias.nii -div ' + result_path)
+runCommand('mrcalc in.mif fast_bias' + fast_suffix + ' -div ' + result_path)
 
 lib.app.moveFileToDest(result_path, lib.app.args.output)
 


### PR DESCRIPTION
- Try to identify the suffix that FAST will use for its output, so that the subsequent command can find it.
- Test input image to make sure it is a valid DWI, rather than relying on dwi2mask.