### PR TITLE
Adding drag-drop to tools

### DIFF
--- a/src/gui/mrview/tool/base.cpp
+++ b/src/gui/mrview/tool/base.cpp
@@ -37,6 +37,7 @@ namespace MR
             setFont (f);
             setFrameShadow (QFrame::Sunken); 
             setFrameShape (QFrame::Panel);
+            setAcceptDrops (true);
           }
 
         void Base::adjustSize () 

--- a/src/gui/mrview/tool/base.h
+++ b/src/gui/mrview/tool/base.h
@@ -139,6 +139,16 @@ namespace MR
             virtual void reset_event () { }
             virtual QCursor* get_cursor ();
             void update_cursor() { window().set_cursor(); }
+
+            void dragEnterEvent (QDragEnterEvent* event) override {
+              event->acceptProposedAction();
+            }
+            void dragMoveEvent (QDragMoveEvent* event) override {
+              event->acceptProposedAction();
+            }
+            void dragLeaveEvent (QDragLeaveEvent* event) override {
+              event->accept();
+            }
         };
 
 

--- a/src/gui/mrview/tool/list_model_base.h
+++ b/src/gui/mrview/tool/list_model_base.h
@@ -115,9 +115,9 @@ namespace MR
 
             Qt::ItemFlags flags (const QModelIndex& index) const {
 
-              static constexpr auto valid_flags = Qt::ItemIsDragEnabled | Qt::ItemIsEnabled |
+              static constexpr const auto valid_flags = Qt::ItemIsDragEnabled | Qt::ItemIsEnabled |
                 Qt::ItemIsSelectable | Qt::ItemIsUserCheckable;
-              static constexpr auto invalid_flags = valid_flags | Qt::ItemIsDropEnabled;
+              static constexpr const auto invalid_flags = valid_flags | Qt::ItemIsDropEnabled;
 
               if (!index.isValid()) return invalid_flags;
               return valid_flags;

--- a/src/gui/mrview/tool/list_model_base.h
+++ b/src/gui/mrview/tool/list_model_base.h
@@ -35,12 +35,14 @@ namespace MR
               QAbstractItemModel (parent) { }
 
             QVariant data (const QModelIndex& index, int role) const {
+              // The item may (temporarily) be null during an intermediate step of reordering items
+              // see insertRows / removeRows
               if (!index.isValid()) return QVariant();
               if (role == Qt::CheckStateRole) {
-                return items[index.row()]->show ? Qt::Checked : Qt::Unchecked;
+                return items[index.row()] && items[index.row()]->show ? Qt::Checked : Qt::Unchecked;
               }
               if (role != Qt::DisplayRole) return QVariant();
-              return shorten (items[index.row()]->get_filename(), 35, 0).c_str();
+              return items[index.row()] ? shorten (items[index.row()]->get_filename(), 35, 0).c_str() : "";
             }
 
             bool setData (const QModelIndex& idx, const QVariant& value, int role) {
@@ -63,9 +65,62 @@ namespace MR
               return QAbstractItemModel::setData (idx, value, role);
             }
 
+            Qt::DropActions supportedDropActions () const override
+            {
+              return Qt::CopyAction | Qt::MoveAction;
+            }
+
+            // For some reason, Qt calls insertRows prior to removeRows in the event of a drag-n-drop
+            // item reordering within a given model.
+            // Hence at this point, we simply want to cache where the rows should be moved
+            bool insertRows(int row, int count, const QModelIndex &) override {
+              if (count < 1 || row < 0 || row > rowCount ()) {
+                swapped_rows = { 0, 0 };
+                return false;
+              }
+
+              swapped_rows = { row, count };
+
+              return true;
+            }
+
+            // As alluded above in insertRows, in the case of a drag-n-drop item reordering,
+            // we have to manually perform the swap within our underlying data store
+            bool removeRows (int row, int count, const QModelIndex& parent = QModelIndex()) override {
+              if (count < 1 || row < 0 || row > rowCount () || count != swapped_rows.second)
+                return false;
+
+              std::vector<std::unique_ptr<Displayable>> swapped_items;
+
+              swapped_items.insert ( swapped_items.begin(),
+                std::make_move_iterator (items.begin() + row),
+                std::make_move_iterator (items.begin() + row + count));
+
+              beginRemoveRows (parent, row, row + count - 1);
+              items.erase (items.begin() + row, items.begin() + row + count);
+              endRemoveRows ();
+
+              // Cached row index was prior to removal, so may need to adjust offset
+              if (swapped_rows.first >= row)
+                swapped_rows.first -= count;
+
+              beginInsertRows (parent, swapped_rows.first, swapped_rows.first + swapped_rows.second - 1);
+              items.insert (items.begin() + swapped_rows.first,
+                std::make_move_iterator (swapped_items.begin ()),
+                std::make_move_iterator (swapped_items.end ()));
+              endInsertRows ();
+
+              return true;
+            }
+
             Qt::ItemFlags flags (const QModelIndex& index) const {
-              if (!index.isValid()) return 0;
-              return Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsUserCheckable;
+
+              static constexpr auto valid_flags = Qt::ItemIsDragEnabled | Qt::ItemIsEnabled |
+                Qt::ItemIsSelectable | Qt::ItemIsUserCheckable;
+              static constexpr auto invalid_flags = valid_flags | Qt::ItemIsDropEnabled;
+
+              if (!index.isValid()) return invalid_flags;
+              return valid_flags;
             }
 
             QModelIndex index (int row, int column, const QModelIndex& parent = QModelIndex()) const { 
@@ -92,6 +147,8 @@ namespace MR
             }
 
             std::vector<std::unique_ptr<Displayable>> items;
+          private:
+            std::pair<int, int> swapped_rows;
         };
 
 

