### PR TITLE
Command-line parsing: Honour min values for ints and floats

### DIFF
--- a/docs/reference/commands/dwi2mask.rst
+++ b/docs/reference/commands/dwi2mask.rst
@@ -60,7 +60,7 @@ Dhollander T, Raffelt D, Connelly A. Unsupervised 3-tissue response function est
 
 
 
-**Author:** David Raffelt (david.raffelt@florey.edu.au) and Thijs Dhollander (thijs.dhollander@gmail.com)
+**Author:** David Raffelt (david.raffelt@florey.edu.au), Thijs Dhollander (thijs.dhollander@gmail.com) and Ben Jeurissen (ben.jeurissen@uantwerpen.be)
 
 **Copyright:** Copyright (c) 2008-2016 the MRtrix3 contributors
 

--- a/docs/reference/commands/dwidenoise.rst
+++ b/docs/reference/commands/dwidenoise.rst
@@ -55,7 +55,9 @@ Standard options
 References
 ^^^^^^^^^^
 
-Veraart, J.; Fieremans, E. & Novikov, D.S. Diffusion MRI noise mapping using random matrix theory Magn. Res. Med., 2016, early view, doi: 10.1002/mrm.26059
+Veraart, J.; Novikov, D.S.; Christiaens, D.; Ades-aron, B.; Sijbers, J. & Fieremans, E. Denoising of diffusion MRI using random matrix theory. NeuroImage, 2016, in press, doi: 10.1016/j.neuroimage.2016.08.016
+
+Veraart, J.; Fieremans, E. & Novikov, D.S. Diffusion MRI noise mapping using random matrix theory. Magn. Res. Med., 2016, early view, doi: 10.1002/mrm.26059
 
 --------------
 

--- a/docs/reference/commands/fixelcfestats.rst
+++ b/docs/reference/commands/fixelcfestats.rst
@@ -39,7 +39,7 @@ Options
 
 -  **-cfe_c value** cfe connectivity exponent (default: 0.5)
 
--  **-angle value** the max angle threshold for computing inter-subject fixel correspondence (Default: 30 degrees)
+-  **-angle value** the max angle threshold for computing inter-subject fixel correspondence (Default: 45 degrees)
 
 -  **-connectivity threshold** a threshold to define the required fraction of shared connections to be included in the neighbourhood (default: 0.01)
 

--- a/docs/reference/commands/fixelcorrespondence.rst
+++ b/docs/reference/commands/fixelcorrespondence.rst
@@ -22,7 +22,7 @@ Obtain angular correpondence by mapping subject fixels to a template fixel mask.
 Options
 -------
 
--  **-angle value** the max angle threshold for computing inter-subject fixel correspondence (Default: 30 degrees)
+-  **-angle value** the max angle threshold for computing inter-subject fixel correspondence (Default: 45 degrees)
 
 Standard options
 ^^^^^^^^^^^^^^^^

