### PR TITLE
Moved Sn_scale_estimator from src/dwi/ to lib/math/

### DIFF
--- a/lib/math/Sn_scale_estimator.h
+++ b/lib/math/Sn_scale_estimator.h
@@ -13,14 +13,17 @@
  * 
  */
 
-#ifndef __dwi_Sn_scale_estimator_h__
-#define __dwi_Sn_scale_estimator_h__
+#ifndef __math_Sn_scale_estimator_h__
+#define __math_Sn_scale_estimator_h__
 
+#include <vector>
+
+#include "types.h"
 #include "math/median.h"
 
 
 namespace MR {
-  namespace DWI {
+  namespace Math {
 
 
     // Sn robust estimator of scale to get solid estimate of standard deviation:

--- a/src/dwi/noise_estimator.h
+++ b/src/dwi/noise_estimator.h
@@ -20,7 +20,7 @@
 #include "dwi/gradient.h"
 #include "math/least_squares.h"
 #include "math/SH.h"
-#include "dwi/Sn_scale_estimator.h"
+#include "math/Sn_scale_estimator.h"
 
 
 namespace MR {
@@ -63,7 +63,7 @@ namespace MR {
             OutputImageType noise;
             Eigen::MatrixXd H, S, R;
             Eigen::VectorXd leverage;
-            Sn_scale_estimator<default_type> scale_estimator;
+            Math::Sn_scale_estimator<default_type> scale_estimator;
             int axis;
         };
     }


### PR DESCRIPTION
@jdtournier This file placement struck me as odd, even though it's only used in DWI-related code. Merge if you're happy with it.