### PR TITLE
marking of override of virtual functions

### DIFF
--- a/src/dwi/tractography/mapping/mapper.cpp
+++ b/src/dwi/tractography/mapping/mapper.cpp
@@ -193,7 +193,7 @@ void TrackMapperTWI::add_vector_data (const std::string& path)
     throw Exception ("Cannot add both an associated image and a vector data file to TWI");
   if (contrast != VECTOR_FILE)
     throw Exception ("Cannot add a vector data file to TWI unless the VECTOR_FILE contrast is used");
-  vector_data.reset (new Eigen::VectorXf (std::move (load_vector<float> (path))));
+  vector_data.reset (new Eigen::VectorXf (load_vector<float> (path)));
 }
 
 

--- a/src/gui/mrview/tool/base.h
+++ b/src/gui/mrview/tool/base.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (c) 2008-2016 the MRtrix3 contributors
- * 
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
- * 
+ *
  * MRtrix is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * 
+ *
  * For more details, see www.mrtrix.org
- * 
+ *
  */
 
 #ifndef __gui_mrview_tool_base_h__
@@ -28,8 +28,8 @@
 
 namespace MR
 {
-  namespace App { 
-    class OptionList; 
+  namespace App {
+    class OptionList;
     class Options;
   }
 
@@ -49,7 +49,7 @@ namespace MR
           public:
             Dock (const QString& name) :
               QDockWidget (name, Window::main), tool (nullptr) { }
-            ~Dock (); 
+            ~Dock ();
 
             void closeEvent (QCloseEvent*) override;
 
@@ -69,7 +69,7 @@ namespace MR
             static void add_commandline_options (MR::App::OptionList& options);
             virtual bool process_commandline_option (const MR::App::ParsedOption& opt);
 
-            virtual QSize sizeHint () const;
+            virtual QSize sizeHint () const override;
 
             void grab_focus () {
               window().tool_has_focus = this;
@@ -158,7 +158,7 @@ namespace MR
 
 
         //! \cond skip
-        
+
         inline Dock::~Dock () { delete tool; }
 
 
@@ -185,7 +185,7 @@ namespace MR
         //! \endcond
 
 
-        template <class T> 
+        template <class T>
           Dock* create (const QString& text)
           {
             Dock* dock = new Dock (text);
@@ -199,7 +199,7 @@ namespace MR
           }
 
 
-        template <class T> 
+        template <class T>
           class Action : public __Action__
         {
           public:

--- a/src/gui/mrview/tool/list_model_base.h
+++ b/src/gui/mrview/tool/list_model_base.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (c) 2008-2016 the MRtrix3 contributors
- * 
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
- * 
+ *
  * MRtrix is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * 
+ *
  * For more details, see www.mrtrix.org
- * 
+ *
  */
 
 #ifndef __gui_mrview_tool_list_model_base_h__
@@ -125,19 +125,19 @@ namespace MR
 
             QModelIndex index (int row, int column, const QModelIndex& parent = QModelIndex()) const override {
               (void) parent; // to suppress warnings about unused parameters
-              return createIndex (row, column); 
+              return createIndex (row, column);
             }
 
             QModelIndex parent (const QModelIndex&) const override { return QModelIndex(); }
 
-            int rowCount (const QModelIndex& parent = QModelIndex()) const { 
+            int rowCount (const QModelIndex& parent = QModelIndex()) const override {
               (void) parent;  // to suppress warnings about unused parameters
-              return items.size(); 
+              return items.size();
             }
 
-            int columnCount (const QModelIndex& parent = QModelIndex()) const { 
+            int columnCount (const QModelIndex& parent = QModelIndex()) const override {
               (void) parent;  // to suppress warnings about unused parameters
-              return 1; 
+              return 1;
             }
 
             void remove_item (QModelIndex& index) {

--- a/src/gui/mrview/tool/roi_editor/roi.h
+++ b/src/gui/mrview/tool/roi_editor/roi.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (c) 2008-2016 the MRtrix3 contributors
- * 
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
- * 
+ *
  * MRtrix is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * 
+ *
  * For more details, see www.mrtrix.org
- * 
+ *
  */
 
 #ifndef __gui_mrview_tool_roi_editor_roi_h__
@@ -53,15 +53,15 @@ namespace MR
             ROI (Dock* parent);
             ~ROI();
 
-            void draw (const Projection& projection, bool is_3D, int axis, int slice);
+            void draw (const Projection& projection, bool is_3D, int axis, int slice) override;
 
             static void add_commandline_options (MR::App::OptionList& options);
-            virtual bool process_commandline_option (const MR::App::ParsedOption& opt);
+            virtual bool process_commandline_option (const MR::App::ParsedOption& opt) override;
 
-            virtual bool mouse_press_event ();
-            virtual bool mouse_move_event ();
-            virtual bool mouse_release_event ();
-            virtual QCursor* get_cursor ();
+            virtual bool mouse_press_event () override;
+            virtual bool mouse_move_event () override;
+            virtual bool mouse_release_event () override;
+            virtual QCursor* get_cursor () override;
 
           private slots:
             void new_slot ();
@@ -100,11 +100,11 @@ namespace MR
              Mode::Slice::Shader shader;
 
              void update_undo_redo ();
-             void updateGL() { 
+             void updateGL() {
                window().get_current_mode()->update_overlays = true;
                window().updateGL();
              }
-             
+
              void load (std::vector<std::unique_ptr<MR::Header>>& list);
              void save (ROI_Item*);
 


### PR DESCRIPTION
To get rid of override warnings with clang due to unmarked overridden virtual functions.

1 unrelated warning is remaining:


    release/src/dwi/tractography/seeding/seeding.o

    clang++ -c -std=c++11 -DMRTRIX_MACOSX -fPIC -mmacosx-version-min=10.11 -DMRTRIX_WORD64 -DMRTRIX_NO_NON_POD_VLA -isystem /usr/local/Cellar/eigen/3.2.8/include/eigen3 -Wall -O2 -DNDEBUG -Isrc -Icmd -I./lib -Icmd -isystem /usr/local/Cellar/eigen/3.2.8/include/eigen3 src/dwi/tractography/mapping/mapper.cpp -o release/src/dwi/tractography/mapping/mapper.o:

    src/dwi/tractography/mapping/mapper.cpp:196:43: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
      vector_data.reset (new Eigen::VectorXf (std::move (load_vector<float> (path))));
                                              ^
    src/dwi/tractography/mapping/mapper.cpp:196:43: note: remove std::move call here
      vector_data.reset (new Eigen::VectorXf (std::move (load_vector<float> (path))));
                                              ^~~~~~~~~~~                         ~
    1 warning generated.