### PR TITLE
Use memory-mapping for output images if held on local FS

### DIFF
--- a/lib/file/mmap.cpp
+++ b/lib/file/mmap.cpp
@@ -69,7 +69,7 @@ namespace MR
           delayed_writeback = true;
         }
 
-        if (fsbuf.f_type == 0xff534d42 /* CIFS */|| fsbuf.f_type == 0x6969 /* NFS */ || fsbuf.f_type == 0x65735546 /* FUSE */) {
+        if (fsbuf.f_type == 0xff534d42 /* CIFS */|| fsbuf.f_type == 0x6969 /* NFS */ || fsbuf.f_type == 0x65735546 /* FUSE */ || fsbuf.f_type == 0x517b /* SMB */) {
           DEBUG ("\"" + Entry::name + "\" appears to reside on a networked filesystem - using delayed write-back");
           delayed_writeback = true;
         }

--- a/lib/file/mmap.cpp
+++ b/lib/file/mmap.cpp
@@ -119,11 +119,6 @@ namespace MR
           DEBUG ("\"" + Entry::name + "\" appears to reside on a networked filesystem - using delayed write-back");
           delayed_writeback = true;
         }
-
-        if (fsbuf.f_flags & 0x0010 /* ST_SYNCHRONOUS */) {
-          DEBUG ("\"" + Entry::name + "\" resides on a synchronous filesystem - using delayed write-back");
-          delayed_writeback = true;
-        }
 #endif
 
         if (delayed_writeback) {

--- a/lib/file/mmap.cpp
+++ b/lib/file/mmap.cpp
@@ -110,7 +110,12 @@ namespace MR
           delayed_writeback = true;
         }
 
-        if (fsbuf.f_type == 0xff534d42 /* CIFS */|| fsbuf.f_type == 0x6969 /* NFS */ || fsbuf.f_type == 0x65735546 /* FUSE */ || fsbuf.f_type == 0x517b /* SMB */) {
+        if (fsbuf.f_type == 0xff534d42 /* CIFS */|| fsbuf.f_type == 0x6969 /* NFS */ || 
+            fsbuf.f_type == 0x65735546 /* FUSE */ || fsbuf.f_type == 0x517b /* SMB */
+#ifdef MRTRIX_MACOSX
+            || fsbuf.f_type == 0x0017 /* OSXFUSE */
+#endif 
+        ) {
           DEBUG ("\"" + Entry::name + "\" appears to reside on a networked filesystem - using delayed write-back");
           delayed_writeback = true;
         }

--- a/lib/file/mmap.h
+++ b/lib/file/mmap.h
@@ -33,14 +33,20 @@ namespace MR
       public:
         //! create a new memory-mapping to file in \a entry
         /*! map file in \a entry at the offset in \a entry. By default, the
-         * file will be mapped read-only. If \a readwrite is set to true, a
-         * write-back RAM buffer will be allocated to store the contents of the
-         * file, and written back when the constructor is invoked. 
+         * file will be mapped read-only. If \a readwrite is set to true,
+         * the file will be accessed with read-write permissions, but the
+         * mechanism used depends on whether the file is detected as residing
+         * on a local or a networked filesystem, and whether the filesystem is
+         * mounted with synchronous IO. If the filesystem is \e local and
+         * \e asynchronous, the file is memory-mapped as-is with read-write
+         * permissions. Otherwise, a write-back RAM buffer is allocated to
+         * store the contents of the file, and written back when the
+         * constructor is invoked. 
          *
-         * By default, the contents of a file mapped read-write will be
-         * preloaded into the RAM buffer. If the file has just been created, \a
-         * preload can be set to false to prevent preloading its contents into
-         * the buffer. 
+         * By default, if the file is mapped using the delayed write-back
+         * mechanism, its contents will be preloaded into the RAM buffer. If
+         * the file has just been created, \a preload should be set to \c false to
+         * prevent this, in which case the contents will set to zero.
          *
          * By default, the whole file is mapped. If \a mapped_size is
          * non-zero, then only the region of size \a mapped_size starting from

--- a/lib/image_io/default.cpp
+++ b/lib/image_io/default.cpp
@@ -77,7 +77,6 @@ namespace MR
 
     void Default::map_files (const Header& header)
     {
-      DEBUG ("mapping image \"" + header.name() + "\"...");
       mmaps.resize (files.size());
       addresses.resize (mmaps.size());
       for (size_t n = 0; n < files.size(); n++) {


### PR DESCRIPTION
As discussed recently in #513.

This detects the filesystem that the file is held on using [statfs()](http://man7.org/linux/man-pages/man2/statfs.2.html), and uses memory-mapping for RW files if the FS isn't reported as NFS, CIFS or FUSE (which should also catch SSHFS & GlusterFS). Otherwise the current delayed write-back approach is used. This also checks whether the FS is mounted with the synchronous flag, and switches to delayed write-back in this case too, since that would also be expected to kill performance (and hammer the drive...).

This also applies to temporary (piped) images, so this will use direct memory-mapping for these data too if the temp folder is local (which it _really_ ought to be). So this should avoid double RAM allocations when using pipelines on `tmpfs`, for instance.

This works fine on Linux, and performance is slightly better - but nothing to get all that excited about. I guess the real driver is the reduced RAM usage this implies, together with allowing more flexibility to the system to manage swapping if necessary on RAM-limited systems.

However, I've only tested this on Linux... It looks like [it should work fine on MacOSX](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man2/statfs.2.html), given that the same call is available. Not so sure about Windows though... haven't had a chance to try it yet. Would appreciate some thorough testing on all platforms. :smiley:

Also, if anyone knows of other network filesystems we should be checking for, please speak up!