### PR TITLE
Tckgen integer postfix fix

### DIFF
--- a/src/dwi/tractography/editing/editing.cpp
+++ b/src/dwi/tractography/editing/editing.cpp
@@ -109,26 +109,26 @@ void load_properties (Tractography::Properties& properties)
   opt = get_options ("maxlength");
   if (opt.size()) {
     if (properties.find ("max_dist") == properties.end()) {
-      properties["max_dist"] = str(opt[0][0]);
+      properties["max_dist"] = str(float (opt[0][0]));
     } else {
       try {
         const float maxlength = std::min (float(opt[0][0]), to<float>(properties["max_dist"]));
         properties["max_dist"] = str(maxlength);
       } catch (...) {
-        properties["max_dist"] = str(opt[0][0]);
+        properties["max_dist"] = str(float (opt[0][0]));
       }
     }
   }
   opt = get_options ("minlength");
   if (opt.size()) {
     if (properties.find ("min_dist") == properties.end()) {
-      properties["min_dist"] = str(opt[0][0]);
+      properties["min_dist"] = str(float (opt[0][0]));
     } else {
       try {
         const float minlength = std::max (float(opt[0][0]), to<float>(properties["min_dist"]));
         properties["min_dist"] = str(minlength);
       } catch (...) {
-        properties["min_dist"] = str(opt[0][0]);
+        properties["min_dist"] = str(float (opt[0][0]));
       }
     }
   }
@@ -146,10 +146,10 @@ void load_properties (Tractography::Properties& properties)
   // Only the thresholds have an influence on Properties
   opt = get_options ("maxweight");
   if (opt.size())
-    properties["max_weight"] = std::string(opt[0][0]);
+    properties["max_weight"] = str (float (opt[0][0]));
   opt = get_options ("minweight");
   if (opt.size())
-    properties["min_weight"] = std::string(opt[0][0]);
+    properties["min_weight"] = str (float (opt[0][0]));
 
 }
 

--- a/src/dwi/tractography/seeding/seeding.cpp
+++ b/src/dwi/tractography/seeding/seeding.cpp
@@ -133,7 +133,7 @@ namespace MR
         }
 
         opt = get_options ("max_seed_attempts");
-        if (opt.size()) properties["max_seed_attempts"] = str (unsigned int (opt[0][0]);)
+        if (opt.size()) properties["max_seed_attempts"] = str<unsigned int> (opt[0][0]);
 
         opt = get_options ("output_seeds");
         if (opt.size()) properties["seed_output"] = std::string (opt[0][0]);

--- a/src/dwi/tractography/seeding/seeding.cpp
+++ b/src/dwi/tractography/seeding/seeding.cpp
@@ -133,7 +133,7 @@ namespace MR
         }
 
         opt = get_options ("max_seed_attempts");
-        if (opt.size()) properties["max_seed_attempts"] = std::string (opt[0][0]);
+        if (opt.size()) properties["max_seed_attempts"] = str (unsigned int (opt[0][0]);)
 
         opt = get_options ("output_seeds");
         if (opt.size()) properties["seed_output"] = std::string (opt[0][0]);

--- a/src/dwi/tractography/seeding/seeding.h
+++ b/src/dwi/tractography/seeding/seeding.h
@@ -17,6 +17,7 @@
 #define __dwi_tractography_seeding_seeding_h__
 
 
+#include "mrtrix.h"
 #include "dwi/tractography/seeding/basic.h"
 #include "dwi/tractography/seeding/dynamic.h"
 #include "dwi/tractography/seeding/gmwmi.h"

--- a/src/dwi/tractography/tracking/tractography.cpp
+++ b/src/dwi/tractography/tracking/tractography.cpp
@@ -14,6 +14,7 @@
  */
 #include "dwi/tractography/tracking/tractography.h"
 
+
 #define MAX_TRIALS 1000
 
 namespace MR
@@ -134,10 +135,10 @@ namespace MR
         if (opt.size()) properties["max_angle"] = std::string (opt[0][0]);
 
         opt = get_options ("number");
-        if (opt.size()) properties["max_num_tracks"] = str (unsigned int(opt[0][0]));
+        if (opt.size()) properties["max_num_tracks"] = str<unsigned int> (opt[0][0]);
 
         opt = get_options ("maxnum");
