### PR TITLE
More info on argument count mismatch

### DIFF
--- a/lib/app.cpp
+++ b/lib/app.cpp
@@ -907,12 +907,35 @@ namespace MR
       }
 
       if (num_optional_arguments && num_args_required > argument.size())
-        throw Exception ("expected at least " + str (num_args_required)
+        throw Exception ("Expected at least " + str (num_args_required)
             + " arguments (" + str (argument.size()) + " supplied)");
 
-      if (num_optional_arguments == 0 && num_args_required != argument.size())
-        throw Exception ("expected exactly " + str (num_args_required)
+      if (num_optional_arguments == 0 && num_args_required != argument.size()) {
+        Exception e ("Expected exactly " + str (num_args_required)
             + " arguments (" + str (argument.size()) + " supplied)");
+        std::string s = "Usage: " + NAME;
+        for (const auto& a : ARGUMENTS)
+          s += " " + std::string(a.id);
+        e.push_back (s);
+        s = "Yours: " + NAME;
+        for (const auto& a : argument)
+          s += " " + std::string(a);
+        e.push_back (s);
+        if (argument.size() > num_args_required) {
+          std::vector<std::string> potential_options;
+          for (const auto& a : argument) {
+            for (const auto& og : OPTIONS) {
+              for (const auto& o : og) {
+                if (std::string(a) == std::string(o.id))
+                  potential_options.push_back ("'-" + a + "'");
+              }
+            }
+          }
+          if (potential_options.size())
+            e.push_back ("(Did you mean " + join(potential_options, " or ") + "?)");
+        }
+        throw e;
+      }
 
       size_t num_extra_arguments = argument.size() - num_args_required;
       size_t num_arg_per_multi = num_optional_arguments ? num_extra_arguments / num_optional_arguments : 0;

--- a/lib/exception.h
+++ b/lib/exception.h
@@ -98,6 +98,9 @@ namespace MR
       const std::string& operator[] (size_t n) const {
         return description[n];
       }
+      void push_back (const std::string& s) {
+        description.push_back (s);
+      }
 
       static void (*display_func) (const Exception& E, int log_level);
 


### PR DESCRIPTION
When the user provides the incorrect number of arguments to a command (that does not have any arguments that are optional or allow multiple), the terminal error output will now provide the expected input and contrast it with the user's input (with options stripped); this will hopefully assist users in identifying precisely what has not been provided correctly.

Elevated due to [this discussion](http://community.mrtrix.org/t/dwi2response-error/355/7).

Closes #536.