### PR TITLE
MRView: proper HSV mapping for complex numbers

### DIFF
--- a/src/gui/mrview/colourmap.cpp
+++ b/src/gui/mrview/colourmap.cpp
@@ -71,11 +71,14 @@ namespace MR
               true),
 
           Entry ("Complex",
-              "float phase = atan (color.r, color.g) * 0.954929658551372;\n"
-              "color.rgb = phase + vec3 (-2.0, 0.0, 2.0);\n"
-              "if (phase > 2.0) color.b -= 6.0;\n"
-              "if (phase < -2.0) color.r += 6.0;\n"
-              "color.rgb = clamp (scale * (amplitude - offset), 0.0, 1.0) * (2.0 - abs (color.rgb));\n",
+              "float C = atan (color.g, color.r) / 1.047197551196598;\n"
+              "if (C < -2.0) color.rgb = vec3 (0.0, -C-2.0, 1.0);\n"
+              "else if (C < -1.0) color.rgb = vec3 (C+2.0, 0.0, 1.0);\n"
+              "else if (C < 0.0) color.rgb = vec3 (1.0, 0.0, -C);\n"
+              "else if (C < 1.0) color.rgb = vec3 (1.0, C, 0.0);\n"
+              "else if (C < 2.0) color.rgb = vec3 (2.0-C, 1.0, 0.0);\n"
+              "else color.rgb = vec3 (0.0, 1.0, C-2.0);\n"
+              "color.rgb = scale * (amplitude - offset) * color.rgb;\n",
               Entry::basic_map_fn(),
               "length (color.rg)",
               true),


### PR DESCRIPTION
The previous colour mapping for complex numbers was a bit of a hack, and looked pretty bad on a colourwheel. Mapping is now a proper phase->hue, mod->value, full saturation mapping.
More explicitly, complex number Z maps to HSV [ phase(Z) 1 abs(Z) ].

The difference can be seen on the colourwheel below: left is current, right is proposed. This shows the final colour for complex numbers with zero at centre, real along y axis (positive at top), and imaginary along x axis (positive on the right).

![complex_colourmapping](https://cloud.githubusercontent.com/assets/3221000/15041237/64ed1230-12b2-11e6-9dc6-53be5c87f332.png)
 