### PR TITLE
notfound: added a simple script to easily identify subject folders that ...

### DIFF
--- a/scripts/notfound
+++ b/scripts/notfound
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+if [ $# -eq 0 ]; then
+  cat << 'HELP_PAGE'
+USAGE: 
+  $ notfound base_directory search_string
+
+  This is a simple script designed to help identify subjects that do not yet have a specific file generated. For example when adding new patients to a study. It is designed to be used when each patient has a folder containing their images. 
+
+  For example: 
+    $ notfound study_folder fod.mif
+  will identify all subject folders (e.g. study_folder/subject001, study_folder/subject002, ...) that do NOT contain a file fod.mif
+
+  Note that this can be used in combination with the foreach script. For example:
+    $ foreach $(notfound study_folder fod.mif) : dwi2fod IN/dwi.mif IN/response.txt IN/fod.mif
+HELP_PAGE
+
+exit 1
+  
+fi
+
+find ${1} -mindepth 1 -maxdepth 2 -type d '!' -exec test -e "{}/${2}" ';' -print
+


### PR DESCRIPTION
…at do not contain a specific file. As per the script help page:
```
USAGE: 
  $ notfound base_directory search_string

  This is a simple script designed to help identify subjects that do not yet have a specific file generated. For example when adding new patients to a study. It is designed to be used when each patient has a folder containing their images. 

  For example: 
    $ notfound study_folder fod.mif
  will identify all subject folders (e.g. study_folder/subject001, study_folder/subject002, ...) that do NOT contain a file fod.mif

  Note that this can be used in combination with the foreach script. For example:
    $ foreach $(notfound study_folder fod.mif) : dwi2fod IN/dwi.mif IN/response.txt IN/fod.mif
```
I know that for most MRtrix3 commands its not such an issue, since the user can run the command on all subjects and any previous files should not be overwritten. However I've come across a few occasions when I've needed this (particularly when using non-MRtrix commands). Even when using MRtrix commands, its also handy since it's often easy to miss genuine errors amongst all the  `dwi2fod: [ERROR] output file "fod.mif" already exists (use -force option to force overwrite)` errors when you have hundreds of subjects.




