### PR TITLE
dwiextract: Always output 4D image

### DIFF
--- a/cmd/dwiextract.cpp
+++ b/cmd/dwiextract.cpp
@@ -66,7 +66,6 @@ void run()
       for (const auto v : shells[s].get_volumes()) 
         volumes.push_back (v);
     }
-    // Remove DW information from header if b=0 is the only 'shell' selected
     bzero = (shells.count() == 1 && shells[0].is_bzero());
   } else {
     const float bzero_threshold = File::Config::get_float ("BValueThreshold", 10.0);
@@ -85,11 +84,7 @@ void run()
 
   Header header (input_image);
   Stride::set_from_command_line (header);
-
-  if (volumes.size() == 1)
-    header.set_ndim (3);
-  else
-    header.size (3) = volumes.size();
+  header.size (3) = volumes.size();
 
   Eigen::MatrixXd new_grad (volumes.size(), grad.cols());
   for (size_t i = 0; i < volumes.size(); i++)
@@ -98,12 +93,6 @@ void run()
 
   auto output_image = Image<float>::create (argument[1], header);
 
-  if (output_image.ndim() == 4) {
-    auto input_volumes = Adapter::make<Adapter::Extract1D> (input_image, 3, volumes);
-    threaded_copy_with_progress_message ("extracting volumes", input_volumes, output_image);
-  }
-  else {
-    input_image.index(3) = volumes[0];
-    threaded_copy_with_progress_message ("extracting volumes", input_image, output_image, 0, 3);
-  }
+  auto input_volumes = Adapter::make<Adapter::Extract1D> (input_image, 3, volumes);
+  threaded_copy_with_progress_message ("extracting volumes", input_volumes, output_image);
 }

--- a/scripts/dwibiascorrect
+++ b/scripts/dwibiascorrect
@@ -89,13 +89,8 @@ if lib.app.args.mask:
 else:
   runCommand('dwi2mask in.mif mask.mif')
 
-# Make a NiFTI image since this is what the external softwares need
-runCommand('dwiextract in.mif bzeros.mif -bzero')
-bzero_sizes = getHeaderInfo('bzeros.mif', 'size')
-if len(bzero_sizes.split()) == 4:
-  runCommand('mrmath bzeros.mif mean - -axis 3 | mrconvert - mean_bzero.mif -stride +1,+2,+3')
-else:
-  runCommand('mrconvert bzeros.mif mean_bzero.mif')
+# Generate a mean b=0 image
+runCommand('dwiextract in.mif - -bzero | mrmath - mean mean_bzero.mif -axis 3')
 
 if lib.app.args.fsl:
   # FAST doesn't accept a mask input; therefore need to explicitly mask the input image

--- a/scripts/src/dwi2response/msmt_5tt.py
+++ b/scripts/src/dwi2response/msmt_5tt.py
@@ -114,15 +114,12 @@ def execute():
   for index, b in enumerate(shells):
     int_b = str(int(round(b)))
     dwi_path = 'dwi_b' + int_b + '.mif'
+    mean_dwi_path = 'dwi_b' + int_b + '_mean.mif'
+    # dwiextract will now yield a 4D image, even if there's only a single volume in a shell
     runCommand('dwiextract dwi.mif -shell ' + str(b) + ' ' + dwi_path)
-    sizes = getHeaderInfo(dwi_path, 'size').split()
-    if len(sizes) == 3:
-      mean_path = dwi_path
-    else:
-      mean_path = 'dwi_b' + int_b + '_mean.mif'
-      runCommand('mrmath ' + dwi_path + ' mean ' + mean_path + ' -axis 3')
-    gm_mean  = float(getImageStat(mean_path, 'mean', 'gm_mask.mif'))
-    csf_mean = float(getImageStat(mean_path, 'mean', 'csf_mask.mif'))
+    runCommand('mrmath ' + dwi_path + ' mean ' + mean_dwi_path + ' -axis 3')
+    gm_mean  = float(getImageStat(mean_dwi_path, 'mean', 'gm_mask.mif'))
+    csf_mean = float(getImageStat(mean_dwi_path, 'mean', 'csf_mask.mif'))
     gm_responses .append( str(gm_mean  * math.sqrt(4.0 * math.pi)) )
     csf_responses.append( str(csf_mean * math.sqrt(4.0 * math.pi)) )
     this_b_lmax_option = ''


### PR DESCRIPTION
This means that e.g. the resulting image can be fed to mrmath -axis 3 to get the mean image, regardless of whether only a single volume was present.
Closes #552.
Reported a number of times in the past, but eventually reached [breaking point](http://community.mrtrix.org/t/error-cannot-perform-operation-along-axis-3-image-only-has-3-axes/164/2).