### PR TITLE
FOD FMLS segmenter: Store multiple peaks per lobe

### DIFF
--- a/cmd/fod2fixel.cpp
+++ b/cmd/fod2fixel.cpp
@@ -188,7 +188,7 @@ bool Segmented_FOD_receiver::operator() (const FOD_lobes& in)
     assign_pos_of (in.vox).to (*peak);
     peak->value().set_size (in.size());
     for (size_t i = 0; i != in.size(); ++i) {
-      FixelMetric this_fixel (in[i].get_peak_dir(), in[i].get_integral(), in[i].get_peak_value());
+      FixelMetric this_fixel (in[i].get_peak_dir(0), in[i].get_integral(), in[i].get_max_peak_value());
       peak->value()[i] = this_fixel;
     }
   }
@@ -197,7 +197,7 @@ bool Segmented_FOD_receiver::operator() (const FOD_lobes& in)
     assign_pos_of (in.vox).to (*disp);
     disp->value().set_size (in.size());
     for (size_t i = 0; i != in.size(); ++i) {
-      FixelMetric this_fixel (in[i].get_mean_dir(), in[i].get_integral(), in[i].get_integral() / in[i].get_peak_value());
+      FixelMetric this_fixel (in[i].get_mean_dir(), in[i].get_integral(), in[i].get_integral() / in[i].get_max_peak_value());
       disp->value()[i] = this_fixel;
     }
   }

--- a/src/dwi/fmls.cpp
+++ b/src/dwi/fmls.cpp
@@ -111,6 +111,42 @@ namespace MR {
 
 
 
+      IntegrationWeights::IntegrationWeights (const DWI::Directions::Set& dirs) :
+          data (dirs.size())
+      {
+        // Calibrate weights
+        const size_t calibration_lmax = Math::SH::LforN (dirs.size()) + 2;
+        Eigen::Matrix<default_type, Eigen::Dynamic, 2> az_el_pairs (dirs.size(), 2);
+        for (size_t row = 0; row != dirs.size(); ++row) {
+          const auto d = dirs.get_dir (row);
+          az_el_pairs (row, 0) = std::atan2 (d[1], d[0]);
+          az_el_pairs (row, 1) = std::acos  (d[2]);
+        }
+        auto calibration_SH2A = Math::SH::init_transform (az_el_pairs, calibration_lmax);
+        const size_t num_basis_fns = calibration_SH2A.cols();
+
+        // Integrating an FOD with constant amplitude 1 (l=0 term = sqrt(4pi) should produce a value of 2pi
+        //   every other integral should produce zero
+        Eigen::Matrix<default_type, Eigen::Dynamic, 1> integral_results = Eigen::Matrix<default_type, Eigen::Dynamic, 1>::Zero (num_basis_fns);
+        integral_results[0] = sqrt(Math::pi);
+
+        // Problem matrix: One row for each SH basis function, one column for each samping direction
+        Eigen::Matrix<default_type, Eigen::Dynamic, Eigen::Dynamic> A;
+        A.resize (num_basis_fns, dirs.size());
+
+        for (size_t basis_fn_index = 0; basis_fn_index != num_basis_fns; ++basis_fn_index) {
+          Eigen::Matrix<default_type, Eigen::Dynamic, 1> SH_in = Eigen::Matrix<default_type, Eigen::Dynamic, 1>::Zero (num_basis_fns);
+          SH_in[basis_fn_index] = 1.0;
+          A.row (basis_fn_index) = calibration_SH2A * SH_in;
+        }
+        data = A.fullPivLu().solve (integral_results);
+      }
+
+
+
+
+
+
 
 
 
@@ -135,30 +171,7 @@ namespace MR {
           az_el_pairs (row, 1) = std::acos  (d[2]);
         }
         transform.reset (new Math::SH::Transform<default_type> (az_el_pairs, lmax));
-
-        // Calibrate weights
-        // These weights are applied to the amplitude along each direction as the integral for each lobe is summed,
-        //   in order to take into account the relative spacing between adjacent directions
-        weights.reset (new Eigen::Array<default_type, Eigen::Dynamic, 1> (dirs.size()));
-        const size_t calibration_lmax = Math::SH::LforN (dirs.size()) + 2;
-        auto calibration_SH2A = Math::SH::init_transform (az_el_pairs, calibration_lmax);
-        const size_t num_basis_fns = calibration_SH2A.cols();
-
-        // Integrating an FOD with constant amplitude 1 (l=0 term = sqrt(4pi) should produce a value of 2pi
-        //   every other integral should produce zero
-        Eigen::Matrix<default_type, Eigen::Dynamic, 1> integral_results = Eigen::Matrix<default_type, Eigen::Dynamic, 1>::Zero (num_basis_fns);
-        integral_results[0] = sqrt(Math::pi);
-
-        // Problem matrix: One row for each SH basis function, one column for each samping direction
-        Eigen::Matrix<default_type, Eigen::Dynamic, Eigen::Dynamic> A;
-        A.resize (num_basis_fns, dirs.size());
-
-        for (size_t basis_fn_index = 0; basis_fn_index != num_basis_fns; ++basis_fn_index) {
-          Eigen::Matrix<default_type, Eigen::Dynamic, 1> SH_in = Eigen::Matrix<default_type, Eigen::Dynamic, 1>::Zero (num_basis_fns);
-          SH_in[basis_fn_index] = 1.0;
-          A.row (basis_fn_index) = calibration_SH2A * SH_in;
-        }
-        *weights = A.fullPivLu().solve (integral_results);
+        weights.reset (new IntegrationWeights (dirs));
       }
 
 
