### PR TITLE
Prevent tckmap hang on Windows

### DIFF
--- a/src/dwi/tractography/tracking/exec.h
+++ b/src/dwi/tractography/tracking/exec.h
@@ -44,7 +44,7 @@
 
 #define MAX_NUM_SEED_ATTEMPTS 100000
 
-#define DYNAMIC_SEEDING_BATCH_SIZE 8
+#define TRACKING_BATCH_SIZE 10
 
 
 
@@ -72,7 +72,7 @@ namespace MR
                 typename Method::Shared shared (diff_path, properties);
                 WriteKernel writer (shared, destination, properties);
                 Exec<Method> tracker (shared);
-                Thread::run_queue (Thread::multi (tracker), Thread::batch (GeneratedTrack()), writer);
+                Thread::run_queue (Thread::multi (tracker), Thread::batch (GeneratedTrack(), TRACKING_BATCH_SIZE), writer);
 
               } else {
 
@@ -103,11 +103,11 @@ namespace MR
 
                 Thread::run_queue (
                     Thread::multi (tracker), 
-                    Thread::batch (GeneratedTrack(), DYNAMIC_SEEDING_BATCH_SIZE),
+                    Thread::batch (GeneratedTrack(), TRACKING_BATCH_SIZE),
                     writer, 
-                    Thread::batch (Streamline<value_type>(), DYNAMIC_SEEDING_BATCH_SIZE),
+                    Thread::batch (Streamline<value_type>(), TRACKING_BATCH_SIZE),
                     Thread::multi (mapper), 
-                    Thread::batch (SetDixel(), DYNAMIC_SEEDING_BATCH_SIZE),
+                    Thread::batch (SetDixel(), TRACKING_BATCH_SIZE),
                     *seeder);
 
               }

--- a/src/dwi/tractography/tracking/exec.h
+++ b/src/dwi/tractography/tracking/exec.h
@@ -44,6 +44,8 @@
 
 #define MAX_NUM_SEED_ATTEMPTS 100000
 
+#define DYNAMIC_SEEDING_BATCH_SIZE 8
+
 
 
 namespace MR
@@ -101,11 +103,11 @@ namespace MR
 
                 Thread::run_queue (
                     Thread::multi (tracker), 
-                    Thread::batch (GeneratedTrack()),
+                    Thread::batch (GeneratedTrack(), DYNAMIC_SEEDING_BATCH_SIZE),
                     writer, 
-                    Thread::batch (Streamline<value_type>()),
+                    Thread::batch (Streamline<value_type>(), DYNAMIC_SEEDING_BATCH_SIZE),
                     Thread::multi (mapper), 
-                    Thread::batch (SetDixel()),
+                    Thread::batch (SetDixel(), DYNAMIC_SEEDING_BATCH_SIZE),
                     *seeder);
 
               }

--- a/src/dwi/tractography/tracking/exec.h
+++ b/src/dwi/tractography/tracking/exec.h
@@ -70,7 +70,7 @@ namespace MR
                 typename Method::Shared shared (diff_path, properties);
                 WriteKernel writer (shared, destination, properties);
                 Exec<Method> tracker (shared);
-                Thread::run_queue (Thread::multi (tracker), GeneratedTrack(), writer);
+                Thread::run_queue (Thread::multi (tracker), Thread::batch (GeneratedTrack()), writer);
 
               } else {
 
@@ -101,11 +101,11 @@ namespace MR
 
                 Thread::run_queue (
                     Thread::multi (tracker), 
-                    GeneratedTrack(), 
+                    Thread::batch (GeneratedTrack()),
                     writer, 
-                    Streamline<value_type>(), 
+                    Thread::batch (Streamline<value_type>()),
                     Thread::multi (mapper), 
-                    SetDixel(), 
+                    Thread::batch (SetDixel()),
                     *seeder);
 
               }


### PR DESCRIPTION
Make use of Thread::batch() to reduce the load on multi-threading queues, which can hang in heavy processing on Windows.
Related to #255.