### PR TITLE
Macosx touchpad fixes

### DIFF
--- a/src/gui/mrview/mode/base.cpp
+++ b/src/gui/mrview/mode/base.cpp
@@ -151,7 +151,7 @@ done_painting:
         void Base::mouse_press_event () { }
         void Base::mouse_release_event () { }
 
-        void Base::slice_move_event (int x) 
+        void Base::slice_move_event (float x) 
         {
           const Projection* proj = get_current_projection();
           if (!proj) return;

--- a/src/gui/mrview/mode/base.h
+++ b/src/gui/mrview/mode/base.h
@@ -84,7 +84,7 @@ namespace MR
             virtual void mouse_press_event ();
             virtual void mouse_release_event ();
             virtual void reset_event ();
-            virtual void slice_move_event (int x);
+            virtual void slice_move_event (float x);
             virtual void set_focus_event ();
             virtual void contrast_event ();
             virtual void pan_event ();

--- a/src/gui/mrview/mode/ortho.cpp
+++ b/src/gui/mrview/mode/ortho.cpp
@@ -140,7 +140,7 @@ namespace MR
 
 
 
-        void Ortho::slice_move_event (int x) 
+        void Ortho::slice_move_event (float x) 
         {
           const Projection* proj = get_current_projection();
           if (!proj) return;

--- a/src/gui/mrview/mode/ortho.h
+++ b/src/gui/mrview/mode/ortho.h
@@ -40,7 +40,7 @@ namespace MR
             virtual void paint (Projection& projection);
 
             virtual void mouse_press_event ();
-            virtual void slice_move_event (int x);
+            virtual void slice_move_event (float x);
             virtual void panthrough_event ();
             virtual const Projection* get_current_projection () const;
 

--- a/src/gui/mrview/mode/volume.cpp
+++ b/src/gui/mrview/mode/volume.cpp
@@ -585,7 +585,7 @@ namespace MR
 
 
 
-        void Volume::slice_move_event (int x) 
+        void Volume::slice_move_event (float x) 
         {
          
           std::vector<GL::vec4*> clip = get_clip_planes_to_be_edited();

--- a/src/gui/mrview/mode/volume.h
+++ b/src/gui/mrview/mode/volume.h
@@ -43,7 +43,7 @@ namespace MR
               }
 
             virtual void paint (Projection& projection);
-            virtual void slice_move_event (int x);
+            virtual void slice_move_event (float x);
             virtual void pan_event ();
             virtual void panthrough_event ();
             virtual void tilt_event ();

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -105,6 +105,7 @@ namespace MR
           setMinimumSize (256, 256);
           setFocusPolicy (Qt::StrongFocus);
           grabGesture (Qt::PinchGesture);
+          grabGesture (Qt::PanGesture);
           QFont font_ = font();
           font_.setPointSize (MR::File::Config::get_int ("FontSize", 10));
           setFont (font_);
@@ -1576,6 +1577,12 @@ namespace MR
       bool Window::gestureEventGL (QGestureEvent* event) 
       {
         assert (mode);
+
+        if (QGesture* pan = event->gesture(Qt::PanGesture)) {
+          QPanGesture* e = static_cast<QPanGesture*> (pan);
+          mouse_displacement_ = QPoint (e->delta().x(), -e->delta().y());
+          mode->pan_event();
+        }
       
         if (QGesture* pinch = event->gesture(Qt::PinchGesture)) {
           QPinchGesture* e = static_cast<QPinchGesture*> (pinch);

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -1524,7 +1524,7 @@ namespace MR
       {
         assert (mode);
 #if QT_VERSION >= 0x050400
-        QPoint delta = event->pixelDelta();
+        QPoint delta = 30 * event->pixelDelta();
         if (delta.isNull())
           delta = event->angleDelta();
 #else

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -105,7 +105,6 @@ namespace MR
           setMinimumSize (256, 256);
           setFocusPolicy (Qt::StrongFocus);
           grabGesture (Qt::PinchGesture);
-          grabGesture (Qt::SwipeGesture);
           QFont font_ = font();
           font_.setPointSize (MR::File::Config::get_int ("FontSize", 10));
           setFont (font_);
@@ -1577,19 +1576,8 @@ namespace MR
       bool Window::gestureEventGL (QGestureEvent* event) 
       {
         assert (mode);
-        
-        if (QGesture *swipe = event->gesture (Qt::SwipeGesture)) {
-          QSwipeGesture* e = static_cast<QSwipeGesture*> (swipe);
-          int dx = e->horizontalDirection() == QSwipeGesture::Left ? -1 : ( 
-             e->horizontalDirection() == QSwipeGesture::Right ? 1 : 0); 
-          if (dx != 0 && image_group->actions().size() > 1) {
-            QAction* action = image_group->checkedAction();
-            int N = image_group->actions().size();
-            int n = image_group->actions().indexOf (action);
-            image_select_slot (image_group->actions()[(n+N+dx)%N]);
-          }
-        }
-        else if (QGesture* pinch = event->gesture(Qt::PinchGesture)) {
+      
+        if (QGesture* pinch = event->gesture(Qt::PinchGesture)) {
           QPinchGesture* e = static_cast<QPinchGesture*> (pinch);
           QPinchGesture::ChangeFlags changeFlags = e->changeFlags();
           if (changeFlags & QPinchGesture::RotationAngleChanged) {

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -1596,7 +1596,7 @@ namespace MR
             // TODO
           }
           if (changeFlags & QPinchGesture::ScaleFactorChanged) {
-            set_FOV (FOV() * e->lastScaleFactor() / e->scaleFactor());
+            set_FOV (FOV() / e->scaleFactor());
             glarea->update();
           }
         }


### PR DESCRIPTION
This fixes up the touchpad scrolling issue on MacOSX (although there is residual weirdness due to the way MacOSX emulates scroll acceleration with a regular mouse). It also fixes up pinch-to-zoom (this had been implemented previously, but never tested), and adds handling of panning using the touchpad - as far as I can tell, this is triggered by a long motionless single touch (not press) and drag. 

Calling all Macbook users to test these changes!