### PR TITLE
better handling of undefined strides

### DIFF
--- a/lib/stride.h
+++ b/lib/stride.h
@@ -63,29 +63,6 @@ namespace MR
 
     extern const App::OptionGroup Options;
 
-    template <class HeaderType> 
-      void set_from_command_line (HeaderType& header, const List& default_strides = List())
-      {
-        auto opt = App::get_options ("stride");
-        size_t n;
-        if (opt.size()) {
-          std::vector<int> strides = opt[0][0];
-          if (strides.size() > header.ndim())
-            WARN ("too many axes supplied to -stride option - ignoring remaining strides");
-          for (n = 0; n < std::min (header.ndim(), strides.size()); ++n)
-            header.stride(n) = strides[n];
-          for (; n < header.ndim(); ++n)
-            header.stride(n) = 0;
-        } 
-        else if (default_strides.size()) {
-          for (n = 0; n < std::min (header.ndim(), default_strides.size()); ++n) 
-            header.stride(n) = default_strides[n];
-          for (; n < header.ndim(); ++n)
-            header.stride(n) = 0;
-        }
-      }
-
-
 
 
 
@@ -431,6 +408,26 @@ namespace MR
         for (size_t n = 3; n < strides.size(); ++n)
           strides[n] = 0;
         return strides;
+      }
+
+
+    template <class HeaderType> 
+      void set_from_command_line (HeaderType& header, const List& default_strides = List())
+      {
+        auto opt = App::get_options ("stride");
+        if (opt.size()) {
+          List strides;
+          { 
+            std::vector<int> tmp = opt[0][0];
+            for (auto x : tmp)
+              strides.push_back (x); 
+          }
+          if (strides.size() > header.ndim())
+            WARN ("too many axes supplied to -stride option - ignoring remaining strides");
+          set (header, get_nearest_match (header, strides));
+        } 
+        else if (default_strides.size()) 
+          set (header, default_strides);
       }
 
 


### PR DESCRIPTION
When converting to volume-contiguous format, we want to be able to
preserve the order of the spatial strides as much as possible, so that
conversion back to e.g. NIfTI preserves the strides of the original. For
example:

    $ mrconvert 4D_image.nii -stride 0,0,0,1 4D_image.mif

would produce a volume-contiguous output image, but its strides were
previously set to `[ 2 3 4 1 ]` regardless of the input image. This might
cause downstream issues and/or confusion if these images are
subsequently used in other packages, if the strides of the original
4D_image.nii weren't `[ 1 2 3 4 ]` (which they often won't be).

This change means that the strides of the input image are preserved
relative to each other for the first 3 (spatial) axes, so that if
4D_image.nii had strides `[ -1 -2 3 4 ]`, the output 4D_image.mif now has
strides `[ -2 -3 4 1 ]`. This means a subsequent conversion back to NIfTI:

    $ mrconvert 4D_image.mif new_4D_image.nii

would result in new_4D_image.nii having the same strides as the original
4D_image.nii.