### PR TITLE
dwipreproc: check gradient output files

### DIFF
--- a/scripts/dwipreproc
+++ b/scripts/dwipreproc
@@ -90,13 +90,17 @@ lib.app.checkOutputFile(lib.app.args.output)
 
 # Convert all input images into MRtrix format and store in temprary directory first;
 #   that way getHeaderInfo() can be run multiple times without having to repeatedly parse e.g. DICOM data
-lib.app.makeTempDir()
-
 grad_option = ''
 if lib.app.args.grad:
   grad_option = ' -grad ' + getUserPath(lib.app.args.grad, True)
+  lib.app.checkOutputFile(getUserPath(lib.app.args.grad, True))
 elif lib.app.args.fslgrad:
   grad_option = ' -fslgrad ' + getUserPath(lib.app.args.fslgrad[0], True) + ' ' + getUserPath(lib.app.args.fslgrad[1], True)
+  lib.app.checkOutputFile(getUserPath(lib.app.args.fslgrad[0], True))
+  lib.app.checkOutputFile(getUserPath(lib.app.args.fslgrad[1], True))
+
+lib.app.makeTempDir()
+
 runCommand('mrconvert ' + getUserPath(lib.app.args.input, True) + ' ' + os.path.join(lib.app.tempDir, 'series.mif') + grad_option)
 if PE_design == 'Pair':
   runCommand('mrconvert ' + getUserPath(lib.app.args.rpe_pair[0], True) + ' ' + os.path.join(lib.app.tempDir, 'pair1.mif'))


### PR DESCRIPTION
`-export_grad_mrtrix` and `-export_grad_fsl` output locations are unchecked and script fails if they exist