### PR TITLE
install docs: fix update PATH command

### DIFF
--- a/docs/installation/linux_install.rst
+++ b/docs/installation/linux_install.rst
@@ -158,7 +158,7 @@ Set up *MRtrix3*
 
    ::
 
-       echo "export PATH=$(pwd)/release/bin:$(pwd)/scripts:$PATH" >> ~/.bashrc
+       echo "export PATH=$(pwd)/release/bin:$(pwd)/scripts:\$PATH" >> ~/.bashrc
 
 2. Close the terminal and start another one to ensure the startup file
    is read (or just type 'bash')

--- a/docs/installation/mac_install.rst
+++ b/docs/installation/mac_install.rst
@@ -120,7 +120,7 @@ Set up *MRtrix3*
 
    ::
 
-       echo "export PATH=$(pwd)/release/bin:$(pwd)/scripts:$PATH" >> ~/.bash_profile
+       echo "export PATH=$(pwd)/release/bin:$(pwd)/scripts:\$PATH" >> ~/.bash_profile
 
 2. Close the terminal and start another one to ensure the startup file
    is read (or just type 'bash')

--- a/docs/installation/windows_install.rst
+++ b/docs/installation/windows_install.rst
@@ -122,7 +122,7 @@ Set up *MRtrix3*
 
    ::
 
-       echo "export PATH=$(pwd)/release/bin:$(pwd)/scripts:$PATH" >> ~/.bashrc
+       echo "export PATH=$(pwd)/release/bin:$(pwd)/scripts:\$PATH" >> ~/.bashrc
 
    Note that although the scripts provided with MRtrix will appear in
    your path, many of these will not work on a Windows installation due


### PR DESCRIPTION
These don't work without escaping the '$', instead causing the full PATH
to be included again, which is not the expected outcome. For some reason, this also caused problems on a fresh Windows install - syntax error on shell startup, and commands not found. What we want to end up with is something like this written to the `~/.bashrc`:

    export PATH=/path/to/mrtrix3/release/bin:/path/to/mrtrix3/scripts:$PATH

rather than having the full PATH as it was when the command was issued substituted in there verbatim...