### PR TITLE
FOD FMLS segmenter: Change decomposition

### DIFF
--- a/src/dwi/fmls.cpp
+++ b/src/dwi/fmls.cpp
@@ -139,7 +139,8 @@ namespace MR {
           SH_in[basis_fn_index] = 1.0;
           A.row (basis_fn_index) = calibration_SH2A * SH_in;
         }
-        data = A.fullPivLu().solve (integral_results);
+
+        data = A.householderQr().solve (integral_results);
       }
 
 
@@ -154,7 +155,6 @@ namespace MR {
       Segmenter::Segmenter (const DWI::Directions::Set& directions, const size_t l) :
           dirs                             (directions),
           lmax                             (l),
-          transform                        (NULL),
           precomputer                      (new Math::SH::PrecomputedAL<default_type> (lmax, 2 * dirs.size())),
           ratio_to_negative_lobe_integral  (FMLS_RATIO_TO_NEGATIVE_LOBE_INTEGRAL_DEFAULT),
           ratio_to_negative_lobe_mean_peak (FMLS_RATIO_TO_NEGATIVE_LOBE_MEAN_PEAK_DEFAULT),

--- a/src/dwi/fmls.h
+++ b/src/dwi/fmls.h
@@ -230,7 +230,7 @@ namespace MR
       {
         public:
           IntegrationWeights (const DWI::Directions::Set& dirs);
-          default_type operator[] (const size_t i) { assert (i < data.size()); return data[i]; }
+          default_type operator[] (const size_t i) { assert (i < size_t(data.size())); return data[i]; }
         private:
           Eigen::Array<default_type, Eigen::Dynamic, 1> data;
       };


### PR DESCRIPTION
Testing showed that for calculating the FOD numerical integration weights, the HouseholderQR solve() method ran fastest and had the minimal error.