### PR TITLE
SIFT model: Disable heuristic GM scaling by default

### DIFF
--- a/docs/getting_started/commands/tcksift.rst
+++ b/docs/getting_started/commands/tcksift.rst
@@ -36,7 +36,7 @@ Options for setting the processing mask for the SIFT fixel-streamlines compariso
 Options affecting the SIFT model
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
--  **-no_fd_scaling** by default, the fibre densities in voxels with grey matter partial volume contamination are scaled appropriately to compensate. Provide this option to override this behaviour and not perform any scaling.
+-  **-fd_scale_gm** provide this option (in conjunction with -act) to heuristically downsize the fibre density estimates based on the presence of GM in the voxel. This can assist in reducing tissue interface effects when using a single-tissue deconvolution algorithm
 
 -  **-no_dilate_lut** do NOT dilate FOD lobe lookup tables; only map streamlines to FOD lobes if the precise tangent lies within the angular spread of that lobe
 

--- a/docs/getting_started/commands/tcksift2.rst
+++ b/docs/getting_started/commands/tcksift2.rst
@@ -32,7 +32,7 @@ Options for setting the processing mask for the SIFT fixel-streamlines compariso
 Options affecting the SIFT model
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
--  **-no_fd_scaling** by default, the fibre densities in voxels with grey matter partial volume contamination are scaled appropriately to compensate. Provide this option to override this behaviour and not perform any scaling.
+-  **-fd_scale_gm** provide this option (in conjunction with -act) to heuristically downsize the fibre density estimates based on the presence of GM in the voxel. This can assist in reducing tissue interface effects when using a single-tissue deconvolution algorithm
 
 -  **-no_dilate_lut** do NOT dilate FOD lobe lookup tables; only map streamlines to FOD lobes if the precise tangent lies within the angular spread of that lobe
 

--- a/src/dwi/tractography/SIFT/model_base.h
+++ b/src/dwi/tractography/SIFT/model_base.h
@@ -210,7 +210,7 @@ namespace MR
         template <class Fixel>
         void ModelBase<Fixel>::scale_FDs_by_GM ()
         {
-          if (App::get_options("no_fd_scaling").size())
+          if (!App::get_options("fd_scale_gm").size())
             return;
           if (!act_5tt.valid()) {
             INFO ("Cannot scale fibre densities according to GM fraction; no ACT image data provided");

--- a/src/dwi/tractography/SIFT/sift.cpp
+++ b/src/dwi/tractography/SIFT/sift.cpp
@@ -28,8 +28,8 @@ using namespace App;
 
 const OptionGroup SIFTModelOption = OptionGroup ("Options affecting the SIFT model")
 
-  + Option ("no_fd_scaling", "by default, the fibre densities in voxels with grey matter partial volume contamination are scaled appropriately to compensate. \n"
-                             "Provide this option to override this behaviour and not perform any scaling.")
+  + Option ("fd_scale_gm", "provide this option (in conjunction with -act) to heuristically downsize the fibre density estimates based on the presence of GM in the voxel. "
+                           "This can assist in reducing tissue interface effects when using a single-tissue deconvolution algorithm")
 
   + Option ("no_dilate_lut", "do NOT dilate FOD lobe lookup tables; only map streamlines to FOD lobes if the precise tangent lies within the angular spread of that lobe")
 


### PR DESCRIPTION
In the SIFT model, it is common for the FODs in voxels containing part WM and part GM to be under-represented by streamlines, as the streamlines are only permitted to exist within some fraction of the voxel volume.
A heuristic was provided to compensate for this by using the ACT 5TT image to down-scale the FOD size in such voxels.
However with the emergence of more tissue-specific spherical deconvolution approaches, this heuristic is no longer required in all circumstances.
Therefore, this heuristic scaling can now be activated via a command-line option, rather than the previous behaviour where it could be de-activated via an option.
Closes #608.

Don't merge until tag is happening, since default behaviour is changing.