### PR TITLE
tckgen: Premature exit mechanism

### DIFF
--- a/docs/reference/commands/maskdump.rst
+++ b/docs/reference/commands/maskdump.rst
@@ -8,14 +8,15 @@ Synopsis
 
 ::
 
-    maskdump [ options ]  input
+    maskdump [ options ]  input[ output ]
 
 -  *input*: the input image.
+-  *output*: The (optional) output text file.
 
 Description
 -----------
 
-Print out the locations of all non-zero voxels in a mask image
+Print out the locations of all non-zero voxels in a mask image. If no destination file is specified, the voxel locations will be printed to stdout.
 
 Options
 -------

--- a/docs/reference/commands/mredit.rst
+++ b/docs/reference/commands/mredit.rst
@@ -16,12 +16,18 @@ Synopsis
 Description
 -----------
 
-Edit the intensities within an image from the command-line. If only one image path is provided, the image will be edited in-place. If input and output image paths are provided, the original image will not be modified.
+Directly edit the intensities within an image from the command-line. A range of options are provided to enable direct editing of voxel intensities based on voxel / real-space coordinates. If only one image path is provided, the image will be edited in-place (use at own risk); if input and output image paths are provided, the output will contain the edited image, and the original image will not be modified in any way.
 
 Options
 -------
 
--  **-voxel position value** Change the intensity of a single voxel
+-  **-plane axis coord value** fill one or more planes on a particular image axis
+
+-  **-sphere position radius value** draw a sphere with radius in mm
+
+-  **-voxel position value** change the image value within a single voxel
+
+-  **-scanner** indicate that coordinates are specified in scanner space, rather than as voxel coordinates
 
 Standard options
 ^^^^^^^^^^^^^^^^

--- a/docs/reference/commands/mrinfo.rst
+++ b/docs/reference/commands/mrinfo.rst
@@ -44,7 +44,7 @@ Options
 
 -  **-transform** the voxel to image transformation
 
--  **-norealign** do not realign transform to near-default RAS coordinate system (the default behaviour on image load). This is useful to inspect the transform and strides as they are actually stored in the header, rather than as MRtrix interprets them.
+-  **-norealign** do not realign transform to near-default RAS coordinate system (the default behaviour on image load). This is useful to inspect the image and/or header contents as they are actually stored in the header, rather than as MRtrix interprets them.
 
 -  **-property key** any text properties embedded in the image header under the specified key (use 'all' to list all keys found)
 

--- a/docs/reference/commands/mrview.rst
+++ b/docs/reference/commands/mrview.rst
@@ -69,6 +69,11 @@ Debugging options
 
 -  **-fps** Display frames per second, averaged over the last 10 frames. The maximum over the last 3 seconds is also displayed.
 
+Other options
+^^^^^^^^^^^^^
+
+-  **-norealign** do not realign transform to near-default RAS coordinate system (the default behaviour on image load). This is useful to inspect the image and/or header contents as they are actually stored in the header, rather than as MRtrix interprets them.
+
 Overlay tool options
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/reference/config_file_options.rst
+++ b/docs/reference/config_file_options.rst
@@ -334,6 +334,11 @@ List of MRtrix3 configuration file options
 
      The default intensity for the specular light in OpenGL renders.
 
+*  **TckgenEarlyExit**
+    *default: 0 (false)*
+
+     Specifies whether tckgen should be terminated prematurely in cases where it appears as though the target number of accepted streamlines is not going to be met.
+
 *  **TerminalColor**
     *default: 1 (true)*
 

--- a/docs/reference/scripts/dwipreproc.rst
+++ b/docs/reference/scripts/dwipreproc.rst
@@ -26,7 +26,7 @@ Options for specifying the acquisition phase-encoding design; note that one of t
 
 - **-rpe_none** Specify that no reversed phase-encoding image data is being provided; eddy will perform eddy current and motion correction only
 
-- **-rpe_pair** Specify that a set of images will be provided for use in inhomogeneity field estimation (using the -topup_images option), where it is assumed that the FIRST volume(s) of this image has the same phase-encoding direction as the input DWIs, and the LAST volume(s) has precisely the OPPOSITE phase encoding
+- **-rpe_pair** Specify that a set of images will be provided for use in inhomogeneity field estimation (using the -se_epi option), where it is assumed that the FIRST volume(s) of this image has the same phase-encoding direction as the input DWIs, and the LAST volume(s) has precisely the OPPOSITE phase encoding
 
 - **-rpe_all** Specify that all DWIs have been acquired with opposing phase-encoding, where it is assumed that the second half of the volumes in the input DWIs have corresponding diffusion sensitisation directions to the first half, but were acquired using the opposite phase-encoding direction
 
@@ -39,7 +39,7 @@ Other options for the dwipreproc script
 
 - **-readout_time time** Manually specify the total readout time of the input series (in seconds)
 
