### PR TITLE
derefence symbolic links in script input

### DIFF
--- a/scripts/blend
+++ b/scripts/blend
@@ -24,13 +24,13 @@ total_num_output_frames = len(file_list1) + len(file_list2) - num_overlap
 for i in range(total_num_output_frames):
     file_name = 'frame' + '%0*d' % (5, i) + '.png'
     if (i <= (len(file_list1) - num_overlap)):
-        os.system('cp ' + input_folder1 + '/' + file_list1[i] + ' ' + output_folder + '/' + file_name)
+        os.system('cp -L ' + input_folder1 + '/' + file_list1[i] + ' ' + output_folder + '/' + file_name)
     if (i > (len(file_list1) - num_overlap)) and (i < (len(file_list1))):
         i2 = i - (len(file_list1) - num_overlap) - 1 
         blend_amount = 100 * float(i2 + 1) / float(num_overlap)
         os.system('convert ' + input_folder1 + '/' + file_list1[i] + ' ' + input_folder2 + '/' + file_list2[i2] + ' -alpha on -compose blend  -define compose:args=' + str(blend_amount) + ' -gravity South  -composite ' + output_folder + '/' + file_name)
     if (i >= (len(file_list1))):
         i2 = i - (len(file_list1) - num_overlap) - 1 
-        os.system('cp ' + input_folder2 + '/' + file_list2[i2] + ' ' + output_folder + '/' + file_name)    
+        os.system('cp -L ' + input_folder2 + '/' + file_list2[i2] + ' ' + output_folder + '/' + file_name)    
     
     

--- a/scripts/dwiintensitynorm
+++ b/scripts/dwiintensitynorm
@@ -33,7 +33,6 @@ lib.app.parser.add_argument('wm_mask', help='The output white matter mask (in te
 options = lib.app.parser.add_argument_group('Options for the dwiintensitynorm script')
 options.add_argument('-fa_threshold', default='0.4', help='The threshold applied to the Fractional Anisotropy group template used to derive an approximate white matter mask')
 
-
 lib.app.initialise()
 
 lib.app.args.input_dir = relpath(lib.app.args.input_dir)

--- a/scripts/dwiintensitynorm
+++ b/scripts/dwiintensitynorm
@@ -75,7 +75,7 @@ lib.app.make_dir(lib.app.args.output_dir)
 lib.app.makeTempDir()
 
 maskTempDir = os.path.join(lib.app.tempDir, os.path.basename(os.path.normpath(maskDir)))
-runCommand ('cp -r ' + maskDir + ' ' + maskTempDir)
+runCommand ('cp -r -L ' + maskDir + ' ' + maskTempDir)
 
 lib.app.gotoTempDir()
 


### PR DESCRIPTION
Changed copy commands for `dwiintensitynorm` and `blend` from cp to cp -L as copying symbolic relative links breaks them.