### PR TITLE
dwi2tensor: Few changes

### DIFF
--- a/cmd/dwi2tensor.cpp
+++ b/cmd/dwi2tensor.cpp
@@ -29,6 +29,15 @@ typedef float value_type;
 
 #define DEFAULT_NITER 2
 
+const char* encoding_description =
+  "The tensor coefficients are stored in the output image as follows: \n"
+  "volumes 0-5: D11, D22, D33, D12, D13, D23 ; \n\n"
+  "If diffusion kurtosis is estimated using the -dkt option, these are stored as follows: \n"
+  "volumes 0-2: W1111, W2222, W3333 ; \n"
+  "volumes 3-8: W1112, W1113, W1222, W1333, W2223, W2333 ; \n"
+  "volumes 9-11: W1122, W1133, W2233 ; \n"
+  "volumes 12-14: W1123, W1223, W1233 ;";
+
 void usage ()
 {
 
@@ -57,7 +66,8 @@ void usage ()
   AUTHOR = "Ben Jeurissen (ben.jeurissen@uantwerpen.be)";
   
   DESCRIPTION
-  + "Diffusion (kurtosis) tensor estimation using iteratively reweighted linear least squares estimator.";
+  + "Diffusion (kurtosis) tensor estimation using iteratively reweighted linear least squares estimator."
+  + encoding_description;
 }
 
 template <class MASKType, class B0Type, class DKTType, class PredictType>

--- a/docs/getting_started/commands/dwi2tensor.rst
+++ b/docs/getting_started/commands/dwi2tensor.rst
@@ -18,6 +18,8 @@ Description
 
 Diffusion (kurtosis) tensor estimation using iteratively reweighted linear least squares estimator.
 
+The tensor coefficients are stored in the output image as follows: volumes 0-5: D11, D22, D33, D12, D13, D23 ; If diffusion kurtosis is estimated using the -dkt option, these are stored as follows: volumes 0-2: W1111, W2222, W3333 ; volumes 3-8: W1112, W1113, W1222, W1333, W2223, W2333 ; volumes 9-11: W1122, W1133, W2233 ; volumes 12-14: W1123, W1223, W1233 ;
+
 Options
 -------
 

--- a/src/dwi/tensor.h
+++ b/src/dwi/tensor.h
@@ -18,6 +18,8 @@
 
 #include "types.h"
 
