### PR TITLE
MRView: a few fixes mostly for MacOSX

### DIFF
--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -444,6 +444,16 @@ namespace MR
 
           menu->addSeparator();
 
+          action = menu->addAction (tr ("Zoom in"), this, SLOT (zoom_in_slot()));
+          action->setShortcut (tr("Ctrl++"));
+          addAction (action);
+
+          action = menu->addAction (tr ("Zoom out"), this, SLOT (zoom_out_slot()));
+          action->setShortcut (tr("Ctrl+-"));
+          addAction (action);
+
+          menu->addSeparator();
+
           action = menu->addAction (tr ("Toggle all annotations"), this, SLOT (toggle_annotations_slot()));
           action->setShortcut (tr("Space"));
           addAction (action);
@@ -960,6 +970,24 @@ namespace MR
         else assert (0);
         glarea->update();
       }
+
+
+
+
+
+      void Window::zoom_in_slot ()
+      {
+        set_FOV (FOV() * std::exp (-0.1));
+        glarea->update();
+      }
+
+      void Window::zoom_out_slot () 
+      {
+        set_FOV (FOV() * std::exp (0.1));
+        glarea->update();
+      }
+
+
 
 
       void Window::reset_view_slot ()

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -1477,9 +1477,9 @@ namespace MR
 #if QT_VERSION >= 0x050400
         QPoint delta = event->pixelDelta();
         if (delta.isNull())
-          delta = event->angleDelta() / 120.0;
+          delta = event->angleDelta();
 #else
-        QPoint delta = event->orientation() == Qt::Vertical ? QPoint (0, event->delta() / 120.0) : QPoint (event->delta() / 120.0, 0);
+        QPoint delta = event->orientation() == Qt::Vertical ? QPoint (0, event->delta()) : QPoint (event->delta(), 0);
 #endif
         if (delta.isNull())
           return;
@@ -1493,13 +1493,13 @@ namespace MR
             if (buttons_ == Qt::NoButton) {
 
               if (modifiers_ == Qt::ControlModifier) {
-                set_FOV (FOV() * std::exp (-0.1*delta.y()));
+                set_FOV (FOV() * std::exp (-delta.y()/1200.0));
                 glarea->update();
                 event->accept();
                 return;
               }
 
-              float dx = delta.y();
+              float dx = delta.y()/120.0;
               if (modifiers_ == Qt::ShiftModifier) dx *= 10.0;
               else if (modifiers_ != Qt::NoModifier) 
                 return;
@@ -1515,7 +1515,7 @@ namespace MR
               QAction* action = image_group->checkedAction();
               int N = image_group->actions().size();
               int n = image_group->actions().indexOf (action);
-              image_select_slot (image_group->actions()[(n+N+delta.y())%N]);
+              image_select_slot (image_group->actions()[(n+N+int(std::round(delta.y()/120.0)))%N]);
             }
           }
         }

--- a/src/gui/mrview/window.h
+++ b/src/gui/mrview/window.h
@@ -172,6 +172,8 @@ namespace MR
           void select_mouse_mode_slot (QAction* action);
           void select_tool_slot (QAction* action);
           void select_plane_slot (QAction* action);
+          void zoom_in_slot ();
+          void zoom_out_slot ();
           void invert_scaling_slot ();
           void full_screen_slot ();
           void toggle_annotations_slot ();

--- a/src/gui/opengl/gl.cpp
+++ b/src/gui/opengl/gl.cpp
@@ -65,7 +65,7 @@ namespace MR
         f.setRedBufferSize (8);
         f.setGreenBufferSize (8);
         f.setBlueBufferSize (8);
-        f.setAlphaBufferSize (8);
+        f.setAlphaBufferSize (0);
 
         int swap_interval = MR::File::Config::get_int ("VSync", 0);
         f.setSwapInterval (swap_interval);


### PR DESCRIPTION
As discussed on #397, this fixes issues with rendering on MacOSX, fixes mouse scroll support for the Apple magic mouse, and adds keyboard shortcuts for zooming.

As always, any attempts to try to break this are appreciated...