### PR TITLE
sh2response: Check validity of provided directions

### DIFF
--- a/cmd/sh2response.cpp
+++ b/cmd/sh2response.cpp
@@ -90,7 +90,17 @@ void run ()
       continue;
 
     Eigen::Vector3d d = dir.row(3);
+    if (!d.allFinite()) {
+      WARN ("voxel with invalid direction [ " + str(dir.index(0)) + " " + str(dir.index(1)) + " " + str(dir.index(2)) + " ]; skipping");
+      continue;
+    }
     d.normalize();
+    // Uncertainty regarding Eigen's behaviour when normalizing a zero vector; may change behaviour between versions
+    if (!d.allFinite() || !d.squaredNorm()) {
+      WARN ("voxel with zero direction [ " + str(dir.index(0)) + " " + str(dir.index(1)) + " " + str(dir.index(2)) + " ]; skipping");
+      continue;
+    }
+
     Math::SH::delta (delta, d, lmax);
 
     for (int l = 0; l <= lmax; l += 2) {


### PR DESCRIPTION
As originally suggested [here](http://community.mrtrix.org/t/msdwi2response-returns-only-nan/209/3).