### PR TITLE
population_template uses rigid registration first. tweaks for linear registration

### DIFF
--- a/cmd/mrregister.cpp
+++ b/cmd/mrregister.cpp
@@ -708,8 +708,7 @@ void run ()
 
     if (do_rigid) {
       affine.set_centre (rigid.get_centre());
-      affine.set_translation (rigid.get_translation());
-      affine.set_matrix (rigid.get_matrix());
+      affine.set_transform (rigid.get_transform());
       affine_registration.set_init_translation_type (Registration::Transform::Init::none);
     }
 

--- a/docs/reference/config_file_options.rst
+++ b/docs/reference/config_file_options.rst
@@ -392,7 +392,27 @@ List of MRtrix3 configuration file options
 *  **reg_coherence_len**
     *default: 3.0*
 
-     Linear registration: estimated spatial coherence length in voxel
+     Linear registration: estimated spatial coherence length in voxels
+
+*  **reg_gd_convergence_data_smooth**
+    *default: 0.8*
+
+     Linear registration: control point trajectory smoothing value used in convergence check parameter range: [0...1]
+
+*  **reg_gd_convergence_min_iter**
+    *default: 10*
+
+     Linear registration: minumum number of iterations until convergence check is activated
+
+*  **reg_gd_convergence_slope_smooth**
+    *default: 0.1*
+
+     Linear registration: control point trajectory slope smoothing value used in convergence check parameter range: [0...1]
+
+*  **reg_gd_convergence_thresh**
+    *default: 5e-3*
+
+     Linear registration: threshold for convergence check using the smoothed control point trajectories measured in fraction of a voxel
 
 *  **reg_gdweight_matrix**
     *default: 0.0003*
@@ -407,5 +427,5 @@ List of MRtrix3 configuration file options
 *  **reg_stop_len**
     *default: 0.0001*
 
-     Linear registration: smallest step in fraction of voxel at which to stop registration
+     Linear registration: smallest gradient descent step measured in fraction of a voxel at which to stop registration
 

--- a/docs/reference/scripts/population_template.rst
+++ b/docs/reference/scripts/population_template.rst
@@ -21,8 +21,12 @@ Generates an unbiased group-average template from a series of images. First a te
 Options
 -------
 
-Options for the population_template script
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Input, output and general options
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- **-type** Specifiy the types of registration stages to perform. Options are "rigid" (perform rigid registration only which might be useful for intra-subject registration in longitudinal analysis), "affine" (perform affine registration) and "nonlinear" as well as cominations of registration types: "rigid_affine", "rigid_nonlinear", "affine_nonlinear", "rigid_affine_nonlinear". Default: rigid_affine_nonlinear
+
+- **-initial_alignment** Method of alignment to form the initial template. Options are "mass" (default), "geometric" and "none".
 
 - **-mask_dir** Optionally input a set of masks inside a single directory, one per input image (with the same file name prefix). Using masks will speed up registration significantly
 
@@ -34,17 +38,10 @@ Options for the population_template script
 
 - **-template_mask** Output a template mask. Only works in -mask_dir has been input. The template mask is computed as the intersection of all subject masks in template space.
 
