### PR TITLE
fixed link to git setup page

### DIFF
--- a/docs/installation/mac_install.rst
+++ b/docs/installation/mac_install.rst
@@ -52,7 +52,7 @@ Git setup
 ---------
 
 Set up your git environment as per the `Git instructions
-page <getting-started-with-git>`__
+page <https://help.github.com/articles/set-up-git/#setting-up-git>`__
 
 Build *MRtrix3* 
 -------------


### PR DESCRIPTION
Minor fix to link in mac setup page as reported here: http://community.mrtrix.org/t/setup-git-environment-mac/120