+#include "dwi/shells.h"
+
 namespace MR
 {
   namespace DWI
@@ -26,31 +28,44 @@ namespace MR
     template <typename T, class MatrixType> 
       inline Eigen::Matrix<T,Eigen::Dynamic,Eigen::Dynamic> grad2bmatrix (const MatrixType& grad, bool dki = false)
     {
+      try {
+        DWI::Shells shells (grad);
+        if (dki) {
+          if (shells.count() < 3)
+            throw Exception ("Kurtosis tensor estimation requires at least 3 b-value shells");
+        } else {
+          if (shells.count() < 2)
+            throw Exception ("Tensor estimation requires at least 2 b-values");
+        }
+      } catch (...) {
+        WARN ("Unable to separate diffusion gradient table into shells; tensor estimation success uncertain");
+      }
+
       Eigen::Matrix<T,Eigen::Dynamic,Eigen::Dynamic> bmat (grad.rows(), (dki ? 22 : 7));
       for (ssize_t i = 0; i < grad.rows(); ++i) {
         bmat (i,0)  = grad(i,3) *  grad(i,0) * grad(i,0);
         bmat (i,1)  = grad(i,3) *  grad(i,1) * grad(i,1);
         bmat (i,2)  = grad(i,3) *  grad(i,2) * grad(i,2);
-        bmat (i,3)  = grad(i,3) *  grad(i,0) * grad(i,1) * 2;
-        bmat (i,4)  = grad(i,3) *  grad(i,0) * grad(i,2) * 2;
-        bmat (i,5)  = grad(i,3) *  grad(i,1) * grad(i,2) * 2;
+        bmat (i,3)  = grad(i,3) *  grad(i,0) * grad(i,1) * T(2.0);
+        bmat (i,4)  = grad(i,3) *  grad(i,0) * grad(i,2) * T(2.0);
+        bmat (i,5)  = grad(i,3) *  grad(i,1) * grad(i,2) * T(2.0);
         bmat (i,6)  = -1.0;
         if (dki) {
-          bmat (i,7)  = -grad(i,3) * grad(i,3) * grad(i,0) * grad(i,0) * grad(i,0) * grad(i,0) * 1/6;
-          bmat (i,8)  = -grad(i,3) * grad(i,3) * grad(i,1) * grad(i,1) * grad(i,1) * grad(i,1) * 1/6;
-          bmat (i,9)  = -grad(i,3) * grad(i,3) * grad(i,2) * grad(i,2) * grad(i,2) * grad(i,2) * 1/6;
-          bmat (i,10) = -grad(i,3) * grad(i,3) * grad(i,0) * grad(i,0) * grad(i,0) * grad(i,1) * 2/3;
-          bmat (i,11) = -grad(i,3) * grad(i,3) * grad(i,0) * grad(i,0) * grad(i,0) * grad(i,2) * 2/3;
-          bmat (i,12) = -grad(i,3) * grad(i,3) * grad(i,0) * grad(i,1) * grad(i,1) * grad(i,1) * 2/3;
-          bmat (i,13) = -grad(i,3) * grad(i,3) * grad(i,0) * grad(i,2) * grad(i,2) * grad(i,2) * 2/3;
-          bmat (i,14) = -grad(i,3) * grad(i,3) * grad(i,1) * grad(i,1) * grad(i,1) * grad(i,2) * 2/3;
-          bmat (i,15) = -grad(i,3) * grad(i,3) * grad(i,1) * grad(i,2) * grad(i,2) * grad(i,2) * 2/3;
+          bmat (i,7)  = -grad(i,3) * grad(i,3) * grad(i,0) * grad(i,0) * grad(i,0) * grad(i,0) * T(1.0/6.0);
+          bmat (i,8)  = -grad(i,3) * grad(i,3) * grad(i,1) * grad(i,1) * grad(i,1) * grad(i,1) * T(1.0/6.0);
+          bmat (i,9)  = -grad(i,3) * grad(i,3) * grad(i,2) * grad(i,2) * grad(i,2) * grad(i,2) * T(1.0/6.0);
+          bmat (i,10) = -grad(i,3) * grad(i,3) * grad(i,0) * grad(i,0) * grad(i,0) * grad(i,1) * T(2.0/3.0);
+          bmat (i,11) = -grad(i,3) * grad(i,3) * grad(i,0) * grad(i,0) * grad(i,0) * grad(i,2) * T(2.0/3.0);
+          bmat (i,12) = -grad(i,3) * grad(i,3) * grad(i,0) * grad(i,1) * grad(i,1) * grad(i,1) * T(2.0/3.0);
+          bmat (i,13) = -grad(i,3) * grad(i,3) * grad(i,0) * grad(i,2) * grad(i,2) * grad(i,2) * T(2.0/3.0);
+          bmat (i,14) = -grad(i,3) * grad(i,3) * grad(i,1) * grad(i,1) * grad(i,1) * grad(i,2) * T(2.0/3.0);
+          bmat (i,15) = -grad(i,3) * grad(i,3) * grad(i,1) * grad(i,2) * grad(i,2) * grad(i,2) * T(2.0/3.0);
           bmat (i,16) = -grad(i,3) * grad(i,3) * grad(i,0) * grad(i,0) * grad(i,1) * grad(i,1);
           bmat (i,17) = -grad(i,3) * grad(i,3) * grad(i,0) * grad(i,0) * grad(i,2) * grad(i,2);
           bmat (i,18) = -grad(i,3) * grad(i,3) * grad(i,1) * grad(i,1) * grad(i,2) * grad(i,2);
-          bmat (i,19) = -grad(i,3) * grad(i,3) * grad(i,0) * grad(i,0) * grad(i,1) * grad(i,2) * 2;
-          bmat (i,20) = -grad(i,3) * grad(i,3) * grad(i,0) * grad(i,1) * grad(i,1) * grad(i,2) * 2;
-          bmat (i,21) = -grad(i,3) * grad(i,3) * grad(i,0) * grad(i,1) * grad(i,2) * grad(i,2) * 2;
+          bmat (i,19) = -grad(i,3) * grad(i,3) * grad(i,0) * grad(i,0) * grad(i,1) * grad(i,2) * T(2.0);
+          bmat (i,20) = -grad(i,3) * grad(i,3) * grad(i,0) * grad(i,1) * grad(i,1) * grad(i,2) * T(2.0);
+          bmat (i,21) = -grad(i,3) * grad(i,3) * grad(i,0) * grad(i,1) * grad(i,2) * grad(i,2) * T(2.0);
         }
       }
       return bmat;

--- a/src/dwi/tensor.h
+++ b/src/dwi/tensor.h
@@ -28,17 +28,20 @@ namespace MR
     template <typename T, class MatrixType> 
       inline Eigen::Matrix<T,Eigen::Dynamic,Eigen::Dynamic> grad2bmatrix (const MatrixType& grad, bool dki = false)
     {
+      std::unique_ptr<DWI::Shells> shells;
       try {
-        DWI::Shells shells (grad);
-        if (dki) {
-          if (shells.count() < 3)
-            throw Exception ("Kurtosis tensor estimation requires at least 3 b-value shells");
-        } else {
-          if (shells.count() < 2)
-            throw Exception ("Tensor estimation requires at least 2 b-values");
-        }
+        shells.reset (new DWI::Shells (grad));
       } catch (...) {
         WARN ("Unable to separate diffusion gradient table into shells; tensor estimation success uncertain");
+      }
+      if (shells) {
+        if (dki) {
+          if (shells->count() < 3)
+            throw Exception ("Kurtosis tensor estimation requires at least 3 b-value shells");
+        } else {
+          if (shells->count() < 2)
+            throw Exception ("Tensor estimation requires at least 2 b-values");
+        }
       }
 
       Eigen::Matrix<T,Eigen::Dynamic,Eigen::Dynamic> bmat (grad.rows(), (dki ? 22 : 7));


### PR DESCRIPTION
- Add output image encoding description to command help page and documentation.
- Get the number of shells in the gradient table, and throw an exception if the user inputs an image that does not contain an adequate number of shells for tensor estimation.
- Enforce floating-point multiplication and division when scaling individual rows of the b-matrix.
Initial discussion in #606, replaces #623.