### PR TITLE
str() function: Fix for unsupported types

### DIFF
--- a/cmd/fixel2tsf.cpp
+++ b/cmd/fixel2tsf.cpp
@@ -83,7 +83,7 @@ void run ()
   DWI::Tractography::ScalarWriter<float> tsf_writer (argument[2], properties);
 
   float angular_threshold = get_option_value ("angle", DEFAULT_ANGULAR_THRESHOLD);
-  const float angular_threshold_dp = cos (angular_threshold * (M_PI/180.0));
+  const float angular_threshold_dp = cos (angular_threshold * (Math::pi/180.0));
 
   const size_t num_tracks = properties["count"].empty() ? 0 : to<int> (properties["count"]);
 

--- a/cmd/fixelcfestats.cpp
+++ b/cmd/fixelcfestats.cpp
@@ -152,7 +152,7 @@ void run() {
   value_type cfe_c = get_option_value ("cfe_c", DEFAULT_CFE_C);
   int num_perms = get_option_value ("nperms", DEFAULT_PERMUTATIONS);
   value_type angular_threshold = get_option_value ("angle", DEFAULT_ANGLE_THRESHOLD);
-  const float angular_threshold_dp = cos (angular_threshold * (M_PI/180.0));
+  const float angular_threshold_dp = cos (angular_threshold * (Math::pi/180.0));
 
   value_type connectivity_threshold = get_option_value ("connectivity", DEFAULT_CONNECTIVITY_THRESHOLD);
   value_type smooth_std_dev = get_option_value ("smooth", DEFAULT_SMOOTHING_STD) / 2.3548;
@@ -259,7 +259,7 @@ void run() {
   value_type gaussian_const1 = 1.0;
   if (smooth_std_dev > 0.0) {
     do_smoothing = true;
-    gaussian_const1 = 1.0 / (smooth_std_dev *  std::sqrt (2.0 * M_PI));
+    gaussian_const1 = 1.0 / (smooth_std_dev *  std::sqrt (2.0 * Math::pi));
   }
   {
     ProgressBar progress ("normalising and thresholding fixel-fixel connectivity matrix", num_fixels);

--- a/lib/mrtrix.h
+++ b/lib/mrtrix.h
@@ -72,7 +72,7 @@ namespace MR
     };
 
   template <typename X>
-    struct max_digits<X, typename std::enable_if<std::is_fundamental<typename X::value_type>::value, int>::type> {
+    struct max_digits<X, typename std::enable_if<std::is_fundamental<typename X::value_type>::value && !std::is_fundamental<typename X::Scalar>::value, int>::type> {
       static constexpr int value () { return std::numeric_limits<typename X::value_type>::max_digits10; }
     };
 

--- a/lib/mrtrix.h
+++ b/lib/mrtrix.h
@@ -58,6 +58,11 @@ namespace MR
 
   template <typename X, typename ReturnType = int>
     struct max_digits {
+      static constexpr int value () { return 0; }
+    };
+
+  template <typename X>
+    struct max_digits<X, typename std::enable_if<std::is_fundamental<X>::value, int>::type> {
       static constexpr int value () { return std::numeric_limits<X>::max_digits10; }
     };
 
@@ -70,6 +75,8 @@ namespace MR
     struct max_digits<X, typename std::enable_if<std::is_fundamental<typename X::value_type>::value, int>::type> {
       static constexpr int value () { return std::numeric_limits<typename X::value_type>::max_digits10; }
     };
+
+
 
   template <class T> inline std::string str (const T& value, int precision = 0)
   {

--- a/src/dwi/tractography/GT/externalenergy.cpp
+++ b/src/dwi/tractography/GT/externalenergy.cpp
@@ -79,7 +79,7 @@ namespace MR {
             for (int l = 0; l <= lmax/2; l++)
               wmr_sh[l] = (l < props.resp_WM.cols()) ? props.resp_WM(s, l) : 0.0;
             wmr_rh = Math::SH::SH2RH(wmr_sh);
-            wmr0 = props.resp_WM(s,0) / std::sqrt(4*M_PI);
+            wmr0 = props.resp_WM(s,0) / std::sqrt(M_4PI);
             
             for (size_t r : shells[s].get_volumes())
             {

--- a/src/dwi/tractography/GT/externalenergy.h
+++ b/src/dwi/tractography/GT/externalenergy.h
@@ -103,7 +103,7 @@ namespace MR {
           
           inline double hanning(const double w) const
           {
-            return (w <= (1.0-beta)/2) ? 0.0 : (w >= (1.0+beta)/2) ? 1.0 : (1 - std::cos(M_PI * (w-(1.0-beta)/2)/beta )) / 2;
+            return (w <= (1.0-beta)/2) ? 0.0 : (w >= (1.0+beta)/2) ? 1.0 : (1 - std::cos(Math::pi * (w-(1.0-beta)/2)/beta )) / 2;
           }
           
         };

--- a/src/dwi/tractography/GT/gt.h
+++ b/src/dwi/tractography/GT/gt.h
@@ -34,7 +34,7 @@ namespace MR {
     namespace Tractography {
       namespace GT {
         
-        const double M_4PI = 4 * M_PI;
+        const double M_4PI = 4.0 * Math::pi;
         const double M_sqrt4PI = std::sqrt(M_4PI);
         
         

--- a/src/stats/cfe.h
+++ b/src/stats/cfe.h
@@ -58,7 +58,7 @@ namespace MR
                           fixel_directions (fixel_directions),
                           fixel_TDI (fixel_TDI),
                           connectivity_matrix (connectivity_matrix) {
-            angular_threshold_dp = cos (angular_threshold * (M_PI/180.0));
+            angular_threshold_dp = cos (angular_threshold * (Math::pi/180.0));
           }
 
           bool operator () (SetVoxelDir& in)


### PR DESCRIPTION
Awaiting testing on Ubuntu 16.04, which fails compilation on current master: see [here](http://community.mrtrix.org/t/compile-error-on-ubuntu-16-04/183).