### PR TITLE
write_mrtrix: handle 2D images properly

### DIFF
--- a/matlab/write_mrtrix.m
+++ b/matlab/write_mrtrix.m
@@ -24,6 +24,11 @@ if isstruct(image)
 else
   dim = size(image);
 end
+
+while prod(size(dim)) < 3
+  dim(end+1) = 1;
+end 
+
 fprintf (fid, '%d', dim(1));
 fprintf (fid, ',%d', dim(2:end));
 


### PR DESCRIPTION
Simple fix to make sure a 2D array gets promoted to a 3D array when writing the image - otherwise MRtrix3 will reject the image...