### PR TITLE
DICOM: don't fail on undefined length tags - assume zero size

### DIFF
--- a/lib/file/dicom/element.cpp
+++ b/lib/file/dicom/element.cpp
@@ -168,10 +168,12 @@ namespace MR {
 
         next = data;
         if (size == LENGTH_UNDEFINED) {
-          if (VR != VR_SQ && !(group == GROUP_SEQUENCE && element == ELEMENT_SEQUENCE_ITEM)) 
-            throw Exception ("undefined length used for DICOM tag " + ( tag_name().size() ? tag_name().substr (2) : "" ) 
+          if (VR != VR_SQ && !(group == GROUP_SEQUENCE && element == ELEMENT_SEQUENCE_ITEM)) {
+            INFO ("undefined length used for DICOM tag " + ( tag_name().size() ? tag_name().substr (2) : "" ) 
                 + " (" + str (group) + ", " + str (element) 
                 + ") in file \"" + fmap->name() + "\"");
+            size = 0;
+          }
         }
         else if (next+size > fmap->address() + fmap->size()) 
           throw Exception ("file \"" + fmap->name() + "\" is too small to contain DICOM elements specified");


### PR DESCRIPTION
Just got sent some GE data were the DICOM import wasn't working. This was due to some private tags in the data being written with undefined lengths, which immediately caused MRtrix3 to (rightly IMO) throw out an Exception. This change modifies this behaviour to issue an info-level warning and assume undefined length means zero length. This fixes the import of the problematic data, and clearly won't affect import of other data since these can't have triggered the issue given that they were successfully imported... 