--- a/lib/app.cpp
+++ b/lib/app.cpp
@@ -400,6 +400,9 @@ namespace MR
         << (flags & AllowMultiple ? '1' : '0') << " ";
 
       switch (type) {
+        case Undefined:
+          assert (0);
+          break;
         case Integer:
           stream << "INT " << limits.i.min << " " << limits.i.max;
           break;
@@ -1156,6 +1159,7 @@ namespace MR
 
     default_type App::ParsedArgument::as_float () const
     {
+      assert (arg->type == Float);
       const default_type retval = to<default_type> (p);
       const default_type min = arg->limits.f.min;
       const default_type max = arg->limits.f.max;

--- a/lib/cmdline_option.h
+++ b/lib/cmdline_option.h
@@ -41,6 +41,7 @@ namespace MR
 
     //! \cond skip
     typedef enum {
+      Undefined,
       Text,
       Boolean,
       Integer,
@@ -105,7 +106,10 @@ namespace MR
          * and description. If default arguments are used, the object corresponds
          * to the end-of-list specifier, as detailed in \ref command_line_parsing. */
         Argument (const char* name = nullptr, std::string description = std::string()) :
-          id (name), desc (description), type (Text), flags (None) { }
+          id (name), desc (description), type (Undefined), flags (None)
+        {
+          memset (&limits, 0x00, sizeof (limits));
+        }
 
         //! the argument name
         const char* id;
@@ -157,40 +161,40 @@ namespace MR
 
         //! specifies that the argument should be a text string */
         Argument& type_text () {
+          assert (type == Undefined);
           type = Text;
-          limits.choices = nullptr;
           return *this;
         }
 
         //! specifies that the argument should be an input image
         Argument& type_image_in () {
+          assert (type == Undefined);
           type = ImageIn;
-          limits.choices = nullptr;
           return *this;
         }
 
         //! specifies that the argument should be an output image
         Argument& type_image_out () {
+          assert (type == Undefined);
           type = ImageOut;
-          limits.choices = nullptr;
           return *this;
         }
 
         //! specifies that the argument should be an integer
         /*! if desired, a range of allowed values can be specified. */
         Argument& type_integer (const int64_t min = std::numeric_limits<int64_t>::min(), const int64_t max = std::numeric_limits<int64_t>::max()) {
+          assert (type == Undefined);
           type = Integer;
           limits.i.min = min;
           limits.i.max = max;
-          limits.choices = nullptr;
           return *this;
         }
 
         //! specifies that the argument should be a boolean
         /*! Valid responses are 0,no,false or any non-zero integer, yes, true. */
         Argument& type_bool () {
+          assert (type == Undefined);
           type = Boolean;
-          limits.choices = nullptr;
           return *this;
         }
 
@@ -198,10 +202,10 @@ namespace MR
         /*! if desired, a range of allowed values can be specified. */
         Argument& type_float (const default_type min = -std::numeric_limits<default_type>::infinity(),
                               const default_type max = std::numeric_limits<default_type>::infinity()) {
+          assert (type == Undefined);
           type = Float;
           limits.f.min = min;
           limits.f.max = max;
-          limits.choices = nullptr;
           return *this;
         }
 
@@ -217,6 +221,7 @@ namespace MR
          * \endcode
          * \note Each string in the list must be supplied in \b lowercase. */
         Argument& type_choice (const char* const* choices) {
+          assert (type == Undefined);
           type = Choice;
           limits.choices = choices;
           return *this;
@@ -224,43 +229,43 @@ namespace MR
 
         //! specifies that the argument should be an input file
         Argument& type_file_in () {
+          assert (type == Undefined);
           type = ArgFileIn;
-          limits.choices = nullptr;
           return *this;
         }
 
         //! specifies that the argument should be an output file
         Argument& type_file_out () {
+          assert (type == Undefined);
           type = ArgFileOut;
-          limits.choices = nullptr;
           return *this;
         }
 
         //! specifies that the argument should be a sequence of comma-separated integer values
         Argument& type_sequence_int () {
+          assert (type == Undefined);
           type = IntSeq;
-          limits.choices = nullptr;
           return *this;
         }
 
         //! specifies that the argument should be a sequence of comma-separated floating-point values.
         Argument& type_sequence_float () {
+          assert (type == Undefined);
           type = FloatSeq;
-          limits.choices = nullptr;
           return *this;
         }
 
         //! specifies that the argument should be an input tracks file
         Argument& type_tracks_in () {
+          assert (type == Undefined);
           type = TracksIn;
-          limits.choices = nullptr;
           return *this;
         }
 
         //! specifies that the argument should be an output tracks file
         Argument& type_tracks_out () {
+          assert (type == Undefined);
           type = TracksOut;
-          limits.choices = nullptr;
           return *this;
         }
 


### PR DESCRIPTION
Because MR::Argument::limits its a union, setting the min/max values permitted for an integer / float argument type then subsequently zeroing the choices field would in fact zero the minimum value.
Also updated some docs based on most up-to-date code.