### PR TITLE
average_response is now python 2 and 3 compatible

### DIFF
--- a/scripts/average_response
+++ b/scripts/average_response
@@ -1,19 +1,19 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 import sys
 import string
 
 def errorMessage (msg):
-  print msg
+  print (msg)
   exit(1)
 
 if len(sys.argv) < 3 :
-  print "example usage: average_response input_response1.txt input_response2.txt input_response3.txt ... output_average_response.txt"
+  print("example usage: average_response input_response1.txt input_response2.txt input_response3.txt ... output_average_response.txt")
   exit(1)
 
 num_bvals = 0
 num_coeff = 0
 num_subjects = len(sys.argv) - 2
-print "Number of subjects: " + str(num_subjects)
+print ("Number of subjects: " + str(num_subjects))
 
 for i in range(1, num_subjects + 1):
   with open(sys.argv[i], 'r') as f:
@@ -31,7 +31,7 @@ for i in range(1, num_subjects + 1):
         if len(l.split()) != num_coeff:
           errorMessage ("Error in file " + sys.argv[i] + ": multi-shell response functions must have the same number of coefficients per b-value (line)")
 
-print "Number of b-values: " + str(num_bvals)
+print ("Number of b-values: " + str(num_bvals))
 
 average_response = [[0 for x in range(num_coeff)] for y in range(num_bvals)] 
 for i in range(1, num_subjects + 1):


### PR DESCRIPTION
Hopefully fixes [this issue](http://community.mrtrix.org/t/average-response-python2-error/553)