-        if (opt.size()) properties["max_num_attempts"] = str (unsigned int (opt[0][0]));
+        if (opt.size()) properties["max_num_attempts"] = str<unsigned int> (opt[0][0]);
 
         opt = get_options ("maxlength");
         if (opt.size()) properties["max_dist"] = std::string (opt[0][0]);
@@ -152,7 +153,7 @@ namespace MR
         if (opt.size()) properties["init_threshold"] = std::string (opt[0][0]);
 
         opt = get_options ("trials");
-        if (opt.size()) properties["max_trials"] = str (unsigned int (opt[0][0]));
+        if (opt.size()) properties["max_trials"] = str<unsigned int> (opt[0][0]);
 
         opt = get_options ("unidirectional");
         if (opt.size()) properties["unidirectional"] = "1";
@@ -167,7 +168,7 @@ namespace MR
         if (opt.size()) properties["fod_power"] = std::string (opt[0][0]);
 
         opt = get_options ("samples");
-        if (opt.size()) properties["samples_per_step"] = str (unsigned int (opt[0][0]));
+        if (opt.size()) properties["samples_per_step"] = str<unsigned int> (opt[0][0]);
 
         opt = get_options ("rk4");
         if (opt.size()) properties["rk4"] = "1";
@@ -181,7 +182,7 @@ namespace MR
         }
 
         opt = get_options ("downsample");
-        if (opt.size()) properties["downsample_factor"] = str (unsigned int (opt[0][0]));
+        if (opt.size()) properties["downsample_factor"] = str<unsigned int> (opt[0][0]);
 
       }
 

--- a/src/dwi/tractography/tracking/tractography.cpp
+++ b/src/dwi/tractography/tracking/tractography.cpp
@@ -134,10 +134,10 @@ namespace MR
         if (opt.size()) properties["max_angle"] = std::string (opt[0][0]);
 
         opt = get_options ("number");
-        if (opt.size()) properties["max_num_tracks"] = std::string (opt[0][0]);
+        if (opt.size()) properties["max_num_tracks"] = str (unsigned int(opt[0][0]));
 
         opt = get_options ("maxnum");
-        if (opt.size()) properties["max_num_attempts"] = std::string (opt[0][0]);
+        if (opt.size()) properties["max_num_attempts"] = str (unsigned int (opt[0][0]));
 
         opt = get_options ("maxlength");
         if (opt.size()) properties["max_dist"] = std::string (opt[0][0]);
@@ -152,7 +152,7 @@ namespace MR
         if (opt.size()) properties["init_threshold"] = std::string (opt[0][0]);
 
         opt = get_options ("trials");
-        if (opt.size()) properties["max_trials"] = std::string (opt[0][0]);
+        if (opt.size()) properties["max_trials"] = str (unsigned int (opt[0][0]));
 
         opt = get_options ("unidirectional");
         if (opt.size()) properties["unidirectional"] = "1";
@@ -167,7 +167,7 @@ namespace MR
         if (opt.size()) properties["fod_power"] = std::string (opt[0][0]);
 
         opt = get_options ("samples");
-        if (opt.size()) properties["samples_per_step"] = std::string (opt[0][0]);
+        if (opt.size()) properties["samples_per_step"] = str (unsigned int (opt[0][0]));
 
         opt = get_options ("rk4");
         if (opt.size()) properties["rk4"] = "1";
@@ -181,7 +181,7 @@ namespace MR
         }
 
         opt = get_options ("downsample");
-        if (opt.size()) properties["downsample_factor"] = std::string (opt[0][0]);
+        if (opt.size()) properties["downsample_factor"] = str (unsigned int (opt[0][0]));
 
       }
 

--- a/src/dwi/tractography/tracking/tractography.h
+++ b/src/dwi/tractography/tracking/tractography.h
@@ -17,6 +17,7 @@
 #define __dwi_tractography_tracking_tractography_h__
 
 #include "app.h"
+#include "mrtrix.h"
 #include "dwi/tractography/properties.h"
 
 namespace MR


### PR DESCRIPTION
Directly copying the option value to the `Tractography::Properties` class does not implicitly cast the command-line contents to an integer, which is where the postfix detection occurs.