### PR TITLE
dwipreproc: fsl fieldmap fix writes 4x4 transformation matrix

### DIFF
--- a/lib/math/math.h
+++ b/lib/math/math.h
@@ -186,7 +186,7 @@ namespace MR
         throw e;
       }
 
-      if (V.size() != 4 || V[0].size() != 4)
+      if ((V.size() != 4 && V.size() != 3) || V[0].size() != 4)
         throw Exception ("transform in file " + filename + " is invalid. Does not contain 4x4 matrix.");
 
       transform_type M;

--- a/scripts/dwipreproc
+++ b/scripts/dwipreproc
@@ -377,6 +377,7 @@ else: # 'All'
     with open( 'transform.txt', 'w' ) as f:
       for line in input_transform_text:
         f.write (line)
+      f.write('\n0 0 0 1\n')
     runCommand('mrtransform ' + field_map_image + ' -linear transform.txt -replace field_map_fix' + fsl_suffix)
     delFile(field_map_image)
     field_map_image = 'field_map_fix' + fsl_suffix


### PR DESCRIPTION
 math.h: `load_transform` also accepts 3x4 matrix (i.e. from output of mrinfo)

