### PR TITLE
Fix fixel correspondence

### DIFF
--- a/cmd/dwi2mask.cpp
+++ b/cmd/dwi2mask.cpp
@@ -25,7 +25,7 @@ using namespace App;
 #define DEFAULT_CLEAN_SCALE 2
 
 void usage () {
-  AUTHOR = "David Raffelt (david.raffelt@florey.edu.au) and Thijs Dhollander (thijs.dhollander@gmail.com)";
+  AUTHOR = "David Raffelt (david.raffelt@florey.edu.au), Thijs Dhollander (thijs.dhollander@gmail.com) and Ben Jeurissen (ben.jeurissen@uantwerpen.be)";
 
 DESCRIPTION
   + "Generates a whole brain mask from a DWI image. "
@@ -66,6 +66,9 @@ void run () {
 
   auto input = Image<float>::open (argument[0]).with_direct_io (3);
   auto grad = DWI::get_DW_scheme (input);
+
+  if (input.ndim() != 4)
+    throw Exception ("input DWI image must be 4D");
 
   Filter::DWIBrainMask dwi_brain_mask_filter (input, grad);
   dwi_brain_mask_filter.set_message ("computing dwi brain mask");

--- a/cmd/fixelcfestats.cpp
+++ b/cmd/fixelcfestats.cpp
@@ -45,7 +45,7 @@ typedef float value_type;
 #define DEFAULT_CFE_E 2.0
 #define DEFAULT_CFE_H 3.0
 #define DEFAULT_CFE_C 0.5
-#define DEFAULT_ANGLE_THRESHOLD 30.0
+#define DEFAULT_ANGLE_THRESHOLD 45.0
 #define DEFAULT_CONNECTIVITY_THRESHOLD 0.01
 #define DEFAULT_SMOOTHING_STD 10.0
 #define DEFAULT_PERMUTATIONS_NONSTATIONARITY 5000
@@ -302,6 +302,7 @@ void run() {
       it->second *= norm_factor;
   }
 
+
   // Load input data
   Eigen::Matrix<value_type, Eigen::Dynamic, Eigen::Dynamic> data (num_fixels, filenames.size());
   {
@@ -345,6 +346,7 @@ void run() {
       progress++;
     }
   }
+
 
   if (!data.allFinite())
     throw Exception ("input data contains non-finite value(s)");

--- a/cmd/fixelcorrespondence.cpp
+++ b/cmd/fixelcorrespondence.cpp
@@ -26,7 +26,7 @@ using namespace App;
 
 using Sparse::FixelMetric;
 
-#define DEFAULT_ANGLE_THRESHOLD 30.0
+#define DEFAULT_ANGLE_THRESHOLD 45.0
 
 void usage ()
 {
@@ -68,8 +68,15 @@ void run ()
       output_fixel.value()[t] = template_fixel.value()[t] ;
       float largest_dp = 0.0;
       int index_of_closest_fixel = -1;
+
       for (size_t s = 0; s != subject_fixel.value().size(); ++s) {
-        float dp = std::abs (template_fixel.value()[t].dir.dot (subject_fixel.value()[s].dir));
+        Eigen::Vector3f template_dir = template_fixel.value()[t].dir;
+        template_dir.normalize();
+        Eigen::Vector3f subject_dir = subject_fixel.value()[s].dir;
+        subject_dir.normalize();
+
+        float dp = std::abs (template_dir.dot (subject_dir));
+
         if (dp > largest_dp) {
           largest_dp = dp;
           index_of_closest_fixel = s;
@@ -77,6 +84,8 @@ void run ()
       }
       if (largest_dp > angular_threshold_dp) {
         output_fixel.value()[t].value  = subject_fixel.value()[index_of_closest_fixel].value;
+      } else {
+        output_fixel.value()[t].value = 0.0;
       }
     }
   }

--- a/src/stats/cfe.h
+++ b/src/stats/cfe.h
@@ -61,7 +61,7 @@ namespace MR
             angular_threshold_dp = cos (angular_threshold * (Math::pi/180.0));
           }
 
-          bool operator () (SetVoxelDir& in)
+          bool operator() (SetVoxelDir& in)
           {
             // For each voxel tract tangent, assign to a fixel
             std::vector<int32_t> tract_fixel_indices;


### PR DESCRIPTION
Fix a small bug in fixel correspondence. Cater for non-normalised direction vectors. And add check to dwi2mask. 