### PR TITLE
dwi2tensor: Check condition number of matrix

### DIFF
--- a/src/dwi/tensor.h
+++ b/src/dwi/tensor.h
@@ -16,6 +16,8 @@
 #ifndef __dwi_tensor_h__
 #define __dwi_tensor_h__
 
+#include <Eigen/SVD>
+
 #include "types.h"
 
 namespace MR
@@ -53,6 +55,10 @@ namespace MR
           bmat (i,21) = -grad(i,3) * grad(i,3) * grad(i,0) * grad(i,1) * grad(i,2) * grad(i,2) * 2;
         }
       }
+      auto v = Eigen::JacobiSVD<Eigen::Matrix<T,Eigen::Dynamic,Eigen::Dynamic>> (bmat).singularValues();
+      auto cond = v[0] / v[v.size()-1];
+      if (cond >= 5e7)
+        WARN ("b-matrix is ill-conditioned (condition number " + str(cond) + "); tensor estimation may be ill-posed (do you have enough b-values?)");
       return bmat;
     }
 


### PR DESCRIPTION
This will hopefully provide the user with a warning if they attempt a tensor / kurtosis tensor estimation with inadequate variation in their b-values.

Arose initially from discussion in #606. However I'm not completely sold: It's the same approach as is used for determining _lmax_ based on the SH transform, but the numbers are completely different: I had a stable fit at condition number 2e6 and unstable at 1e9. So would appreciate people's thoughts on this, or consider reverting to a _b_value shell count method instead.