### PR TITLE
fix mrinfo -export_grad_mrtrix output

### DIFF
--- a/src/dwi/gradient.cpp
+++ b/src/dwi/gradient.cpp
@@ -250,10 +250,8 @@ namespace MR
       };
 
       auto opt = get_options ("export_grad_mrtrix");
-      if (opt.size()) {
-        File::OFStream out (opt[0][0]);
-        out << check(header).keyval().find ("dw_scheme")->second << "\n";;
-      }
+      if (opt.size()) 
+        save_matrix (parse_DW_scheme (check (header)), opt[0][0]);
 
       opt = get_options ("export_grad_fsl");
       if (opt.size()) 


### PR DESCRIPTION
As reported in
http://community.mrtrix.org/t/mrinfo-delimiter-in-encoding-b/354?u=jdtournier