--- a/src/gui/mrview/tool/list_model_base.h
+++ b/src/gui/mrview/tool/list_model_base.h
@@ -34,7 +34,7 @@ namespace MR
             ListModelBase (QObject* parent) :
               QAbstractItemModel (parent) { }
 
-            QVariant data (const QModelIndex& index, int role) const {
+            QVariant data (const QModelIndex& index, int role) const override {
               // The item may (temporarily) be null during an intermediate step of reordering items
               // see insertRows / removeRows
               if (!index.isValid()) return QVariant();
@@ -45,7 +45,7 @@ namespace MR
               return items[index.row()] ? shorten (items[index.row()]->get_filename(), 35, 0).c_str() : "";
             }
 
-            bool setData (const QModelIndex& idx, const QVariant& value, int role) {
+            bool setData (const QModelIndex& idx, const QVariant& value, int role) override {
               if (role == Qt::CheckStateRole) {
                 Qt::KeyboardModifiers keyMod = QApplication::keyboardModifiers ();
                 if (keyMod.testFlag (Qt::ShiftModifier)) {
@@ -113,22 +113,22 @@ namespace MR
               return true;
             }
 
-            Qt::ItemFlags flags (const QModelIndex& index) const {
+            Qt::ItemFlags flags (const QModelIndex& index) const override {
 
-              static constexpr const auto valid_flags = Qt::ItemIsDragEnabled | Qt::ItemIsEnabled |
+              static const auto valid_flags = Qt::ItemIsDragEnabled | Qt::ItemIsEnabled |
                 Qt::ItemIsSelectable | Qt::ItemIsUserCheckable;
-              static constexpr const auto invalid_flags = valid_flags | Qt::ItemIsDropEnabled;
+              static const auto invalid_flags = valid_flags | Qt::ItemIsDropEnabled;
 
               if (!index.isValid()) return invalid_flags;
               return valid_flags;
             }
 
-            QModelIndex index (int row, int column, const QModelIndex& parent = QModelIndex()) const { 
+            QModelIndex index (int row, int column, const QModelIndex& parent = QModelIndex()) const override {
               (void) parent; // to suppress warnings about unused parameters
               return createIndex (row, column); 
             }
 
-            QModelIndex parent (const QModelIndex&) const { return QModelIndex(); }
+            QModelIndex parent (const QModelIndex&) const override { return QModelIndex(); }
 
             int rowCount (const QModelIndex& parent = QModelIndex()) const { 
               (void) parent;  // to suppress warnings about unused parameters

--- a/src/gui/mrview/tool/overlay.cpp
+++ b/src/gui/mrview/tool/overlay.cpp
@@ -103,6 +103,8 @@ namespace MR
             image_list_view = new QListView (this);
             image_list_view->setSelectionMode (QAbstractItemView::ExtendedSelection);
             image_list_view->setDragEnabled (true);
+            image_list_view->setDragDropMode (QAbstractItemView::InternalMove);
+            image_list_view->setAcceptDrops (true);
             image_list_view->viewport()->setAcceptDrops (true);
             image_list_view->setDropIndicatorShown (true);
 
@@ -218,6 +220,31 @@ namespace MR
           QModelIndex last = image_list_model->index (image_list_model->rowCount()-1, 0, QModelIndex());
           image_list_view->selectionModel()->select (QItemSelection (first, last), QItemSelectionModel::Select);
         }
+
+
+
+
+        void Overlay::dropEvent (QDropEvent* event)
+        {
+          static constexpr int max_files = 32;
+
+          const QMimeData* mimeData = event->mimeData();
+          if (mimeData->hasUrls()) {
+            std::vector<std::unique_ptr<MR::Header>> list;
+            QList<QUrl> urlList = mimeData->urls();
+            for (int i = 0; i < urlList.size() && i < max_files; ++i) {
+              try {
+                list.push_back (std::unique_ptr<MR::Header> (new MR::Header (MR::Header::open (urlList.at (i).path().toUtf8().constData()))));
+              }
+              catch (Exception& e) {
+                e.display();
+              }
+            }
+            if (list.size())
+              add_images (list);
+          }
+        }
+
 
 
 

--- a/src/gui/mrview/tool/overlay.h
+++ b/src/gui/mrview/tool/overlay.h
@@ -106,6 +106,7 @@ namespace MR
              }
              
              void add_images (std::vector<std::unique_ptr<MR::Header>>& list);
+             void dropEvent (QDropEvent* event) override;
         };
 
       }

--- a/src/gui/mrview/tool/roi_editor/roi.h
+++ b/src/gui/mrview/tool/roi_editor/roi.h
@@ -79,6 +79,7 @@ namespace MR
             void update_slot ();
             void colour_changed ();
             void opacity_changed (int unused);
+            void model_rows_changed ();
 
           protected:
              QPushButton *hide_all_button, *close_button, *save_button;
@@ -108,6 +109,8 @@ namespace MR
              void save (ROI_Item*);
 
              int normal2axis (const Eigen::Vector3f&, const MR::Transform&) const;
+
+             void dropEvent (QDropEvent* event) override;
         };
 
 

--- a/src/gui/mrview/tool/tractography/tractography.cpp
+++ b/src/gui/mrview/tool/tractography/tractography.cpp
@@ -301,6 +301,28 @@ namespace MR
         }
 
 
+        void Tractography::dropEvent (QDropEvent* event)
+        {
+          static constexpr int max_files = 32;
+
+          const QMimeData* mimeData = event->mimeData();
+          if (mimeData->hasUrls()) {
+            std::vector<std::string> list;
+            QList<QUrl> urlList = mimeData->urls();
+            for (int i = 0; i < urlList.size() && i < max_files; ++i) {
+                list.push_back (urlList.at (i).path().toUtf8().constData());
+            }
+            try {
+              tractogram_list_model->add_items (list, *this);
+              window().updateGL();
+            }
+            catch (Exception& e) {
+              e.display();
+            }
+          }
+        }
+
+
         void Tractography::tractogram_close_slot ()
         {
           MRView::GrabContext context;

--- a/src/gui/mrview/tool/tractography/tractography.h
+++ b/src/gui/mrview/tool/tractography/tractography.h
@@ -102,6 +102,7 @@ namespace MR
             TrackScalarFileOptions *scalar_file_options;
             LightingDock *lighting_dock;
 
+            void dropEvent (QDropEvent* event) override;
             void update_scalar_options();
 
         };

--- a/src/gui/mrview/tool/vector.cpp
+++ b/src/gui/mrview/tool/vector.cpp
@@ -295,6 +295,12 @@ namespace MR
           std::vector<std::string> list = Dialog::File::get_files (this,
                                                                    "Select fixel images to open",
                                                                    GUI::Dialog::File::image_filter_string);
+          add_images (list);
+        }
+
+
+        void Vector::add_images (std::vector<std::string> &list)
+        {
           if (list.empty())
             return;
           size_t previous_size = fixel_list_model->rowCount();
@@ -307,6 +313,27 @@ namespace MR
             QModelIndex last = fixel_list_model->index (new_size -1, 0, QModelIndex());
             fixel_list_view->selectionModel()->select (QItemSelection (first, last), QItemSelectionModel::Select);
             update_selection();
+          }
+        }
+
+
+        void Vector::dropEvent (QDropEvent* event)
+        {
+          static constexpr int max_files = 32;
+
+          const QMimeData* mimeData = event->mimeData();
+          if (mimeData->hasUrls()) {
+            std::vector<std::string> list;
+            QList<QUrl> urlList = mimeData->urls();
+            for (int i = 0; i < urlList.size() && i < max_files; ++i) {
+                list.push_back (urlList.at (i).path().toUtf8().constData());
+            }
+            try {
+              add_images (list);
+            }
+            catch (Exception& e) {
+              e.display();
+            }
           }
         }
 

--- a/src/gui/mrview/tool/vector.h
+++ b/src/gui/mrview/tool/vector.h
@@ -101,6 +101,9 @@ namespace MR
             QSlider *opacity_slider;
 
             QGroupBox *lock_to_grid, *crop_to_slice;
+
+            void add_images (std::vector<std::string>& list);
+            void dropEvent (QDropEvent* event) override;
         };
       }
     }


### PR DESCRIPTION
Feature request #560

* Support to load files via drag and drop (Overlay, ROI, Tractography and Vector for now)
* Support to reorder loaded files within the list view (Overlay and ROI)

I avoided supporting reordering of files for the Tractography and Vector tools as both use depth-testing when rendering.