### PR TITLE
Changes to header handling in updated syntax

### DIFF
--- a/cmd/5tt2gmwmi.cpp
+++ b/cmd/5tt2gmwmi.cpp
@@ -131,7 +131,7 @@ void run ()
 {
 
   auto input = Image<float>::open (argument[0]);
-  DWI::Tractography::ACT::verify_5TT_image (input);
+  DWI::Tractography::ACT::verify_5TT_image (input.header());
 
   // TODO It would be nice to have the capability to define this mask based on another image
   // This will however require the use of interpolators
@@ -146,11 +146,11 @@ void run ()
 
   Header H;
   if (mask.valid()) {
-    H = mask.original_header();
+    H = mask.header();
     H.datatype() = DataType::Float32;
     H.datatype().set_byte_order_native();
   } else {
-    H = input.original_header();
+    H = input.header();
     H.set_ndim (3);
   }
   auto output = Image<float>::create (argument[1], H);

--- a/cmd/5tt2vis.cpp
+++ b/cmd/5tt2vis.cpp
@@ -86,11 +86,10 @@ void usage ()
 
 void run ()
 {
-
   auto input = Image<float>::open (argument[0]);
-  DWI::Tractography::ACT::verify_5TT_image (input);
+  DWI::Tractography::ACT::verify_5TT_image (input.header());
 
-  Header H (input.original_header());
+  Header H (input.header());
   H.set_ndim (3);
 
   const float bg_multiplier   = get_option_value ("bg", VALUE_DEFAULT_BG);

--- a/cmd/5ttedit.cpp
+++ b/cmd/5ttedit.cpp
@@ -151,8 +151,8 @@ void run ()
 {
 
   auto in = Image<float>::open (argument[0]);
-  DWI::Tractography::ACT::verify_5TT_image (in);
-  auto out = Image<float>::create (argument[1], in.original_header());
+  DWI::Tractography::ACT::verify_5TT_image (in.header());
+  auto out = Image<float>::create (argument[1], in.header());
 
   Modifier modifier (in, out);
 

--- a/cmd/afdconnectivity.cpp
+++ b/cmd/afdconnectivity.cpp
@@ -123,7 +123,7 @@ class AFDConnectivity : public DWI::Tractography::SIFT::ModelBase<Fixel>
         DWI::Tractography::SIFT::ModelBase<Fixel> (fod_buffer, dirs),
         have_wbft (wbft_path.size()),
         all_fixels (false),
-        mapper (fod_buffer, dirs),
+        mapper (fod_buffer.header(), dirs),
         v_fod (fod_buffer)
     {
       if (have_wbft) {
@@ -132,7 +132,7 @@ class AFDConnectivity : public DWI::Tractography::SIFT::ModelBase<Fixel>
       } else {
         fmls.reset (new DWI::FMLS::Segmenter (dirs, Math::SH::LforN (fod_buffer.size (3))));
       }
-      mapper.set_upsample_ratio (DWI::Tractography::Mapping::determine_upsample_ratio (fod_buffer, tck_path, 0.1));
+      mapper.set_upsample_ratio (DWI::Tractography::Mapping::determine_upsample_ratio (fod_buffer.header(), tck_path, 0.1));
       mapper.set_use_precise_mapping (true);
     }
 
@@ -268,7 +268,7 @@ value_type AFDConnectivity::get (const std::string& path)
 
 void AFDConnectivity::save (const std::string& path)
 {
-  auto out = Image<value_type>::create (path, original_header());
+  auto out = Image<value_type>::create (path, header());
   VoxelAccessor v (accessor());
   for (auto l = Loop(v) (v, out); l; ++l) {
     value_type value = 0.0;
@@ -300,7 +300,7 @@ void run ()
 
   DWI::Directions::FastLookupSet dirs (1281);
   auto fod = Image<value_type>::open (argument[0]);
-  Math::SH::check (fod);
+  Math::SH::check (fod.header());
   AFDConnectivity model (fod, dirs, argument[1], wbft_path);
 
   opt = get_options ("all_fixels");

--- a/cmd/amp2sh.cpp
+++ b/cmd/amp2sh.cpp
@@ -212,7 +212,7 @@ class Amp2SH {
 void run ()
 {
   auto amp = Image<value_type>::open (argument[0]).with_direct_io (Stride::contiguous_along_axis (3));
-  auto header = amp.original_header();
+  auto header = amp.header();
 
   std::vector<size_t> bzeros, dwis;
   Eigen::MatrixXd dirs;
@@ -235,7 +235,7 @@ void run ()
       }
     } 
     else {
-      auto grad = DWI::get_valid_DW_scheme (amp.original_header());
+      auto grad = DWI::get_valid_DW_scheme (amp.header());
       DWI::Shells shells (grad);
       shells.select_shells (true, true);
       if (shells.smallest().is_bzero())

--- a/cmd/bogus.cpp
+++ b/cmd/bogus.cpp
@@ -32,7 +32,7 @@ void run ()
 
   std::cout << linear_transform.matrix() << std::endl;
 
-//  auto output = Image<float>::create (argument[2], input.original_header());
+//  auto output = Image<float>::create (argument[2], input.header());
 //  Registration::Transform::compose (linear_transform, input, output);
 
 

--- a/cmd/connectome2tck.cpp
+++ b/cmd/connectome2tck.cpp
@@ -212,7 +212,7 @@ void run ()
         ++volumes[index];
       }
     }
-    Transform transform (image);
+    Transform transform (image.header());
     for (node_t index = 1; index <= max_node_index; ++index) {
       if (volumes[index])
         COMs[index] = (transform.voxel2scanner * (COMs[index] * (1.0f / float(volumes[index]))).cast<default_type>()).cast<float>();

--- a/cmd/dwi2adc.cpp
+++ b/cmd/dwi2adc.cpp
@@ -86,7 +86,7 @@ class DWI2ADC {
 
 void run () {
   auto dwi = Header::open (argument[0]).get_image<value_type>();
-  auto grad = DWI::get_valid_DW_scheme (dwi.original_header());
+  auto grad = DWI::get_valid_DW_scheme (dwi.header());
 
   size_t dwi_axis = 3;
   while (dwi.size (dwi_axis) < 2)
@@ -101,7 +101,7 @@ void run () {
 
   auto binv = Math::pinv (b);
 
-  auto header = dwi.original_header();
+  auto header = dwi.header();
   header.datatype() = DataType::Float32;
   header.set_ndim (4);
   header.size(3) = 2;

--- a/cmd/dwi2fod.cpp
+++ b/cmd/dwi2fod.cpp
@@ -148,13 +148,13 @@ void run ()
   }
 
 
-  DWI::CSDeconv::Shared shared (dwi.original_header());
+  DWI::CSDeconv::Shared shared (dwi.header());
   shared.parse_cmdline_options();
   shared.set_response (argument[1]);
   shared.init();
 
 
-  auto header = Header(dwi);
+  auto header = dwi.header();
   header.set_ndim (4);
   header.size(3) = shared.nSH();
   header.datatype() = DataType::Float32;

--- a/cmd/dwi2mask.cpp
+++ b/cmd/dwi2mask.cpp
@@ -53,8 +53,8 @@ OPTIONS
 
 void run () {
   auto input = Image<float>::open (argument[0]).with_direct_io (Stride::contiguous_along_axis (3));
-  auto grad = DWI::get_DW_scheme (input);
-  Filter::DWIBrainMask dwi_brain_mask_filter (input, grad);
+  auto grad = DWI::get_DW_scheme (input.header());
+  Filter::DWIBrainMask dwi_brain_mask_filter (input.header(), grad);
   dwi_brain_mask_filter.set_message ("computing dwi brain mask... ");
   auto output = Image<bool>::create (argument[1], dwi_brain_mask_filter);
   dwi_brain_mask_filter (input, output);

--- a/cmd/dwi2noise.cpp
+++ b/cmd/dwi2noise.cpp
@@ -68,15 +68,15 @@ void run ()
 {
   auto dwi_in = Image<value_type>::open (argument[0]);
 
-  auto header = Header (dwi_in);
-  header.set_ndim (3);
-  header.datatype() = DataType::Float32;
-  auto noise = Image<value_type>::create (argument[1], header);
+  auto H_out = dwi_in.header();
+  H_out.set_ndim (3);
+  H_out.datatype() = DataType::Float32;
+  auto noise = Image<value_type>::create (argument[1], H_out);
 
   std::vector<size_t> dwis;
   Eigen::MatrixXd mapping;
   {
-    auto grad = DWI::get_valid_DW_scheme (dwi_in.original_header());
+    auto grad = DWI::get_valid_DW_scheme (dwi_in.header());
     dwis = DWI::Shells (grad).select_shells (true, true).largest().get_volumes();
     auto dirs = DWI::gen_direction_matrix (grad, dwis);
     mapping = DWI::compute_SH2amp_mapping (dirs);

--- a/cmd/dwi2tensor.cpp
+++ b/cmd/dwi2tensor.cpp
@@ -150,7 +150,7 @@ inline Processor<MASKType, B0Type, DKTType> processor (const Eigen::MatrixXd& b,
 void run ()
 {
   auto dwi = Header::open (argument[0]).get_image<value_type>();
-  auto grad = DWI::get_valid_DW_scheme (dwi.original_header());
+  auto grad = DWI::get_valid_DW_scheme (dwi.header());
   
   Image<bool>* mask = nullptr;
   auto opt = get_options ("mask");
@@ -161,7 +161,7 @@ void run ()
   
   auto iter = get_option_value ("iter", default_iter);
 
-  auto header = dwi.original_header();
+  auto header = dwi.header();
   header.datatype() = DataType::Float32;
   header.set_ndim (4);
   header.size(3) = 6;

--- a/cmd/dwiextract.cpp
+++ b/cmd/dwiextract.cpp
@@ -51,10 +51,10 @@ void usage ()
     + DWI::ShellOption;
 }
 
-void run() {
+void run()
+{
   auto input_image = Image<float>::open (argument[0]).with_direct_io (Stride::contiguous_along_axis(3));
-
-  Eigen::MatrixXd grad = DWI::get_valid_DW_scheme (input_image);
+  Eigen::MatrixXd grad = DWI::get_valid_DW_scheme (input_image.header());
 
   // Want to support non-shell-like data if it's just a straight extraction
   //   of all dwis or all bzeros i.e. don't initialise the Shells class
@@ -86,7 +86,7 @@ void run() {
 
   std::sort (volumes.begin(), volumes.end());
 
-  Header header (input_image);
+  Header header (input_image.header());
 
   if (volumes.size() == 1)
     header.set_ndim (3);

--- a/cmd/dwinormalise.cpp
+++ b/cmd/dwinormalise.cpp
@@ -64,11 +64,11 @@ void run () {
 
   auto input = Image<float>::open (argument[0]);
   auto mask = Image<bool>::open (argument[1]);
-  auto output = Image<float>::create (argument[2], input);
+  auto output = Image<float>::create (argument[2], input.header());
 
   check_dimensions (input, mask, 0, 3);
 
-  auto grad = DWI::get_DW_scheme (input);
+  auto grad = DWI::get_DW_scheme (input.header());
   DWI::Shells grad_shells (grad);
 
   std::vector<size_t> bzeros;

--- a/cmd/fixel2tsf.cpp
+++ b/cmd/fixel2tsf.cpp
@@ -94,7 +94,7 @@ void run ()
   ProgressBar progress ("mapping fixel values to streamline points...", num_tracks);
   DWI::Tractography::Streamline<float> tck;
 
-  Transform transform (input_fixel);
+  Transform transform (input_fixel.header());
   Eigen::Vector3 voxel_pos;
 
   while (reader (tck)) {

--- a/cmd/fixelcfestats.cpp
+++ b/cmd/fixelcfestats.cpp
@@ -196,7 +196,7 @@ void run() {
   std::vector<Eigen::Vector3> positions;
   std::vector<Eigen::Vector3f> directions;
 
-  Transform image_transform (mask_fixel_image);
+  Transform image_transform (mask_fixel_image.header());
   for (auto i = Loop (mask_fixel_image)(mask_fixel_image, fixel_index_image); i; ++i) {
     fixel_index_image.index(3) = 0;
     fixel_index_image.value() = directions.size();

--- a/cmd/fod2dec.cpp
+++ b/cmd/fod2dec.cpp
@@ -260,7 +260,7 @@ void run () {
     {
       auto fod_img = fod_hdr.get_image<value_type>().with_direct_io(Stride::contiguous_along_axis(3, fod_hdr));
 
-      auto dec_hdr = Header(fod_img);
+      Header dec_hdr = fod_img.header();
       dec_hdr.set_ndim(4);
       dec_hdr.size(3) = 3;
       Stride::set (dec_hdr, Stride::contiguous_along_axis (3, dec_hdr));
@@ -273,7 +273,7 @@ void run () {
         mask_img = mask_hdr.get_image<bool>();
 
       if (!get_options("no-weight").size() && !map_hdr) {
-        auto int_hdr = Header(dec_img);
+        Header int_hdr = dec_hdr;
         int_hdr.size(3) = 1;
         w_img = Image<value_type>::scratch(int_hdr,"FOD integral map");
       }
@@ -282,7 +282,7 @@ void run () {
         .run (DecComputer (DecTransform (Math::SH::LforN(fod_img.size(3)), dirs, thresh), mask_img, w_img), fod_img, dec_img);  
     }
 
-    auto out_hdr = map_hdr.valid() ? Header(map_hdr) : Header(dec_img);
+    Header out_hdr = map_hdr.valid() ? map_hdr : dec_img.header();
     out_hdr.datatype() = DataType::Float32;
     out_hdr.set_ndim(4);
     out_hdr.size(3) = 3;

--- a/cmd/label2colour.cpp
+++ b/cmd/label2colour.cpp
@@ -130,7 +130,7 @@ void run ()
   }
 
 
-  Header H = nodes.original_header();
+  Header H = nodes.header();
   H.set_ndim (4);
   H.size (3) = 3;
   H.datatype() = DataType::UInt8;

--- a/cmd/label2mesh.cpp
+++ b/cmd/label2mesh.cpp
@@ -66,7 +66,7 @@ void run ()
 {
 
   auto labels = Image<uint32_t>::open (argument[0]);
-  if (!labels.original_header().datatype().is_integer())
+  if (!labels.header().datatype().is_integer())
     throw Exception ("Input image must have an integer data type");
 
   typedef Eigen::Array<int, 3, 1> voxel_corner_t;
@@ -110,7 +110,7 @@ void run ()
       }
       Adapter::Subset<decltype(labels)> subset (labels, from, dimensions);
 
-      auto scratch = Image<bool>::scratch (subset, "Node " + str(in) + " mask");
+      auto scratch = Image<bool>::scratch (subset.header(), "Node " + str(in) + " mask");
       for (auto i = Loop (subset) (subset, scratch); i; ++i)
         scratch.value() = (subset.value() == in);
 
@@ -118,7 +118,7 @@ void run ()
         MR::Mesh::vox2mesh (scratch, meshes[in]);
       else
         MR::Mesh::vox2mesh_mc (scratch, 0.5, meshes[in]);
-      meshes[in].transform_voxel_to_realspace (scratch);
+      meshes[in].transform_voxel_to_realspace (scratch.header());
       meshes[in].set_name (str(in));
       std::lock_guard<std::mutex> lock (mutex);
       ++progress;

--- a/cmd/labelconfig.cpp
+++ b/cmd/labelconfig.cpp
@@ -114,7 +114,7 @@ void run ()
   auto in = Image<node_t>::open (argument[0]);
 
   // Create a new header for the output file
-  Header H (in.original_header());
+  Header H (in.header());
   add_line (H.keyval()["comments"], "Created by labelconfig using " + Path::basename (argument[0]) + " and " + Path::basename (argument[1]));
 
   // Create the output file
@@ -146,7 +146,7 @@ void run ()
         WARN ("Spine node is being created from the mask image provided using -spine option using nearest-neighbour interpolation;");
         WARN ("recommend using the parcellation image as the basis for this mask so that interpolation is not required");
 
-        Transform transform (out);
+        Transform transform (H);
         Interp::Nearest<decltype(in_spine)> nearest (in_spine);
         for (auto l = Loop (out) (out); l; ++l) {
           Eigen::Vector3 p (out.index (0), out.index (1), out.index (2));

--- a/cmd/maskfilter.cpp
+++ b/cmd/maskfilter.cpp
@@ -105,7 +105,7 @@ void run () {
   int filter_index = argument[1];
 
   if (filter_index == 0) { // Connected components
-    Filter::ConnectedComponents filter (input_image, std::string("applying connected-component filter to image ") + Path::basename (argument[0]) + "... ");
+    Filter::ConnectedComponents filter (input_image.header(), std::string("applying connected-component filter to image ") + Path::basename (argument[0]) + "... ");
     auto opt = get_options ("axes");
     std::vector<int> axes;
     if (opt.size()) {
@@ -144,20 +144,20 @@ void run () {
   }
 
   if (filter_index == 1) { // Dilate
-    Filter::Dilate filter (input_image, std::string("applying dilate filter to image ") + Path::basename (argument[0]) + "... ");
+    Filter::Dilate filter (input_image.header(), std::string("applying dilate filter to image ") + Path::basename (argument[0]) + "... ");
     auto opt = get_options ("npass");
     if (opt.size())
       filter.set_npass (int(opt[0][0]));
 
     Stride::set_from_command_line (filter);
 
-    auto output_image = Image<value_type>::create (argument[2], filter);
+    auto output_image = Image<value_type>::create (argument[2], filter.header());
     filter (input_image, output_image);
     return;
   }
 
   if (filter_index == 2) { // Erode
-    Filter::Erode filter (input_image, std::string("applying erode filter to image ") + Path::basename (argument[0]) + "... ");
+    Filter::Erode filter (input_image.header(), std::string("applying erode filter to image ") + Path::basename (argument[0]) + "... ");
     auto opt = get_options ("npass");
     if (opt.size())
       filter.set_npass (int(opt[0][0]));
@@ -170,7 +170,7 @@ void run () {
   }
 
   if (filter_index == 3) { // Median
-    Filter::Median filter (input_image, std::string("applying median filter to image ") + Path::basename (argument[0]) + "... ");
+    Filter::Median filter (input_image.header(), std::string("applying median filter to image ") + Path::basename (argument[0]) + "... ");
     auto opt = get_options ("extent");
     if (opt.size())
       filter.set_extent (parse_ints (opt[0][0]));

--- a/cmd/mrcalc.cpp
+++ b/cmd/mrcalc.cpp
@@ -294,7 +294,7 @@ class Evaluator
 
 
 inline bool StackEntry::is_complex () const {
-  if (image) return image->original_header().datatype().is_complex();
+  if (image) return image->header().datatype().is_complex();
   if (evaluator) return evaluator->is_complex();
   return value.imag() != 0.0;
 }
@@ -567,7 +567,7 @@ void get_header (const StackEntry& entry, Header& header)
     return;
 
   if (header.ndim() == 0) {
-    header = entry.image->original_header();
+    header = entry.image->header();
     return;
   }
 

--- a/cmd/mrcat.cpp
+++ b/cmd/mrcat.cpp
@@ -65,7 +65,6 @@ void run () {
   int num_images = argument.size()-1;
   std::vector<std::unique_ptr<Image<value_type>>> in (num_images);
   in[0].reset (new Image<value_type> (Image<value_type>::open (argument[0])));
-  Header header_in (*in[0]);
 
   int ndims = 0;
   int last_dim;
@@ -88,7 +87,7 @@ void run () {
 
   if (axis >= ndims) ndims = axis+1;
 
-  Header header_out (header_in);
+  Header header_out (in[0]->header());
   header_out.set_ndim (ndims);
 
   for (size_t i = 0; i < header_out.ndim(); i++) {
@@ -107,7 +106,7 @@ void run () {
   {
     size_t axis_dim = 0;
     for (int n = 0; n < num_images; n++) {
-      if (in[n]->original_header().datatype().is_complex())
+      if (in[n]->header().datatype().is_complex())
         header_out.datatype() = DataType::CFloat32;
       axis_dim += in[n]->ndim() > size_t (axis) ? (in[n]->size (axis) > 1 ? in[n]->size (axis) : 1) : 1;
     }
@@ -122,7 +121,7 @@ void run () {
     size_t nrows = 0;
     std::vector<Eigen::MatrixXd> input_grads;
     for (int n = 0; n < num_images; ++n) {
-      auto grad = DWI::get_DW_scheme (in[n]->original_header());
+      auto grad = DWI::get_DW_scheme (in[n]->header());
       input_grads.push_back (grad);
       if (grad.rows() == 0 || grad.cols() != 4) {
         nrows = 0;

--- a/cmd/mrconvert.cpp
+++ b/cmd/mrconvert.cpp
@@ -102,7 +102,7 @@ inline std::vector<int> set_header (Header& header, const ImageType& input)
     header.stride(n) = input.stride(n);
   }
   header.transform() = input.transform();
-  header.datatype() = input.original_header().datatype();
+  header.datatype() = input.header().datatype();
   header.reset_intensity_scaling();
 
   if (get_options ("grad").size() || get_options ("fslgrad").size())
@@ -157,7 +157,7 @@ inline void copy_permute (Header& header_in, Header& header_out, const std::vect
     const auto axes = set_header (header_out, in);
 
     auto out = Header::create (output_filename, header_out).get_image<T>();
-    DWI::export_grad_commandline (out.original_header());
+    DWI::export_grad_commandline (out.header());
 
     auto perm = Adapter::make <Adapter::PermuteAxes> (in, axes); 
     threaded_copy_with_progress (perm, out, 0, std::numeric_limits<size_t>::max(), 2);
@@ -167,7 +167,7 @@ inline void copy_permute (Header& header_in, Header& header_out, const std::vect
     auto extract = Adapter::make<Adapter::Extract> (in, pos); 
     const auto axes = set_header (header_out, extract);
     auto out = Header::create (output_filename, header_out).get_image<T>();
-    DWI::export_grad_commandline (out.original_header());
+    DWI::export_grad_commandline (out.header());
 
     auto perm = Adapter::make <Adapter::PermuteAxes> (extract, axes); 
     threaded_copy_with_progress (perm, out, 0, std::numeric_limits<size_t>::max(), 2);

--- a/cmd/mrcrop.cpp
+++ b/cmd/mrcrop.cpp
@@ -149,7 +149,7 @@ void run ()
   }
 
   auto cropped = Adapter::make<Adapter::Subset> (in, from, size);
-  auto out = Image<float>::create (argument[1], cropped);
+  auto out = Image<float>::create (argument[1], cropped.header());
   threaded_copy_with_progress_message ("cropping image...", cropped, out);
 }
 

--- a/cmd/mrfilter.cpp
+++ b/cmd/mrfilter.cpp
@@ -137,7 +137,7 @@ void run () {
       // FIXME Had to use cdouble throughout; seems to fail at compile time even trying to
       //   convert between cfloat and cdouble...
       auto input = Image<cdouble>::open (argument[0]).with_direct_io();
-      Filter::FFT filter (input, get_options ("inverse").size());
+      Filter::FFT filter (input.header(), get_options ("inverse").size());
 
       auto opt = get_options ("axes");
       if (opt.size())
@@ -154,7 +154,7 @@ void run () {
         for (auto l = Loop (output) (temp, output); l; ++l)
           output.value() = std::abs (cdouble(temp.value()));
       } else {
-        auto output = Image<cdouble>::create (argument[2], filter);
+        auto output = Image<cdouble>::create (argument[2], filter.header());
         filter (input, output);
       }
       break;
@@ -164,7 +164,7 @@ void run () {
     case 1:
     {
       auto input = Image<float>::open (argument[0]);
-      Filter::Gradient filter (input, get_options ("magnitude").size());
+      Filter::Gradient filter (input.header(), get_options ("magnitude").size());
 
       std::vector<default_type> stdev;
       auto opt = get_options ("stdev");
@@ -185,7 +185,7 @@ void run () {
       filter.set_message (std::string("applying ") + std::string(argument[1]) + " filter to image " + std::string(argument[0]) + "...");
       Stride::set_from_command_line (filter);
 
-      auto output = Image<float>::create (argument[2], filter);
+      auto output = Image<float>::create (argument[2], filter.header());
       filter (input, output);
     break;
     }
@@ -194,7 +194,7 @@ void run () {
     case 2:
     {
       auto input = Image<float>::open (argument[0]);
-      Filter::Median filter (input);
+      Filter::Median filter (input.header());
 
       auto opt = get_options ("extent");
       if (opt.size())
@@ -202,7 +202,7 @@ void run () {
       filter.set_message (std::string("applying ") + std::string(argument[1]) + " filter to image " + std::string(argument[0]) + "...");
       Stride::set_from_command_line (filter);
 
-      auto output = Image<float>::create (argument[2], filter);
+      auto output = Image<float>::create (argument[2], filter.header());
       filter (input, output);
       break;
      }
@@ -211,7 +211,7 @@ void run () {
     case 3:
     {
       auto input = Image<float>::open (argument[0]);
-      Filter::Smooth filter (input);
+      Filter::Smooth filter (input.header());
 
       auto opt = get_options ("stdev");
       const bool stdev_supplied = opt.size();
@@ -232,7 +232,7 @@ void run () {
       filter.set_message (std::string("applying ") + std::string(argument[1]) + " filter to image " + std::string(argument[0]) + "...");
       Stride::set_from_command_line (filter);
 
-      auto output = Image<float>::create (argument[2], filter);
+      auto output = Image<float>::create (argument[2], filter.header());
       filter (input, output);
       break;
     }

--- a/cmd/mrmath.cpp
+++ b/cmd/mrmath.cpp
@@ -332,7 +332,7 @@ void run ()
       throw Exception ("Cannot perform operation along axis " + str (axis) + "; image only has " + str(image_in.ndim()) + " axes");
 
 
-    Header header_out (image_in.original_header());
+    Header header_out (image_in.header());
 
     header_out.datatype() = DataType::from_command_line (DataType::Float32);
     header_out.size(axis) = 1;

--- a/cmd/mrresize.cpp
+++ b/cmd/mrresize.cpp
@@ -70,7 +70,7 @@ void run () {
 
   auto input = Image<float>::open (argument[0]);
 
-  Filter::Resize resize_filter (input);
+  Filter::Resize resize_filter (input.header());
 
   size_t resize_option_count = 0;
 

--- a/cmd/mrstats.cpp
+++ b/cmd/mrstats.cpp
@@ -106,7 +106,7 @@ void run ()
 {
 
   auto data = Image<complex_type>::open (argument[0]);
-  const bool is_complex = data.original_header().datatype().is_complex();
+  const bool is_complex = data.header().datatype().is_complex();
   if (data.ndim() > 4)
     throw Exception ("mrstats is not designed to handle images greater than 4D");
 

--- a/cmd/mrthreshold.cpp
+++ b/cmd/mrthreshold.cpp
@@ -145,7 +145,7 @@ void run ()
   const bool ignore_zeroes = get_options ("ignorezero").size();
 
   auto in = Image<float>::open (argument[0]);
-  if (in.original_header().datatype().is_complex())
+  if (in.header().datatype().is_complex())
     throw Exception ("Cannot perform thresholding on complex images");
 
   if (voxel_count (in) < topN || voxel_count (in) < bottomN)
@@ -160,7 +160,7 @@ void run ()
     else topN = std::round (voxel_count (in) * (1.0 - percentile));
   }
 
-  Header header_out (in.original_header());
+  Header header_out (in.header());
   header_out.datatype() = use_NaN ? DataType::Float32 : DataType::Bit;
 
   auto out = Image<float>::create (argument[1], header_out);

--- a/cmd/mrtransform.cpp
+++ b/cmd/mrtransform.cpp
@@ -300,7 +300,7 @@ void run ()
     // compose warp with affine
     std::shared_ptr<Image<float> > warp_composed_ptr;
     if (warp_ptr && linear) {
-      warp_composed_ptr = std::make_shared<Image<float> > (Image<float>::scratch (*warp_ptr));
+      warp_composed_ptr = std::make_shared<Image<float> > (Image<float>::scratch (warp_ptr->header()));
       Registration::Transform::compose (linear_transform, *warp_ptr, *warp_composed_ptr);
     } else {
       warp_composed_ptr = warp_ptr;

--- a/cmd/msdwi2fod.cpp
+++ b/cmd/msdwi2fod.cpp
@@ -247,7 +247,7 @@ inline Processor<MASKType, ODFType>  processor (const Shared& shared, MASKType* 
 void run ()
 {
   auto dwi = Header::open (argument[0]).get_image<value_type>();
-  auto grad = DWI::get_valid_DW_scheme (dwi.original_header());
+  auto grad = DWI::get_valid_DW_scheme (dwi.header());
   
   DWI::Shells shells (grad);
   size_t nbvals = shells.count();
@@ -297,7 +297,7 @@ void run ()
     check_dimensions (dwi, *mask, 0, 3);
   }
   
-  auto header = dwi.original_header();
+  auto header = dwi.header();
   header.datatype() = DataType::Float32;
   header.set_ndim (4);
   

--- a/cmd/peaks2amp.cpp
+++ b/cmd/peaks2amp.cpp
@@ -48,7 +48,7 @@ void run ()
 {
   auto dir = Image<float>::open (argument[0]);
 
-  auto header = dir.original_header();
+  auto header = dir.header();
   header.size(3) = header.size(3)/3;
 
   auto amp = Image<float>::create (argument[1], header);

--- a/cmd/sh2amp.cpp
+++ b/cmd/sh2amp.cpp
@@ -90,9 +90,9 @@ class SH2Amp
 void run ()
 {
   auto sh_data = Image<value_type>::open(argument[0]);
-  Math::SH::check (sh_data);
+  Math::SH::check (sh_data.header());
 
-  auto amp_header = sh_data.original_header();
+  auto amp_header = sh_data.header();
 
   Eigen::MatrixXd directions;
 

--- a/cmd/sh2peaks.cpp
+++ b/cmd/sh2peaks.cpp
@@ -294,7 +294,7 @@ extern value_type default_directions [];
 void run ()
 {
   auto SH_data = Image<value_type>::open (argument[0]).with_direct_io (Stride::contiguous_along_axis(3));
-  Math::SH::check (SH_data);
+  Math::SH::check (SH_data.header());
 
   auto opt = get_options ("mask");
 
@@ -325,7 +325,7 @@ void run ()
 
   value_type threshold = get_option_value("threshold", -INFINITY);
 
-  auto header = Header(SH_data);
+  auto header = SH_data.header();
   header.datatype() = DataType::Float32;
 
   opt = get_options ("peaks");

--- a/cmd/sh2power.cpp
+++ b/cmd/sh2power.cpp
@@ -39,15 +39,15 @@ void usage () {
 }
 
 
-void run () {
-  auto SH_data = Image<float>::open(argument[0]);
-  Math::SH::check (SH_data);
+void run ()
+{
+  auto SH_data = Image<float>::open (argument[0]);
+  Math::SH::check (SH_data.header());
 
-  auto power_header = SH_data.original_header();
-
-  int lmax = Math::SH::LforN (SH_data.size (3));
+  const int lmax = Math::SH::LforN (SH_data.size (3));
   INFO ("calculating spherical harmonic power up to degree " + str (lmax));
 
+  Header power_header = SH_data.header();
   power_header.size (3) = 1 + lmax/2;
   power_header.datatype() = DataType::Float32;
 

--- a/cmd/sh2response.cpp
+++ b/cmd/sh2response.cpp
@@ -72,7 +72,7 @@ typedef double value_type;
 void run () 
 {
   auto SH = Image<value_type>::open(argument[0]);
-  Math::SH::check (SH);
+  Math::SH::check (SH.header());
   auto mask = Image<bool>::open(argument[1]);
   auto dir = Image<value_type>::open(argument[2]).with_direct_io();
 

--- a/cmd/shconv.cpp
+++ b/cmd/shconv.cpp
@@ -82,10 +82,11 @@ class SConvFunctor {
 };
 
 
-void run() {
+void run()
+{
 
   auto image_in = Image<value_type>::open (argument[0]).with_direct_io (Stride::contiguous_along_axis(3));
-  Math::SH::check (image_in);
+  Math::SH::check (image_in.header());
 
   auto responseSH = load_vector<value_type>(argument[1]);
   Eigen::Matrix<value_type, Eigen::Dynamic, 1> responseRH;
@@ -98,7 +99,7 @@ void run() {
     check_dimensions (image_in, mask, 0, 3);
   }
 
-  auto header = Header(image_in);
+  auto header = image_in.header();
   Stride::set_from_command_line (header);
   auto image_out = Image<value_type>::create (argument[2], header);
   

--- a/cmd/tcksift.cpp
+++ b/cmd/tcksift.cpp
@@ -95,7 +95,7 @@ void run ()
   const bool out_debug = opt.size();
 
   auto in_dwi = Image<float>::open (argument[1]);
-  Math::SH::check (in_dwi);
+  Math::SH::check (in_dwi.header());
   DWI::Directions::FastLookupSet dirs (1281);
 
   SIFTer sifter (in_dwi, dirs);

--- a/cmd/tensor2metric.cpp
+++ b/cmd/tensor2metric.cpp
@@ -259,7 +259,7 @@ class Processor
 void run ()
 {
   auto dt_img = Image<value_type>::open (argument[0]);
-  auto header = dt_img.original_header();
+  auto header = dt_img.header();
   header.datatype() = DataType::Float32;
 
   auto mask_img = Image<bool>();

--- a/cmd/warpcorrect.cpp
+++ b/cmd/warpcorrect.cpp
@@ -60,7 +60,7 @@ void run ()
   if (input.size(3) != 3)
     throw Exception ("input warp should have 3 volumes in the 4th dimension");
 
-  auto output = Image<value_type>::create (argument[1], input);
+  auto output = Image<value_type>::create (argument[1], input.header());
 
   Eigen::Matrix<value_type, 3, 1> nans (std::numeric_limits<value_type>::quiet_NaN(),
                                         std::numeric_limits<value_type>::quiet_NaN(),

--- a/lib/adapter/base.h
+++ b/lib/adapter/base.h
@@ -41,15 +41,14 @@ namespace MR
       class Base {
         public:
           Base (const ImageType& parent) :
-            parent_ (parent) {
-            }
+              parent_ (parent) { }
 
           typedef typename ImageType::value_type value_type;
 
           template <class U> 
             const Base& operator= (const U& V) { return parent_ = V; }
 
-          FORCE_INLINE const Header& original_header () const { return parent_.original_header(); }
+          FORCE_INLINE const Header& header () const { return parent_.header(); }
           FORCE_INLINE ImageType& parent () { return parent_; }
           FORCE_INLINE bool valid () const { return parent_.valid(); }
           FORCE_INLINE bool operator! () const { return !valid(); }

--- a/lib/adapter/jacobian.h
+++ b/lib/adapter/jacobian.h
@@ -39,7 +39,7 @@ namespace MR
           Jacobian (const WarpType& parent, bool wrt_scanner = true) :
             Base<WarpType> (parent),
             gradient1D (parent, 0, wrt_scanner),
-            transform (parent),
+            transform (parent.header()),
             wrt_scanner (wrt_scanner) { }
 
 

--- a/lib/adapter/median3D.h
+++ b/lib/adapter/median3D.h
@@ -33,17 +33,19 @@ namespace MR
 
 
     template <class ImageType>
-      class Median3D : public Base<ImageType> {
+    class Median3D : public Base<ImageType> {
       public:
         Median3D (const ImageType& parent) :
-          Base<ImageType> (parent) {
-            set_extent (std::vector<int>(1,3));
-          }
+            Base<ImageType> (parent)
+        {
+          set_extent (std::vector<int>(1,3));
+        }
 
         Median3D (const ImageType& parent, const std::vector<int>& extent) :
-          Base<ImageType> (parent) {
-            set_extent (extent);
-          }
+            Base<ImageType> (parent)
+        {
+          set_extent (extent);
+        }
 
         typedef typename ImageType::value_type value_type;
         typedef Median3D voxel_type;

--- a/lib/adapter/replicate.h
+++ b/lib/adapter/replicate.h
@@ -42,7 +42,7 @@ namespace MR
         using Base<ImageType>::ndim;
         using Base<ImageType>::spacing;
 
-          Replicate (ImageType& original, const Header& replication_template) :
+        Replicate (ImageType& original, const Header& replication_template) :
             Base<ImageType> (original),
             header_ (replication_template),
             pos_ (ndim(), 0)
@@ -53,7 +53,7 @@ namespace MR
             }
           }
 
-        const Header& original_header() const {
+        const Header& header() const {
           return header_;
         }
 

--- a/lib/adapter/subset.h
+++ b/lib/adapter/subset.h
@@ -40,30 +40,20 @@ namespace MR
         using Base<ImageType>::spacing;
 
         template <class VectorType>
-          Subset (const ImageType& original, const VectorType& from, const VectorType& dimensions) :
+        Subset (const ImageType& original, const VectorType& from, const VectorType& dimensions) :
             Base<ImageType> (original),
             from_ (container_cast<decltype(from_)>(from)),
             size_ (container_cast<decltype(size_)>(dimensions)),
-            transform_ (original.transform()) {
-
-              for (size_t n = 0; n < ndim(); ++n) 
-                if (from_[n] + size_[n] > original.size(n))
-                  throw Exception ("FIXME: dimensions requested for Subset adapter are out of bounds!");
-
-              for (size_t j = 0; j < 3; ++j)
-                for (size_t i = 0; i < 3; ++i)
-                  transform_(i,3) += from[j] * spacing(j) * transform_(i,j);
-            }
+            header_ (original.header(), from, dimensions) { }
 
         void reset () {
-          for (size_t n = 0; n < ndim(); ++n)
+          for (size_t n = 0; n < parent().ndim(); ++n)
             set_pos (n, 0);
         }
 
-        size_t ndim () const { return size_.size(); }
-        ssize_t size (size_t axis) const { return size_ [axis]; }
-        const transform_type& transform() const { return transform_; }
+        const MR::Header& header() const { return header_; }
 
+        ssize_t size (const size_t axis) const { return size_[axis]; }
         ssize_t index (size_t axis) const { return parent().index(axis)-from_[axis]; }
         auto index (size_t axis) -> decltype(Helper::index(*this, axis)) { return { *this, axis }; } 
         void move_index (size_t axis, ssize_t increment) { parent().index(axis) += increment; }
@@ -71,7 +61,25 @@ namespace MR
       protected:
         using Base<ImageType>::parent;
         const std::vector<ssize_t> from_, size_;
-        transform_type transform_;
+
+        class Header : public MR::Header
+        {
+          public:
+            template <class VectorType>
+            Header (const MR::Header& original, const VectorType& from, const VectorType& dimensions) :
+                MR::Header (original)
+            {
+              for (size_t n = 0; n < MR::Header::ndim(); ++n) {
+                if (ssize_t(from[n] + dimensions[n]) > MR::Header::size(n))
+                  throw Exception ("FIXME: dimensions requested for Subset adapter are out of bounds!");
+                MR::Header::size(n) = dimensions[n];
+              }
+              for (size_t j = 0; j < 3; ++j) {
+                for (size_t i = 0; i < 3; ++i)
+                  MR::Header::transform_(i,3) += from[j] * MR::Header::spacing(j) * MR::Header::transform_(i,j);
+              }
+            }
+        } header_;
     };
 
   }

--- a/lib/algo/threaded_loop.h
+++ b/lib/algo/threaded_loop.h
@@ -269,15 +269,15 @@ namespace MR
       return { axes.begin()+num_inner_axes, axes.end() };
     }
 
-    template <class HeaderType>
-      inline std::vector<size_t> get_inner_axes (const HeaderType& source, size_t num_inner_axes, size_t from_axis, size_t to_axis) {
-        return get_inner_axes (Stride::order (source, from_axis, to_axis), num_inner_axes);
-      }
+    template <class ImageType>
+    inline std::vector<size_t> get_inner_axes (const ImageType& source, size_t num_inner_axes, size_t from_axis, size_t to_axis) {
+      return get_inner_axes (Stride::order (source, from_axis, to_axis), num_inner_axes);
+    }
 
-    template <class HeaderType>
-      inline std::vector<size_t> get_outer_axes (const HeaderType& source, size_t num_inner_axes, size_t from_axis, size_t to_axis) {
-        return get_outer_axes (Stride::order (source, from_axis, to_axis), num_inner_axes);
-      }
+    template <class ImageType>
+    inline std::vector<size_t> get_outer_axes (const ImageType& source, size_t num_inner_axes, size_t from_axis, size_t to_axis) {
+      return get_outer_axes (Stride::order (source, from_axis, to_axis), num_inner_axes);
+    }
 
 
     template <int N, class Functor, class... ImageType>
@@ -393,26 +393,26 @@ namespace MR
 
 
 
-  template <class HeaderType>
+  template <class ImageType>
     inline ThreadedLoopRunOuter<decltype(Loop(std::vector<size_t>()))> ThreadedLoop (
-        const HeaderType& source,
+        const ImageType& source,
         const std::vector<size_t>& outer_axes,
         const std::vector<size_t>& inner_axes) {
       return { source, Loop (outer_axes), inner_axes };
     }
 
 
-  template <class HeaderType>
+  template <class ImageType>
     inline ThreadedLoopRunOuter<decltype(Loop(std::vector<size_t>()))> ThreadedLoop (
-        const HeaderType& source,
+        const ImageType& source,
         const std::vector<size_t>& axes,
         size_t num_inner_axes = 1) {
       return { source, Loop (get_outer_axes (axes, num_inner_axes)), get_inner_axes (axes, num_inner_axes) }; 
     }
 
-  template <class HeaderType>
+  template <class ImageType>
     inline ThreadedLoopRunOuter<decltype(Loop(std::vector<size_t>()))> ThreadedLoop (
-        const HeaderType& source,
+        const ImageType& source,
         size_t from_axis = 0,
         size_t to_axis = std::numeric_limits<size_t>::max(),
         size_t num_inner_axes = 1) {
@@ -421,19 +421,19 @@ namespace MR
         get_inner_axes (source, num_inner_axes, from_axis, to_axis) };
       }
 
-  template <class HeaderType>
+  template <class ImageType>
     inline ThreadedLoopRunOuter<decltype(Loop("", std::vector<size_t>()))> ThreadedLoop (
         const std::string& progress_message,
-        const HeaderType& source,
+        const ImageType& source,
         const std::vector<size_t>& outer_axes,
         const std::vector<size_t>& inner_axes) {
       return { source, Loop (progress_message, outer_axes), inner_axes };
     }
 
-  template <class HeaderType>
+  template <class ImageType>
     inline ThreadedLoopRunOuter<decltype(Loop("", std::vector<size_t>()))> ThreadedLoop (
         const std::string& progress_message,
-        const HeaderType& source,
+        const ImageType& source,
         const std::vector<size_t>& axes,
         size_t num_inner_axes = 1) {
       return { source, 
@@ -441,10 +441,10 @@ namespace MR
         get_inner_axes (axes, num_inner_axes) };
       }
 
-  template <class HeaderType>
+  template <class ImageType>
     inline ThreadedLoopRunOuter<decltype(Loop("", std::vector<size_t>()))> ThreadedLoop (
         const std::string& progress_message,
-        const HeaderType& source,
+        const ImageType& source,
         size_t from_axis = 0,
         size_t to_axis = std::numeric_limits<size_t>::max(), 
         size_t num_inner_axes = 1) {

--- a/lib/filter/base.h
+++ b/lib/filter/base.h
@@ -50,18 +50,22 @@ namespace MR
     class Base : public Header
     {
       public:
-        template <class HeaderType>
-        Base (const HeaderType& in) :
-            Header (in) { }
-
-        template <class HeaderType>
-        Base (const HeaderType& in, const std::string& message) :
+        Base (const Header& in) :
             Header (in),
+            orig_header (in) { }
+
+        Base (const Header& in, const std::string& message) :
+            Header (in),
+            orig_header (in),
             message (message) { }
 
         virtual ~Base() { }
 
         const Header& original_header () const {
+          return orig_header;
+        }
+
+        const Header& header() const {
           return *this;
         }
 
@@ -74,6 +78,7 @@ namespace MR
         }
 
       protected:
+        const Header orig_header;
         std::string message;
 
     };

--- a/lib/filter/connected_components.h
+++ b/lib/filter/connected_components.h
@@ -119,7 +119,7 @@ namespace MR
         template <class MaskImageType>
         const std::vector<std::vector<int> >& precompute_adjacency (MaskImageType& mask) {
 
-          auto index_image = Image<uint32_t>::scratch (mask);
+          auto index_image = Image<uint32_t>::scratch (mask.header());
 
           // 1st pass, store mask image indices and their index in the array
           for (auto l = Loop (mask) (mask, index_image); l; ++l) {
@@ -274,11 +274,10 @@ namespace MR
     {
       public:
 
-      template <class HeaderType>
-      ConnectedComponents (const HeaderType& in) :
-        Base (in),
-        largest_only (false),
-        do_26_connectivity (false)
+      ConnectedComponents (const Header& in) :
+          Base (in),
+          largest_only (false),
+          do_26_connectivity (false)
       {
         if (this->ndim() > 4)
           throw Exception ("Cannot run connected components analysis with more than 4 dimensions");
@@ -288,9 +287,8 @@ namespace MR
           dim_to_ignore[3] = true;
       }
 
-      template <class HeaderType>
-      ConnectedComponents (const HeaderType& in, const std::string& message) :
-        ConnectedComponents (in)
+      ConnectedComponents (const Header& in, const std::string& message) :
+          ConnectedComponents (in)
       {
         set_message (message);
       }

--- a/lib/filter/dilate.h
+++ b/lib/filter/dilate.h
@@ -56,16 +56,14 @@ namespace MR
     {
 
       public:
-        template <class HeaderType>
-        Dilate (const HeaderType& in) :
+        Dilate (const Header& in) :
             Base (in),
             npass (1)
         {
           datatype_ = DataType::Bit;
         }
 
-        template <class HeaderType>
-        Dilate (const HeaderType& in, const std::string& message) :
+        Dilate (const Header& in, const std::string& message) :
             Base (in, message),
             npass (1)
         {
@@ -76,13 +74,13 @@ namespace MR
         template <class InputImageType, class OutputImageType>
         void operator() (InputImageType& input, OutputImageType& output)
         {
-          std::shared_ptr <Image<bool> > in (new Image<bool> (Image<bool>::scratch (input)));
+          std::shared_ptr <Image<bool> > in (new Image<bool> (Image<bool>::scratch (input.header())));
           copy (input, *in);
           std::shared_ptr <Image<bool> > out;
           std::shared_ptr<ProgressBar> progress (message.size() ? new ProgressBar (message, npass + 1) : nullptr);
 
           for (unsigned int pass = 0; pass < npass; pass++) {
-            out = std::make_shared<Image<bool>> (Image<bool>::scratch (input));
+            out = std::make_shared<Image<bool>> (Image<bool>::scratch (input.header()));
             for (auto l = Loop (*in) (*in, *out); l; ++l)
               out->value() = dilate (*in);
             if (pass < npass - 1)

--- a/lib/filter/erode.h
+++ b/lib/filter/erode.h
@@ -55,16 +55,14 @@ namespace MR
     {
 
       public:
-        template <class HeaderType>
-        Erode (const HeaderType& in) :
+        Erode (const Header& in) :
             Base (in),
             npass (1)
         {
           datatype_ = DataType::Bit;
         }
 
-        template <class HeaderType>
-        Erode (const HeaderType& in, const std::string& message) :
+        Erode (const Header& in, const std::string& message) :
             Base (in, message),
             npass (1)
         {
@@ -75,13 +73,13 @@ namespace MR
         template <class InputImageType, class OutputImageType>
         void operator() (InputImageType& input, OutputImageType& output)
         {
-          std::shared_ptr <Image<bool> > in = std::make_shared<Image<bool> > (Image<bool>::scratch (input));
+          std::shared_ptr <Image<bool> > in = std::make_shared<Image<bool> > (Image<bool>::scratch (input.header()));
           copy (input, *in);
           std::shared_ptr <Image<bool> > out;
           std::shared_ptr<ProgressBar> progress (message.size() ? new ProgressBar (message, npass + 1) : nullptr);
 
           for (unsigned int pass = 0; pass < npass; pass++) {
-            out = std::make_shared<Image<bool> > (Image<bool>::scratch (input));
+            out = std::make_shared<Image<bool> > (Image<bool>::scratch (input.header()));
             for (auto l = Loop (*in) (*in, *out); l; ++l)
              out->value() = erode (*in);
 

--- a/lib/filter/fft.h
+++ b/lib/filter/fft.h
@@ -56,8 +56,7 @@ namespace MR
     {
       public:
 
-        template <class HeaderType>
-        FFT (const HeaderType& in, const bool inverse) :
+        FFT (const Header& in, const bool inverse) :
             Base (in),
             inverse (inverse),
             centre_zero_ (false)
@@ -94,13 +93,13 @@ namespace MR
 
           std::shared_ptr<ProgressBar> progress (message.size() ? new ProgressBar (message, axes_to_process.size() + 2) : nullptr);
 
-            auto temp = Image<cdouble>::scratch (original_header());
+            auto temp = Image<cdouble>::scratch (header());
             copy (input, temp);
             if (progress)
               ++(*progress);
 
             for (std::vector<size_t>::const_iterator axis = axes_to_process.begin(); axis != axes_to_process.end(); ++axis) {
-              std::vector<size_t> axes = Stride::order (temp);
+              std::vector<size_t> axes = Stride::order (temp.header());
               for (size_t n = 0; n < axes.size(); ++n) {
                 if (axes[n] == *axis) {
                   axes.erase (axes.begin() + n);

--- a/lib/filter/gradient.h
+++ b/lib/filter/gradient.h
@@ -52,8 +52,7 @@ namespace MR
     class Gradient : public Base
     {
       public:
-        template <class HeaderType>
-        Gradient (const HeaderType& in, const bool magnitude = false) :
+        Gradient (const Header& in, const bool magnitude = false) :
             Base (in),
             smoother (in),
             wrt_scanner (true),
@@ -101,9 +100,9 @@ namespace MR
         void operator() (InputImageType& in, OutputImageType& out)
         {
           if (magnitude) {
-            Gradient full_gradient (in, false);
+            Gradient full_gradient (in.header(), false);
             full_gradient.set_message (message);
-            auto temp = Image<float>::scratch (full_gradient, "full 3D gradient image");
+            auto temp = Image<float>::scratch (full_gradient.header(), "full 3D gradient image");
             full_gradient (in, temp);
             for (auto l = Loop (out)(out, temp); l; ++l) {
               if (out.ndim() == 4) {
@@ -118,7 +117,7 @@ namespace MR
             return;
           }
 
-          auto smoothed = Image<float>::scratch (smoother);
+          auto smoothed = Image<float>::scratch (smoother.header());
           if (message.size())
             smoother.set_message ("applying smoothing prior to calculating gradient... ");
           smoother (in, smoothed);
@@ -147,7 +146,7 @@ namespace MR
             if (progress) ++(*progress);
 
             if (wrt_scanner) {
-              Transform transform (in);
+              Transform transform (in.header());
               for (auto l = Loop(0,3) (out); l; ++l)
                 out.row(3) = transform.image2scanner.linear().template cast<typename OutputImageType::value_type>() * out.row(3);
             }

--- a/lib/filter/median.h
+++ b/lib/filter/median.h
@@ -50,33 +50,33 @@ namespace MR
     {
 
       public:
-        template <class HeaderType>
-        Median (const HeaderType& in) :
+        Median (const Header& in) :
             Base (in),
-            extent (1,3) {
+            extent (1,3)
+        {
           datatype() = DataType::Float32;
         }
 
-        template <class HeaderType>
-          Median (const HeaderType& in, const std::string& message) :
+        Median (const Header& in, const std::string& message) :
             Base (in, message),
-            extent (1,3) { 
-              datatype() = DataType::Float32;
-            }
-
-        template <class HeaderType>
-        Median (const HeaderType& in, const std::vector<int>& extent) :
-            Base (in),
-            extent (extent) {
+            extent (1,3)
+        {
           datatype() = DataType::Float32;
         }
 
-        template <class HeaderType>
-          Median (const HeaderType& in, const std::string& message, const std::vector<int>& extent) :
+        Median (const Header& in, const std::vector<int>& extent) :
+            Base (in),
+            extent (extent)
+        {
+          datatype() = DataType::Float32;
+        }
+
+        Median (const Header& in, const std::string& message, const std::vector<int>& extent) :
             Base (in, message),
-            extent (extent) { 
-              datatype() = DataType::Float32;
-            }
+            extent (extent)
+        {
+          datatype() = DataType::Float32;
+        }
 
         //! Set the extent of median filtering neighbourhood in voxels.
         //! This must be set as a single value for all three dimensions

--- a/lib/filter/optimal_threshold.h
+++ b/lib/filter/optimal_threshold.h
@@ -150,7 +150,7 @@ namespace MR
                 count = 0;
 
                 if (mask.valid()) {
-                  Adapter::Replicate<MaskType> replicated_mask (mask, input);
+                  Adapter::Replicate<MaskType> replicated_mask (mask, input.header());
                   ThreadedLoop (input).run (MeanStdFunctor (sum, sum_sqr, count), input, replicated_mask);
                 }
                 else {
@@ -166,7 +166,7 @@ namespace MR
               double mean_xy = 0.0;
 
               if (mask.valid()) {
-                Adapter::Replicate<MaskType> replicated_mask (mask, input);
+                Adapter::Replicate<MaskType> replicated_mask (mask, input.header());
                 ThreadedLoop (input).run (CorrelationFunctor (threshold, sum, mean_xy), input, replicated_mask);
               }
               else

--- a/lib/filter/resize.h
+++ b/lib/filter/resize.h
@@ -63,8 +63,7 @@ namespace MR
     {
 
       public:
-        template <class HeaderType>
-        Resize (const HeaderType& in) :
+        Resize (const Header& in) :
             Base (in),
             interp_type (2) { }
 
@@ -150,9 +149,9 @@ namespace MR
             }
 
             if (do_smoothing) {
-              Filter::Smooth smooth_filter (input);
+              Filter::Smooth smooth_filter (input.header());
               smooth_filter.set_stdev (stdev);
-              auto smoothed = Image<float>::scratch (input, input.name());
+              auto smoothed = Image<float>::scratch (input.header(), input.name());
               {
                 LogLevelLatch log_level (0);
                 smooth_filter (input, smoothed);

--- a/lib/filter/reslice.h
+++ b/lib/filter/reslice.h
@@ -58,7 +58,7 @@ namespace MR
           const std::vector<int>& oversampling = Adapter::AutoOverSample,
           const typename ImageTypeDestination::value_type value_when_out_of_bounds = Transform::default_out_of_bounds_value<typename ImageTypeDestination::value_type>())
       {
-        Adapter::Reslice<Interpolator, ImageTypeSource> interp (source, destination, transform, oversampling, value_when_out_of_bounds);
+        Adapter::Reslice<Interpolator, ImageTypeSource> interp (source, destination.header(), transform, oversampling, value_when_out_of_bounds);
         threaded_copy_with_progress_message ("reslicing \"" + source.name() + "\"...", interp, destination, 0, source.ndim(), 2);
       }
 

--- a/lib/filter/smooth.h
+++ b/lib/filter/smooth.h
@@ -53,8 +53,7 @@ namespace MR
     {
 
       public:
-        template <class HeaderType>
-        Smooth (const HeaderType& in) :
+        Smooth (const Header& in) :
             Base (in),
             extent (3, 0),
             stdev (3, 0.0)
@@ -64,8 +63,7 @@ namespace MR
           datatype() = DataType::Float32;
         }
 
-        template <class HeaderType>
-        Smooth (const HeaderType& in, const std::vector<default_type>& stdev) :
+        Smooth (const Header& in, const std::vector<default_type>& stdev) :
             Base (in),
             extent (3, 0),
             stdev (3, 0.0)
@@ -120,7 +118,7 @@ namespace MR
         template <class InputImageType, class OutputImageType, typename ValueType = float>
         void operator() (InputImageType& input, OutputImageType& output)
         {
-          std::shared_ptr <Image<ValueType> > in (std::make_shared<Image<ValueType> > (Image<ValueType>::scratch (input)));
+          std::shared_ptr <Image<ValueType> > in (std::make_shared<Image<ValueType> > (Image<ValueType>::scratch (input.header())));
           threaded_copy (input, *in);
           std::shared_ptr <Image<ValueType> > out;
 
@@ -135,7 +133,7 @@ namespace MR
 
           for (size_t dim = 0; dim < 3; dim++) {
             if (stdev[dim] > 0) {
-              out = std::make_shared<Image<ValueType> > (Image<ValueType>::scratch (input));
+              out = std::make_shared<Image<ValueType> > (Image<ValueType>::scratch (input.header()));
               Adapter::Gaussian1D<Image<ValueType> > gaussian (*in, stdev[dim], dim, extent[dim]);
               threaded_copy (gaussian, *out);
               in = out;

--- a/lib/filter/warp.h
+++ b/lib/filter/warp.h
@@ -79,7 +79,7 @@ namespace MR
            !dimensions_match (warp, destination, 0, 3) ||
            !spacings_match (warp, destination, 0, 3)) {
 
-           auto header = destination.original_header();
+           auto header = destination.header();
            header.set_ndim(4);
            header.size(3) = 3;
            Stride::set (header, Stride::contiguous_along_axis (3));

--- a/lib/header.cpp
+++ b/lib/header.cpp
@@ -142,8 +142,7 @@ namespace MR
 
 
 
-  // specialisation for Header:
-  template<> Header Header::create (const std::string& image_name, const Header& template_header)
+  Header Header::create (const std::string& image_name, const Header& template_header)
   {
     if (image_name.empty())
       throw Exception ("no name supplied to open image!");
@@ -250,8 +249,6 @@ namespace MR
 
     return H;
   }
-  // force instantiation:
-  template Header Header::create<Header> (const std::string& image_name, const Header& template_header);
 
 
 
@@ -259,8 +256,7 @@ namespace MR
 
 
 
-  // specialisation for Header:
-  template<> Header Header::scratch (const Header& template_header, const std::string& label) 
+  Header Header::scratch (const Header& template_header, const std::string& label)
   {
     Header H (template_header);
     H.name() = label;
@@ -270,8 +266,6 @@ namespace MR
     H.io = std::move (std::unique_ptr<ImageIO::Scratch> (new ImageIO::Scratch (H))); 
     return H;
   }
-  // force instantiation:
-  template Header Header::scratch<Header> (const Header& template_header, const std::string& label);
 
 
 

--- a/lib/header.h
+++ b/lib/header.h
@@ -96,20 +96,6 @@ namespace MR
         offset_ (0.0),
         scale_ (1.0) { }
 
-      //! \copydoc Header (const Header&)
-      template <class HeaderType>
-        Header (const HeaderType& original) :
-          Header (original.original_header()) {
-            name() = original.name();
-            set_ndim (original.ndim());
-            for (size_t n = 0; n < original.ndim(); ++n) {
-              size(n) = original.size(n);
-              stride(n) = original.stride(n);
-              spacing(n) = original.spacing(n);
-            }
-            transform() = original.transform();
-          }
-
       //! assignment operator
       /*! This copies everything over apart from the IO handler and the
        * intensity scaling. */
@@ -125,23 +111,6 @@ namespace MR
         io.reset();
         return *this;
       }
-
-      //! \copydoc operator=(const Header&)
-      template <class HeaderType>
-        Header& operator= (const HeaderType& original) {
-          *this = original.original_header();
-          set_ndim (original.ndim());
-          for (size_t n = 0; n < ndim(); ++n) {
-            size(n) = original.size(n);
-            spacing(n) = original.spacing(n);
-            stride(n) = original.stride(n);
-          }
-          transform() = original.transform();
-          offset_ = 0.0;
-          scale_ = 1.0;
-          io.reset();
-          return *this;
-        }
 
       ~Header () { 
         if (io) {
@@ -262,11 +231,10 @@ namespace MR
           keyval()["dw_scheme"] = dw_scheme;
         }
 
+      //! Primary interface for image open/formation
       static Header open (const std::string& image_name);
-      template <class HeaderType>
-        static Header create (const std::string& image_name, const HeaderType& template_header);
-      template <class HeaderType>
-        static Header scratch (const HeaderType& template_header, const std::string& label = "scratch image");
+      static Header create (const std::string& image_name, const Header& template_header);
+      static Header scratch (const Header& template_header, const std::string& label = "scratch image");
 
       /*! use to prevent automatic realignment of transform matrix into
        * near-standard (RAS) coordinate system. */
@@ -337,20 +305,6 @@ namespace MR
 
   inline const ssize_t& Header::stride (size_t axis) const { return axes_[axis].stride; }
   inline ssize_t& Header::stride (size_t axis) { return axes_[axis].stride; } 
-
-  template <class HeaderType>
-    inline Header Header::create (const std::string& image_name, const HeaderType& template_header) {
-      return create (image_name, Header (template_header)); 
-    }
-  template <> Header Header::create (const std::string& image_name, const Header& template_header);
-  extern template Header Header::create<Header> (const std::string& image_name, const Header& template_header);
-
-  template <class HeaderType>
-    inline Header Header::scratch (const HeaderType& template_header, const std::string& label) {
-      return scratch (Header (template_header), label);
-    }
-  template<> Header Header::scratch (const Header& template_header, const std::string& label);
-  extern template Header Header::scratch<Header> (const Header& template_header, const std::string& label);
 
   //! @}
 }

--- a/lib/interp/cubic.h
+++ b/lib/interp/cubic.h
@@ -89,11 +89,11 @@ namespace MR
         using Transform::out_of_bounds;
         using Transform::bounds;
 
-        //! construct a Nearest object to obtain interpolated values using the
-        // parent DataSet class
+        /*! construct a Nearest object to obtain interpolated values using the
+         *  parent DataSet class */
         SplineInterpBase (const ImageType& parent, value_type value_when_out_of_bounds = Transform::default_out_of_bounds_value<value_type>()) :
           ImageType (parent),
-          Transform (parent),
+          Transform (parent.header()),
           out_of_bounds_value (value_when_out_of_bounds),
           H { SplineType(PType), SplineType(PType), SplineType(PType) }
         { }

--- a/lib/interp/linear.h
+++ b/lib/interp/linear.h
@@ -85,11 +85,11 @@ namespace MR
         using Transform::out_of_bounds;
         using Transform::bounds;
 
-        //! construct an Linear object to obtain interpolated values using the
-        // parent DataSet class
+        /*! construct an Linear object to obtain interpolated values using the
+         *  parent DataSet class */
         Linear (const ImageType& parent, value_type value_when_out_of_bounds = Transform::default_out_of_bounds_value<value_type>()) :
           ImageType (parent),
-          Transform (parent),
+          Transform (parent.header()),
           out_of_bounds_value (value_when_out_of_bounds) { }
 
         //! Set the current position to <b>voxel space</b> position \a pos

--- a/lib/interp/nearest.h
+++ b/lib/interp/nearest.h
@@ -80,11 +80,11 @@ namespace MR
         using Transform::out_of_bounds;
         using Transform::bounds;
 
-        //! construct an Nearest object to obtain interpolated values using the
-        // parent DataSet class
+        /*! construct an Nearest object to obtain interpolated values using the
+         *  parent DataSet class */
         Nearest (const ImageType& parent, value_type value_when_out_of_bounds = Transform::default_out_of_bounds_value<value_type>()) :
           ImageType (parent),
-          Transform (parent),
+          Transform (parent.header()),
           out_of_bounds_value (value_when_out_of_bounds) { }
 
         //! Set the current position to <b>voxel space</b> position \a pos

--- a/lib/interp/sinc.h
+++ b/lib/interp/sinc.h
@@ -85,11 +85,11 @@ namespace MR
         using Transform::out_of_bounds;
         using Transform::bounds;
 
-        //! construct an Interp object to obtain interpolated values using the
-        // parent DataSet class
+        /*! construct an Interp object to obtain interpolated values using the
+         *  parent DataSet class */
         Sinc (const ImageType& parent, value_type value_when_out_of_bounds = Transform::default_out_of_bounds_value<value_type>(), const size_t w = SINC_WINDOW_SIZE) :
             ImageType (parent),
-            Transform (parent),
+            Transform (parent.header()),
             out_of_bounds_value (value_when_out_of_bounds),
             window_size (w),
             kernel_width ((window_size-1)/2),

--- a/lib/math/SH.cpp
+++ b/lib/math/SH.cpp
@@ -28,6 +28,14 @@ namespace MR
         "etc...\n";
 
 
+      void check (const Header& H) {
+        if (H.ndim() < 4)
+          throw Exception ("image \"" + H.name() + "\" does not contain SH coefficients - not 4D");
+        size_t l = LforN (H.size(3));
+        if (l%2 || NforL (l) != size_t (H.size(3)))
+          throw Exception ("image \"" + H.name() + "\" does not contain SH coefficients - unexpected number of coefficients");
+      }
+
     }
   }
 }

--- a/lib/math/SH.h
+++ b/lib/math/SH.h
@@ -27,6 +27,7 @@
 # warning using non-orthonormal SH basis
 #endif
 
+#include "header.h"
 #include "math/legendre.h"
 #include "math/least_squares.h"
 
@@ -817,14 +818,7 @@ namespace MR
 
 
       //! convenience function to check if an input image can contain SH coefficients
-      template <class ImageType>
-        void check (const ImageType& H) {
-          if (H.ndim() < 4)
-            throw Exception ("image \"" + H.name() + "\" does not contain SH coefficients - not 4D");
-          size_t l = LforN (H.size(3));
-          if (l%2 || NforL (l) != size_t (H.size(3)))
-            throw Exception ("image \"" + H.name() + "\" does not contain SH coefficients - unexpected number of coefficients");
-        }
+      void check (const Header&);
       /** @} */
 
     }

--- a/lib/sparse/image.h
+++ b/lib/sparse/image.h
@@ -116,7 +116,7 @@ namespace MR
         typedef uint64_t value_type;
         typedef DataType sparse_data_type;
 
-        using ::MR::Image<uint64_t>::original_header;
+        using ::MR::Image<uint64_t>::header;
 
         Value<DataType> value () { return { *this, *io }; }
         const Value<DataType> value () const { return { *this, *io }; }
@@ -131,15 +131,15 @@ namespace MR
           if (typeid (*buffer->get_io()) != typeid (ImageIO::Sparse))
             throw Exception ("cannot create sparse image to access non-sparse data");
           // Use the header information rather than trying to access this from the handler
-          std::map<std::string, std::string>::const_iterator name_it = original_header().keyval().find (Sparse::name_key);
-          if (name_it == original_header().keyval().end())
+          std::map<std::string, std::string>::const_iterator name_it = header().keyval().find (Sparse::name_key);
+          if (name_it == header().keyval().end())
             throw Exception ("cannot create sparse image without knowledge of underlying class type in the image header");
           // TODO temporarily disabled this to allow updated_syntax tests to pass with files generated with master branch.
 //          const std::string& class_name = name_it->second;
 //          if (str(typeid(DataType).name()) != class_name)
 //            throw Exception ("class type of sparse image buffer (" + str(typeid(DataType).name()) + ") does not match that in image header (" + class_name + ")");
-          std::map<std::string, std::string>::const_iterator size_it = original_header().keyval().find (Sparse::size_key);
-          if (size_it == original_header().keyval().end())
+          std::map<std::string, std::string>::const_iterator size_it = header().keyval().find (Sparse::size_key);
+          if (size_it == header().keyval().end())
             throw Exception ("cannot create sparse image without knowledge of underlying class size in the image header");
           const size_t class_size = to<size_t>(size_it->second);
           if (sizeof(DataType) != class_size)

--- a/lib/transform.h
+++ b/lib/transform.h
@@ -23,6 +23,7 @@
 #ifndef __image_transform_h__
 #define __image_transform_h__
 
+#include "header.h"
 #include "types.h"
 
 namespace MR
@@ -32,8 +33,7 @@ namespace MR
     public:
 
       //! An object for transforming between voxel, scanner and image coordinate spaces
-      template <class HeaderType>
-        Transform (const HeaderType& header) :
+      Transform (const Header& header) :
           voxelsize (header.spacing(0), header.spacing(1), header.spacing(2)),
           voxel2scanner (header.transform() * voxelsize),
           scanner2voxel (voxel2scanner.inverse()),
@@ -56,8 +56,7 @@ namespace MR
           return std::numeric_limits<ValueType>::quiet_NaN(); 
         }
 
-      template <class HeaderType>
-        static inline transform_type get_default (const HeaderType& header) {
+      static inline transform_type get_default (const Header& header) {
           transform_type M;
           M.setIdentity();
           M.translation() = Eigen::Vector3d (

--- a/src/dwi/fixel_map.h
+++ b/src/dwi/fixel_map.h
@@ -85,7 +85,7 @@ namespace MR
         // Functions can copy-construct their own voxel accessor from this and retain const-ness:
         const VoxelAccessor& accessor() const { return _accessor; }
 
-        const ::MR::Header& original_header() const { return _accessor.original_header(); }
+        const ::MR::Header& header() const { return _accessor.header(); }
 
       protected:
         std::vector<Fixel> fixels;
@@ -99,7 +99,7 @@ namespace MR
               set_ndim (3);
             }
             HeaderHelper() = default;
-            const ::MR::Header& original_header() const { return *this; }
+            const ::MR::Header& header() const { return *this; }
         } _header;
 
         VoxelAccessor _accessor;

--- a/src/dwi/tractography/ACT/shared.h
+++ b/src/dwi/tractography/ACT/shared.h
@@ -44,7 +44,7 @@ namespace MR
               voxel (Image<float>::open (path)),
               bt (false)
             {
-              verify_5TT_image (voxel.original_header());
+              verify_5TT_image (voxel.header());
               property_set.set (bt, "backtrack");
               if (property_set.find ("crop_at_gmwmi") != property_set.end())
                 gmwmi_finder.reset (new GMWMI_finder (voxel));

--- a/src/dwi/tractography/SIFT/model.h
+++ b/src/dwi/tractography/SIFT/model.h
@@ -75,7 +75,7 @@ namespace MR
           Model (Set& dwi, const DWI::Directions::FastLookupSet& dirs) :
               ModelBase<Fixel> (dwi, dirs)
           {
-            Track_fixel_contribution::set_scaling (dwi);
+            Track_fixel_contribution::set_scaling (dwi.header());
           }
           Model (const Model& that) = delete;
 
@@ -181,8 +181,8 @@ namespace MR
 
         {
           Mapping::TrackLoader loader (file, count);
-          Mapping::TrackMapperBase mapper (Fixel_map<Fixel>::original_header(), dirs);
-          mapper.set_upsample_ratio (Mapping::determine_upsample_ratio (Fixel_map<Fixel>::original_header(), properties, 0.1));
+          Mapping::TrackMapperBase mapper (Fixel_map<Fixel>::header(), dirs);
+          mapper.set_upsample_ratio (Mapping::determine_upsample_ratio (Fixel_map<Fixel>::header(), properties, 0.1));
           mapper.set_use_precise_mapping (true);
           MappedTrackReceiver receiver (*this);
           Thread::run_queue (

--- a/src/dwi/tractography/SIFT/model_base.h
+++ b/src/dwi/tractography/SIFT/model_base.h
@@ -139,8 +139,8 @@ namespace MR
 
           public:
             ModelBase (Image<float>& dwi, const DWI::Directions::FastLookupSet& dirs) :
-                Mapping::Fixel_TD_map<Fixel> (dwi.original_header(), dirs),
-                proc_mask (Image<float>::scratch (Fixel_map<Fixel>::original_header(), "SIFT model processing mask")),
+                Mapping::Fixel_TD_map<Fixel> (dwi.header(), dirs),
+                proc_mask (Image<float>::scratch (Fixel_map<Fixel>::header(), "SIFT model processing mask")),
                 FOD_sum (0.0),
                 TD_sum (0.0),
                 have_null_lobes (false)
@@ -202,7 +202,7 @@ namespace MR
         template <class Fixel>
         void ModelBase<Fixel>::perform_FOD_segmentation (Image<float>& data)
         {
-          Math::SH::check (data);
+          Math::SH::check (data.header());
           DWI::FMLS::FODQueueWriter writer (data, proc_mask);
           DWI::FMLS::Segmenter fmls (dirs, Math::SH::LforN (data.size(3)));
           fmls.set_dilate_lookup_table (!App::get_options ("no_dilate_lut").size());
@@ -250,8 +250,8 @@ namespace MR
             throw Exception ("Cannot map streamlines: track file " + Path::basename(path) + " is empty");
 
           Mapping::TrackLoader loader (file, count);
-          Mapping::TrackMapperBase mapper (Fixel_map<Fixel>::original_header(), dirs);
-          mapper.set_upsample_ratio (Mapping::determine_upsample_ratio (Fixel_map<Fixel>::original_header(), properties, 0.1));
+          Mapping::TrackMapperBase mapper (Fixel_map<Fixel>::header(), dirs);
+          mapper.set_upsample_ratio (Mapping::determine_upsample_ratio (Fixel_map<Fixel>::header(), properties, 0.1));
           mapper.set_use_precise_mapping (true);
           Thread::run_queue (
               loader,

--- a/src/dwi/tractography/SIFT/output.h
+++ b/src/dwi/tractography/SIFT/output.h
@@ -56,7 +56,7 @@ namespace MR
       template <class Fixel>
       void ModelBase<Fixel>::output_target_image (const std::string& path) const
       {
-        auto out = Image<float>::create (path, Fixel_map<Fixel>::original_header());
+        auto out = Image<float>::create (path, Fixel_map<Fixel>::header());
         VoxelAccessor v (accessor());
         for (auto l = Loop(out) (out, v); l; ++l) {
           if (v.value()) {
@@ -76,7 +76,7 @@ namespace MR
         const size_t L = 8;
         const size_t N = Math::SH::NforL (L);
         Math::SH::aPSF<float> aPSF (L);
-        Header H_sh (Fixel_map<Fixel>::original_header());
+        Header H_sh (Fixel_map<Fixel>::header());
         H_sh.set_ndim (4);
         H_sh.size(3) = N;
         H_sh.stride (3) = 0;
@@ -107,7 +107,7 @@ namespace MR
       void ModelBase<Fixel>::output_target_image_fixel (const std::string& path) const
       {
         using Sparse::FixelMetric;
-        Header H_fixel (Fixel_map<Fixel>::original_header());
+        Header H_fixel (Fixel_map<Fixel>::header());
         H_fixel.datatype() = DataType::UInt64;
         H_fixel.datatype().set_byte_order_native();
         H_fixel.keyval()[Sparse::name_key] = str(typeid(FixelMetric).name());
@@ -130,7 +130,7 @@ namespace MR
       void ModelBase<Fixel>::output_tdi (const std::string& path) const
       {
         const double current_mu = mu();
-        auto out = Image<float>::create (path, Fixel_map<Fixel>::original_header());
+        auto out = Image<float>::create (path, Fixel_map<Fixel>::header());
         VoxelAccessor v (accessor());
         for (auto l = Loop (out) (out, v); l; ++l) {
           if (v.value()) {
@@ -148,7 +148,7 @@ namespace MR
       void ModelBase<Fixel>::output_tdi_null_lobes (const std::string& path) const
       {
         const double current_mu = mu();
-        auto out = Image<float>::create (path, Fixel_map<Fixel>::original_header());
+        auto out = Image<float>::create (path, Fixel_map<Fixel>::header());
         VoxelAccessor v (accessor());
         for (auto l = Loop (out) (out, v); l; ++l) {
           if (v.value()) {
@@ -171,7 +171,7 @@ namespace MR
         const size_t L = 8;
         const size_t N = Math::SH::NforL (L);
         Math::SH::aPSF<float> aPSF (L);
-        Header H_sh (Fixel_map<Fixel>::original_header());
+        Header H_sh (Fixel_map<Fixel>::header());
         H_sh.set_ndim (4);
         H_sh.size(3) = N;
         H_sh.stride (3) = 0;
@@ -203,7 +203,7 @@ namespace MR
       {
         using Sparse::FixelMetric;
         const double current_mu = mu();
-        Header H_fixel (Fixel_map<Fixel>::original_header());
+        Header H_fixel (Fixel_map<Fixel>::header());
         H_fixel.datatype() = DataType::UInt64;
         H_fixel.datatype().set_byte_order_native();
         H_fixel.keyval()[Sparse::name_key] = str(typeid(FixelMetric).name());
@@ -226,9 +226,9 @@ namespace MR
       void ModelBase<Fixel>::output_error_images (const std::string& max_abs_diff_path, const std::string& diff_path, const std::string& cost_path) const
       {
         const double current_mu = mu();
-        auto out_max_abs_diff = Image<float>::create (max_abs_diff_path, Fixel_map<Fixel>::original_header());
-        auto out_diff = Image<float>::create (diff_path, Fixel_map<Fixel>::original_header());
-        auto out_cost = Image<float>::create (cost_path, Fixel_map<Fixel>::original_header());
+        auto out_max_abs_diff = Image<float>::create (max_abs_diff_path, Fixel_map<Fixel>::header());
+        auto out_diff = Image<float>::create (diff_path, Fixel_map<Fixel>::header());
+        auto out_cost = Image<float>::create (cost_path, Fixel_map<Fixel>::header());
         VoxelAccessor v (accessor());
         for (auto l = Loop (v) (v, out_max_abs_diff, out_diff, out_cost); l; ++l) {
           if (v.value()) {
@@ -255,7 +255,7 @@ namespace MR
       {
         using Sparse::FixelMetric;
         const double current_mu = mu();
-        Header H_fixel (Fixel_map<Fixel>::original_header());
+        Header H_fixel (Fixel_map<Fixel>::header());
         H_fixel.datatype() = DataType::UInt64;
         H_fixel.datatype().set_byte_order_native();
         H_fixel.keyval()[Sparse::name_key] = str(typeid(FixelMetric).name());
@@ -292,7 +292,7 @@ namespace MR
       template <class Fixel>
       void ModelBase<Fixel>::output_fixel_count_image (const std::string& path) const
       {
-        Header H_out (Fixel_map<Fixel>::original_header());
+        Header H_out (Fixel_map<Fixel>::header());
         H_out.datatype() = DataType::UInt8;
         auto out = Image<uint8_t>::create (path, H_out);
         VoxelAccessor v (accessor());
@@ -307,10 +307,10 @@ namespace MR
       template <class Fixel>
       void ModelBase<Fixel>::output_untracked_fixels (const std::string& path_count, const std::string& path_amps) const
       {
-        Header H_uint8_t (Fixel_map<Fixel>::original_header());
+        Header H_uint8_t (Fixel_map<Fixel>::header());
         H_uint8_t.datatype() = DataType::UInt8;
         auto out_count = Image<uint8_t>::create (path_count, H_uint8_t);
-        auto out_amps = Image<float>::create (path_amps, Fixel_map<Fixel>::original_header());
+        auto out_amps = Image<float>::create (path_amps, Fixel_map<Fixel>::header());
         VoxelAccessor v (accessor());
         for (auto l = Loop (v) (v, out_count, out_amps, v); l; ++l) {
           if (v.value()) {

--- a/src/dwi/tractography/SIFT/proc_mask.cpp
+++ b/src/dwi/tractography/SIFT/proc_mask.cpp
@@ -67,9 +67,9 @@ namespace MR
             if (opt.size()) {
 
               auto in_5tt = Image<float>::open (opt[0][0]);
-              ACT::verify_5TT_image (in_5tt);
+              ACT::verify_5TT_image (in_5tt.header());
 
-              Header H_5tt = in_dwi.original_header();
+              Header H_5tt = in_dwi.header();
               H_5tt.set_ndim (4);
               H_5tt.size(3) = 5;
               assert (!out_5tt.valid());
@@ -107,7 +107,7 @@ namespace MR
 
         ResampleFunctor::ResampleFunctor (Image<float>& dwi, Image<float>& anat, Image<float>& out) :
             dwi (dwi),
-            voxel2scanner (new transform_type (Transform(dwi).voxel2scanner.cast<float>())),
+            voxel2scanner (new transform_type (Transform(dwi.header()).voxel2scanner.cast<float>())),
             interp_anat (anat),
             out (out)
         {

--- a/src/dwi/tractography/SIFT2/tckfactor.cpp
+++ b/src/dwi/tractography/SIFT2/tckfactor.cpp
@@ -384,7 +384,7 @@ namespace MR {
         }
 
         using Sparse::FixelMetric;
-        Header H_fixel (original_header());
+        Header H_fixel (header());
         H_fixel.datatype() = DataType::UInt64;
         H_fixel.datatype().set_byte_order_native();
         H_fixel.keyval()[Sparse::name_key] = str(typeid(FixelMetric).name());

--- a/src/dwi/tractography/algorithms/tensor_det.h
+++ b/src/dwi/tractography/algorithms/tensor_det.h
@@ -70,7 +70,7 @@ namespace MR
 
           properties["method"] = "TensorDet";
 
-          auto grad = DWI::get_valid_DW_scheme (source);
+          auto grad = DWI::get_valid_DW_scheme (source.header());
 
           auto bmat_double = grad2bmatrix<double> (grad);
           binv = Math::pinv (bmat_double).cast<float>();

--- a/src/dwi/tractography/connectome/tck2nodes.h
+++ b/src/dwi/tractography/connectome/tck2nodes.h
@@ -52,7 +52,7 @@ class Tck2nodes_base {
   public:
     Tck2nodes_base (const Image<node_t>& nodes_data, const bool pair) :
         nodes     (nodes_data),
-        transform (new Transform (nodes)),
+        transform (new Transform (nodes.header())),
         pair      (pair) { }
 
     Tck2nodes_base (const Tck2nodes_base& that) = default;

--- a/src/dwi/tractography/mapping/gaussian/mapper.h
+++ b/src/dwi/tractography/mapping/gaussian/mapper.h
@@ -47,10 +47,10 @@ namespace MR {
             typedef Mapping::TrackMapperTWI BaseMapper;
 
             public:
-            template <class HeaderType>
-              TrackMapper (const HeaderType& template_image, const contrast_t c) :
-              BaseMapper (template_image, c, GAUSSIAN),
-              gaussian_denominator  (0.0) {
+              TrackMapper (const Header& template_image, const contrast_t c) :
+                  BaseMapper (template_image, c, GAUSSIAN),
+                  gaussian_denominator  (0.0)
+              {
                 assert (c == SCALAR_MAP || c == SCALAR_MAP_COUNT || c == FOD_AMP || c == CURVATURE);
               }
 
@@ -132,7 +132,7 @@ namespace MR {
               Eigen::Vector3i vox;
               for (size_t i = 0; i != last; ++i) {
                 vox = round (scanner2voxel * tck[i]);
-                if (check (vox, info)) {
+                if (check (vox, header)) {
                   const Eigen::Vector3f dir ((tck[i+1] - tck[prev]).normalized());
                   const float factor = tck_index_to_factor (i);
                   add_to_set (output, vox, dir, 1.0f, factor);
@@ -141,7 +141,7 @@ namespace MR {
               }
 
               vox = round (scanner2voxel * tck[last]);
-              if (check (vox, info)) {
+              if (check (vox, header)) {
                 const Eigen::Vector3f dir ((tck[last] - tck[prev]).normalized());
                 const float factor = tck_index_to_factor (last);
                 add_to_set (output, vox, dir, 1.0f, factor);
@@ -162,7 +162,7 @@ namespace MR {
             {
               typedef Eigen::Vector3f PointF;
 
-              static const float accuracy = Math::pow2 (0.005 * std::min (info.spacing (0), std::min (info.spacing (1), info.spacing (2))));
+              static const float accuracy = Math::pow2 (0.005 * std::min (header.spacing (0), std::min (header.spacing (1), header.spacing (2))));
 
               if (tck.size() < 2)
                 return;
@@ -230,7 +230,7 @@ namespace MR {
 
                 length += (p_prev - p_voxel_exit).norm();
                 PointF traversal_vector = (p_voxel_exit - p_voxel_entry).normalized();
-                if (traversal_vector.allFinite() && check (this_voxel, info)) {
+                if (traversal_vector.allFinite() && check (this_voxel, header)) {
                   const float index_voxel_exit = float(p) + mu;
                   const size_t mean_tck_index = std::round (0.5 * (index_voxel_entry + index_voxel_exit));
                   const float factor = tck_index_to_factor (mean_tck_index);
@@ -248,7 +248,7 @@ namespace MR {
             {
               for (size_t end = 0; end != 2; ++end) {
                 const Eigen::Vector3i vox = round (scanner2voxel * (end ? tck.back() : tck.front()));
-                if (check (vox, info)) {
+                if (check (vox, header)) {
                   const Eigen::Vector3f dir = (end ? (tck[tck.size()-1] - tck[tck.size()-2]) : (tck[0] - tck[1])).normalized();
                   const float factor = (end ? factors.back() : factors.front());
                   add_to_set (out, vox, dir, 1.0f, factor);

--- a/src/dwi/tractography/mapping/mapper.cpp
+++ b/src/dwi/tractography/mapping/mapper.cpp
@@ -37,7 +37,7 @@ void TrackMapperBase::voxelise (const Streamline<>& tck, SetVoxel& voxels) const
   Eigen::Vector3i vox;
   for (const auto& i : tck) {
     vox = round (scanner2voxel * i);
-    if (check (vox, info))
+    if (check (vox, header))
       voxels.std::set<Voxel>::insert (vox);
   }
 }

--- a/src/dwi/tractography/mapping/mapper_plugins.h
+++ b/src/dwi/tractography/mapping/mapper_plugins.h
@@ -139,7 +139,7 @@ namespace MR {
               TWIImagePluginBase (input_image),
               sh_coeffs (interp.size(3)),
               precomputer (new Math::SH::PrecomputedAL<float> ()) {
-                Math::SH::check (Header (interp));
+                Math::SH::check (interp.header());
                 precomputer->init (Math::SH::LforN (sh_coeffs.size()));
               }
 

--- a/src/dwi/tractography/mapping/voxel.h
+++ b/src/dwi/tractography/mapping/voxel.h
@@ -44,10 +44,10 @@ namespace MR {
           return { int(std::lround (p[0])), int(std::lround (p[1])), int(std::lround (p[2])) };
         }
 
-        template <class HeaderType>
-          inline bool check (const Eigen::Vector3i& V, const HeaderType& H)
+        template <class ImageType>
+          inline bool check (const Eigen::Vector3i& V, const ImageType& I)
           {
-            return (V[0] >= 0 && V[0] < H.size(0) && V[1] >= 0 && V[1] < H.size(1) && V[2] >= 0 && V[2] < H.size(2));
+            return (V[0] >= 0 && V[0] < I.size(0) && V[1] >= 0 && V[1] < I.size(1) && V[2] >= 0 && V[2] < I.size(2));
           }
 
         inline Eigen::Vector3f vec2DEC (const Eigen::Vector3f& d)

--- a/src/dwi/tractography/roi.cpp
+++ b/src/dwi/tractography/roi.cpp
@@ -111,7 +111,7 @@ namespace MR {
         top[2] = std::min (size_t (data.size(2)-bottom[2]), top[2]+2-bottom[2]);
 
         auto sub = Adapter::make<Adapter::Subset> (data, bottom, top);
-        Header mask_header (sub);
+        Header mask_header (sub.header());
         mask_header.set_ndim (3);
         auto mask = Image<bool>::scratch (mask_header, data.name());
         threaded_copy (sub, mask, 0, 3);

--- a/src/dwi/tractography/roi.h
+++ b/src/dwi/tractography/roi.h
@@ -51,8 +51,8 @@ namespace MR
           Mask (const Mask&) = default;
           Mask (const std::string& name) :
               Image<bool> (__get_mask (name)),
-              scanner2voxel (new transform_type (Transform(*this).scanner2voxel.cast<float>())),
-              voxel2scanner (new transform_type (Transform(*this).voxel2scanner.cast<float>())) { }
+              scanner2voxel (new transform_type (Transform(header()).scanner2voxel.cast<float>())),
+              voxel2scanner (new transform_type (Transform(header()).voxel2scanner.cast<float>())) { }
 
           std::shared_ptr<transform_type> scanner2voxel, voxel2scanner; // Ptr to prevent unnecessary copy-construction
 

--- a/src/dwi/tractography/seeding/basic.cpp
+++ b/src/dwi/tractography/seeding/basic.cpp
@@ -187,7 +187,7 @@ namespace MR
           top[2] = std::min (size_t (vox.size(2)-bottom[2]), top[2]+2-bottom[2]);
 
           auto sub = Adapter::make<Adapter::Subset> (vox, bottom, top);
-          Header header = sub;
+          Header header = sub.header();
           header.set_ndim (3);
 
           auto buf = Image<float>::scratch (header);
@@ -198,7 +198,7 @@ namespace MR
           interp = Interp::Linear<Image<float>> (buf);
 #else
           image = buf;
-          voxel2scanner = Transform (image).voxel2scanner.cast<float>();
+          voxel2scanner = Transform (image.header()).voxel2scanner.cast<float>();
 #endif
         }
 

--- a/src/dwi/tractography/seeding/dynamic.cpp
+++ b/src/dwi/tractography/seeding/dynamic.cpp
@@ -82,7 +82,7 @@ namespace MR
           seed_output ("seeds.tck", Tractography::Properties()),
           test_fixel (0),
 #endif
-          transform (fod_data.original_header())
+          transform (fod_data.header())
       {
         auto opt = App::get_options ("act");
         if (opt.size())

--- a/src/dwi/tractography/tracking/exec.h
+++ b/src/dwi/tractography/tracking/exec.h
@@ -84,7 +84,7 @@ namespace MR
 
                 DWI::Directions::FastLookupSet dirs (1281);
                 auto fod_data = Image<float>::open (fod_path);
-                Math::SH::check (fod_data);
+                Math::SH::check (fod_data.header());
                 Seeding::Dynamic* seeder = new Seeding::Dynamic (fod_path, fod_data, num_tracks, dirs);
                 properties.seeds.add (seeder); // List is responsible for deleting this from memory
 
@@ -93,8 +93,8 @@ namespace MR
                 Writer       writer  (shared, destination, properties);
                 Exec<Method> tracker (shared);
 
-                TckMapper mapper (fod_data, dirs);
-                mapper.set_upsample_ratio (Mapping::determine_upsample_ratio (fod_data, properties, 0.25));
+                TckMapper mapper (fod_data.header(), dirs);
+                mapper.set_upsample_ratio (Mapping::determine_upsample_ratio (fod_data.header(), properties, 0.25));
                 mapper.set_use_precise_mapping (true);
 
                 Thread::run_queue (

--- a/src/gui/mrview/tool/connectome/connectome.cpp
+++ b/src/gui/mrview/tool/connectome/connectome.cpp
@@ -2340,7 +2340,7 @@ namespace MR
                   dim[axis] = node_upper_corners[node_index][axis] - node_lower_corners[node_index][axis] + 1;
                 }
                 MR::Adapter::Subset< MR::Image<node_t> > subset (*buffer, from, dim);
-                MR::Image<bool> node_mask (MR::Image<bool>::scratch (subset.original_header(), "Node " + str(node_index) + " mask"));
+                MR::Image<bool> node_mask (MR::Image<bool>::scratch (subset.header(), "Node " + str(node_index) + " mask"));
 
                 auto copy_func = [&] (const decltype(subset)& in, decltype(node_mask)& out) { out.value() = (in.value() == node_index); };
                 MR::ThreadedLoop (subset).run (copy_func, subset, node_mask);

--- a/src/gui/mrview/tool/connectome/node_list.h
+++ b/src/gui/mrview/tool/connectome/node_list.h
@@ -101,8 +101,8 @@ namespace MR
             void setModel (QAbstractItemModel* model)
             {
               QTableView::setModel (model);
-              //setColumnWidth (0, model->original_headerData (0, Qt::Horizontal, Qt::SizeHintRole).toInt());
-              //setColumnWidth (1, model->original_headerData (1, Qt::Horizontal, Qt::SizeHintRole).toInt());
+              //setColumnWidth (0, model->headerData (0, Qt::Horizontal, Qt::SizeHintRole).toInt());
+              //setColumnWidth (1, model->headerData (1, Qt::Horizontal, Qt::SizeHintRole).toInt());
             }
         };
 

--- a/src/gui/mrview/tool/fixel.h
+++ b/src/gui/mrview/tool/fixel.h
@@ -173,7 +173,7 @@ namespace MR
               MR::Transform transform;
 
               void request_update_interp_image_buffer (const Projection& projection) override {
-                update_interp_image_buffer (projection, *fixel_data, transform);
+                update_interp_image_buffer (projection, fixel_data->header(), transform);
               }
         };
 


### PR DESCRIPTION
Related to #377 and #225.

Kind of two changes bundled in to the one branch since I was doing all kinds of gymnastics at the time:

* Reverted `original_header()` back to `header()`. Although I appreciate that the behaviour when copy-constructing a header from an image with manual strides may not have been as expected (#225), the potential marginal gain from this rename is more than offset by the confusion arising from having `original_header()` called everywhere, yet there being no corresponding 'not-original' `header()`. As I think Donald said, in such an instance it shouldn't be too hard to copy-construct the header, then set the strides just as was done for the `.with_direct_IO()` call. I'll probably also look into potential ways of doing this within the `Image` class. But the rename solution is an absolute no-go IMO.

* Something that I thought would happen as part of the new syntax, but perhaps wasn't entirely complete. Prior to the current `master` branch, we standardized the '`DataSet`' interface, where anything that could be looped over had to define a particular set of member functions. To me, the new `Header` / `Image` construct is different to this; but there was a lot of remaining code using e.g. templated constructors for a '`HeaderType`' / '`ImageType`', that was in fact only using members of the `Header` class; moreover, I found a number of places were constructing a `Header` from an `Image` using this templating, even though there's a `header()` member right there in the `Image` class.

So, what I've done is: _Remove the `Header` template copy-constructors_. These to me could only cause confusion as to what information was actually being used to construct the header (particularly with the `.original_header()` rename, where the templated copy-constructor initialized the new `Header` using `= in.original_header()`, but then manually set _some_ members using direct '`DataSet`' function calls). So now these are gone. Take a look and see what you think.

This did however highlight an alternative location where discriminating between `.original_header()` and `.header()` makes sense: Adapters and filters (well, arguably anything that requires this shouldn't be a _filter_, but let's leave that for now). I've set this up so that such classes retain a copy of the template image's header on construction, but construction of a specific e.g. Adapter class may modify e.g. image dimensions in the _base_ `Header` class. That way, `.header()` returns a fully-formed const header to whatever the output image will look like, whereas `.original_header()` shows the template image header (though nothing's actually using it as yet).

Note that this means that Adapter classes should produce and provide access to a _fully-formed_ `Header` class, not just individual member functions (and I've done this for a couple of examples where it was required). This to me makes a helluva lot of sense, given you probably want to construct your output image based on whatever your adapter is going to provide; but relying on overloading individual '`DataSet`' member functions just introduces ambiguity as to whether the combination of those data and the rest of the header makes sense, or indeed whether those functions are even being called in the relevant construction. Making an image using `Adapter.header()` is better.