### PR TITLE
New function DWI::stash_DW_scheme()

### DIFF
--- a/cmd/amp2sh.cpp
+++ b/cmd/amp2sh.cpp
@@ -229,6 +229,8 @@ void run ()
         dirs(i/2, 0) = dir_vector[i];
         dirs(i/2, 1) = dir_vector[i+1];
       }
+      header.keyval()["basis_directions"] = hit->second;
+      header.keyval().erase (hit);
     } 
     else {
       auto grad = DWI::get_valid_DW_scheme (amp);
@@ -238,6 +240,7 @@ void run ()
         bzeros = shells.smallest().get_volumes();
       dwis = shells.largest().get_volumes();
       dirs = DWI::gen_direction_matrix (grad, dwis);
+      DWI::stash_DW_scheme (header, grad);
     }
   }
 

--- a/cmd/dwi2adc.cpp
+++ b/cmd/dwi2adc.cpp
@@ -101,6 +101,7 @@ void run () {
   header.datatype() = DataType::Float32;
   header.ndim() = 4;
   header.size(3) = 2;
+  DWI::stash_DW_scheme (header, grad);
 
   auto adc = Image<value_type>::create (argument[1], header);
 

--- a/cmd/dwi2fod.cpp
+++ b/cmd/dwi2fod.cpp
@@ -252,6 +252,7 @@ void run ()
     shared.init();
 
     header_out.size(3) = shared.nSH();
+    DWI::stash_DW_scheme (header_out, shared.grad);
     auto fod = Image<float>::create (argument[3], header_out);
 
     CSD_Processor processor (shared, mask);
@@ -282,6 +283,8 @@ void run ()
     }
 
     shared.init();
+
+    DWI::stash_DW_scheme (header_out, shared.grad);
 
     std::vector< Image<float> > odfs;
     for (size_t i = 0; i < num_tissues; ++i) {

--- a/cmd/dwi2noise.cpp
+++ b/cmd/dwi2noise.cpp
@@ -69,22 +69,23 @@ void run ()
   WARN ("Command dwi2noise is deprecated. Try using dwidenoise with -noise option instead.");
   
   auto dwi_in = Image<value_type>::open (argument[0]);
-
-  auto header = Header (dwi_in);
-  header.ndim() = 3;
-  header.datatype() = DataType::Float32;
-  auto noise = Image<value_type>::create (argument[1], header);
+  const auto grad = DWI::get_valid_DW_scheme (dwi_in);
 
   std::vector<size_t> dwis;
   Eigen::MatrixXd mapping;
   {
-    auto grad = DWI::get_valid_DW_scheme (dwi_in);
     dwis = DWI::Shells (grad).select_shells (true, true).largest().get_volumes();
-    auto dirs = DWI::gen_direction_matrix (grad, dwis);
+    const auto dirs = DWI::gen_direction_matrix (grad, dwis);
     mapping = DWI::compute_SH2amp_mapping (dirs);
   }
 
   auto dwi = Adapter::make <Adapter::Extract1D> (dwi_in, 3, container_cast<std::vector<int>> (dwis));
+
+  auto header = Header (dwi_in);
+  header.ndim() = 3;
+  header.datatype() = DataType::Float32;
+  DWI::stash_DW_scheme (header, grad);
+  auto noise = Image<value_type>::create (argument[1], header);
 
   DWI::estimate_noise (dwi, noise, mapping);
 }

--- a/cmd/dwi2tensor.cpp
+++ b/cmd/dwi2tensor.cpp
@@ -181,6 +181,7 @@ void run ()
   Header header (dwi);
   header.datatype() = DataType::Float32;
   header.ndim() = 4;
+  DWI::stash_DW_scheme (header, grad);
   
   Image<value_type>* predict = nullptr;
   opt = get_options ("predicted_signal");

--- a/lib/filter/dwi_brain_mask.h
+++ b/lib/filter/dwi_brain_mask.h
@@ -72,6 +72,7 @@ namespace MR
 
             Header header (input);
             header.ndim() = 3;
+            DWI::stash_DW_scheme (header, grad);
 
             // Generate a 'master' scratch buffer mask, to which all shells will contribute
             auto mask_image = Image<bool>::scratch (header, "DWI mask");

--- a/src/dwi/gradient.h
+++ b/src/dwi/gradient.h
@@ -162,6 +162,26 @@ namespace MR
 
 
 
+    //! 'stash' the DW gradient table
+    /*! Store the _used_ DW gradient table to Header::keyval() key
+     *  'basis_dw_scheme', and delete the key 'dw_scheme' if it exists.
+     *  This means that the scheme will no longer be identified by function
+     *  parse_DW_scheme(), but still resides within the header data and
+     *  can be extracted manually. This should be used when
+     *  diffusion-weighted images are used to generate something that is
+     *  _not_ diffusion_weighted volumes.
+     */
+    template <class MatrixType>
+    void stash_DW_scheme (Header& header, const MatrixType& grad)
+    {
+      set_DW_scheme (header, grad);
+      auto dw_scheme = header.keyval().find ("dw_scheme");
+      header.keyval()["basis_dw_scheme"] = dw_scheme->second;
+      header.keyval().erase (dw_scheme);
+    }
+
+
+
 
     //! get the DW gradient encoding matrix
     /*! attempts to find the DW gradient encoding matrix, using the following

--- a/src/dwi/gradient.h
+++ b/src/dwi/gradient.h
@@ -164,7 +164,7 @@ namespace MR
 
     //! 'stash' the DW gradient table
     /*! Store the _used_ DW gradient table to Header::keyval() key
-     *  'basis_dw_scheme', and delete the key 'dw_scheme' if it exists.
+     *  'prior_dw_scheme', and delete the key 'dw_scheme' if it exists.
      *  This means that the scheme will no longer be identified by function
      *  parse_DW_scheme(), but still resides within the header data and
      *  can be extracted manually. This should be used when
@@ -176,7 +176,7 @@ namespace MR
     {
       set_DW_scheme (header, grad);
       auto dw_scheme = header.keyval().find ("dw_scheme");
-      header.keyval()["basis_dw_scheme"] = dw_scheme->second;
+      header.keyval()["prior_dw_scheme"] = dw_scheme->second;
       header.keyval().erase (dw_scheme);
     }
 


### PR DESCRIPTION
Finishing off #375 

Took the liberty of ensuring that it's the gradient table _used_ in processing that gets captured in the header, not just what was stored in the header (which could have been either absent or over-ruled by providing such information at the command-line).

Alternative function / keyval naming suggestions welcome.