@@ -218,7 +231,7 @@ namespace MR {
             // Changed handling of lobe merges
             // Merge lobes as they appear to be merged, but update the
             //   contents of retrospective_assignments accordingly
-            if (std::abs (i.first) / out[adj_lobes.back()].get_peak_value() > ratio_of_peak_value_to_merge) {
+            if (std::abs (i.first) / out[adj_lobes.back()].get_max_peak_value() > ratio_of_peak_value_to_merge) {
 
               std::sort (adj_lobes.begin(), adj_lobes.end());
               for (size_t j = 1; j != adj_lobes.size(); ++j)
@@ -265,7 +278,7 @@ namespace MR {
         uint32_t neg_lobe_count = 0;
         for (const auto& i : out) {
           if (i.is_negative()) {
-            mean_neg_peak += i.get_peak_value();
+            mean_neg_peak += i.get_max_peak_value();
             ++neg_lobe_count;
             max_neg_integral = std::max (max_neg_integral, default_type(i.get_integral()));
           }
@@ -276,15 +289,17 @@ namespace MR {
 
         for (auto i = out.begin(); i != out.end();) { // Empty increment
 
-          if (i->is_negative() || i->get_peak_value() < std::max (min_peak_amp, peak_value_threshold) || i->get_integral() < min_integral) {
+          if (i->is_negative() || i->get_max_peak_value() < std::max (min_peak_amp, peak_value_threshold) || i->get_integral() < min_integral) {
             i = out.erase (i);
           } else {
-            const dir_t peak_bin (i->get_peak_dir_bin());
-            auto newton_peak = dirs.get_dir (peak_bin);
-            const default_type new_peak_value = Math::SH::get_peak (in, lmax, newton_peak, &(*precomputer));
-            if (std::isfinite (new_peak_value) && new_peak_value > i->get_peak_value() && std::isfinite (newton_peak[0]))
-              i->revise_peak (newton_peak, new_peak_value);
-            i->finalise();
+            // Revise multiple peaks if present
+            for (size_t peak_index = 0; peak_index != i->num_peaks(); ++peak_index) {
+              Eigen::Vector3f newton_peak = i->get_peak_dir (peak_index);
+              const default_type new_peak_value = Math::SH::get_peak (in, lmax, newton_peak, &(*precomputer));
+              if (std::isfinite (new_peak_value) && newton_peak.allFinite())
+                i->revise_peak (peak_index, newton_peak, new_peak_value);
+              i->finalise();
+            }
 #ifdef FMLS_OPTIMISE_MEAN_DIR
             optimise_mean_dir (*i);
 #endif

--- a/src/dwi/fmls.h
+++ b/src/dwi/fmls.h
@@ -70,10 +70,9 @@ namespace MR
           FOD_lobe (const DWI::Directions::Set& dirs, const dir_t seed, const default_type value, const default_type weight) :
               mask (dirs),
               values (dirs.size(), 0.0),
-              peak_dir_bin (seed),
-              peak_value (std::abs (value)),
-              peak_dir (dirs.get_dir (seed)),
-              mean_dir (peak_dir * value * weight),
+              max_peak_value (std::abs (value)),
+              peak_dirs (1, dirs.get_dir (seed)),
+              mean_dir (peak_dirs.front() * value * weight),
               integral (std::abs (value * weight)),
               neg (value <= 0.0)
           {
@@ -86,8 +85,7 @@ namespace MR
           FOD_lobe (const DWI::Directions::Mask& i) :
               mask (i),
               values (i.size(), 0.0),
-              peak_dir_bin (i.size()),
-              peak_value (0.0),
+              max_peak_value (0.0),
               integral (0.0),
               neg (false) { }
 
@@ -98,16 +96,18 @@ namespace MR
             mask[bin] = true;
             values[bin] = value;
             const Eigen::Vector3f& dir = mask.get_dirs()[bin];
-            const float multiplier = (peak_dir.dot (dir)) > 0.0 ? 1.0 : -1.0;
+            const float multiplier = (mean_dir.dot (dir)) > 0.0 ? 1.0 : -1.0;
             mean_dir += dir * multiplier * value * weight;
             integral += std::abs (value * weight);
           }
 
-          void revise_peak (const Eigen::Vector3f& real_peak, const float value)
+          void revise_peak (const size_t index, const Eigen::Vector3f& real_peak, const float value)
           {
             assert (!neg);
-            peak_dir = real_peak;
-            peak_value = value;
+            assert (index < num_peaks());
+            peak_dirs[index] = real_peak;
+            if (!index)
+              max_peak_value = value;
           }
 
 #ifdef FMLS_OPTIMISE_MEAN_DIR
@@ -133,10 +133,11 @@ namespace MR
             mask |= that.mask;
             for (size_t i = 0; i != mask.size(); ++i)
               values[i] += that.values[i];
-            if (that.peak_value > peak_value) {
-              peak_dir_bin = that.peak_dir_bin;
-              peak_value = that.peak_value;
-              peak_dir = that.peak_dir;
+            if (that.max_peak_value > max_peak_value) {
+              max_peak_value = that.max_peak_value;
+              peak_dirs.insert (peak_dirs.begin(), that.peak_dirs.begin(), that.peak_dirs.end());
+            } else {
+              peak_dirs.insert (peak_dirs.end(), that.peak_dirs.begin(), that.peak_dirs.end());
             }
             const float multiplier = (mean_dir.dot (that.mean_dir)) > 0.0 ? 1.0 : -1.0;
             mean_dir += that.mean_dir * that.integral * multiplier;
@@ -145,9 +146,9 @@ namespace MR
 
           const DWI::Directions::Mask& get_mask() const { return mask; }
           const std::vector<float>& get_values() const { return values; }
-          dir_t get_peak_dir_bin() const { return peak_dir_bin; }
-          float get_peak_value() const { return peak_value; }
-          const Eigen::Vector3f& get_peak_dir() const { return peak_dir; }
+          float get_max_peak_value() const { return max_peak_value; }
+          size_t num_peaks() const { return peak_dirs.size(); }
+          const Eigen::Vector3f& get_peak_dir (const size_t i) const { assert (i < num_peaks()); return peak_dirs[i]; }
           const Eigen::Vector3f& get_mean_dir() const { return mean_dir; }
           float get_integral() const { return integral; }
           bool is_negative() const { return neg; }
@@ -156,9 +157,8 @@ namespace MR
         private:
           DWI::Directions::Mask mask;
           std::vector<float> values;
-          dir_t peak_dir_bin;
-          float peak_value;
-          Eigen::Vector3f peak_dir;
+          float max_peak_value;
+          std::vector<Eigen::Vector3f> peak_dirs;
           Eigen::Vector3f mean_dir;
           float integral;
           bool neg;
@@ -223,6 +223,19 @@ namespace MR
       };
 
 
+      // Store a vector of weights to be applied when computing integrals, to account for non-uniformities in direction distribution
+      // These weights are applied to the amplitude along each direction as the integral for each lobe is summed,
+      //   in order to take into account the relative spacing between adjacent directions
+      class IntegrationWeights
+      {
+        public:
+          IntegrationWeights (const DWI::Directions::Set& dirs);
+          default_type operator[] (const size_t i) { assert (i < data.size()); return data[i]; }
+        private:
+          Eigen::Array<default_type, Eigen::Dynamic, 1> data;
+      };
+
+
 
 
       class Segmenter {
@@ -257,9 +270,7 @@ namespace MR
 
           std::shared_ptr<Math::SH::Transform    <default_type>> transform;
           std::shared_ptr<Math::SH::PrecomputedAL<default_type>> precomputer;
-
-          // Store a vector of weights to be applied when computing integrals, to account for non-uniformities in direction distribution
-          std::shared_ptr<Eigen::Array<default_type, Eigen::Dynamic, 1>> weights;
+          std::shared_ptr<IntegrationWeights> weights;
 
           default_type ratio_to_negative_lobe_integral; // Integral of positive lobe must be at least this ratio larger than the largest negative lobe integral
           default_type ratio_to_negative_lobe_mean_peak; // Peak value of positive lobe must be at least this ratio larger than the mean negative lobe peak


### PR DESCRIPTION
In the case where the FMLS 'peak ratio to merge' parameter is less than 1.0, peaks that do not have an adequately deep trough between them will be merged into a single lobe.
This change allows the 'FOD_lobe' class to track the orientations of multiple FOD peaks when this occurs.
This will not affect default behaviour in any way, since 1.0 is the default value for this parameter; but it may be useful in other applications making use of this method.
Calculation of appropriate weights for numerical integration of FODs has also been moved to a discrete class in order to enable external access.