-- **-topup_images file** Provide an additional image series that is to be used exclusively by topup for estimating the inhomogeneity field (i.e. it will not form part of the output image series)
+- **-se_epi file** Provide an additional image series consisting of spin-echo EPI images, which is to be used exclusively by topup for estimating the inhomogeneity field (i.e. it will not form part of the output image series)
 
 - **-json_import JSON_file** Import image header information from an associated JSON file (may be necessary to determine phase encoding information)
 

--- a/src/dwi/tractography/tracking/early_exit.cpp
+++ b/src/dwi/tractography/tracking/early_exit.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2008-2016 the MRtrix3 contributors
+ * 
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ * 
+ * MRtrix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * 
+ * For more details, see www.mrtrix.org
+ * 
+ */
+
+
+#include "dwi/tractography/tracking/early_exit.h"
+
+
+namespace MR
+{
+  namespace DWI
+  {
+    namespace Tractography
+    {
+      namespace Tracking
+      {
+
+
+
+        bool EarlyExit::operator() (const Writer<>& writer)
+        {
+          if (++counter != next_test)
+            return false;
+
+          const size_t num_attempts = writer.total_count;
+          const size_t num_tracks = writer.count;
+          if ((num_attempts / default_type(max_num_attempts) > TCKGEN_EARLY_EXIT_STOP_TESTING_PERCENTAGE) ||
+              (num_tracks   / default_type(max_num_tracks)   > TCKGEN_EARLY_EXIT_STOP_TESTING_PERCENTAGE)) {
+            DEBUG ("tckgen early exit: No longer testing (tracking progressed beyond " + str<int>(std::round(100.0*TCKGEN_EARLY_EXIT_STOP_TESTING_PERCENTAGE)) + "%)");
+            next_test = 0;
+            return false;
+          }
+
+          const Eigen::Array<default_type, 2, 1> a ( { default_type(num_attempts-num_tracks), default_type(num_attempts-num_tracks) });
+          const Eigen::Array<default_type, 2, 1> b ( { default_type(num_tracks+1), default_type(num_tracks+1) });
+          const Eigen::Array<default_type, 2, 1> x ( { 1.0-(max_num_tracks/default_type(max_num_attempts)), 1.0 });
+          const auto incomplete_betas = Eigen::betainc (a, b, x);
+          const default_type conditional = incomplete_betas[0] / incomplete_betas[1];
+
+          DEBUG ("tckgen early exit: Target " + str(max_num_tracks) + "/" + str(max_num_attempts) + " (" + str(max_num_tracks/default_type(max_num_attempts)) + "), current " + str(num_tracks) + "/" + str(num_attempts) + " (" + str(num_tracks/default_type(num_attempts)) + "), conditional probability " + str(conditional));
+          next_test *= 2;
+          return (conditional < TCKGEN_EARLY_EXIT_PROB_THRESHOLD);
+        }
+
+
+
+      }
+    }
+  }
+}
+

--- a/src/dwi/tractography/tracking/early_exit.cpp
+++ b/src/dwi/tractography/tracking/early_exit.cpp
@@ -16,6 +16,8 @@
 
 #include "dwi/tractography/tracking/early_exit.h"
 
