### PR TITLE
mrview ODF tool: Fix preview in dixel mode

### DIFF
--- a/src/gui/mrview/tool/odf/odf.cpp
+++ b/src/gui/mrview/tool/odf/odf.cpp
@@ -760,8 +760,11 @@ namespace MR
           assert (settings->dixel.dirs);
           assert (renderer);
           renderer->dixel.update_mesh (*(settings->dixel.dirs));
-          if (preview)
+          if (preview) {
             preview->render_frame->set_dixels (*(settings->dixel.dirs));
+            // Values at the focus point change if we're now looking at a different shell
+            update_preview();
+          }
           updateGL();
         }
 

--- a/src/gui/mrview/tool/odf/odf.h
+++ b/src/gui/mrview/tool/odf/odf.h
@@ -109,7 +109,7 @@ namespace MR
              virtual void closeEvent (QCloseEvent* event) override;
 
              ODF_Item* get_image ();
-             void get_values (Eigen::VectorXf& SH, MRView::Image& image, const Eigen::Vector3f& pos, const bool interp);
+             void get_values (Eigen::VectorXf&, ODF_Item&, const Eigen::Vector3f&, const bool);
              void setup_ODFtype_UI (const ODF_Item*);
 
              friend class ODF_Preview;

--- a/src/gui/mrview/tool/odf/preview.h
+++ b/src/gui/mrview/tool/odf/preview.h
@@ -58,6 +58,7 @@ namespace MR
             ODF_Preview (ODF*);
             void set (const Eigen::VectorXf&);
             bool interpolate() const { return interpolation_box->isChecked(); }
+            void set_lod_enabled (const bool i) { level_of_detail_selector->setEnabled (i); }
             Window& window () const { return *Window::main; }
           private slots:
             void lock_orientation_to_image_slot (int);


### PR DESCRIPTION
Amplitude data sent to the preview renderer was not being filtered based on the selected shell, resulting in noisy ODF shapes as the wrong amplitude would be read for each direction.
Also enable / disable the level of detail control in the preview window according to whether the data is dixel-based (and hence whether this control has any meaning).
Closes #500.
Also modified so that b=0 shells no longer appear in the list of available shells to display.

@thijsdhollander Have a quick go at breaking it?