### PR TITLE
dwiintensitynorm: cp -r --> cp -R 

### DIFF
--- a/scripts/dwiintensitynorm
+++ b/scripts/dwiintensitynorm
@@ -74,7 +74,7 @@ lib.app.make_dir(lib.app.args.output_dir)
 lib.app.makeTempDir()
 
 maskTempDir = os.path.join(lib.app.tempDir, os.path.basename(os.path.normpath(maskDir)))
-runCommand ('cp -r -L ' + maskDir + ' ' + maskTempDir)
+runCommand ('cp -R -L ' + maskDir + ' ' + maskTempDir)
 
 lib.app.gotoTempDir()
 


### PR DESCRIPTION
for osx compatibility of recursive copying and dereferencing symlinks (http://community.mrtrix.org/t/dwintensitynorm-error/557/4)