### PR TITLE
GUI apps: Prevent segfault on failed cmdline parsing

### DIFF
--- a/src/gui/dialog/dialog.cpp
+++ b/src/gui/dialog/dialog.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2008-2016 the MRtrix3 contributors
+ * 
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ * 
+ * MRtrix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * 
+ * For more details, see www.mrtrix.org
+ * 
+ */
+
+
+#include "gui/dialog/dialog.h"
+
+#include "app.h"
+#include "exception.h"
+#include "progressbar.h"
+#include "file/dicom/tree.h"
+
+#include "gui/dialog/dicom.h"
+#include "gui/dialog/file.h"
+#include "gui/dialog/progress.h"
+#include "gui/dialog/report_exception.h"
+
+namespace MR
+{
+  namespace GUI
+  {
+    namespace Dialog
+    {
+
+
+
+      void init()
+      {
+        ::MR::ProgressInfo::display_func = ::MR::GUI::Dialog::ProgressBar::display;
+        ::MR::ProgressInfo::done_func = ::MR::GUI::Dialog::ProgressBar::done;
+        ::MR::File::Dicom::select_func = ::MR::GUI::Dialog::select_dicom;
+        ::MR::Exception::display_func = ::MR::GUI::Dialog::display_exception;
+
+        ::MR::App::check_overwrite_files_func = ::MR::GUI::Dialog::File::check_overwrite_files_func;
+      }
+
+
+
+    }
+  }
+}
+

--- a/src/gui/dialog/dialog.h
+++ b/src/gui/dialog/dialog.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2008-2016 the MRtrix3 contributors
+ * 
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ * 
+ * MRtrix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * 
+ * For more details, see www.mrtrix.org
+ * 
+ */
+
+#ifndef __gui_dialog_dialog_h__
+#define __gui_dialog_dialog_h__
+
+namespace MR
+{
+  namespace GUI
+  {
+    namespace Dialog
+    {
+
+      void init();
+
+    }
+  }
+}
+
+#endif

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -17,13 +17,8 @@
 #define __gui_app_h__
 
 #include "app.h"
-#include "progressbar.h"
 #include "file/config.h"
 #include "gui/opengl/gl.h"
-#include "gui/dialog/progress.h"
-#include "gui/dialog/report_exception.h"
-#include "gui/dialog/dicom.h"
-#include "gui/dialog/file.h"
 
 namespace MR
 {
@@ -69,13 +64,6 @@ namespace MR
           new QApplication (cmdline_argc, cmdline_argv);
           ::MR::App::init (cmdline_argc, cmdline_argv); 
           qApp->setAttribute (Qt::AA_DontCreateNativeWidgetSiblings);
-
-          ::MR::ProgressInfo::display_func = Dialog::ProgressBar::display;
-          ::MR::ProgressInfo::done_func = Dialog::ProgressBar::done;
-          ::MR::File::Dicom::select_func = Dialog::select_dicom;
-          ::MR::Exception::display_func = Dialog::display_exception;
-
-          ::MR::App::check_overwrite_files_func = Dialog::File::check_overwrite_files_func;
         }
 
         ~App () {

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -19,6 +19,7 @@
 #include "algo/copy.h"
 #include "gui/opengl/gl.h"
 #include "gui/opengl/lighting.h"
+#include "gui/dialog/dialog.h"
 #include "gui/dialog/file.h"
 #include "gui/dialog/opengl.h"
 #include "gui/dialog/progress.h"
@@ -232,6 +233,7 @@ namespace MR
         show_FPS (false) {
           main = this;
           GUI::App::set_main_window (this);
+          GUI::Dialog::init();
 
           setDockOptions (AllowTabbedDocks | VerticalTabs);
           setDocumentMode (true);

--- a/src/gui/shview/render_window.cpp
+++ b/src/gui/shview/render_window.cpp
@@ -19,6 +19,7 @@
 #include "gui/dwi/render_frame.h"
 #include "gui/lighting_dock.h"
 #include "gui/dialog/file.h"
+#include "gui/dialog/dialog.h"
 #include "math/math.h"
 #include "math/SH.h"
 
@@ -35,6 +36,8 @@ namespace MR
         current (0),
         is_response (is_response_coefs)
       {
+        GUI::Dialog::init();
+
         setWindowIcon (QPixmap (":/mrtrix.png"));
         setMinimumSize (300, 300);
 


### PR DESCRIPTION
Delays modification of dialog function pointers from terminal to GUI versions until the relevant GUI initialization has taken place.
Following discussion in #764.
Closes #323.