### PR TITLE
Image::with_direct_io(): don't modify datatype of internal Buffer

### DIFF
--- a/lib/image.h
+++ b/lib/image.h
@@ -441,8 +441,6 @@ namespace MR
         threaded_copy_with_progress_message ("preloading data for \"" + name() + "\"", src, dest); 
       }
 
-      buffer->datatype() = DataType::from<ValueType>();
-
       return Image (buffer, with_strides);
     }
 


### PR DESCRIPTION
This causes crashes on write-back for the rare cases where an _output_
image is accessed using .with_direct_io() (see e.g. #489).