### PR TITLE
fix compilation issues with Intel compiler

### DIFF
--- a/cmd/label2mesh.cpp
+++ b/cmd/label2mesh.cpp
@@ -103,7 +103,7 @@ void run ()
         from.push_back (lower_corners[in][axis]);
         dimensions.push_back (upper_corners[in][axis] - lower_corners[in][axis] + 1);
       }
-      Adapter::Subset<decltype(labels)> subset (labels, from, dimensions);
+      Adapter::Subset<Image<uint32_t>> subset (labels, from, dimensions);
 
       auto scratch = Image<bool>::scratch (subset, "Node " + str(in) + " mask");
       for (auto i = Loop (subset) (subset, scratch); i; ++i)

--- a/lib/adapter/base.h
+++ b/lib/adapter/base.h
@@ -25,7 +25,7 @@ namespace MR
   namespace Adapter
   {
 
-    template <template <class> class AdapterType, class ImageType, typename... Args>
+    template <template <class ImageType> class AdapterType, class ImageType, typename... Args>
       inline AdapterType<ImageType> make (const ImageType& parent, Args&&... args) {
         return AdapterType<ImageType> (parent, std::forward<Args> (args)...);
       }

--- a/lib/adapter/base.h
+++ b/lib/adapter/base.h
@@ -25,7 +25,7 @@ namespace MR
   namespace Adapter
   {
 
-    template <template <class AdapterType> class AdapterType, class ImageType, typename... Args>
+    template <template <class> class AdapterType, class ImageType, typename... Args>
       inline AdapterType<ImageType> make (const ImageType& parent, Args&&... args) {
         return AdapterType<ImageType> (parent, std::forward<Args> (args)...);
       }

--- a/src/dwi/tractography/seeding/base.h
+++ b/src/dwi/tractography/seeding/base.h
@@ -62,7 +62,7 @@ namespace MR
       uint32_t get_count (ImageType& data)
       {
         std::atomic<uint32_t> count (0);
-        ThreadedLoop (data).run ([&] (decltype(data)& v) { if (v.value()) count.fetch_add (1, std::memory_order_relaxed); }, data);
+        ThreadedLoop (data).run ([&] (ImageType& v) { if (v.value()) count.fetch_add (1, std::memory_order_relaxed); }, data);
         return count;
       }
 


### PR DESCRIPTION
I'm trying to compile MRtrix 0.3.14 with the Intel compilers (I tried with both versions 2016.1.150 and 2016.3.210).

719e416 fixes this problem:

```
In file included from ./lib/adapter/subset.h(20),
                from src/gui/mrview/tool/connectome/connectome.cpp(21):
./lib/adapter/base.h(28): error: a template template parameter cannot have the same name as one of its template parameters
     template <template <class AdapterType> class AdapterType, class ImageType, typename... Args>
                                                        ^
```

I'm still running into another problem I haven't figured out though (I'm not exactly a C++ expert), suggestions welcome:

```
src/dwi/tractography/seeding/base.h(65): error: expression must have class type
          ThreadedLoop (data).run ([&] (decltype(data)& v) { if (v.value()) count.fetch_add (1, std::memory_order_relaxed); }, data);
                                                                   ^
```