### PR TITLE
tck2connectome: Small fix to radial search

### DIFF
--- a/src/dwi/tractography/connectome/tck2nodes.cpp
+++ b/src/dwi/tractography/connectome/tck2nodes.cpp
@@ -47,7 +47,7 @@ node_t Tck2nodes_end_voxels::select_node (const Tractography::Streamline<>& tck,
 
 void Tck2nodes_radial::initialise_search ()
 {
-  const int max_axis_offset (std::floor ((max_dist + max_add_dist) / std::min (nodes.spacing(0), std::min (nodes.spacing(1), nodes.spacing(2)))));
+  const int max_axis_offset (std::ceil ((max_dist + max_add_dist) / std::min ( { nodes.spacing(0), nodes.spacing(1), nodes.spacing(2) } )));
   std::multimap<default_type, voxel_type> radial_search_map;
   voxel_type offset;
   for (offset[2] = -max_axis_offset; offset[2] <= +max_axis_offset; ++offset[2]) {
@@ -82,7 +82,7 @@ node_t Tck2nodes_radial::select_node (const Tractography::Streamline<>& tck, Ima
     const Eigen::Vector3 p_voxel (transform->voxel2scanner * this_voxel.matrix().cast<default_type>());
     const default_type dist ((p - p_voxel).norm());
 
-    if (dist > max_dist + max_add_dist)
+    if (dist > min_dist + 2*max_add_dist)
       return node;
 
     if (dist < min_dist) {


### PR DESCRIPTION
Better fix for radial search. The premature exit from the radial search wasn't doing what it was supposed to. This fixes it, so the premature exit can still be used to improve execution speed with a larger search radius.

As reported [here](http://community.mrtrix.org/t/assignment-radial-search-choice/448/4).