### PR TITLE
transformconvert

### DIFF
--- a/cmd/transformcalc.cpp
+++ b/cmd/transformcalc.cpp
@@ -14,20 +14,21 @@
  */
 
 
+#include <unsupported/Eigen/MatrixFunctions>
+#include <algorithm>
 #include "command.h"
 #include "math/math.h"
 #include "math/average_space.h"
 #include "image.h"
 #include "file/nifti1_utils.h"
 #include "transform.h"
-#include <unsupported/Eigen/MatrixFunctions>
+#include "file/key_value.h"
 
 
 using namespace MR;
 using namespace App;
 
 const char* operations[] = {
-  "flirt_import",
   "invert",
   "half",
   "rigid",
@@ -36,11 +37,6 @@ const char* operations[] = {
   "interpolate",
   NULL
 };
-
-// const char description_flirt_import[] = "flirt_import" + "convert the transformation matrix provided by FSL's flirt command to a format usable in MRtrix";
-
-  // VAR(join(description_flirt_import, ", "));
-  // VAR(join(description_flirt_import, ", ").c_str());
 
 void usage ()
 {
@@ -53,11 +49,6 @@ void usage ()
   ARGUMENTS
   + Argument ("input", "the input for the specified operation").allow_multiple()
   + Argument ("operation", "the operation to perform, one of: " + join(operations, ", ") + "."
-    + "\n\nflirt_import: "
-    + "Convert a transformation matrix produced by FSL's flirt command into a format usable by MRtrix. "
-        "You'll need to provide as additional arguments the save NIfTI images that were passed to flirt "
-        "with the -in and -ref options:\nmatrix_in in ref flirt_import output"
-
     + "\n\ninvert: invert the input transformation:\nmatrix_in invert output"
 
     + "\n\nhalf: calculate the matrix square root of the input transformation:\nmatrix_in half output"
@@ -78,75 +69,9 @@ void usage ()
   + Argument ("output", "the output transformation matrix.").type_file_out ();
 }
 
-
-transform_type get_flirt_transform (const Header& header)
-{
-  std::vector<size_t> axes;
-  transform_type nifti_transform = File::NIfTI::adjust_transform (header, axes);
-  if (nifti_transform.matrix().topLeftCorner<3,3>().determinant() < 0.0)
-    return nifti_transform;
-  transform_type coord_switch;
-  coord_switch.setIdentity();
-  coord_switch(0,0) = -1.0f;
-  coord_switch(0,3) = (header.size(axes[0])-1) * header.spacing(axes[0]);
-  return nifti_transform * coord_switch;
-}
-
-transform_type get_surfer_transform (const Header& header) {
-  // TODO
-  return transform_type();
-}
-
-//! read matrix data into a 2D vector \a filename
-template <class ValueType = default_type>
-  transform_type parse_surfer_transform (const std::string& filename) {
-    std::ifstream stream (filename, std::ios_base::in | std::ios_base::binary);
-    std::vector<std::vector<ValueType>> V;
-    std::string sbuf;
-    std::string file_version;
-    while (getline (stream, sbuf)) {
-      if (sbuf.substr (0,1) == "#")
-        continue;
-      if (sbuf.find("1 4 4") != std::string::npos)
-        break;
-      if (sbuf.find("type") == std::string::npos)
-        continue;
-      file_version = sbuf.substr (sbuf.find_first_of ('=')+1);
-    }
-    if (file_version.empty())
-      throw Exception ("not a surfer transformation");
-    // so far we only understand vox2vox transformations
-    // vox2vox = inverse(colrowslice_to_xyz(moving))*M*colrowslice_to_xyz(target)
-    if (stoi(file_version)!=0)
-      throw Exception ("not a vox2vox transformation");
-
-    for (auto i = 0; i<4 && getline (stream, sbuf); ++i){
-      // sbuf = strip (sbuf.substr (0, sbuf.find_first_of ('type')));
-      V.push_back (std::vector<ValueType>());
-      const auto elements = MR::split (sbuf, " ,;\t", true);
-      for (const auto& entry : elements)
-        V.back().push_back (to<ValueType> (entry));
-      if (V.size() > 1)
-        if (V.back().size() != V[0].size())
-          throw Exception ("uneven rows in matrix");
-    }
-    if (stream.bad())
-      throw Exception (strerror (errno));
-    if (!V.size())
-      throw Exception ("no data in file");
-
-    transform_type M;
-    for (ssize_t i = 0; i < 3; i++)
-      for (ssize_t j = 0; j < 4; j++)
-        M(i,j) = V[i][j];
-    return M;
-  }
-
 template <typename T> int sgn(T val) {
     return (T(0) < val) - (val < T(0));
 }
-
-
 
 void run ()
 {
@@ -155,35 +80,14 @@ void run ()
   const std::string& output_path = argument.back();
 
   switch (op) {
-    case 0: { // flirt_import
-      if (num_inputs != 3)
-        throw Exception ("flirt_import requires 3 inputs");
-      transform_type transform = load_transform<default_type> (argument[0]);
-      auto src_header = Header::open (argument[1]); // -in
-      auto dest_header = Header::open (argument[2]); // -ref
-
-      if (transform.matrix().topLeftCorner<3,3>().determinant() == float(0.0))
-          WARN ("Transformation matrix determinant is zero.");
-      if (transform.matrix().topLeftCorner<3,3>().determinant() < 0)
-          INFO ("Transformation matrix determinant is negative.");
-
-      transform_type src_flirt_to_scanner = get_flirt_transform (src_header);
-      transform_type dest_flirt_to_scanner = get_flirt_transform (dest_header);
-
-      transform_type forward_transform = dest_flirt_to_scanner * transform * src_flirt_to_scanner.inverse();
-      if (((forward_transform.matrix().array() != forward_transform.matrix().array())).any())
-        WARN ("NAN in transformation.");
-      save_transform (forward_transform.inverse(), output_path);
-      break;
-    }
-    case 1: { // invert
+    case 0: { // invert
       if (num_inputs != 1)
         throw Exception ("invert requires 1 input");
       transform_type input = load_transform<default_type> (argument[0]);
       save_transform (input.inverse(), output_path);
       break;
     }
-    case 2: { // half
+    case 1: { // half
       if (num_inputs != 1)
         throw Exception ("half requires 1 input");
       Eigen::Transform<default_type, 3, Eigen::Projective> input = load_transform<default_type> (argument[0]);
@@ -193,7 +97,7 @@ void run ()
       save_transform (output, output_path);
       break;
     }
-    case 3: { // rigid
+    case 2: { // rigid
       if (num_inputs != 1)
         throw Exception ("rigid requires 1 input");
       transform_type input = load_transform<default_type> (argument[0]);
@@ -202,7 +106,7 @@ void run ()
       save_transform (output, output_path);
       break;
     }
-    case 4: { // header
+    case 3: { // header
       if (num_inputs != 2)
         throw Exception ("header requires 2 inputs");
       auto orig_header = Header::open (argument[0]);
@@ -212,7 +116,7 @@ void run ()
       save_transform (forward_transform.inverse(), output_path);
       break;
     }
-    case 5: { // average
+    case 4: { // average
       if (num_inputs < 2)
         throw Exception ("average requires at least 2 inputs");
       transform_type transform_out;
@@ -231,7 +135,7 @@ void run ()
       save_transform (transform_out, output_path);
       break;
     }
-    case 6: { // interpolate
+    case 5: { // interpolate
       if (num_inputs != 3)
         throw Exception ("interpolation requires 3 inputs");
       transform_type transform1 = load_transform<default_type> (argument[0]);

--- a/cmd/transformconvert.cpp
+++ b/cmd/transformconvert.cpp
@@ -38,19 +38,19 @@ void usage ()
   + "This command's function is to convert linear transformation matrices."
 
   + "It allows to convert the transformation matrix provided by FSL's flirt command "
-  + "and ITK's (ANT's) linear transformation format to a format usable in MRtrix."
+  + "and ITK's linear transformation format to a format usable in MRtrix."
   ;
 
   ARGUMENTS
   + Argument ("input", "the input for the specified operation").allow_multiple()
-  + Argument ("operation", "the operation to perform, one of: " + join(operations, ", ") + "."
+  + Argument ("operation", "the operation to perform, one of:\n" + join(operations, ", ") + "."
     + "\n\nflirt_import: "
     + "Convert a transformation matrix produced by FSL's flirt command into a format usable by MRtrix. "
-        "You'll need to provide as additional arguments the save NIfTI images that were passed to flirt "
+        "You'll need to provide as additional arguments the NIfTI images that were passed to flirt "
         "with the -in and -ref options:\nmatrix_in in ref flirt_import output"
 
     + "\n\nitk_import: "
-    + "Convert a plain text transformation matrix file produced by ITK's or ANT's affine registration "
+    + "Convert a plain text transformation matrix file produced by ITK's (ANTS, Slicer) affine registration "
     + "into a format usable by MRtrix."
     ).type_choice (operations)
 
@@ -128,14 +128,14 @@ template <typename TransformationType>
 void parse_itk_trafo (const std::string& itk_file, TransformationType& transformation, Eigen::Vector3d& centre_of_rotation) {
   const std::string first_line = "#Insight Transform File V1.0";
   std::vector<std::string> supported_transformations = {"MatrixOffsetTransformBase_double_3_3",
-                                                        "MatrixOffsetTransformBase_float_3_3"
+                                                        "MatrixOffsetTransformBase_float_3_3",
+                                                        "AffineTransform_double_3_3",
+                                                        "AffineTransform_float_3_3"
                                                       };
   // TODO, support derived classes that are compatible
   // FixedCenterOfRotationAffineTransform_float_3_3?
   // QuaternionRigidTransform_double_3_3?
   // QuaternionRigidTransform_float_3_3?
-  // "AffineTransform_double_3_3",
-  // "AffineTransform_float_3_3",
 
   File::KeyValue file (itk_file, first_line.c_str());
   std::string line;

--- a/cmd/transformconvert.cpp
+++ b/cmd/transformconvert.cpp
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2008-2016 the MRtrix3 contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ *
+ * MRtrix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * For more details, see www.mrtrix.org
+ *
+ */
+
+
+#include <unsupported/Eigen/MatrixFunctions>
+#include <algorithm>
+#include "command.h"
+#include "math/math.h"
+#include "image.h"
+#include "file/nifti1_utils.h"
+#include "transform.h"
+#include "file/key_value.h"
+
+using namespace MR;
+using namespace App;
+
+const char* operations[] = {
+  "flirt_import",
+  "itk_import",
+  NULL
+};
+
+void usage ()
+{
+  DESCRIPTION
+  + "This command's function is to convert linear transformation matrices."
+
+  + "It allows to convert the transformation matrix provided by FSL's flirt command "
+  + "and ITK's (ANT's) linear transformation format to a format usable in MRtrix."
+  ;
+
+  ARGUMENTS
+  + Argument ("input", "the input for the specified operation").allow_multiple()
+  + Argument ("operation", "the operation to perform, one of: " + join(operations, ", ") + "."
+    + "\n\nflirt_import: "
+    + "Convert a transformation matrix produced by FSL's flirt command into a format usable by MRtrix. "
+        "You'll need to provide as additional arguments the save NIfTI images that were passed to flirt "
+        "with the -in and -ref options:\nmatrix_in in ref flirt_import output"
+
+    + "\n\nitk_import: "
+    + "Convert a plain text transformation matrix file produced by ITK's or ANT's affine registration "
+    + "into a format usable by MRtrix."
+    ).type_choice (operations)
+
+  + Argument ("output", "the output transformation matrix.").type_file_out ();
+}
+
+
+transform_type get_flirt_transform (const Header& header) {
+  std::vector<size_t> axes;
+  transform_type nifti_transform = File::NIfTI::adjust_transform (header, axes);
+  if (nifti_transform.matrix().topLeftCorner<3,3>().determinant() < 0.0)
+    return nifti_transform;
+  transform_type coord_switch;
+  coord_switch.setIdentity();
+  coord_switch(0,0) = -1.0f;
+  coord_switch(0,3) = (header.size(axes[0])-1) * header.spacing(axes[0]);
+  return nifti_transform * coord_switch;
+}
+
+// transform_type parse_surfer_transform (const Header& header) {
+//   // TODO
+//   return transform_type();
+// }
+
+// //! read matrix data into a 2D vector \a filename
+// template <class ValueType = default_type>
+//   transform_type parse_surfer_transform (const std::string& filename) {
+//     std::ifstream stream (filename, std::ios_base::in | std::ios_base::binary);
+//     std::vector<std::vector<ValueType>> V;
+//     std::string sbuf;
+//     std::string file_version;
+//     while (getline (stream, sbuf)) {
+//       if (sbuf.substr (0,1) == "#")
+//         continue;
+//       if (sbuf.find("1 4 4") != std::string::npos)
+//         break;
+//       if (sbuf.find("type") == std::string::npos)
+//         continue;
+//       file_version = sbuf.substr (sbuf.find_first_of ('=')+1);
+//     }
+//     if (file_version.empty())
+//       throw Exception ("not a surfer transformation");
+//     // so far we only understand vox2vox transformations
+//     // vox2vox = inverse(colrowslice_to_xyz(moving))*M*colrowslice_to_xyz(target)
+//     if (stoi(file_version)!=0)
+//       throw Exception ("not a vox2vox transformation");
+
+//     for (auto i = 0; i<4 && getline (stream, sbuf); ++i){
+//       // sbuf = strip (sbuf.substr (0, sbuf.find_first_of ('type')));
+//       V.push_back (std::vector<ValueType>());
+//       const auto elements = MR::split (sbuf, " ,;\t", true);
+//       for (const auto& entry : elements)
+//         V.back().push_back (to<ValueType> (entry));
+//       if (V.size() > 1)
+//         if (V.back().size() != V[0].size())
+//           throw Exception ("uneven rows in matrix");
+//     }
+//     if (stream.bad())
+//       throw Exception (strerror (errno));
+//     if (!V.size())
+//       throw Exception ("no data in file");
+
+//     transform_type M;
+//     for (ssize_t i = 0; i < 3; i++)
+//       for (ssize_t j = 0; j < 4; j++)
+//         M(i,j) = V[i][j];
+//     return M;
+//   }
+
+// template <typename T> int sgn(T val) {
+//     return (T(0) < val) - (val < T(0));
+// }
+
+template <typename TransformationType>
+void parse_itk_trafo (const std::string& itk_file, TransformationType& transformation, Eigen::Vector3d& centre_of_rotation) {
+  const std::string first_line = "#Insight Transform File V1.0";
+  std::vector<std::string> supported_transformations = {"MatrixOffsetTransformBase_double_3_3",
+                                                        "MatrixOffsetTransformBase_float_3_3"
+                                                      };
+  // TODO, support derived classes that are compatible
+  // FixedCenterOfRotationAffineTransform_float_3_3?
+  // QuaternionRigidTransform_double_3_3?
+  // QuaternionRigidTransform_float_3_3?
+  // "AffineTransform_double_3_3",
+  // "AffineTransform_float_3_3",
+
+  File::KeyValue file (itk_file, first_line.c_str());
+  std::string line;
+  size_t invalid (2);
+  while (file.next()) {
+    if (file.key() == "Transform") {
+      if (std::find(supported_transformations.begin(), supported_transformations.end(), file.value()) == supported_transformations.end())
+        throw Exception ("The " + file.value() + " transform type is currenly not supported or tested");
+    }
+    else if (file.key() == "Parameters") {
+      line = file.value();
+      std::replace (line.begin(), line.end(), ' ', ',');
+      std::vector<default_type> parameters (parse_floats (line));
+      if (parameters.size() != 12)
+        throw Exception ("Expected itk file with 12 parameters but has " + str(parameters.size()) + " parameters.");
+      transformation.linear().row(0) << parameters[0], parameters[1], parameters[2];
+      transformation.linear().row(1) << parameters[3], parameters[4], parameters[5];
+      transformation.linear().row(2) <<  parameters[6], parameters[7], parameters[8];
+      transformation.translation() << parameters[9], parameters[10], parameters[11];
+      invalid--;
+    }
+    else if (file.key() == "FixedParameters") {
+      line = file.value();
+      std::replace (line.begin(), line.end(), ' ', ',');
+      std::vector<default_type> fixed_parameters (parse_floats (line));
+      centre_of_rotation << fixed_parameters[0], fixed_parameters[1], fixed_parameters[2];
+      invalid--;
+    }
+  }
+  file.close();
+  if (invalid != 0)
+    throw Exception ("ITK transformation could not be read");
+}
+
+void run ()
+{
+  const size_t num_inputs = argument.size() - 2;
+  const int op = argument[num_inputs];
+  const std::string& output_path = argument.back();
+
+  switch (op) {
+    case 0: { // flirt_import
+      if (num_inputs != 3)
+        throw Exception ("flirt_import requires 3 inputs");
+      transform_type transform = load_transform<default_type> (argument[0]);
+      auto src_header = Header::open (argument[1]); // -in
+      auto dest_header = Header::open (argument[2]); // -ref
+
+      if (transform.matrix().topLeftCorner<3,3>().determinant() == float(0.0))
+          WARN ("Transformation matrix determinant is zero.");
+      if (transform.matrix().topLeftCorner<3,3>().determinant() < 0)
+          INFO ("Transformation matrix determinant is negative.");
+
+      transform_type src_flirt_to_scanner = get_flirt_transform (src_header);
+      transform_type dest_flirt_to_scanner = get_flirt_transform (dest_header);
+
+      transform_type forward_transform = dest_flirt_to_scanner * transform * src_flirt_to_scanner.inverse();
+      if (((forward_transform.matrix().array() != forward_transform.matrix().array())).any())
+        WARN ("NAN in transformation.");
+      save_transform (forward_transform.inverse(), output_path);
+      break;
+    }
+    case 1: { // ITK import
+      if (num_inputs != 1)
+        throw Exception ("itk_import requires 1 input, " + str(num_inputs) + " provided.");
+
+      transform_type transform;
+      Eigen::Vector3d centre_of_rotation (3);
+      parse_itk_trafo (argument[0], transform, centre_of_rotation);
+      INFO("Centre of rotation:\n" + str(centre_of_rotation.transpose()));
+
+      // rejig translation to correct for centre of rotation
+      transform.translation() = transform.translation() + centre_of_rotation - transform.linear() * centre_of_rotation;
+
+      // TODO is the coordinate switch robust to large rotations?
+      auto coord_switch = Eigen::DiagonalMatrix<default_type, 4>();
+      coord_switch.setIdentity();
+      coord_switch.diagonal()(0) = -1.0f;
+      coord_switch.diagonal()(1) = -1.0f;
+      transform.matrix() = coord_switch * transform.matrix() * coord_switch;
+
+      INFO("linear:\n" + str(transform.matrix()));
+      INFO("translation:\n" + str(transform.translation().transpose()));
+      if (((transform.matrix().array() != transform.matrix().array())).any())
+        WARN ("NAN in transformation.");
+
+      save_transform (transform, output_path);
+    }
+    default: assert (0);
+  }
+
+
+}

--- a/testing/tests/transformcalc
+++ b/testing/tests/transformcalc
@@ -1,4 +1,3 @@
-transformcalc moving2templateFSL.txt moving.mif.gz template.mif.gz flirt_import tmp.txt --force; testing_diff_matrix tmp.txt transformcalc/out.txt 0.001
 transformcalc moving2templateFSL.txt transformcalc/out.txt average tmp.txt --force; testing_diff_matrix tmp.txt transformcalc/out2.txt 0.001
 transformcalc transformcalc/out.txt moving2templateFSL.txt average tmp2.txt --force; testing_diff_matrix tmp.txt tmp2.txt 0.001
 transformcalc moving2templateFSL.txt moving2template.txt 1 interpolate tmp.txt --force; testing_diff_matrix tmp.txt moving2template.txt 0.001

--- a/testing/tests/transformconvert
+++ b/testing/tests/transformconvert
@@ -1,0 +1,3 @@
+transformconvert transformconvert/affine_ants_zero.txt itk_import tmp.txt --force; testing_diff_matrix tmp.txt transformconvert/affine_mrtrix_zero.txt 0.0001
+transformconvert transformconvert/affine_ants.txt itk_import tmp.txt --force; testing_diff_matrix tmp.txt transformconvert/affine_mrtrix.txt 0.0001
+transformconvert moving2templateFSL.txt moving.mif.gz template.mif.gz flirt_import tmp.txt --force; testing_diff_matrix tmp.txt transformcalc/out.txt 0.001

--- a/testing/tests/transformconvert
+++ b/testing/tests/transformconvert
@@ -1,3 +1,4 @@
 transformconvert transformconvert/affine_ants_zero.txt itk_import tmp.txt --force; testing_diff_matrix tmp.txt transformconvert/affine_mrtrix_zero.txt 0.0001
 transformconvert transformconvert/affine_ants.txt itk_import tmp.txt --force; testing_diff_matrix tmp.txt transformconvert/affine_mrtrix.txt 0.0001
-transformconvert moving2templateFSL.txt moving.mif.gz template.mif.gz flirt_import tmp.txt --force; testing_diff_matrix tmp.txt transformcalc/out.txt 0.001
+transformconvert transformconvert/affine2_slicer.txt itk_import tmp.txt --force; testing_diff_matrix tmp.txt transformconvert/affine2_mrtrix.txt 0.0001
+transformconvert moving2templateFSL.txt moving.mif.gz template.mif.gz flirt_import tmp.txt --force; testing_diff_matrix tmp.txt transformconvert/out.txt 0.001


### PR DESCRIPTION
#602 

- transformconvert: ITK (ANTS, Slicer) linear transform conversion to mrtrix format
- moved FSL linear transform conversion to mrtrix format from transformcalc to transformconvert

TODO: is the coordinate sign [flip](https://github.com/MRtrix3/mrtrix3/commit/cc405f44018c5e7bfa086fdb028f4c2b43e3aafd#diff-3c75e88716145025c395ac182dd6d0f8R213) robust towards large rotations?

Testdata generated with old transformcalc and verified with ITK's [RegisterTransform](https://itk.org/Wiki/ITK/Examples/IO/RegisterTransform) assuming `offset` in ITK is translation in mrtrix:

    cat ~/mrtrix3/testing/data/transformconvert/affine_ants.txt
    #Insight Transform File V1.0
    #Transform 0
    Transform: MatrixOffsetTransformBase_double_3_3
    Parameters: 1.0572473616430247 -0.006601364847695607 -0.0070867633345200794 0.03352848882249912 1.030530257142083 0.000047846215762016586 0.005639888295176873 0.04607689224416719     1.035830884086977 -0.23411262138879582 -4.353264772234075 2.79844117278082
    FixedParameters: 2.141132567397102 4.698518521995613 24.3860890660148

    RegisterTransform ~/mrtrix3/testing/data/transformconvert/affine_ants.txt   
    MatrixOffsetTransformBase (0x23399f0)
      RTTI typeinfo:   itk::MatrixOffsetTransformBase<float, 3u, 3u>
      Reference Count: 3
      Modified Time: 663
      Debug: Off
      Object Name: 
      Observers: 
        none
      Matrix: 
        1.05725 -0.00660136 -0.00708676 
        0.0335285 1.03053 4.78462e-05 
        0.00563989 0.0460769 1.03583 
      Offset: [-0.152852, -4.56967, 1.6961]
      Center: [2.14113, 4.69852, 24.3861]
      Translation: [-0.234113, -4.35326, 2.79844]
      Inverse: 
        0.945635 0.00576831 0.00646921 
        -0.0307661 0.970189 -0.000255197 
        -0.0037802 -0.0431881 0.965385 
      Singular: 0


    cat ~/mrtrix3/testing/data/transformconvert/affine_mrtrix.txt
    1.0572474 -0.006601364817 0.007086763158 0.1528518647 
    0.03352848813 1.030530214 -4.784621706e-05 4.569667339 
    -0.005639888346 -0.04607689381 1.035830855 1.696098328 
    0 0 0 1 
