### PR TITLE
Improve error handling in matlab functions

### DIFF
--- a/matlab/read_mrtrix.m
+++ b/matlab/read_mrtrix.m
@@ -8,15 +8,11 @@ function image = read_mrtrix (filename)
 image.comments = {};
 
 f = fopen (filename, 'r');
-if (f<1) 
-  disp (['error opening ' filename ]);
-  return
-end
+assert(f ~= -1, 'error opening %s', filename);
 L = fgetl(f);
 if ~strncmp(L, 'mrtrix image', 12)
   fclose(f);
-  disp ([filename ' is not in MRtrix format']);
-  return
+  error('%s is not in MRtrix format', filename);
 end
 
 transform = [];
@@ -74,8 +70,7 @@ end
 
 if ~isfield (image, 'dim') || ~exist ('file') || ...
   ~isfield (image, 'layout') || ~isfield (image, 'datatype')
-  disp ('critical entries missing in header - not reading data')
-  return
+  error('critical entries missing in header - not reading data');
 end
 
 layout = split_strings(image.layout, ',');
@@ -104,10 +99,7 @@ else
   end
 end
 
-if (f<1) 
-  disp (['error opening ' filename ]);
-  return
-end
+assert(f ~= -1, 'error opening %s', filename);
 
 fseek (f, offset, -1);
 image.data = fread (f, inf, datatype);
@@ -131,4 +123,3 @@ function S = split_strings (V, delim)
     [R, V] = strtok(V,delim);
     S{end+1} = R;
   end
-

--- a/matlab/read_mrtrix_tracks.m
+++ b/matlab/read_mrtrix_tracks.m
@@ -10,15 +10,11 @@ function tracks = read_mrtrix_tracks (filename)
 image.comments = {};
 
 f = fopen (filename, 'r');
-if (f<1) 
-  disp (['error opening ' filename ]);
-  return
-end
+assert(f ~= -1, 'error opening %s', filename);
 L = fgetl(f);
 if ~strncmp(L, 'mrtrix tracks', 13)
   fclose(f);
-  disp ([filename ' is not in MRtrix format']);
-  return
+  error('%s is not in MRtrix format', filename);
 end
 
 tracks = struct();
@@ -45,21 +41,14 @@ while 1
 end
 fclose(f);
 
-if ~exist ('file') || ~isfield (tracks, 'datatype')
-  disp ('critical entries missing in header - aborting')
-  return
-end
+assert(exist('file') && isfield(tracks, 'datatype'), ...
+  'critical entries missing in header - aborting');
 
 [ file, offset ] = strtok(file);
-if ~strcmp(file,'.')
-  disp ('unexpected file entry (should be set to current ''.'') - aborting')
-  return;
-end
+assert(strcmp(file, '.'), ...
+  'unexpected file entry (should be set to current ''.'') - aborting');
 
-if isempty(offset)
-  disp ('no offset specified - aborting')
-  return;
-end
+assert(~isempty(offset), 'no offset specified - aborting');
 offset = str2num(char(offset));
 
 datatype = lower(tracks.datatype);
@@ -72,14 +61,10 @@ elseif strcmp(byteorder, 'be')
   f = fopen (filename, 'r', 'b');
   datatype = datatype(1:end-2);
 else
-  disp ('unexpected data type - aborting')
-  return;
+  error('unexpected data type - aborting');
 end
 
-if (f<1) 
-  disp (['error opening ' filename ]);
-  return
-end
+assert(f ~= -1, 'error opening %s', filename);
 
 fseek (f, offset, -1);
 data = fread(f, inf, datatype);
@@ -95,5 +80,3 @@ for n = 1:(prod(size(k))-1)
   tracks.data{end+1} = data(pk:(k(n)-1),:);
   pk = k(n)+1;
 end
-  
-

--- a/matlab/write_mrtrix.m
+++ b/matlab/write_mrtrix.m
@@ -15,8 +15,8 @@ function write_mrtrix (image, filename)
 %    image.transform:       a 4x4 matrix [optional]
 %    image.DW_scheme:       a NDWx4 matrix of gradient directions [optional]
 
-
 fid = fopen (filename, 'w');
+assert(fid ~= -1, 'error opening %s', filename);
 fprintf (fid, 'mrtrix image\ndim: ');
 
 if isstruct(image)
@@ -99,17 +99,17 @@ if isstruct (image) && isfield (image, 'DW_scheme')
    end
 end
 
-if filename(end-3:end) == '.mif'
+if strcmp(filename(end-3:end), '.mif')
   datafile = filename;
   dataoffset = ftell (fid) + 24;
   fprintf (fid, '\nfile: . %d\nEND\n                         ', dataoffset);
-elseif filename(end-3:end) == '.mih'
+elseif strcmp(filename(end-3:end), '.mih')
   datafile = [ filename(end-3:end) '.dat' ];
   dataoffset = 0;
   fprintf (fid, '\nfile: %s %d\nEND\n', datafile, dataoffset);
-else 
-  disp ('unknown file suffix - aborting');
-  return
+else
+  fclose(fid);
+  error('unknown file suffix - aborting');
 end
 
 fclose(fid);
@@ -123,4 +123,3 @@ else
   fwrite (fid, image, precision);
 end
 fclose (fid);
-

--- a/matlab/write_mrtrix_tracks.m
+++ b/matlab/write_mrtrix_tracks.m
@@ -7,21 +7,14 @@ function write_mrtrix_tracks (tracks, filename)
 % of the tracks variable will be written as text entries in the header, and are
 % expected to supplied as character arrays.
 
-if ~isfield (tracks, 'data')
-  disp ('ERROR: input tracks variable does not contain required ''data'' field');
-  return;
-end
+assert(isfield(tracks, 'data'), ...
+  'input tracks variable does not contain required ''data'' field');
 
-if ~iscell (tracks.data)
-  disp ('ERROR: input tracks.data variable should be a cell array');
-  return;
-end
+assert(iscell(tracks.data), ...
+  'input tracks.data variable should be a cell array');
 
 f = fopen (filename, 'w', 'ieee-le');
-if (f<1) 
-  disp (['error opening ' filename ]);
-  return;
-end
+assert(f ~= -1, 'error opening %s', filename);
 
 fprintf (f, 'mrtrix tracks\ndatatype: Float32LE\ncount: %d\n', prod(size(tracks.data)));
 names = fieldnames(tracks);


### PR DESCRIPTION
Using read_mrtrix_tracks.m, I have noticed a very minor problem with the error handling.
For example, when fopen() fails because the filename was not correctly specified, this is currently handled by printing an error message and then returning. This leads to the wrong type of error.
```
>> t = read_mrtrix_tracks('wrong_filename.tck');
error opening wrong_filename.tck
Error in read_mrtrix_tracks (line 10)
image.comments = {};

Output argument "tracks" (and maybe others) not assigned during call to
"read_mrtrix_tracks.m>read_mrtrix_tracks".
```
I changed the error handling in read_mrtrix_tracks.m and the other functions so that the functions assert() and error() are used instead of disp()/return().