### PR TITLE
DICOM: minor fixes to Siemens private DW tags

### DIFF
--- a/lib/file/dicom/dict.cpp
+++ b/lib/file/dicom/dict.cpp
@@ -3564,7 +3564,7 @@ namespace MR {
 
         // Siemens private tags:
         dict[0x0019100CUL] =  "DSSiemensBValue";
-        dict[0x0019100EUL] =  "FDSiemensBValue";
+        dict[0x0019100EUL] =  "FDSiemensDWDirection";
         dict[0x00291010UL] =  "UNSiemensCSA1";
         dict[0x00291020UL] =  "UNSiemensCSA2";
         

--- a/lib/file/dicom/element.cpp
+++ b/lib/file/dicom/element.cpp
@@ -311,7 +311,7 @@ namespace MR {
         else if (VR == VR_FL)
           for (const uint8_t* p = data; p < data + size; p += sizeof (float32)) 
             V.push_back (get<float32> (p, is_BE));
-        else if (VR == VR_DS) {
+        else if (VR == VR_DS || VR == VR_IS) {
           std::vector<std::string> strings (split (std::string (reinterpret_cast<const char*> (data), size), "\\", false));
           V.resize (strings.size());
           for (size_t n = 0; n < V.size(); n++) 


### PR DESCRIPTION
Allow integer tags to be read as floating-point (provides more tolerance to variations in the inputs), and correct typo in DICOM dictionary.

I wouldn't expect either of these changes to be particularly controversial...