### PR TITLE
mrtransform: apply the inverse transformation to DW gradients

### DIFF
--- a/cmd/mrtransform.cpp
+++ b/cmd/mrtransform.cpp
@@ -368,7 +368,7 @@ void run ()
 
   // Rotate/Flip gradient directions if present
   if (linear && input_header.ndim() == 4 && !warp && !fod_reorientation) {
-    Eigen::MatrixXd rotation = linear_transform.linear();
+    Eigen::MatrixXd rotation = linear_transform.linear().inverse();
     Eigen::MatrixXd test = rotation.transpose() * rotation;
     test = test.array() / test.diagonal().mean();
     if (!test.isIdentity (0.001)) {


### PR DESCRIPTION
As discussed on the [community forum](
http://community.mrtrix.org/t/gradient-orientation-after-alignment-of-nifti-dwi-data-to-structural-data/584/1).

I think this should fix the issue, but I haven't a chance to test. I'd really like people to had a good look at it to make sure it's actually doing what it's supposed to, so please give it a crack if you have a minute... 