### PR TITLE
Tractography writer classes: Prevent segfault

### DIFF
--- a/src/dwi/tractography/file_base.h
+++ b/src/dwi/tractography/file_base.h
@@ -66,7 +66,8 @@ namespace MR
               total_count (0),
               name (name), 
               dtype (DataType::from<ValueType>()),
-              count_offset (0)
+              count_offset (0),
+              open_success (false)
           {
             dtype.set_byte_order_native();
             if (dtype != DataType::Float32LE && dtype != DataType::Float32BE &&
@@ -78,8 +79,10 @@ namespace MR
 
             ~__WriterBase__()
             {
-              File::OFStream out (name, std::ios::in | std::ios::out | std::ios::binary);
-              update_counts (out);
+              if (open_success) {
+                File::OFStream out (name, std::ios::in | std::ios::out | std::ios::binary);
+                update_counts (out);
+              }
             }
 
             void create (File::OFStream& out, const Properties& properties, const std::string& type) {
@@ -124,7 +127,8 @@ namespace MR
           protected:
             std::string name;
             DataType dtype;
-            int64_t  count_offset;
+            int64_t count_offset;
+            bool open_success;
 
 
             void verify_stream (const File::OFStream& out) {

--- a/src/dwi/tractography/scalar_file.h
+++ b/src/dwi/tractography/scalar_file.h
@@ -171,6 +171,7 @@ namespace MR
           using __WriterBase__<T>::create;
           using __WriterBase__<T>::update_counts;
           using __WriterBase__<T>::verify_stream;
+          using __WriterBase__<T>::open_success;
 
           ScalarWriter (const std::string& file, const Properties& properties) :
             __WriterBase__<T> (file),
@@ -178,10 +179,17 @@ namespace MR
             buffer (new value_type [buffer_capacity+1]),
             buffer_size (0)
           {
-            File::OFStream out (name, std::ios::out | std::ios::binary | std::ios::trunc);
+            File::OFStream out;
+            try {
+              out.open (name, std::ios::out | std::ios::binary | std::ios::trunc);
+            } catch (Exception& e) {
+              throw Exception (e, "Unable to create output track scalar file");
+            }
+
             // Do NOT set Properties timestamp here! (Must match corresponding .tck file)
             const_cast<Properties&> (properties).set_version_info();
             create (out, properties, "track scalars");
+            open_success = true;
             current_offset = out.tellp();
           }
 
@@ -231,7 +239,7 @@ namespace MR
 
           void commit ()
           {
-            if (buffer_size == 0)
+            if (buffer_size == 0 || !open_success)
               return;
             File::OFStream out (name, std::ios::in | std::ios::out | std::ios::binary | std::ios::ate);
             out.seekp (current_offset, out.beg);


### PR DESCRIPTION
Error due to `File::OFstream` being unable to open an output image for writing, but class destructors then trying to write to the same file during stack unwinding.
Closes #585.