### PR TITLE
strides handling: fix issue with ignoring stride flips

### DIFF
--- a/lib/stride.h
+++ b/lib/stride.h
@@ -411,21 +411,16 @@ namespace MR
       }
 
 
+
+    List __from_command_line (const List& current);
+
+
     template <class HeaderType> 
       void set_from_command_line (HeaderType& header, const List& default_strides = List())
       {
-        auto opt = App::get_options ("stride");
-        if (opt.size()) {
-          List strides;
-          { 
-            std::vector<int> tmp = opt[0][0];
-            for (auto x : tmp)
-              strides.push_back (x); 
-          }
-          if (strides.size() > header.ndim())
-            WARN ("too many axes supplied to -stride option - ignoring remaining strides");
-          set (header, get_nearest_match (header, strides));
-        } 
+        auto cmdline_strides = __from_command_line (get (header));
+        if (cmdline_strides.size())
+          set (header, cmdline_strides);
         else if (default_strides.size()) 
           set (header, default_strides);
       }


### PR DESCRIPTION
fixes #570.

Note that this also add support for constructs such as:

    $ mrconvert in.mif -stride 0,0,0,4 out.mif

Those strides specified will be used as is, those left as zero will be populated with the corresponding strides from the original. This can be used to force spatially-contiguous strides without affecting their relative order or sign. In other words:

    $ mrconvert in.nii -stride 0,0,0,1 - | mrconvert - -stride 0,0,0,4 out.mif

should now result in out.mif having the same strides as in.nii, regardless of what these were (as long as its last stride was indeed 4, which will always be the case for NIfTI).

This also implies that the strides are interpreted as being strictly symbolic: whereas before a stride of 3,6,-7,2 would have been interpreted as 2,3,-4,1 (i.e. the order of the absolute strides is what matters), it would now throw an Exception since the strides are interpreted as-is: values larger than the number of image axes will throw an error (as will duplicate entries). If anything, I expect this is exactly what users would assume anyway...