### PR TITLE
Scripts signal handling

### DIFF
--- a/scripts/lib/app.py
+++ b/scripts/lib/app.py
@@ -43,7 +43,8 @@ def addCitation(condition, reference, is_external):
 
 
 def initialise():
-  import os, sys
+  import os, signal, sys
+  import lib.signalHandler
   from lib.errorMessage          import errorMessage
   from lib.printMessage          import printMessage
   from lib.readMRtrixConfSetting import readMRtrixConfSetting
@@ -109,6 +110,8 @@ def initialise():
     citation_warning += '. Please consult the help page (-help option) for more information.'
     printMessage(citation_warning)
     printMessage('')
+
+  lib.signalHandler.initialise()
 
   if args.cont:
     tempDir = os.path.abspath(args.cont[0])

--- a/scripts/lib/signalHandler.py
+++ b/scripts/lib/signalHandler.py
@@ -1,0 +1,57 @@
+_data = { 'SIGALRM': 'Timer expiration',
+          'SIGBUS' : 'Bus error: Accessing invalid address (out of storage space?)',
+          'SIGFPE' : 'Floating-point arithmetic exception',
+          'SIGHUP' : 'Disconnection of terminal',
+          'SIGILL' : 'Illegal instruction (corrupt binary command file?)',
+          'SIGINT' : 'Program manually interrupted by terminal',
+          'SIGPIPE': 'Nothing on receiving end of pipe',
+          'SIGPWR' : 'Power failure restart',
+          'SIGQUIT': 'Received terminal quit signal',
+          'SIGSEGV': 'Segmentation fault: Invalid memory reference',
+          'SIGSYS' : 'Bad system call',
+          'SIGTERM': 'Terminated by kill command',
+          'SIGXCPU': 'CPU time limit exceeded',
+          'SIGXFSZ': 'File size limit exceeded' }
+           # Can't be handled; see https://bugs.python.org/issue9524
+           # 'CTRL_C_EVENT': 'Terminated by user Ctrl-C input',
+           # 'CTRL_BREAK_EVENT': Terminated by user Ctrl-Break input'
+
+
+
+def initialise():
+  import signal
+  from lib.debugMessage import debugMessage
+  global _data
+  
+  successful = [ ]
+  for s in _data:
+    if hasattr(signal, s):
+      signal.signal(getattr(signal, s), _handler)
+      successful.append(s)
+  debugMessage('Signal handler capturing ' + str(len(successful)) + ' signals: ' + str(successful))
+
+
+
+def _handler(signum, frame):
+  import lib.app, os, signal, sys
+  from lib.runCommand import _processes
+  global _data
+  # First, kill any child processes
+  for p in _processes:
+    os.killpg(p.pid, signum)
+    p = [ ]
+  _processes = [ ]
+  msg = '[SYSTEM FATAL CODE: '
+  signal_found = False
+  for (key, value) in signals.items():
+    if hasattr(signal, key) and signum == getattr(signal, key):
+      msg += key + ' (' + str(int(getattr(signal, key))) + ')] ' + s.value
+      signal_found = True
+      break
+  if not signal_found:
+    msg += '?] Unknown system signal'
+  sys.stderr.write(os.path.basename(sys.argv[0]) + ': ' + lib.app.colourError + msg + lib.app.colourClear + '\n')
+  lib.app.complete()
+  exit(signum)
+  
+  

--- a/scripts/lib/signalHandler.py
+++ b/scripts/lib/signalHandler.py
@@ -38,14 +38,13 @@ def _handler(signum, frame):
   global _data
   # First, kill any child processes
   for p in _processes:
-    os.killpg(p.pid, signum)
-    p = [ ]
+    p.terminate()
   _processes = [ ]
   msg = '[SYSTEM FATAL CODE: '
   signal_found = False
-  for (key, value) in signals.items():
+  for (key, value) in _data.items():
     if hasattr(signal, key) and signum == getattr(signal, key):
-      msg += key + ' (' + str(int(getattr(signal, key))) + ')] ' + s.value
+      msg += key + ' (' + str(int(getattr(signal, key))) + ')] ' + value
       signal_found = True
       break
   if not signal_found:
@@ -53,5 +52,5 @@ def _handler(signum, frame):
   sys.stderr.write(os.path.basename(sys.argv[0]) + ': ' + lib.app.colourError + msg + lib.app.colourClear + '\n')
   lib.app.complete()
   exit(signum)
-  
-  
+
+


### PR DESCRIPTION
Will catch Ctrl-C or anything else terminating a Python script, provide a terminal error message comparable to those given by the signal handler now implemented in the binaries, and sends `SIGTERM` to any underlying subprocesses so that they can clean up as best they can (including deleting any piped MRtrix images).

Remaining question is whether or not the deletion or non-deletion of the script temporary directory should be influenced by the fact that a signal has been received...?