### PR TITLE
5ttgen fsl: -t2 option

### DIFF
--- a/scripts/dwipreproc
+++ b/scripts/dwipreproc
@@ -15,6 +15,7 @@ from lib.getFSLEddyPath import getFSLEddyPath
 from lib.getFSLSuffix   import getFSLSuffix
 from lib.getHeaderInfo  import getHeaderInfo
 from lib.getPEDir       import getPEDir
+from lib.imagesMatch    import imagesMatch
 from lib.isWindows      import isWindows
 from lib.printMessage   import printMessage
 from lib.runCommand     import runCommand
@@ -356,27 +357,22 @@ else: # 'All'
   with open('bvals_combined', 'w') as f:
     f.write(' '.join(bvals))
 
+
   # Prior to 5.0.8, a bug resulted in the output field map image from topup having an identity transform,
   #   regardless of the transform of the input image
   # Detect this, and manually replace the transform if necessary
   #   (even if this doesn't cause an issue with the subsequent mrcalc command, it may in the future, it's better for
   #   visualising the script temporary files, and it gives the user a warning about an out-of-date FSL)
-  input_transform_text = getHeaderInfo('topup_in.nii', 'transform')
-  input_transform = [ float(f) for f in input_transform_text.replace('\n', ' ').replace(',', ' ').split() ]
-  topup_transform = [ float(f) for f in getHeaderInfo('field_map' + fsl_suffix, 'transform').replace('\n', ' ').replace(',', ' ').split() ]
-  transform_error = False
   field_map_image = 'field_map' + fsl_suffix
-  for i, t in zip(input_transform, topup_transform):
-    if abs(i-t) > 1e-4:
-      transform_error = True
-  if transform_error:
-    warnMessage('topup output field image has incorrect transform; recommend updating FSL to version 5.0.8 or later')
+  if not imagesMatch('topup_in.nii', field_map_image):
+    warnMessage('topup output field image has erroneous header; recommend updating FSL to version 5.0.8 or later')
+    input_transform_text = getHeaderInfo('topup_in.nii', 'transform')
     with open( 'transform.txt', 'w' ) as f:
       for line in input_transform_text:
         f.write (line)
+    runCommand('mrtransform ' + field_map_image + ' -linear transform.txt -replace field_map_fix' + fsl_suffix)
+    delFile(field_map_image)
     field_map_image = 'field_map_fix' + fsl_suffix
-    runCommand('mrtransform field_map' + fsl_suffix + ' -linear transform.txt -replace ' + field_map_image)
-    delFile('field_map' + fsl_suffix)
 
 
   # Derive the weight images

--- a/scripts/lib/imagesMatch.py
+++ b/scripts/lib/imagesMatch.py
@@ -1,0 +1,24 @@
+def imagesMatch(image_one, image_two):
+  import math
+  from lib.getHeaderInfo import getHeaderInfo
+  # Image dimensions
+  one_dim = [ int(i) for i in getHeaderInfo(image_one, 'size').split() ]
+  two_dim = [ int(i) for i in getHeaderInfo(image_two, 'size').split() ]
+  if not one_dim == two_dim:
+    return False
+  # Voxel size
+  one_spacing = [ float(f) for f in getHeaderInfo(image_one, 'vox').split() ]
+  two_spacing = [ float(f) for f in getHeaderInfo(image_two, 'vox').split() ]
+  for one, two in zip(one_spacing, two_spacing):
+    if one and two and not math.isnan(one) and not math.isnan(two):
+      if (abs(two-one) / (0.5*(one+two))) > 1e-04:
+        return False
+  # Image transform
+  one_transform = [ float(f) for f in getHeaderInfo(image_one, 'transform').replace('\n', ' ').replace(',', ' ').split() ]
+  two_transform = [ float(f) for f in getHeaderInfo(image_two, 'transform').replace('\n', ' ').replace(',', ' ').split() ]
+  for one, two in zip(one_transform, two_transform):
+    if abs(one-two) > 1e-4:
+      return False
+  # Everything matches!
+  return True
+  


### PR DESCRIPTION
Provide a T2-weighted image to accompany the default T1-weighted image input.
This will be used as a second input channel to FSL FAST; it will not influence any other steps.

Notes:
* _Think_ I've tested every combination....
* Originally did this in a privately distributed script: `act_anat_prepare_hcp`. Re-implemented here so that anyone using that script doesn't have to manage an older MRtrix3 install to keep it working. 
* Not convinced that it's beneficial; and may be detrimental in some instances.