### PR TITLE
Fix Eigen-related alignment issues 

### DIFF
--- a/lib/adapter/extract.h
+++ b/lib/adapter/extract.h
@@ -31,6 +31,8 @@ namespace MR
         using Base<ImageType>::parent;
         typedef typename ImageType::value_type value_type;
 
+        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
         Extract1D (const ImageType& original, const size_t axis, const std::vector<int>& indices) :
           Base<ImageType> (original),
           extract_axis (axis),

--- a/lib/adapter/reslice.h
+++ b/lib/adapter/reslice.h
@@ -76,6 +76,8 @@ namespace MR
       public:
         typedef typename ImageType::value_type value_type;
 
+        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
         template <class HeaderType>
           Reslice (const ImageType& original,
                    const HeaderType& reference,

--- a/lib/adapter/subset.h
+++ b/lib/adapter/subset.h
@@ -28,6 +28,7 @@ namespace MR
     {
       public:
         typedef typename ImageType::value_type value_type;
+        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
         using Base<ImageType>::name;
         using Base<ImageType>::spacing;

--- a/lib/header.h
+++ b/lib/header.h
@@ -47,6 +47,8 @@ namespace MR
     public:
       class Axis;
 
+      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
       Header () :
         transform_ (Eigen::Matrix<default_type,3,4>::Constant (NaN)),
         format_ (nullptr),

--- a/lib/transform.h
+++ b/lib/transform.h
@@ -22,7 +22,10 @@ namespace MR
 {
   class Transform
   {
+
     public:
+
+      EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
       //! An object for transforming between voxel, scanner and image coordinate spaces
       template <class HeaderType>

--- a/src/dwi/tractography/GT/externalenergy.h
+++ b/src/dwi/tractography/GT/externalenergy.h
@@ -33,6 +33,8 @@ namespace MR {
         class ExternalEnergyComputer : public EnergyComputer
         {
         public:
+
+          EIGEN_MAKE_ALIGNED_OPERATOR_NEW
           
           ExternalEnergyComputer(Stats& stat, const Image<float>& dwimage, const Properties& props);
           

--- a/src/dwi/tractography/GT/particlegrid.h
+++ b/src/dwi/tractography/GT/particlegrid.h
@@ -38,6 +38,7 @@ namespace MR {
         class ParticleGrid
         {
         public:
+          EIGEN_MAKE_ALIGNED_OPERATOR_NEW
           
           typedef std::vector<Particle*> ParticleVectorType;
           

--- a/src/dwi/tractography/seeding/basic.h
+++ b/src/dwi/tractography/seeding/basic.h
@@ -140,6 +140,8 @@ namespace MR
         class Rejection : public Base
         {
           public:
+            EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
             typedef Eigen::Transform<float, 3, Eigen::AffineCompact> transform_type;
             Rejection (const std::string&);
 


### PR DESCRIPTION
As originally reported here:
http://community.mrtrix.org/t/mrview-segmentationfault-core-dumb-ubuntu-16-04/185

The issue is that Eigen expect fixed-sized types to be aligned for vectorised instructions - or rather, SSE/SSE2 expects data to be aligned for these operations. While Eigen does what it can, the standard `operator new()` doesn't provide any alignment guarantees, being type-agnostic. So Eigen provides a macro that is used to add an appropriate `operator new()` member to classes that contain fixed-size Eigen classes such as `Vector3f`, etc. Failing to do this means that dynamic allocation of classes containing fixed-sized Eigen types may fail to align the data properly, and lead to crashes when the classes are subsequently used in vectorised operations. This may not manifest on all hardware, since it depends on the alignment that the default `operator new()` call will use (no problem if it's actually aligning on 16-byte boundaries anyway), and whether the CPU supports SSE4 instructions, which don't require alignment anyway... 

So this adds the requisite `EIGEN_MAKE_ALIGNED_OPERATOR_NEW` to all classes that I could see that contain a `transform_type` (which is what caused the crash in the original post). I expect there'll be lots more cases cropping up as time goes on, since this will probably affect _all_ `Vector3f`, `Vector4d`, `Matrix3d`, etc. types, which are used extensively in MRtrix3. Thankfully, this is only a problem with _dynamic_ allocation of a class that have one of these as a member... 