-- **-rigid** perform rigid registration instead of affine. This should be used for intra-subject registration in longitudinal analysis
+- **-noreorientation** Turn off FOD reorientation in mrregister. Reorientation is on by default if the number of volumes in the 4th dimension corresponds to the number of coefficients in an antipodally symmetric spherical harmonic series (i.e. 6, 15, 28, 45, 66 etc
 
-- **-linear_no_pause** Do not pause the script if a linear registration seems implausible
-
-- **-linear_scale** Specifiy the multi-resolution pyramid used to build the rigid or affine template, in the form of a list of scale factors (default: 0.3,0.4,0.6,0.8,1.0,1.0). This implicitly defines the number of template levels
-
-- **-linear_lmax** Specifiy the lmax used for rigid or affine registration for each scale factor, in the form of a list of integers (default: 2,2,2,4,4,4). The list must be the same length as the linear_scale factor list
-
-- **-linear_niter** Specifiy the number of registration iterations used within each level before updating the template, in the form of a list of integers (default:500 for each scale). The must be a single number or a list of same length as the linear_scale factor list
-
-- **-linear_estimator** Choose estimator for intensity difference metric. Valid choices are: l1 (least absolute: |x|), l2 (ordinary least squares), lp (least powers: |x|^1.2), Default: l2
+Options for the non-linear registration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - **-nl_scale** Specifiy the multi-resolution pyramid used to build the non-linear template, in the form of a list of scale factors (default: 0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0). This implicitly defines the number of template levels
 
@@ -58,9 +55,24 @@ Options for the population_template script
 
 - **-nl_grad_step** The gradient step size for non-linear registration (Default: 0.5)
 
-- **-noreorientation** Turn off FOD reorientation in mrregister. Reorientation is on by default if the number of volumes in the 4th dimension corresponds to the number of coefficients in an antipodally symmetric spherical harmonic series (i.e. 6, 15, 28, 45, 66 etc
+Options for the linear registration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- **-initial_alignment** Method of alignment to form the initial template. Options are "mass" (default), "geometric" and "none".
+- **-linear_no_pause** Do not pause the script if a linear registration seems implausible
+
+- **-linear_estimator** Choose estimator for intensity difference metric. Valid choices are: l1 (least absolute: |x|), l2 (ordinary least squares), lp (least powers: |x|^1.2), Default: l2
+
+- **-rigid_scale** Specifiy the multi-resolution pyramid used to build the rigid template, in the form of a list of scale factors (default: 0.3,0.4,0.6,0.8,1.0,1.0). This and affine_scale implicitly  define the number of template levels
+
+- **-rigid_lmax** Specifiy the lmax used for rigid registration for each scale factor, in the form of a list of integers (default: 2,2,2,4,4,4). The list must be the same length as the linear_scale factor list
+
+- **-rigid_niter** Specifiy the number of registration iterations used within each level before updating the template, in the form of a list of integers (default:50 for each scale). This must be a single number or a list of same length as the linear_scale factor list
+
+- **-affine_scale** Specifiy the multi-resolution pyramid used to build the affine template, in the form of a list of scale factors (default: 0.3,0.4,0.6,0.8,1.0,1.0). This and rigid_scale implicitly define the number of template levels
+
+- **-affine_lmax** Specifiy the lmax used for affine registration for each scale factor, in the form of a list of integers (default: 2,2,2,4,4,4). The list must be the same length as the linear_scale factor list
+
+- **-affine_niter** Specifiy the number of registration iterations used within each level before updating the template, in the form of a list of integers (default:500 for each scale). This must be a single number or a list of same length as the linear_scale factor list
 
 Standard options
 ^^^^^^^^^^^^^^^^

--- a/docs/reference/scripts/profile_mrregister.py.rst
+++ b/docs/reference/scripts/profile_mrregister.py.rst
@@ -1,0 +1,90 @@
+profile_mrregister.py
+===========
+
+Synopsis
+--------
+
+    profile_mrregister.py [ options ] input_pattern mask_pattern
+
+- *input_pattern*: Input file path. Use wildcards for multiple files
+- *mask_pattern*: Mask file name. Lives in same directory as corresponding input file
+
+Description
+-----------
+
+Desciption
+
+Options
+-------
+
+- **-rigid** perform rigid registration instead of affine.
+
+- **-linear_scale** Specifiy the multi-resolution pyramid used to build the rigid or affine template, in the form of a list of scale factors (default: 0.3,0.4,0.5,0.6,0.7,1.0,1.0,1.0,1.0,1.0). This implicitly defines the number of template levels
+
+- **-linear_lmax** Specifiy the lmax used for rigid or affine registration for each scale factor, in the form of a list of integers (default: 0,0,2,2,2,2,2,2,4,4,4,4,4,4,4,4). The list must be the same length as the affine_scale factor list
+
+- **-nl_scale** Specifiy the multi-resolution pyramid used to build the non-linear template, in the form of a list of scale factors (default: 0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0). This implicitly defines the number of template levels
+
+- **-nl_lmax** Specifiy the lmax used for non-linear registration for each scale factor, in the form of a list of integers (default: 0,0,2,2,2,2,2,2,2,2,4,4,4,4). The list must be the same length as the nl_scale factor list
+
+- **-nl_niter** Specifiy the number of registration iterations used within each level before updating the template, in the form of a list of integers (default:5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5). The list must be the same length as the nl_scale factor list
+
+- **-nl_update_smooth** Regularise the gradient update field with Gaussian smoothing (standard deviation in voxel units, Default 2.0 x voxel_size)
+
+- **-nl_disp_smooth** Regularise the displacement field with Gaussian smoothing (standard deviation in voxel units, Default 1.0 x voxel_size)
+
+- **-nl_grad_step** The gradient step size for non-linear registration (Default: 0.5)
+
+- **-noreorientation** Turn off FOD reorientation. Reorientation is on by default if the number of volumes in the 4th dimension corresponds to the number of coefficients in an antipodally symmetric spherical harmonic series (i.e. 6, 15, 28, 45, 66 etc
+
+- **-initial_alignment** Method of alignment to form the initial template. Options are "mass" (default), "geometric" and "none".
+
+- **-log** log mrregister output to text file
+
+- **-results** write stdout to text file
+
+- **-linear_transform_dir** save linear transformations
+
+- **-mrregister_args** more arguments to pass to mrregister, comma separated enclosed in square brackets: [-debug,-affine_niter,1]
+
+Standard options
+^^^^^^^^^^^^^^^^
+
+
+- **-continue <TempDir> <LastFile>** Continue the script from a previous execution; must provide the temporary directory path, and the name of the last successfully-generated file
+
+- **-force** Force overwrite of output files if pre-existing
+
+- **-help** Display help information for the script
+
+- **-nocleanup** Do not delete temporary directory at script completion
+
+- **-nthreads number** Use this number of threads in MRtrix multi-threaded applications (0 disables multi-threading)
+
+- **-tempdir /path/to/tmp/** Manually specify the path in which to generate the temporary directory
+
+- **-quiet** Suppress all console output during script execution
+
+- **-verbose** Display additional information for every command invoked
+
+References
+^^^^^^^^^^
+
+
+
+---
+
+**Author:** Max
+
+**Copyright:** 
+Copyright (c) 2008-2016 the MRtrix3 contributors
+
+This Source Code Form is subject to the terms of the Mozilla Public 
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+MRtrix is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of 
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+For more details, see www.mrtrix.org

--- a/lib/algo/random_threaded_loop.h
+++ b/lib/algo/random_threaded_loop.h
@@ -46,8 +46,8 @@ namespace MR
             const Functor& functor, const double voxel_density, const std::vector<size_t> dimensions, ImageType&... voxels) :
           outer_axes (outer_axes),
           loop (Loop (inner_axes)),
-          func (functor), 
-          density (voxel_density), 
+          func (functor),
+          density (voxel_density),
           dims(dimensions),
           vox (voxels...) { }
 
@@ -96,10 +96,10 @@ namespace MR
           loop (Loop (inner_axes)),
           func (functor),
           density (voxel_density),
-          dims (dimensions) { 
+          dims (dimensions) {
             assert (inner_axes.size() == 1);
-            // VAR(inner_axes); 
-            // VAR(outer_axes); 
+            // VAR(inner_axes);
+            // VAR(outer_axes);
             Math::RNG rng;
             typename std::default_random_engine::result_type seed = rng.get_seed();
             random_engine = std::default_random_engine{static_cast<std::default_random_engine::result_type>(seed)};
@@ -113,7 +113,7 @@ namespace MR
           it = std::begin(idx);
           stop = std::end(idx);
           max_cnt = //size_t (density * dims[inner[0]]);
-          (size_t) ceil (density * dims[inner[0]]);
+          (size_t) std::ceil (density * dims[inner[0]]);
           // VAR(max_cnt);
           for (size_t i = 0; i < max_cnt; ++i){
             pos.index(inner[0]) = *it;
@@ -142,11 +142,11 @@ namespace MR
         std::vector<size_t> inner_axes;
 
         //! invoke \a functor (const Iterator& pos) per voxel <em> in the outer axes only</em>
-        template <class Functor> 
+        template <class Functor>
           void run_outer (Functor&& functor, const double voxel_density, const std::vector<size_t>& dimensions)
           {
             if (Thread::number_of_threads() == 0) {
-              for (auto i = outer_loop (iterator); i; ++i){ 
+              for (auto i = outer_loop (iterator); i; ++i){
                 // std::cerr << "outer: " << str(iterator) << " " << voxel_density << " " << dimensions << std::endl;
                 functor (iterator);
               }
@@ -188,9 +188,9 @@ namespace MR
         template <class Functor, class... ImageType>
           void run (Functor&& functor, const double voxel_density, std::vector<size_t> dimensions, ImageType&&... vox)
           {
-            RandomThreadedLoopRunInner< 
+            RandomThreadedLoopRunInner<
               sizeof...(ImageType),
-              typename std::remove_reference<Functor>::type, 
+              typename std::remove_reference<Functor>::type,
               typename std::remove_reference<ImageType>::type...
                 > loop_thread (outer_loop.axes, inner_axes, functor, voxel_density, dimensions, vox...);
             run_outer (loop_thread, voxel_density, dimensions);
@@ -219,7 +219,7 @@ namespace MR
         const HeaderType& source,
         const std::vector<size_t>& axes,
         size_t num_inner_axes = 1) {
-      return { source, Loop (get_outer_axes (axes, num_inner_axes)), get_inner_axes (axes, num_inner_axes) }; 
+      return { source, Loop (get_outer_axes (axes, num_inner_axes)), get_inner_axes (axes, num_inner_axes) };
     }
 
   template <class HeaderType>
@@ -228,8 +228,8 @@ namespace MR
         size_t from_axis = 0,
         size_t to_axis = std::numeric_limits<size_t>::max(),
         size_t num_inner_axes = 1) {
-      return { source, 
-        Loop (get_outer_axes (source, num_inner_axes, from_axis, to_axis)), 
+      return { source,
+        Loop (get_outer_axes (source, num_inner_axes, from_axis, to_axis)),
         get_inner_axes (source, num_inner_axes, from_axis, to_axis) };
       }
 
@@ -248,7 +248,7 @@ namespace MR
         const HeaderType& source,
         const std::vector<size_t>& axes,
         size_t num_inner_axes = 1) {
-      return { source, 
+      return { source,
         Loop (progress_message, get_outer_axes (axes, num_inner_axes)),
         get_inner_axes (axes, num_inner_axes) };
       }
@@ -258,7 +258,7 @@ namespace MR
         const std::string& progress_message,
         const HeaderType& source,
         size_t from_axis = 0,
-        size_t to_axis = std::numeric_limits<size_t>::max(), 
+        size_t to_axis = std::numeric_limits<size_t>::max(),
         size_t num_inner_axes = 1) {
       return { source,
         Loop (progress_message, get_outer_axes (source, num_inner_axes, from_axis, to_axis)),

--- a/scripts/dwiintensitynorm
+++ b/scripts/dwiintensitynorm
@@ -85,12 +85,12 @@ for i in input:
   runCommand('dwi2tensor ' + abspath(i.directory, i.filename) + ' -mask ' + abspath(i.mask_directory, i.mask_filename) + ' - | tensor2metric - -fa fa/' + i.prefix + '.mif')
 
 printMessage('Generating FA population template')
-runCommand('population_template fa -mask_dir ' + maskTempDir + ' fa_template.mif -linear_scale 0.25,0.5,1.0,1.0 -nl_scale 0.5,0.75,1.0,1.0,1.0 -nl_niter 5,5,5,5,5 -warp_dir warps -nocleanup -tempdir population_template')
+runCommand('population_template fa -mask_dir ' + maskTempDir + ' fa_template.mif -type rigid_affine_nonlinear -rigid_scale 0.25,0.5,0.8,1.0 -affine_scale 0.7,0.8,1.0,1.0 -nl_scale 0.5,0.75,1.0,1.0,1.0 -nl_niter 5,5,5,5,5 -tempdir population_template -linear_no_pause -nocleanup')
 
 runCommand('mrthreshold fa_template.mif -abs ' +  lib.app.args.fa_threshold + ' template_wm_mask.mif')
 lib.app.make_dir('wm_mask_warped')
 for i in input:
-  runCommand('mrtransform template_wm_mask.mif -interp nearest -warp_full warps/' + i.prefix + '.mif wm_mask_warped/' + i.prefix + '.mif -from 2 -template fa/' + i.prefix + '.mif')
+  runCommand('mrtransform template_wm_mask.mif -interp nearest -warp_full population_template/warps/' + i.prefix + '.mif wm_mask_warped/' + i.prefix + '.mif -from 2 -template fa/' + i.prefix + '.mif')
   runCommand('dwinormalise ' + abspath(i.directory, i.filename) + ' wm_mask_warped/' + i.prefix + '.mif ' + getUserPath(os.path.join(lib.app.args.output_dir, i.filename), True) + lib.app.mrtrixForce)
 
 runCommand('mrconvert template_wm_mask.mif ' + getUserPath(lib.app.args.wm_mask, True) + lib.app.mrtrixForce)

--- a/scripts/population_template
+++ b/scripts/population_template
@@ -109,6 +109,8 @@ nl_scales = [0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0]
 nl_niter =  [5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5  ,5  ,5  ,5  ,5  ]
 nl_lmax =   [2,  2,  2,  2,  2,  2,  2,  2,  4,  4,  4,  4  ,4  ,4  ,4  ,4  ]
 
+registration_modes = ["rigid","affine","nonlinear","rigid_affine","rigid_nonlinear","affine_nonlinear","rigid_affine_nonlinear"]
+
 
 lib.app.author = 'David Raffelt (david.raffelt@florey.edu.au) & Max Pietsch (maximilian.pietsch@kcl.ac.uk) & Thijs Dhollander thijs.dhollander@gmail.com)'
 lib.cmdlineParser.initialise('Generates an unbiased group-average template from a series of images. First a template is optimised with linear registration (rigid or affine, affine is default), then non-linear registration is used to optimise the template further.')
@@ -116,10 +118,8 @@ lib.app.parser.add_argument('input_dir', help='The input directory containing al
 lib.app.parser.add_argument('template', help='The output template image')
 
 linoptions = lib.app.parser.add_argument_group('Options for the linear registration')
-linoptions.add_argument('-linear_type', help='Specifiy the linear registration mode. Options are "affine" (perform affine registration only), "rigid" (perform rigid registration only, this should be used for intra-subject registration in longitudinal analysis) and "rigid_affine" (perform rigid registration followed by affine registration, default).', default='rigid_affine')
 linoptions.add_argument('-linear_no_pause', action='store_true', help='Do not pause the script if a linear registration seems implausible')
 linoptions.add_argument('-linear_estimator', help='Choose estimator for intensity difference metric. Valid choices are: l1 (least absolute: |x|), l2 (ordinary least squares), lp (least powers: |x|^1.2), Default: l2')
-linoptions.add_argument('-initial_alignment', default='mass', help='Method of alignment to form the initial template. Options are "mass" (default), "geometric" and "none".')
 linoptions.add_argument('-rigid_scale', help='Specifiy the multi-resolution pyramid used to build the rigid template, in the form of a list of scale factors (default: %s). This and affine_scale implicitly  define the number of template levels' % ','.join([str(x) for x in rigid_scales]))
 linoptions.add_argument('-rigid_lmax', help='Specifiy the lmax used for rigid registration for each scale factor, in the form of a list of integers (default: %s). The list must be the same length as the linear_scale factor list' % ','.join([str(x) for x in rigid_lmax]))
 linoptions.add_argument('-rigid_niter', help='Specifiy the number of registration iterations used within each level before updating the template, in the form of a list of integers (default:50 for each scale). This must be a single number or a list of same length as the linear_scale factor list')
@@ -135,7 +135,9 @@ nloptions.add_argument('-nl_update_smooth', default='2.0', help='Regularise the 
 nloptions.add_argument('-nl_disp_smooth', default='1.0', help='Regularise the displacement field with Gaussian smoothing (standard deviation in voxel units, Default 1.0 x voxel_size)')
 nloptions.add_argument('-nl_grad_step', default='0.5', help='The gradient step size for non-linear registration (Default: 0.5)')
 
-options = lib.app.parser.add_argument_group('Optional input and output and general options')
+options = lib.app.parser.add_argument_group('Input, output and general options')
+options.add_argument('-type', help='Specifiy the types of registration stages to perform. Options are "rigid" (perform rigid registration only which might be useful for intra-subject registration in longitudinal analysis), "affine" (perform affine registration) and "nonlinear" as well as cominations of registration types: %s. Default: rigid_affine_nonlinear' % ', '.join('"'+x+'"' for x in registration_modes if "_" in x), default='rigid_affine_nonlinear')
+options.add_argument('-initial_alignment', default='mass', help='Method of alignment to form the initial template. Options are "mass" (default), "geometric" and "none".')
 options.add_argument('-mask_dir', help='Optionally input a set of masks inside a single directory, one per input image (with the same file name prefix). Using masks will speed up registration significantly')
 options.add_argument('-warp_dir', help='Output a directory containing warps from each input to the template. If the folder does not exist it will be created')
 options.add_argument('-transformed_dir', help='Output a directory containing the input images transformed to the template. If the folder does not exist it will be created')
@@ -146,6 +148,14 @@ options.add_argument('-noreorientation', action='store_true', help='Turn off FOD
 
 
 lib.app.initialise()
+
+if not lib.app.args.type in registration_modes:
+  errorMessage("registration type must be one of %s. provided: %s" % (str(["rigid", "affine", "rigid_affine"]), lib.app.args.type))
+dorigid     = "rigid"     in lib.app.args.type
+doaffine    = "affine"    in lib.app.args.type
+dolinear    = dorigid or doaffine
+dononlinear = "nonlinear" in lib.app.args.type
+assert (dorigid + doaffine + dononlinear >= 1), "FIXME: registration type not valid"
 
 lib.app.args.input_dir = relpath(lib.app.args.input_dir)
 inputDir = lib.app.args.input_dir
@@ -163,7 +173,9 @@ if initial_alignment not in ["mass", "geometric", "none"]:
 
 linear_estimator = lib.app.args.linear_estimator
 if linear_estimator:
-  if lib.app.args.linear_estimator not in ["l1", "l1", "lp"]:
+  if not dononlinear:
+    errorMessage('linear_estimator specified when no linear registration is requested');
+  if linear_estimator not in ["l1", "l1", "lp"]:
     errorMessage('linear_estimator must be one of ' + " ".join(["l1", "l1", "lp"]));
 
 useMasks = False
@@ -202,14 +214,11 @@ for i in inFiles:
 
 noreorientation = lib.app.args.noreorientation
 
-dorigid = "rigid" in lib.app.args.linear_type
-doaffine = "affine" in lib.app.args.linear_type
-if not lib.app.args.linear_type in ["rigid", "affine", "rigid_affine"]:
-  errorMessage("linear_type must be one of " + str(["rigid", "affine", "rigid_affine"]))
-
 do_pause_on_warn = True
 if lib.app.args.linear_no_pause:
   do_pause_on_warn = False
+  if not dolinear:
+    errorMessage("linear option set when no linear registration is performed")
 
 lib.app.args.template = relpath(lib.app.args.template)
 lib.app.checkOutputFile(lib.app.args.template)
@@ -223,6 +232,8 @@ if lib.app.args.transformed_dir:
   lib.app.checkOutputFile(lib.app.args.transformed_dir)
 
 if lib.app.args.linear_transformations_dir:
+  if not dolinear:
+    errorMessage("linear option set when no linear registration is performed")
   lib.app.args.linear_transformations_dir = relpath(lib.app.args.linear_transformations_dir)
   lib.app.checkOutputFile(lib.app.args.linear_transformations_dir)
 
@@ -238,27 +249,21 @@ if len(image_size) == 4:
     printMessage("SH Series detected, performing FOD registration")
     do_fod_registration = True
 
-
-if lib.app.args.affine_scale:
-  affine_scales = [float(x) for x in lib.app.args.affine_scale.split(',')]
-if lib.app.args.affine_lmax:
-  affine_lmax = [int(x) for x in lib.app.args.affine_lmax.split(',')]
-affine_niter =   [500] * len(affine_scales)
-if lib.app.args.affine_niter:
-  if not doaffine:
-    errorMessage("affine_niter specified when no affine registration is performed")
-  affine_niter = [int(x) for x in lib.app.args.affine_niter.split(',')]
-  if len(affine_niter) == 1:
-    affine_niter = affine_niter * len(affine_scales)
-  elif len(affine_scales) != len(affine_niter):
-      errorMessage('affine_scales and affine_niter schedules are not equal in length')
-
-
+#rigid options
 if lib.app.args.rigid_scale:
   rigid_scales = [float(x) for x in lib.app.args.rigid_scale.split(',')]
+  if not dorigid:
+    errorMessage("rigid_scales option set when no rigid registration is performed")
 if lib.app.args.rigid_lmax:
+  if not dorigid:
+    errorMessage("rigid_lmax option set when no rigid registration is performed")
   rigid_lmax = [int(x) for x in lib.app.args.rigid_lmax.split(',')]
-rigid_niter =   [50] * len(rigid_scales)
+  if do_fod_registration and len(rigid_scales) != len(rigid_lmax):
+    errorMessage('rigid_scales and rigid_lmax schedules are not equal in length')
+# if not do_fod_registration:
+  # rigid_lmax = [-1] * len(rigid_scales)
+
+rigid_niter = [100] * len(rigid_scales)
 if lib.app.args.rigid_niter:
   if not dorigid:
     errorMessage("rigid_niter specified when no rigid registration is performed")
@@ -267,6 +272,30 @@ if lib.app.args.rigid_niter:
     rigid_niter = rigid_niter * len(rigid_scales)
   elif len(rigid_scales) != len(rigid_niter):
       errorMessage('rigid_scales and rigid_niter schedules are not equal in length')
+
+# affine options
+if lib.app.args.affine_scale:
+  affine_scales = [float(x) for x in lib.app.args.affine_scale.split(',')]
+  if not doaffine:
+    errorMessage("affine_scale option set when no affine registration is performed")
+if lib.app.args.affine_lmax:
+  if not doaffine:
+    errorMessage("affine_lmax option set when no affine registration is performed")
+  affine_lmax = [int(x) for x in lib.app.args.affine_lmax.split(',')]
+  if do_fod_registration and len(affine_scales) != len(affine_lmax):
+    errorMessage('affine_scales and affine_lmax schedules are not equal in length')
+# if not do_fod_registration:
+  # affine_lmax = [-1] * len(affine_scales)
+
+affine_niter = [500] * len(affine_scales)
+if lib.app.args.affine_niter:
+  if not doaffine:
+    errorMessage("affine_niter specified when no affine registration is performed")
+  affine_niter = [int(x) for x in lib.app.args.affine_niter.split(',')]
+  if len(affine_niter) == 1:
+    affine_niter = affine_niter * len(affine_scales)
+  elif len(affine_scales) != len(affine_niter):
+      errorMessage('affine_scales and affine_niter schedules are not equal in length')
 
 linear_scales = []
 linear_lmax   = []
@@ -277,32 +306,59 @@ if dorigid:
   linear_lmax   += rigid_lmax
   linear_niter  += rigid_niter
   linear_type   += ['rigid'] * len(rigid_scales)
-  if do_fod_registration and len(rigid_scales) != len(rigid_lmax):
-    errorMessage('rigid_scales and rigid_lmax schedules are not equal in length')
+
 if doaffine:
   linear_scales += affine_scales
   linear_lmax   += affine_lmax
   linear_niter  += affine_niter
   linear_type   += ['affine'] * len(affine_scales)
-  if do_fod_registration and len(affine_scales) != len(affine_lmax):
-    errorMessage('affine_scales and affine_lmax schedules are not equal in length')
+
+assert (len(linear_type) == len(linear_scales))
+assert (len(linear_scales) == len(linear_niter))
+if do_fod_registration:
+  assert (len(linear_lmax) == len(linear_niter))
+
+printMessage('initial alignment of images: %s' % initial_alignment)
+
+if dolinear:
+  printMessage('linear registration stages:')
+  if do_fod_registration:
+    for istage, [tpe, scale, lmax, niter] in enumerate(zip (linear_type, linear_scales, linear_lmax, linear_niter)):
+      printMessage('(%02i) %s scale: %.4f, niter: %i, lmax: %i' %(istage, tpe.ljust(9), scale, niter, lmax))
+  else:
+    for istage, [tpe, scale, niter] in enumerate(zip (linear_type, linear_scales, linear_niter)):
+      printMessage('(%02i) %s scale: %.4f, niter: %i, no reorientation' %(istage, tpe.ljust(9), scale, niter))
 
 datatype = ' -datatype float32'
 
-if lib.app.args.nl_scale:
-  nl_scales = [float(x) for x in lib.app.args.nl_scale.split(',')]
-if lib.app.args.nl_niter:
-  nl_niter = [int(x) for x in lib.app.args.nl_niter.split(',')]
-if lib.app.args.nl_lmax:
-  nl_lmax = [int(x) for x in lib.app.args.nl_lmax.split(',')]
+if not dononlinear:
+  nl_scales = []
+  nl_lmax   = []
+  nl_niter  = []
+  if lib.app.args.warp_dir:
+    errorMessage('warp_dir specified when no nonlinear registration is performed')
+else:
+  if lib.app.args.nl_scale:
+      nl_scales = [float(x) for x in lib.app.args.nl_scale.split(',')]
+  if lib.app.args.nl_niter:
+    nl_niter = [int(x) for x in lib.app.args.nl_niter.split(',')]
+  if lib.app.args.nl_lmax:
+    nl_lmax = [int(x) for x in lib.app.args.nl_lmax.split(',')]
 
+  if len(nl_scales) != len(nl_niter):
+    errorMessage('nl_scales and nl_niter schedules are not equal in length')
 
-if len(nl_scales) != len(nl_niter):
-  errorMessage('nl_scales and nl_niter schedules are not equal in length')
+  printMessage('nonlinear registration stages:')
+  if do_fod_registration:
+    if len(nl_scales) != len(nl_lmax):
+      errorMessage('nl_scales and nl_lmax schedules are not equal in length')
 
-if do_fod_registration:
-  if len(nl_scales) != len(nl_lmax):
-    errorMessage('nl_scales and nl_lmax schedules are not equal in length')
+  if do_fod_registration:
+    for istage, [scale, lmax, niter] in enumerate(zip (nl_scales, nl_lmax, nl_niter)):
+      printMessage('(%02i) nonlinear scale: %.4f, niter: %i, lmax: %i' %(istage, scale, niter, lmax))
+  else:
+    for istage, [scale, niter] in enumerate(zip (nl_scales, nl_niter)):
+      printMessage('(%02i) nonlinear scale: %.4f, niter: %i, no reorientation' %(istage, scale, niter))
 
 lib.app.makeTempDir()
 lib.app.gotoTempDir()
@@ -319,8 +375,6 @@ if useMasks:
   lib.app.make_dir('masks_transformed')
 if lib.app.args.verbose:
   lib.app.make_dir('log')
-
-
 
 # Make initial template in average space
 printMessage('Generating initial template')
@@ -348,6 +402,10 @@ if useMasks:
 if initial_alignment == 'none':
   for i in input:
     runCommand('mrtransform ' + abspath(i.directory, i.filename) + ' -interp linear -template average_header.mif input_transformed/' + i.prefix + '.mif' + datatype)
+  if not dolinear:
+    for i in input:
+      with open('linear_transforms_initial/%s.txt' % (i.prefix),'w') as fout:
+        fout.write('1 0 0 0\n0 1 0 0\n0 0 1 0\n0 0 0 1\n')
 else:
   mask = ''
   for i in input:
@@ -392,7 +450,7 @@ else:
     runCommand('mrmath ' + ' '.join(mask_filenames) + ' max mask_translated.mif' )
     runCommand('rm -f mask_translated_smooth.mif')
     runCommand('mrcrop ' + 'average_header.mif -mask mask_translated.mif average_header_cropped.mif')
-    # pad average space to allow for deviation from centre of mass alignment
+    # pad average space to allow for deviation from initial alignment
     runCommand('mrpad -uniform 10 average_header_cropped.mif -force average_header.mif')
     runCommand('rm -f average_header_cropped.mif')
     for i in input:
@@ -418,91 +476,95 @@ runCommand('mrmath ' + allindir('input_transformed') + ' mean initial_template.m
 current_template = 'initial_template.mif'
 
 
-# Optimise template with linear registration
-printMessage('Optimising template with linear registration')
-for level in range(0, len(linear_scales)):
+# Optimise template with linear registration_modes
+if not dolinear:
   for i in input:
-    initialise = ''
-    if useMasks:
-      mask = ' -mask1 ' + abspath(i.mask_directory, i.mask_filename)
-    else:
-      mask = ''
-    lmax = ''
-    metric = ''
-    mrregister_log = ''
+    runCommand('cp linear_transforms_initial/%s.txt linear_transforms/' % (i.prefix))
+else:
+  printMessage('Optimising template with linear registration')
+  for level in range(0, len(linear_scales)):
+    for i in input:
+      initialise = ''
+      if useMasks:
+        mask = ' -mask1 ' + abspath(i.mask_directory, i.mask_filename)
+      else:
+        mask = ''
+      lmax = ''
+      metric = ''
+      mrregister_log = ''
+      if linear_type[level] == 'rigid':
+        scale = ' -rigid_scale ' + str(linear_scales[level])
+        niter = ' -rigid_niter ' + str(linear_niter[level])
+        regtype = ' -type rigid'
+        output = ' -rigid linear_transforms_%i/%s.txt' % (level, i.prefix)
+        if level > 0:
+          initialise = ' -rigid_init_matrix linear_transforms_%i/%s.txt' % (level-1, i.prefix)
+        if do_fod_registration:
+          lmax = ' -rigid_lmax ' + str(linear_lmax[level])
+        else:
+          lmax = ' -noreorientation'
+        if linear_estimator:
+          metric = ' -rigid_metric.diff.estimator ' + linear_estimator
+        if lib.app.args.verbose:
+          mrregister_log = ' -info -rigid_log ' + 'log/' + i.filename + "_" + str(level) + '.log'
+      else:
+        scale = ' -affine_scale ' + str(linear_scales[level])
+        niter = ' -affine_niter ' + str(linear_niter[level])
+        regtype = ' -type affine'
+        output = ' -affine linear_transforms_%i/%s.txt' % (level, i.prefix)
+        if level > 0:
+          initialise = ' -affine_init_matrix linear_transforms_%i/%s.txt' % (level-1, i.prefix)
+        if do_fod_registration:
+          lmax = ' -affine_lmax ' + str(linear_lmax[level])
+        else:
+          lmax = ' -noreorientation'
+        if linear_estimator:
+          metric = ' -affine_metric.diff.estimator ' + linear_estimator
+        if lib.app.args.verbose:
+          mrregister_log = ' -info -affine_log ' + 'log/' + i.filename + "_" + str(level) + '.log'
+
+
+      runCommand('mrregister ' + abspath(i.directory, i.filename) + ' ' + current_template +
+                 ' -force' +
+                   initialise +
+                   mask +
+                   scale +
+                   niter +
+                   lmax +
+                   regtype +
+                   metric +
+                   datatype +
+                   output +
+                   mrregister_log)
+      check_linear_transformation('linear_transforms_%i/%s.txt' % (level, i.prefix), pause_on_warn=do_pause_on_warn)
+
+    # Here we ensure the template doesn't drift or scale
+    runCommand('transformcalc ' + allindir('linear_transforms_%i' % level) + ' average linear_transform_average.txt -force -quiet')
     if linear_type[level] == 'rigid':
-      scale = ' -rigid_scale ' + str(linear_scales[level])
-      niter = ' -rigid_niter ' + str(linear_niter[level])
-      regtype = ' -type rigid'
-      output = ' -rigid linear_transforms_%i/%s.txt' % (level, i.prefix)
-      if level > 0:
-        initialise = ' -rigid_init_matrix linear_transforms_%i/%s.txt' % (level-1, i.prefix)
-      if do_fod_registration:
-        lmax = ' -rigid_lmax ' + str(linear_lmax[level])
-      else:
-        lmax = ' -noreorientation'
-      if linear_estimator:
-        metric = ' -rigid_metric.diff.estimator ' + linear_estimator
-      if lib.app.args.verbose:
-        mrregister_log = ' -info -rigid_log ' + 'log/' + i.filename + "_" + str(level) + '.log'
-    else:
-      scale = ' -affine_scale ' + str(linear_scales[level])
-      niter = ' -affine_niter ' + str(linear_niter[level])
-      regtype = ' -type affine'
-      output = ' -affine linear_transforms_%i/%s.txt' % (level, i.prefix)
-      if level > 0:
-        initialise = ' -affine_init_matrix linear_transforms_%i/%s.txt' % (level-1, i.prefix)
-      if do_fod_registration:
-        lmax = ' -affine_lmax ' + str(linear_lmax[level])
-      else:
-        lmax = ' -noreorientation'
-      if linear_estimator:
-        metric = ' -affine_metric.diff.estimator ' + linear_estimator
-      if lib.app.args.verbose:
-        mrregister_log = ' -info -affine_log ' + 'log/' + i.filename + "_" + str(level) + '.log'
+      runCommand('transformcalc linear_transform_average.txt rigid linear_transform_average.txt -force -quiet')
+    runCommand('transformcalc linear_transform_average.txt invert linear_transform_average_inv.txt -force -quiet')
 
+    average_inv = loadtxt('linear_transform_average_inv.txt')
+    for i in input:
+      transform = dot(loadtxt('linear_transforms_%i/%s.txt' % (level, i.prefix)), average_inv)
+      savetxt('linear_transforms_%i/%s.txt'% (level, i.prefix), transform)
 
-    runCommand('mrregister ' + abspath(i.directory, i.filename) + ' ' + current_template +
-               ' -force' +
-                 initialise +
-                 mask +
-                 scale +
-                 niter +
-                 lmax +
-                 regtype +
-                 metric +
+    for i in input:
+      runCommand('mrtransform ' + abspath(i.directory, i.filename) +
+                 ' -template ' + current_template +
+                 ' -linear linear_transforms_%i/%s.txt' % (level, i.prefix) +
+                 ' input_transformed/' + i.prefix + '.mif' +
                  datatype +
-                 output +
-                 mrregister_log)
-    check_linear_transformation('linear_transforms_%i/%s.txt' % (level, i.prefix), pause_on_warn=do_pause_on_warn)
+                 ' -force')
 
-  # Here we ensure the template doesn't drift or scale
-  runCommand('transformcalc ' + allindir('linear_transforms_%i' % level) + ' average linear_transform_average.txt -force -quiet')
-  if linear_type[level] == 'rigid':
-    runCommand('transformcalc linear_transform_average.txt rigid linear_transform_average.txt -force -quiet')
-  runCommand('transformcalc linear_transform_average.txt invert linear_transform_average_inv.txt -force -quiet')
-
-  average_inv = loadtxt('linear_transform_average_inv.txt')
-  for i in input:
-    transform = dot(loadtxt('linear_transforms_%i/%s.txt' % (level, i.prefix)), average_inv)
-    savetxt('linear_transforms_%i/%s.txt'% (level, i.prefix), transform)
-
-  for i in input:
-    runCommand('mrtransform ' + abspath(i.directory, i.filename) +
-               ' -template ' + current_template +
-               ' -linear linear_transforms_%i/%s.txt' % (level, i.prefix) +
-               ' input_transformed/' + i.prefix + '.mif' +
-               datatype +
-               ' -force')
-
-  runCommand ('mrmath ' + allindir('input_transformed') + ' mean linear_template' + str(level) + '.mif -force')
-  current_template = 'linear_template' + str(level) + '.mif'
+    runCommand ('mrmath ' + allindir('input_transformed') + ' mean linear_template' + str(level) + '.mif -force')
+    current_template = 'linear_template' + str(level) + '.mif'
 
 
-runCommand('cp ' + allindir('linear_transforms_%i' % level) + ' linear_transforms/')
+  runCommand('cp ' + allindir('linear_transforms_%i' % level) + ' linear_transforms/')
 
 # Create a template mask for nl registration by taking the intersection of all transformed input masks and dilating
-if useMasks:
+if useMasks and (dononlinear or lib.app.args.template_mask):
   for i in input:
     runCommand('mrtransform ' + abspath(i.mask_directory, i.mask_filename) +
                ' -template ' + current_template +
@@ -512,72 +574,72 @@ if useMasks:
                ' -force')
   runCommand ('mrmath ' + allindir('masks_transformed') + ' min - | maskfilter - median - | maskfilter - dilate -npass 5 init_nl_template_mask.mif -force')
   current_template_mask = 'init_nl_template_mask.mif'
-
-# Optimise the template with non-linear registration
-printMessage('Optimising template with non-linear registration')
-lib.app.make_dir('warps')
-for level in range(0, len(nl_scales)):
-  for i in input:
-    if level > 0:
-      initialise = ' -nl_init warps_%i/%s.mif' % (level-1, i.prefix)
-      scale = ''
-    else:
-      scale = ' -nl_scale ' + str(nl_scales[level])
-      if not doaffine:
-        initialise = ' -rigid_init_matrix linear_transforms/' + i.prefix + '.txt'
-      else:
-        initialise = ' -affine_init_matrix linear_transforms/' + i.prefix + '.txt'
-
-    if useMasks:
-      mask = ' -mask1 ' + abspath(i.mask_directory, i.mask_filename) + ' -mask2 ' + current_template_mask
-    else:
-      mask = ''
-
-    if do_fod_registration:
-      lmax = ' -nl_lmax ' + str(nl_lmax[level])
-    else:
-      lmax = ' -noreorientation'
-
-    runCommand('mrregister ' + abspath(i.directory, i.filename) + ' ' + current_template +
-               ' -type nonlinear' +
-               ' -nl_niter ' + str(nl_niter[level]) +
-               ' -nl_warp_full warps_%i/%s.mif' % (level, i.prefix) +
-               ' -transformed input_transformed/' + i.prefix + '.mif' +
-               ' -nl_update_smooth ' +  lib.app.args.nl_update_smooth +
-               ' -nl_disp_smooth ' +  lib.app.args.nl_disp_smooth +
-               ' -nl_grad_step ' +  lib.app.args.nl_grad_step +
-               ' -force ' +
-                 initialise +
-                 scale +
-                 mask +
-                 datatype +
-                 lmax)
-    if level > 0:
-      runCommand('rm warps_%i/%s.mif' % (level-1, i.prefix))
-    if useMasks:
-      runCommand('mrtransform ' + abspath(i.mask_directory, i.mask_filename) +
-                 ' -template ' + current_template +
-                 ' -warp_full warps_%i/%s.mif' % (level, i.prefix) +
-                 ' masks_transformed/' + i.prefix + '.mif' +
-                 ' -interp nearest ' +
-                 ' -force')
-
-  runCommand ('mrmath ' + allindir('input_transformed') + ' mean nl_template' + str(level) + '.mif')
-  current_template = 'nl_template' + str(level) + '.mif'
-
-  if useMasks:
-    runCommand ('mrmath ' + allindir('masks_transformed') + ' min - | maskfilter - median - | maskfilter - dilate -npass 5 nl_template_mask' + str(level) + '.mif')
-    current_template_mask = 'nl_template_mask' + str(level) + '.mif'
-
-  if level < len(nl_scales) - 1:
-    if (nl_scales[level] < nl_scales[level + 1]):
-      upsample_factor = nl_scales[level + 1] / nl_scales[level]
-      for i in input:
-        runCommand('mrresize warps_%i/%s.mif -scale %f tmp.mif' % (level, i.prefix, upsample_factor))
-        runCommand('mv tmp.mif warps_%i/%s.mif' % (level, i.prefix))
-  else:
+if dononlinear:
+  # Optimise the template with non-linear registration
+  printMessage('Optimising template with non-linear registration')
+  lib.app.make_dir('warps')
+  for level in range(0, len(nl_scales)):
     for i in input:
-      shutil.move('warps_%i/%s.mif'  % (level, i.prefix), 'warps/')
+      if level > 0:
+        initialise = ' -nl_init warps_%i/%s.mif' % (level-1, i.prefix)
+        scale = ''
+      else:
+        scale = ' -nl_scale ' + str(nl_scales[level])
+        if not doaffine:
+          initialise = ' -rigid_init_matrix linear_transforms/' + i.prefix + '.txt'
+        else:
+          initialise = ' -affine_init_matrix linear_transforms/' + i.prefix + '.txt'
+
+      if useMasks:
+        mask = ' -mask1 ' + abspath(i.mask_directory, i.mask_filename) + ' -mask2 ' + current_template_mask
+      else:
+        mask = ''
+
+      if do_fod_registration:
+        lmax = ' -nl_lmax ' + str(nl_lmax[level])
+      else:
+        lmax = ' -noreorientation'
+
+      runCommand('mrregister ' + abspath(i.directory, i.filename) + ' ' + current_template +
+                 ' -type nonlinear' +
+                 ' -nl_niter ' + str(nl_niter[level]) +
+                 ' -nl_warp_full warps_%i/%s.mif' % (level, i.prefix) +
+                 ' -transformed input_transformed/' + i.prefix + '.mif' +
+                 ' -nl_update_smooth ' +  lib.app.args.nl_update_smooth +
+                 ' -nl_disp_smooth ' +  lib.app.args.nl_disp_smooth +
+                 ' -nl_grad_step ' +  lib.app.args.nl_grad_step +
+                 ' -force ' +
+                   initialise +
+                   scale +
+                   mask +
+                   datatype +
+                   lmax)
+      if level > 0:
+        runCommand('rm warps_%i/%s.mif' % (level-1, i.prefix))
+      if useMasks:
+        runCommand('mrtransform ' + abspath(i.mask_directory, i.mask_filename) +
+                   ' -template ' + current_template +
+                   ' -warp_full warps_%i/%s.mif' % (level, i.prefix) +
+                   ' masks_transformed/' + i.prefix + '.mif' +
+                   ' -interp nearest ' +
+                   ' -force')
+
+    runCommand ('mrmath ' + allindir('input_transformed') + ' mean nl_template' + str(level) + '.mif')
+    current_template = 'nl_template' + str(level) + '.mif'
+
+    if useMasks:
+      runCommand ('mrmath ' + allindir('masks_transformed') + ' min - | maskfilter - median - | maskfilter - dilate -npass 5 nl_template_mask' + str(level) + '.mif')
+      current_template_mask = 'nl_template_mask' + str(level) + '.mif'
+
+    if level < len(nl_scales) - 1:
+      if (nl_scales[level] < nl_scales[level + 1]):
+        upsample_factor = nl_scales[level + 1] / nl_scales[level]
+        for i in input:
+          runCommand('mrresize warps_%i/%s.mif -scale %f tmp.mif' % (level, i.prefix, upsample_factor))
+          runCommand('mv tmp.mif warps_%i/%s.mif' % (level, i.prefix))
+    else:
+      for i in input:
+        shutil.move('warps_%i/%s.mif'  % (level, i.prefix), 'warps/')
 
 
 runCommand('mrconvert ' + current_template + ' ' + getUserPath(lib.app.args.template, True) + lib.app.mrtrixForce)

--- a/scripts/population_template
+++ b/scripts/population_template
@@ -69,7 +69,11 @@ def check_linear_transformation (transformation, max_scaling = 0.5, max_shear = 
 
   bGood = True
   runCommand ('transformcalc ' + transformation + ' decompose ' + transformation + 'decomp')
-  data = load_key_value(transformation + 'decomp')
+  if os.path.isfile(transformation + 'decomp'): # does not exist if run with -continue option
+    data = load_key_value(transformation + 'decomp')
+  else:
+    printMessage(transformation + 'decomp not found. skipping check')
+    return True
   os.remove(transformation + 'decomp')
   scaling = [float(x) for x in data['scaling']]
   if any([x < 0 for x in scaling]) or any([x > (1 + max_scaling) for x in scaling]) or any([x < (1 - max_scaling) for x in scaling]):
@@ -96,8 +100,10 @@ class Input:
     self.mask_filename = mask_filename
     self.mask_directory = mask_directory
 
-linear_scales = [0.3,0.4,0.6,0.8,1.0,1.0]
-linear_lmax =   [2,2,2,4,4,4]
+rigid_scales  = [0.3,0.4,0.6,0.8,1.0,1.0]
+rigid_lmax    = [2,2,2,4,4,4]
+affine_scales = [0.3,0.4,0.6,0.8,1.0,1.0]
+affine_lmax   = [2,2,2,4,4,4]
 
 nl_scales = [0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0]
 nl_niter =  [5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5  ,5  ,5  ,5  ,5  ]
@@ -109,26 +115,35 @@ lib.cmdlineParser.initialise('Generates an unbiased group-average template from 
 lib.app.parser.add_argument('input_dir', help='The input directory containing all images used to build the template')
 lib.app.parser.add_argument('template', help='The output template image')
 
-options = lib.app.parser.add_argument_group('Options for the population_template script')
+linoptions = lib.app.parser.add_argument_group('Options for the linear registration')
+linoptions.add_argument('-linear_type', help='Specifiy the linear registration mode. Options are "affine" (perform affine registration only), "rigid" (perform rigid registration only, this should be used for intra-subject registration in longitudinal analysis) and "rigid_affine" (perform rigid registration followed by affine registration, default).', default='rigid_affine')
+linoptions.add_argument('-linear_no_pause', action='store_true', help='Do not pause the script if a linear registration seems implausible')
+linoptions.add_argument('-linear_estimator', help='Choose estimator for intensity difference metric. Valid choices are: l1 (least absolute: |x|), l2 (ordinary least squares), lp (least powers: |x|^1.2), Default: l2')
+linoptions.add_argument('-initial_alignment', default='mass', help='Method of alignment to form the initial template. Options are "mass" (default), "geometric" and "none".')
+linoptions.add_argument('-rigid_scale', help='Specifiy the multi-resolution pyramid used to build the rigid template, in the form of a list of scale factors (default: %s). This and affine_scale implicitly  define the number of template levels' % ','.join([str(x) for x in rigid_scales]))
+linoptions.add_argument('-rigid_lmax', help='Specifiy the lmax used for rigid registration for each scale factor, in the form of a list of integers (default: %s). The list must be the same length as the linear_scale factor list' % ','.join([str(x) for x in rigid_lmax]))
+linoptions.add_argument('-rigid_niter', help='Specifiy the number of registration iterations used within each level before updating the template, in the form of a list of integers (default:50 for each scale). This must be a single number or a list of same length as the linear_scale factor list')
+linoptions.add_argument('-affine_scale', help='Specifiy the multi-resolution pyramid used to build the affine template, in the form of a list of scale factors (default: %s). This and rigid_scale implicitly define the number of template levels' % ','.join([str(x) for x in affine_scales]))
+linoptions.add_argument('-affine_lmax', help='Specifiy the lmax used for affine registration for each scale factor, in the form of a list of integers (default: %s). The list must be the same length as the linear_scale factor list' % ','.join([str(x) for x in affine_lmax]))
+linoptions.add_argument('-affine_niter', help='Specifiy the number of registration iterations used within each level before updating the template, in the form of a list of integers (default:500 for each scale). This must be a single number or a list of same length as the linear_scale factor list')
+
+nloptions = lib.app.parser.add_argument_group('Options for the non-linear registration')
+nloptions.add_argument('-nl_scale', help='Specifiy the multi-resolution pyramid used to build the non-linear template, in the form of a list of scale factors (default: %s). This implicitly defines the number of template levels' % ','.join([str(x) for x in nl_scales]))
+nloptions.add_argument('-nl_lmax', help='Specifiy the lmax used for non-linear registration for each scale factor, in the form of a list of integers (default: %s). The list must be the same length as the nl_scale factor list' % ','.join([str(x) for x in nl_lmax]))
+nloptions.add_argument('-nl_niter', help='Specifiy the number of registration iterations used within each level before updating the template, in the form of a list of integers (default: %s). The list must be the same length as the nl_scale factor list' % ','.join([str(x) for x in nl_niter]))
+nloptions.add_argument('-nl_update_smooth', default='2.0', help='Regularise the gradient update field with Gaussian smoothing (standard deviation in voxel units, Default 2.0 x voxel_size)')
+nloptions.add_argument('-nl_disp_smooth', default='1.0', help='Regularise the displacement field with Gaussian smoothing (standard deviation in voxel units, Default 1.0 x voxel_size)')
+nloptions.add_argument('-nl_grad_step', default='0.5', help='The gradient step size for non-linear registration (Default: 0.5)')
+
+options = lib.app.parser.add_argument_group('Optional input and output and general options')
 options.add_argument('-mask_dir', help='Optionally input a set of masks inside a single directory, one per input image (with the same file name prefix). Using masks will speed up registration significantly')
 options.add_argument('-warp_dir', help='Output a directory containing warps from each input to the template. If the folder does not exist it will be created')
 options.add_argument('-transformed_dir', help='Output a directory containing the input images transformed to the template. If the folder does not exist it will be created')
 options.add_argument('-linear_transformations_dir', help='Output a directory containing the linear transformations used to generate the template. If the folder does not exist it will be created')
 options.add_argument('-template_mask', help='Output a template mask. Only works in -mask_dir has been input. The template mask is computed as the intersection of all subject masks in template space.')
-options.add_argument('-rigid', action='store_true', help='perform rigid registration instead of affine. This should be used for intra-subject registration in longitudinal analysis')
-options.add_argument('-linear_no_pause', action='store_true', help='Do not pause the script if a linear registration seems implausible')
-options.add_argument('-linear_scale', help='Specifiy the multi-resolution pyramid used to build the rigid or affine template, in the form of a list of scale factors (default: %s). This implicitly defines the number of template levels' % ','.join([str(x) for x in linear_scales]))
-options.add_argument('-linear_lmax', help='Specifiy the lmax used for rigid or affine registration for each scale factor, in the form of a list of integers (default: %s). The list must be the same length as the linear_scale factor list' % ','.join([str(x) for x in linear_lmax]))
-options.add_argument('-linear_niter', help='Specifiy the number of registration iterations used within each level before updating the template, in the form of a list of integers (default:500 for each scale). The must be a single number or a list of same length as the linear_scale factor list')
-options.add_argument('-linear_estimator', help='Choose estimator for intensity difference metric. Valid choices are: l1 (least absolute: |x|), l2 (ordinary least squares), lp (least powers: |x|^1.2), Default: l2')
-options.add_argument('-nl_scale', help='Specifiy the multi-resolution pyramid used to build the non-linear template, in the form of a list of scale factors (default: %s). This implicitly defines the number of template levels' % ','.join([str(x) for x in nl_scales]))
-options.add_argument('-nl_lmax', help='Specifiy the lmax used for non-linear registration for each scale factor, in the form of a list of integers (default: %s). The list must be the same length as the nl_scale factor list' % ','.join([str(x) for x in nl_lmax]))
-options.add_argument('-nl_niter', help='Specifiy the number of registration iterations used within each level before updating the template, in the form of a list of integers (default: %s). The list must be the same length as the nl_scale factor list' % ','.join([str(x) for x in nl_niter]))
-options.add_argument('-nl_update_smooth', default='2.0', help='Regularise the gradient update field with Gaussian smoothing (standard deviation in voxel units, Default 2.0 x voxel_size)')
-options.add_argument('-nl_disp_smooth', default='1.0', help='Regularise the displacement field with Gaussian smoothing (standard deviation in voxel units, Default 1.0 x voxel_size)')
-options.add_argument('-nl_grad_step', default='0.5', help='The gradient step size for non-linear registration (Default: 0.5)')
 options.add_argument('-noreorientation', action='store_true', help='Turn off FOD reorientation in mrregister. Reorientation is on by default if the number of volumes in the 4th dimension corresponds to the number of coefficients in an antipodally symmetric spherical harmonic series (i.e. 6, 15, 28, 45, 66 etc')
-options.add_argument('-initial_alignment', default='mass', help='Method of alignment to form the initial template. Options are "mass" (default), "geometric" and "none".')
+
+
 
 lib.app.initialise()
 
@@ -186,7 +201,12 @@ for i in inFiles:
 
 
 noreorientation = lib.app.args.noreorientation
-dorigid = lib.app.args.rigid
+
+dorigid = "rigid" in lib.app.args.linear_type
+doaffine = "affine" in lib.app.args.linear_type
+if not lib.app.args.linear_type in ["rigid", "affine", "rigid_affine"]:
+  errorMessage("linear_type must be one of " + str(["rigid", "affine", "rigid_affine"]))
+
 do_pause_on_warn = True
 if lib.app.args.linear_no_pause:
   do_pause_on_warn = False
@@ -219,21 +239,53 @@ if len(image_size) == 4:
     do_fod_registration = True
 
 
-if lib.app.args.linear_scale:
-  linear_scales = [float(x) for x in lib.app.args.linear_scale.split(',')]
-if lib.app.args.linear_lmax:
-  linear_lmax = [int(x) for x in lib.app.args.linear_lmax.split(',')]
-linear_niter =   [500] * len(linear_scales)
-if lib.app.args.linear_niter:
-  linear_niter = [int(x) for x in lib.app.args.linear_niter.split(',')]
-  if len(linear_niter) == 1:
-    linear_niter = linear_niter * len(linear_scales)
-  elif len(linear_scales) != len(linear_niter):
-      errorMessage('linear_scales and linear_niter schedules are not equal in length')
+if lib.app.args.affine_scale:
+  affine_scales = [float(x) for x in lib.app.args.affine_scale.split(',')]
+if lib.app.args.affine_lmax:
+  affine_lmax = [int(x) for x in lib.app.args.affine_lmax.split(',')]
+affine_niter =   [500] * len(affine_scales)
+if lib.app.args.affine_niter:
+  if not doaffine:
+    errorMessage("affine_niter specified when no affine registration is performed")
+  affine_niter = [int(x) for x in lib.app.args.affine_niter.split(',')]
+  if len(affine_niter) == 1:
+    affine_niter = affine_niter * len(affine_scales)
+  elif len(affine_scales) != len(affine_niter):
+      errorMessage('affine_scales and affine_niter schedules are not equal in length')
 
-if do_fod_registration:
-  if len(linear_scales) != len(linear_lmax):
-    errorMessage('linear_scales and linear_lmax schedules are not equal in length')
+
+if lib.app.args.rigid_scale:
+  rigid_scales = [float(x) for x in lib.app.args.rigid_scale.split(',')]
+if lib.app.args.rigid_lmax:
+  rigid_lmax = [int(x) for x in lib.app.args.rigid_lmax.split(',')]
+rigid_niter =   [50] * len(rigid_scales)
+if lib.app.args.rigid_niter:
+  if not dorigid:
+    errorMessage("rigid_niter specified when no rigid registration is performed")
+  rigid_niter = [int(x) for x in lib.app.args.rigid_niter.split(',')]
+  if len(rigid_niter) == 1:
+    rigid_niter = rigid_niter * len(rigid_scales)
+  elif len(rigid_scales) != len(rigid_niter):
+      errorMessage('rigid_scales and rigid_niter schedules are not equal in length')
+
+linear_scales = []
+linear_lmax   = []
+linear_niter  = []
+linear_type   = []
+if dorigid:
+  linear_scales += rigid_scales
+  linear_lmax   += rigid_lmax
+  linear_niter  += rigid_niter
+  linear_type   += ['rigid'] * len(rigid_scales)
+  if do_fod_registration and len(rigid_scales) != len(rigid_lmax):
+    errorMessage('rigid_scales and rigid_lmax schedules are not equal in length')
+if doaffine:
+  linear_scales += affine_scales
+  linear_lmax   += affine_lmax
+  linear_niter  += affine_niter
+  linear_type   += ['affine'] * len(affine_scales)
+  if do_fod_registration and len(affine_scales) != len(affine_lmax):
+    errorMessage('affine_scales and affine_lmax schedules are not equal in length')
 
 datatype = ' -datatype float32'
 
@@ -378,7 +430,7 @@ for level in range(0, len(linear_scales)):
     lmax = ''
     metric = ''
     mrregister_log = ''
-    if dorigid:
+    if linear_type[level] == 'rigid':
       scale = ' -rigid_scale ' + str(linear_scales[level])
       niter = ' -rigid_niter ' + str(linear_niter[level])
       regtype = ' -type rigid'
@@ -426,7 +478,7 @@ for level in range(0, len(linear_scales)):
 
   # Here we ensure the template doesn't drift or scale
   runCommand('transformcalc ' + allindir('linear_transforms_%i' % level) + ' average linear_transform_average.txt -force -quiet')
-  if dorigid:
+  if linear_type[level] == 'rigid':
     runCommand('transformcalc linear_transform_average.txt rigid linear_transform_average.txt -force -quiet')
   runCommand('transformcalc linear_transform_average.txt invert linear_transform_average_inv.txt -force -quiet')
 
@@ -471,7 +523,7 @@ for level in range(0, len(nl_scales)):
       scale = ''
     else:
       scale = ' -nl_scale ' + str(nl_scales[level])
-      if dorigid:
+      if not doaffine:
         initialise = ' -rigid_init_matrix linear_transforms/' + i.prefix + '.txt'
       else:
         initialise = ' -affine_init_matrix linear_transforms/' + i.prefix + '.txt'

--- a/src/registration/linear.h
+++ b/src/registration/linear.h
@@ -358,11 +358,30 @@ namespace MR
 
               // convergence check using slope of smoothed parameter trajectories
               Eigen::VectorXd slope_threshold = Eigen::VectorXd::Ones (12);
+              //CONF option: reg_gd_convergence_thresh
+              //CONF default: 5e-3
+              //CONF Linear registration: threshold for convergence check using the smoothed control point trajectories
+              //CONF measured in fraction of a voxel
               slope_threshold.fill (spacing.mean() * File::Config::get_float ("reg_gd_convergence_thresh", 5e-3f));
               DEBUG ("convergence slope threshold: " + str(slope_threshold[0]));
+              //CONF option: reg_gd_convergence_data_smooth
+              //CONF default: 0.8
+              //CONF Linear registration: control point trajectory smoothing value used in convergence check
+              //CONF parameter range: [0...1]
               const default_type alpha (MR::File::Config::get_float ("reg_gd_convergence_data_smooth", 0.8));
+              if ( alpha < 0.0f | alpha > 1.0f )
+                throw Exception ("config file option reg_gd_convergence_data_smooth has to be in the range: [0...1]");
+              //CONF option: reg_gd_convergence_slope_smooth
+              //CONF default: 0.1
+              //CONF Linear registration: control point trajectory slope smoothing value used in convergence check
+              //CONF parameter range: [0...1]
               const default_type beta (MR::File::Config::get_float ("reg_gd_convergence_slope_smooth", 0.1));
+              if ( beta < 0.0f | beta > 1.0f )
+                throw Exception ("config file option reg_gd_convergence_slope_smooth has to be in the range: [0...1]");
               size_t buffer_len (MR::File::Config::get_float ("reg_gd_convergence_buffer_len", 4));
+              //CONF option: reg_gd_convergence_min_iter
+              //CONF default: 10
+              //CONF Linear registration: minumum number of iterations until convergence check is activated
               size_t min_iter (MR::File::Config::get_float ("reg_gd_convergence_min_iter", 10));
               transform.get_gradient_descent_updator()->set_convergence_check (slope_threshold, alpha, beta, buffer_len, min_iter);
 

--- a/src/registration/linear.h
+++ b/src/registration/linear.h
@@ -344,7 +344,7 @@ namespace MR
               Eigen::Vector3d stop(spacing);
               //CONF option: reg_coherence_len
               //CONF default: 3.0
-              //CONF Linear registration: estimated spatial coherence length in voxel
+              //CONF Linear registration: estimated spatial coherence length in voxels
               default_type reg_coherence_len = File::Config::get_float ("reg_coherence_len", 3.0); // = 3 stdev blur
               coherence *= reg_coherence_len * 1.0 / (2.0 * scale_factor[level]);
               //CONF option: reg_stop_len
@@ -358,11 +358,12 @@ namespace MR
 
               // convergence check using slope of smoothed parameter trajectories
               Eigen::VectorXd slope_threshold = Eigen::VectorXd::Ones (12);
-              slope_threshold.fill (MR::File::Config::get_float ("reg_gd_conv_slope_threshold", 5e-4f));
-              const default_type alpha (MR::File::Config::get_float ("reg_gd_conv_alpha", 0.8));
-              const default_type beta (MR::File::Config::get_float ("reg_gd_conv_beta", 0.55));
-              size_t buffer_len (MR::File::Config::get_float ("reg_gd_conv_buffer_len", 4));
-              size_t min_iter (MR::File::Config::get_float ("reg_gd_conv_min_iter", 10));
+              slope_threshold.fill (spacing.mean() * File::Config::get_float ("reg_gd_convergence_thresh", 5e-3f));
+              DEBUG ("convergence slope threshold: " + str(slope_threshold[0]));
+              const default_type alpha (MR::File::Config::get_float ("reg_gd_convergence_data_smooth", 0.8));
+              const default_type beta (MR::File::Config::get_float ("reg_gd_convergence_slope_smooth", 0.1));
+              size_t buffer_len (MR::File::Config::get_float ("reg_gd_convergence_buffer_len", 4));
+              size_t min_iter (MR::File::Config::get_float ("reg_gd_convergence_min_iter", 10));
               transform.get_gradient_descent_updator()->set_convergence_check (slope_threshold, alpha, beta, buffer_len, min_iter);
 
               Metric::Evaluate<MetricType, ParamType> evaluate (metric, parameters);

--- a/src/registration/linear.h
+++ b/src/registration/linear.h
@@ -369,14 +369,14 @@ namespace MR
               //CONF Linear registration: control point trajectory smoothing value used in convergence check
               //CONF parameter range: [0...1]
               const default_type alpha (MR::File::Config::get_float ("reg_gd_convergence_data_smooth", 0.8));
-              if ( alpha < 0.0f | alpha > 1.0f )
+              if ( (alpha < 0.0f ) || (alpha > 1.0f) )
                 throw Exception ("config file option reg_gd_convergence_data_smooth has to be in the range: [0...1]");
               //CONF option: reg_gd_convergence_slope_smooth
               //CONF default: 0.1
               //CONF Linear registration: control point trajectory slope smoothing value used in convergence check
               //CONF parameter range: [0...1]
               const default_type beta (MR::File::Config::get_float ("reg_gd_convergence_slope_smooth", 0.1));
-              if ( beta < 0.0f | beta > 1.0f )
+              if ( (beta < 0.0f ) || (beta > 1.0f) )
                 throw Exception ("config file option reg_gd_convergence_slope_smooth has to be in the range: [0...1]");
               size_t buffer_len (MR::File::Config::get_float ("reg_gd_convergence_buffer_len", 4));
               //CONF option: reg_gd_convergence_min_iter

--- a/src/registration/transform/affine.cpp
+++ b/src/registration/transform/affine.cpp
@@ -13,8 +13,6 @@
  *
  */
 
-#include <deque>
-#include <algorithm> // std::min_element
 #include <iterator>
 #include "registration/transform/affine.h"
 #include "math/gradient_descent.h"
@@ -29,88 +27,6 @@ namespace MR
   {
     namespace Transform
     {
-      // TODO: implement gradient descent oscillation detection via DoubleExpSmoothSlopeCheck
-      class DoubleExpSmoothSlopeCheck
-      {
-        public:
-          DoubleExpSmoothSlopeCheck (const Eigen::Matrix<default_type, Eigen::Dynamic, 1> slope_threshold,
-            default_type alpha = 0.8,
-            default_type beta = 0.55,
-            size_t buffer_len = 4,
-            size_t min_iter = 5):
-            stop_cnt (0),
-            alpha (alpha),
-            beta (beta),
-            thresh (slope_threshold),
-            buffer_len (buffer_len),
-            min_iter (min_iter),
-            iter_count (0),
-            len (0) { }
-
-            bool go_on (const Eigen::Matrix<default_type, Eigen::Dynamic, 1>& element) {
-              ++iter_count;
-              // initialise
-              if (len == 0) {
-                if (!x0.size()) {
-                  x0 = element;
-                  return true;
-                } else {
-                  ds.emplace_back(element);
-                  db.emplace_back(element - x0);
-                  if (check_all(db.back()))
-                    ++stop_cnt;
-                  else
-                    stop_cnt = 0;
-                  ++len;
-                  return true;
-                }
-              }
-              // add smoothed elements
-              ds.emplace_back(alpha * element + (1.0-alpha) * (ds.back() + db.back()));
-              db.emplace_back(beta * (ds.at(len) - ds.at(len - 1)) + (1.0-beta) * db.at(len-1));
-              if (check_all(db.back()))
-                ++stop_cnt;
-              else
-                stop_cnt = 0;
-
-              // trim if buffer full
-              if (len == buffer_len) {
-                ds.pop_front();
-                db.pop_front();
-                if (stop_cnt > buffer_len) --stop_cnt;
-              } else {
-                ++len;
-              }
-              return (stop_cnt != buffer_len) or (iter_count < min_iter);
-            }
-
-            bool last_b (Eigen::Matrix<default_type, Eigen::Dynamic, 1>& b) const {
-              if (!len) return false;
-              b = db.back();
-              return true;
-            }
-
-            bool last_s (Eigen::Matrix<default_type, Eigen::Dynamic, 1>& s) const {
-              if (!len) return false;
-              s = ds.back();
-              return true;
-            }
-
-        private:
-          size_t stop_cnt;
-          default_type alpha, beta;
-          const Eigen::Matrix<default_type, Eigen::Dynamic, 1> thresh;
-          Eigen::Matrix<default_type, Eigen::Dynamic, 1> x0;
-          const size_t buffer_len, min_iter;
-          size_t iter_count, len;
-          std::deque<Eigen::Matrix<default_type, Eigen::Dynamic, 1>> ds, db;
-
-          inline bool check_all (const Eigen::Matrix<default_type, Eigen::Dynamic, 1>& vec) {
-            return (vec.array().abs() < thresh.array()).all();
-          }
-
-        };
-
 
       bool AffineUpdate::operator() (Eigen::Matrix<default_type, Eigen::Dynamic, 1>& newx,
           const Eigen::Matrix<default_type, Eigen::Dynamic, 1>& x,

--- a/src/registration/transform/affine.cpp
+++ b/src/registration/transform/affine.cpp
@@ -37,7 +37,7 @@ namespace MR
           assert (g.size() == 12);
 
           Eigen::Matrix<default_type, 12, 1> delta;
-          Eigen::Matrix<default_type, 4, 4> X, Delta, G, A, Asqrt, B, Bsqrt, Bsqrtinv, Xnew, P, Diff;
+          Eigen::Matrix<default_type, 4, 4> X, Delta, G, A, Asqrt, B, Bsqrt, Bsqrtinv, Xnew, P, Diff, XnewP;
           Registration::Transform::param_vec2mat(g, G);
           Registration::Transform::param_vec2mat(x, X);
 
@@ -129,33 +129,40 @@ namespace MR
 
           Registration::Transform::param_mat2vec(Xnew, newx);
 
-          // stop criterion based on max shift of control points
+          if (newx.isApprox(x)) {
+            DEBUG ("parameters unchanged");
+            return false;
+          }
+
           if (control_points.size()) {
+            XnewP = (Xnew * P).eval();
+
+            // stop criterion based on slope of smoothed control point trajectories
+            if (use_convergence_check) {
+              Registration::Transform::param_mat2vec (XnewP, new_control_points_vec);
+              if (MR::File::Config::get_bool ("reg_gd_convergence_debug", false))
+                convergence_check.debug(new_control_points_vec);
+              if (!convergence_check.go_on (new_control_points_vec)) {
+                DEBUG ("control point trajectories converged");
+                return false;
+              }
+            }
+
+            // stop criterion based on maximum shift of control points
+            Diff.noalias() = (XnewP - X * P).cwiseAbs();
             Diff.row(0) *= recip_spacing(0);
             Diff.row(1) *= recip_spacing(1);
             Diff.row(2) *= recip_spacing(2);
             Diff.colwise() -= stop_len;
-            // MAT(Diff);
             if (Diff.template block<3,4>(0,0).maxCoeff() <= 0.0) {
-              DEBUG("max control point movement (" + str(Diff.template block<3,4>(0,0).maxCoeff()) +
+              DEBUG ("max control point movement (" + str(Diff.template block<3,4>(0,0).maxCoeff()) +
               ") smaller than tolerance" );
               return false;
             }
           }
-// #ifdef REGISTRATION_GRADIENT_DESCENT_DEBUG
-//             if (newx.isApprox(x)){
-//               ValueType debug = 0;
-//               for (ssize_t i=0; i<newx.size(); ++i){
-//                 debug += std::abs(newx[i]-x[i]);
-//               }
-//               INFO("affine update parameter cumulative change: " + str(debug));
-//               VEC(newx);
-//               VEC(g);
-//               VAR(step_size);
-//             }
-// #endif
-            return !(newx.isApprox(x));
-          }
+
+          return true;
+        }
 
           void AffineUpdate::set_control_points (
             const Eigen::Matrix<default_type, Eigen::Dynamic, Eigen::Dynamic>& points,

--- a/src/registration/transform/affine.h
+++ b/src/registration/transform/affine.h
@@ -45,6 +45,8 @@ namespace MR
 
       class AffineUpdate {
         public:
+          AffineUpdate (): use_convergence_check (false) { }
+
           bool operator() (Eigen::Matrix<default_type, Eigen::Dynamic, 1>& newx,
               const Eigen::Matrix<default_type, Eigen::Dynamic, 1>& x,
               const Eigen::Matrix<default_type, Eigen::Dynamic, 1>& g,
@@ -56,7 +58,16 @@ namespace MR
             const Eigen::Vector3d& stop_length,
             const Eigen::Vector3d& voxel_spacing );
 
+          void set_convergence_check (const Eigen::Matrix<default_type, Eigen::Dynamic, 1>& slope_threshold,
+                                      default_type alpha,
+                                      default_type beta,
+                                      size_t buffer_len,
+                                      size_t min_iter) {
+            use_convergence_check = false; // TODO
+          }
+
         private:
+          bool use_convergence_check;
           Eigen::Matrix<default_type, Eigen::Dynamic, Eigen::Dynamic> control_points;
           Eigen::Vector3d coherence_distance;
           Eigen::Matrix<default_type, 4, 1> stop_len, recip_spacing;

--- a/src/registration/transform/affine.h
+++ b/src/registration/transform/affine.h
@@ -63,7 +63,8 @@ namespace MR
                                       default_type beta,
                                       size_t buffer_len,
                                       size_t min_iter) {
-            use_convergence_check = false; // TODO
+            convergence_check.set_parameters (slope_threshold, alpha, beta, buffer_len, min_iter);
+            use_convergence_check = true;
           }
 
         private:
@@ -71,6 +72,8 @@ namespace MR
           Eigen::Matrix<default_type, Eigen::Dynamic, Eigen::Dynamic> control_points;
           Eigen::Vector3d coherence_distance;
           Eigen::Matrix<default_type, 4, 1> stop_len, recip_spacing;
+          DoubleExpSmoothSlopeCheck convergence_check;
+          Eigen::Matrix<default_type, Eigen::Dynamic, 1> new_control_points_vec;
       };
 
       class AffineRobustEstimator {

--- a/src/registration/transform/affine.h
+++ b/src/registration/transform/affine.h
@@ -65,6 +65,7 @@ namespace MR
                                       size_t min_iter) {
             convergence_check.set_parameters (slope_threshold, alpha, beta, buffer_len, min_iter);
             use_convergence_check = true;
+            new_control_points_vec.resize(12);
           }
 
         private:

--- a/src/registration/transform/base.h
+++ b/src/registration/transform/base.h
@@ -21,6 +21,8 @@
 #include <Eigen/SVD>
 #include <Eigen/Geometry> // Eigen::Translation
 #include "datatype.h" // debug
+#include "file/config.h"
+#include "registration/transform/convergence_check.h"
 
 namespace MR
 {
@@ -85,13 +87,13 @@ namespace MR
 
           typedef default_type ParameterType;
           Base (size_t number_of_parameters) :
-            number_of_parameters(number_of_parameters),
-            optimiser_weights (number_of_parameters) {
+              number_of_parameters (number_of_parameters),
+              optimiser_weights (number_of_parameters) {
               trafo.matrix().setIdentity();
               trafo_half.matrix().setIdentity();
               trafo_half_inverse.matrix().setIdentity();
               centre.setZero();
-          }
+            }
 
           EIGEN_MAKE_ALIGNED_OPERATOR_NEW  // avoid memory alignment errors in Eigen3;
 
@@ -135,7 +137,7 @@ namespace MR
           }
 
           template <class TrafoType>
-          void set_transform (TrafoType& transform) {
+          void set_transform (const TrafoType& transform) {
             trafo.matrix().template block<3,4>(0,0) = transform.matrix().template block<3,4>(0,0);
             compute_halfspace_transformations();
           }
@@ -147,17 +149,17 @@ namespace MR
           }
 
           // set_matrix updates the 3x3 matrix and also updates the translation
-          void set_matrix (const Eigen::Matrix<ParameterType, 3, 3>& mat) {
-            transform_type Tc2, To, R0;
-            Tc2.setIdentity();
-            To.setIdentity();
-            R0.setIdentity();
-            To.translation() = offset;
-            Tc2.translation() = centre - 0.5 * offset;
-            R0.linear() = mat;
-            trafo = Tc2 * To * R0 * Tc2.inverse();
-            compute_halfspace_transformations();
-          }
+          // void set_matrix (const Eigen::Matrix<ParameterType, 3, 3>& mat) {
+          //   transform_type Tc2, To, R0;
+          //   Tc2.setIdentity();
+          //   To.setIdentity();
+          //   R0.setIdentity();
+          //   To.translation() = offset;
+          //   Tc2.translation() = centre - 0.5 * offset;
+          //   R0.linear() = mat;
+          //   trafo = Tc2 * To * R0 * Tc2.inverse();
+          //   compute_halfspace_transformations();
+          // }
 
           const Eigen::Matrix<ParameterType, 3, 3> get_matrix () const {
             return trafo.linear();
@@ -259,16 +261,11 @@ namespace MR
           }
 
           size_t number_of_parameters;
-          // TODO matrix, translation and offset are only here for the rigid class. to be removed
-          Eigen::Matrix<ParameterType, 3, 3> matrix;
-          Eigen::Vector3 translation;
-          Eigen::Vector3 offset;
           Eigen::Transform<ParameterType, 3, Eigen::AffineCompact> trafo;
           Eigen::Transform<ParameterType, 3, Eigen::AffineCompact> trafo_half;
           Eigen::Transform<ParameterType, 3, Eigen::AffineCompact> trafo_half_inverse;
           Eigen::Vector3 centre;
           Eigen::VectorXd optimiser_weights;
-
       };
       //! @}
     }

--- a/src/registration/transform/convergence_check.cpp
+++ b/src/registration/transform/convergence_check.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "registration/transform/convergence_check.h"
+#include "debug.h"
 
 namespace MR
 {
@@ -44,7 +45,8 @@ namespace MR
             // add smoothed elements
             ds.emplace_back(alpha * element + (1.0-alpha) * (ds.back() + db.back()));
             db.emplace_back(beta * (ds.at(len) - ds.at(len - 1)) + (1.0-beta) * db.at(len-1));
-            DEBUG ("Smooth check b: " + str(db.back()));
+            DEBUG ("Smooth check b: " + str(db.back().transpose()));
+            DEBUG ("Smooth check t: " + str(thresh.transpose()));
             if (check_all(db.back()))
               ++stop_cnt;
             else
@@ -89,6 +91,22 @@ namespace MR
             if (!len) return false;
             s = ds.back();
             return true;
+          }
+
+          void DoubleExpSmoothSlopeCheck::debug (const Eigen::Matrix<default_type, Eigen::Dynamic, 1>& control_points_vec) const {
+            if (!is_initialised) {
+              WARN ("DoubleExpSmoothSlopeCheck not initialised");
+              return;
+            }
+            std::cout << str(control_points_vec.transpose()) << std::endl;
+            if (len == 0) {
+              INFO ("DoubleExpSmoothSlopeCheck did not run");
+              return;
+            }
+
+            std::cout << "#b " + str(db.back().transpose()) << std::endl;
+            std::cout << "#s " + str(ds.back().transpose()) << std::endl;
+            DEBUG ("bmax : " + str(db.back().array().abs().maxCoeff()));
           }
               //! @}
     }

--- a/src/registration/transform/convergence_check.cpp
+++ b/src/registration/transform/convergence_check.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2008-2016 the MRtrix3 contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ *
+ * MRtrix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * For more details, see www.mrtrix.org
+ *
+ */
+
+#include "registration/transform/convergence_check.h"
+
+namespace MR
+{
+  using namespace MR::Math;
+  namespace Registration
+  {
+    namespace Transform
+    {
+          bool DoubleExpSmoothSlopeCheck::go_on (const Eigen::Matrix<default_type, Eigen::Dynamic, 1>& element) {
+            assert (is_initialised);
+            ++iter_count;
+            // initialise
+            if (len == 0) {
+              if (!x0.size()) {
+                x0 = element;
+                return true;
+              } else {
+                ds.emplace_back(element);
+                db.emplace_back(element - x0);
+                if (check_all(db.back()))
+                  ++stop_cnt;
+                else
+                  stop_cnt = 0;
+                ++len;
+                return true;
+              }
+            }
+            // add smoothed elements
+            ds.emplace_back(alpha * element + (1.0-alpha) * (ds.back() + db.back()));
+            db.emplace_back(beta * (ds.at(len) - ds.at(len - 1)) + (1.0-beta) * db.at(len-1));
+            DEBUG ("Smooth check b: " + str(db.back()));
+            if (check_all(db.back()))
+              ++stop_cnt;
+            else
+              stop_cnt = 0;
+
+            // trim if buffer full
+            if (len == buffer_len) {
+              ds.pop_front();
+              db.pop_front();
+              if (stop_cnt > buffer_len) --stop_cnt;
+            } else {
+              ++len;
+            }
+            return (stop_cnt != buffer_len) or (iter_count < min_iter);
+          }
+
+          void DoubleExpSmoothSlopeCheck::set_parameters (
+              const Eigen::Matrix<default_type, Eigen::Dynamic, 1>& slope_threshold,
+              default_type alpha_in,
+              default_type beta_in,
+              size_t buffer_length,
+              size_t min_iter_in) {
+            // set parameters and reset iter_count. only reset iter_count, keeps previously filled buffers
+            thresh = slope_threshold;
+            alpha = alpha_in;
+            beta = beta_in;
+            buffer_len = buffer_length;
+            min_iter = min_iter_in;
+            is_initialised = true;
+            iter_count = 0;
+          }
+
+          bool DoubleExpSmoothSlopeCheck::last_b (Eigen::Matrix<default_type, Eigen::Dynamic, 1>& b) const {
+            assert (is_initialised);
+            if (!len) return false;
+            b = db.back();
+            return true;
+          }
+
+          bool DoubleExpSmoothSlopeCheck::last_s (Eigen::Matrix<default_type, Eigen::Dynamic, 1>& s) const {
+            assert (is_initialised);
+            if (!len) return false;
+            s = ds.back();
+            return true;
+          }
+              //! @}
+    }
+  }
+}

--- a/src/registration/transform/convergence_check.h
+++ b/src/registration/transform/convergence_check.h
@@ -52,6 +52,8 @@ namespace MR
 
             bool last_s (Eigen::Matrix<default_type, Eigen::Dynamic, 1>& s) const;
 
+            void debug (const Eigen::Matrix<default_type, Eigen::Dynamic, 1>& vec) const;
+
         private:
           size_t stop_cnt;
           default_type alpha, beta;

--- a/src/registration/transform/convergence_check.h
+++ b/src/registration/transform/convergence_check.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2008-2016 the MRtrix3 contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/
+ *
+ * MRtrix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * For more details, see www.mrtrix.org
+ *
+ */
+
+#include <iterator>
+#include <deque>
+#include <iterator>
+// #include <algorithm> // std::min_element
+#include "math/math.h"
+#include "math/median.h"
+// #include "math/gradient_descent.h"
+
+
+namespace MR
+{
+  using namespace MR::Math;
+  namespace Registration
+  {
+    namespace Transform
+    {
+      // convergence check using linear trend of each parameter during gradient descent
+      // we use double exponential smoothing to get rid of small oscillations
+      class DoubleExpSmoothSlopeCheck
+      {
+        public:
+            DoubleExpSmoothSlopeCheck ( ):
+              stop_cnt (0),
+              iter_count (0),
+              len (0),
+              is_initialised (false) { }
+
+            void set_parameters (const Eigen::Matrix<default_type, Eigen::Dynamic, 1>& slope_threshold,
+                                 default_type alpha_in,
+                                 default_type beta_in,
+                                 size_t buffer_length,
+                                 size_t min_iter_in);
+
+            bool go_on (const Eigen::Matrix<default_type, Eigen::Dynamic, 1>& element);
+
+            bool last_b (Eigen::Matrix<default_type, Eigen::Dynamic, 1>& b) const;
+
+            bool last_s (Eigen::Matrix<default_type, Eigen::Dynamic, 1>& s) const;
+
+        private:
+          size_t stop_cnt;
+          default_type alpha, beta;
+          Eigen::Matrix<default_type, Eigen::Dynamic, 1> thresh;
+          Eigen::Matrix<default_type, Eigen::Dynamic, 1> x0;
+          size_t buffer_len, min_iter;
+          size_t iter_count, len;
+          std::deque<Eigen::Matrix<default_type, Eigen::Dynamic, 1>> ds, db;
+          bool is_initialised;
+
+          inline bool check_all (const Eigen::Matrix<default_type, Eigen::Dynamic, 1>& vec) {
+            return (vec.array().abs() < thresh.array()).all();
+          }
+
+        };
+    }
+  }
+}

--- a/src/registration/transform/rigid.cpp
+++ b/src/registration/transform/rigid.cpp
@@ -184,7 +184,13 @@ namespace MR
 //               VAR(step_size);
 //             }
 // #endif
-            return !(newx.isApprox(x));
+            if (newx.isApprox(x))
+              return false;
+            if (use_convergence_check and !convergence_check.go_on(newx)) {
+              INFO("convergence_check: converged");
+              return false;
+            }
+            return true;
           }
 
           void RigidLinearNonSymmetricUpdate::set_control_points (

--- a/src/registration/transform/rigid.h
+++ b/src/registration/transform/rigid.h
@@ -32,6 +32,7 @@ namespace MR
       class RigidLinearNonSymmetricUpdate
       {
         public:
+          EIGEN_MAKE_ALIGNED_OPERATOR_NEW  // avoid memory alignment errors in Eigen3;
           RigidLinearNonSymmetricUpdate ( ):
             use_convergence_check (false) {  }
 
@@ -63,6 +64,7 @@ namespace MR
           Eigen::Vector3d coherence_distance;
           Eigen::Matrix<default_type, 4, 1> stop_len, recip_spacing;
           DoubleExpSmoothSlopeCheck convergence_check;
+          Eigen::Matrix<default_type, Eigen::Dynamic, 1> new_control_points_vec;
       };
 
       class RigidRobustEstimator {

--- a/src/registration/transform/rigid.h
+++ b/src/registration/transform/rigid.h
@@ -52,13 +52,14 @@ namespace MR
                                       default_type beta,
                                       size_t buffer_len,
                                       size_t min_iter) {
-            // convergence check using double exponential smoothing of parameters
+            // convergence check using double exponential smoothing
             convergence_check.set_parameters (slope_threshold, alpha, beta, buffer_len, min_iter);
             use_convergence_check = true;
+            new_control_points_vec.resize(12);
           }
 
         private:
-          bool use_convergence_check = false;
+          bool use_convergence_check;
           Eigen::Matrix<default_type, Eigen::Dynamic, Eigen::Dynamic> control_points;
           Eigen::Vector3d coherence_distance;
           Eigen::Matrix<default_type, 4, 1> stop_len, recip_spacing;

--- a/src/registration/transform/rigid.h
+++ b/src/registration/transform/rigid.h
@@ -53,7 +53,6 @@ namespace MR
                                       size_t buffer_len,
                                       size_t min_iter) {
             // convergence check using double exponential smoothing of parameters
-            // TODO: take gdweight into account or alternatively use control points
             convergence_check.set_parameters (slope_threshold, alpha, beta, buffer_len, min_iter);
             use_convergence_check = true;
           }

--- a/testing/tests/population_template
+++ b/testing/tests/population_template
@@ -1,1 +1,1 @@
-population_template population_template/in population_template/out.mif.gz -linear_scale 0.2,0.3 -linear_niter 20,20 -nl_scale 0.2,0.3 -nl_niter 1,1 -force; rm population_template/out.mif.gz  
+population_template population_template/in population_template/out.mif.gz -type rigid_nonlinear -rigid_scale 0.2,0.3 -rigid_niter 20,20 -nl_scale 0.2,0.3 -nl_niter 1,1 -force; rm population_template/out.mif.gz  


### PR DESCRIPTION
related to #827:

- `population_template`
    - rigid, affine and nonlinear registration are optional
    - defaults to run rigid registration before affine before nonlinear registration
    - changed arguments to be more similar to mrregister: for instance `-type rigid_affine_nonlinear`
- `mrregister`
    - added convergence check to speed up rigid registration
    - cleaned up base transformation class
- `dwiintensitynorm`
    - use new population_template syntax, 
    - avoid copy of warps
    - changed linear scale to `-rigid_scale 0.25,0.5,0.8,1.0 -affine_scale 0.7,0.8,1.0,1.0`

Do we want to tag this merge as it changes the command line interface of population_template?