+#include "file/config.h"
+
 
 namespace MR
 {
@@ -32,6 +34,16 @@ namespace MR
         {
           if (++counter != next_test)
             return false;
+
+          //CONF option: TckgenEarlyExit
+          //CONF default: 0 (false)
+          //CONF Specifies whether tckgen should be terminated prematurely
+          //CONF in cases where it appears as though the target number of
+          //CONF accepted streamlines is not going to be met.
+          if (!File::Config::get_bool ("TckgenEarlyExit", false)) {
+            next_test = 0;
+            return false;
+          }
 
           const size_t num_attempts = writer.total_count;
           const size_t num_tracks = writer.count;

--- a/src/dwi/tractography/tracking/early_exit.h
+++ b/src/dwi/tractography/tracking/early_exit.h
@@ -16,15 +16,22 @@
 #ifndef __dwi_tractography_tracking_early_exit_h__
 #define __dwi_tractography_tracking_early_exit_h__
 
+#include <Eigen/Core>
+
+#if EIGEN_VERSION_AT_LEAST(3,3,0)
+#define TCKGEN_EARLY_EXIT_USE_FULL_BINOMIAL
 #include <unsupported/Eigen/SpecialFunctions>
+#define TCKGEN_EARLY_EXIT_PROB_THRESHOLD 0.001
+#else
+#define TCKGEN_EARLY_EXIT_PROB_THRESHOLD 1e-6
+#define TCKGEN_EARLY_EXIT_ZVALUE -4.753408 // For a p-value of 1e-6; should be negative
+#endif
 
 #include "dwi/tractography/file.h"
 #include "dwi/tractography/tracking/shared.h"
 
 
-#define TCKGEN_EARLY_EXIT_PROB_THRESHOLD 0.01
-#define TCKGEN_EARLY_EXIT_STOP_TESTING_PERCENTAGE 0.25
-
+#define TCKGEN_EARLY_EXIT_STOP_TESTING_PERCENTAGE 0.20
 
 
 namespace MR
@@ -51,7 +58,6 @@ namespace MR
           private:
             const size_t max_num_attempts, max_num_tracks;
             size_t counter, next_test;
-
         };
 
 

--- a/src/dwi/tractography/tracking/early_exit.h
+++ b/src/dwi/tractography/tracking/early_exit.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2008-2016 the MRtrix3 contributors
+ * 
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ * 
+ * MRtrix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * 
+ * For more details, see www.mrtrix.org
+ * 
+ */
+
+#ifndef __dwi_tractography_tracking_early_exit_h__
+#define __dwi_tractography_tracking_early_exit_h__
+
+#include <unsupported/Eigen/SpecialFunctions>
+
+#include "dwi/tractography/file.h"
+#include "dwi/tractography/tracking/shared.h"
+
+
+#define TCKGEN_EARLY_EXIT_PROB_THRESHOLD 0.01
+#define TCKGEN_EARLY_EXIT_STOP_TESTING_PERCENTAGE 0.25
+
+
+
+namespace MR
+{
+  namespace DWI
+  {
+    namespace Tractography
+    {
+      namespace Tracking
+      {
+
+
+        class EarlyExit
+        {
+          public:
+            EarlyExit (const SharedBase& shared) :
+              max_num_attempts (shared.max_num_attempts),
+              max_num_tracks (shared.max_num_tracks),
+              counter (0),
+              next_test ((max_num_attempts && max_num_tracks) ? (10 * max_num_attempts / max_num_tracks) : 0) { }
+
+            bool operator() (const Writer<>&);
+
+          private:
+            const size_t max_num_attempts, max_num_tracks;
+            size_t counter, next_test;
+
+        };
+
+
+
+      }
+    }
+  }
+}
+
+#endif
+
+

--- a/src/dwi/tractography/tracking/write_kernel.cpp
+++ b/src/dwi/tractography/tracking/write_kernel.cpp
@@ -37,6 +37,10 @@ namespace MR
             }
             writer (tck);
             progress.update ([&](){ return printf ("%8" PRIu64 " generated, %8" PRIu64 " selected", writer.total_count, writer.count); }, always_increment ? true : tck.size());
+            if (early_exit (writer)) {
+              WARN ("Track generation terminating prematurely: Highly unlikely to reach target number of streamlines (p<" + str(TCKGEN_EARLY_EXIT_PROB_THRESHOLD,1) + ")");
+              return false;
+            }
             return true;
           }
 

--- a/src/dwi/tractography/tracking/write_kernel.h
+++ b/src/dwi/tractography/tracking/write_kernel.h
@@ -27,6 +27,7 @@
 #include "dwi/tractography/properties.h"
 #include "dwi/tractography/streamline.h"
 
+#include "dwi/tractography/tracking/early_exit.h"
 #include "dwi/tractography/tracking/generated_track.h"
 #include "dwi/tractography/tracking/shared.h"
 #include "dwi/tractography/tracking/types.h"
@@ -54,7 +55,8 @@ namespace MR
                 writer (output_file, properties),
                 always_increment (S.properties.seeds.is_finite() || !S.max_num_tracks),
                 warn_on_max_attempts (S.implicit_max_num_attempts),
-                progress (printf ("       0 generated,        0 selected", 0, 0), always_increment ? S.max_num_attempts : S.max_num_tracks)
+                progress (printf ("       0 generated,        0 selected", 0, 0), always_increment ? S.max_num_attempts : S.max_num_tracks),
+                early_exit (shared)
           {
             const auto seed_output = properties.find ("seed_output");
             if (seed_output != properties.end()) {
@@ -93,7 +95,9 @@ namespace MR
           const bool always_increment, warn_on_max_attempts;
           std::unique_ptr<File::OFStream> seeds;
           ProgressBar progress;
+          EarlyExit early_exit;
       };
+
 
 
 


### PR DESCRIPTION
OK @jdtournier, this is what I've ended up with for #828. I'm pretty sure my conditional probability is right but my priors were wrong, so I've simplified and am just testing that conditional directly.

Logic is as follows:

Requested maximum number of streamlines _N_, maximum number of attempts _A_ (whether set by default to _100N_ or set manually). Hypothesis _H_ is that the fixed probability of any generated streamline being accepted is greater than _N/A_, so we should reach the requested number of streamlines before we reach the maximum number of attempts.

If _H_ is true: what is the probability that, after _a_ streamline attempts, you will observe no more than _n_ streamlines (where _n_ and _a_ are the running values for streamline number and attempts respectively)?

If _n_ is so low that observing such after _a_ under _H_ is highly unlikely, then it's highly unlikely that _n_ will reach _N_ by the time _a_ reaches _A_.

By discarding the priors, I'm basically saying _P(H|n,a) = P(n,a|H)_.

Open to discuss, modify, reject, belittle.