### PR TITLE
allow setting of number of threads from environment variable

### DIFF
--- a/lib/thread.cpp
+++ b/lib/thread.cpp
@@ -51,7 +51,7 @@ namespace MR
         return __number_of_threads;
       }
 
-      __number_of_threads = std::thread::hardware_concurrency();
+      __number_of_threads = File::Config::get_int ("NumberOfThreads", std::thread::hardware_concurrency());
       return __number_of_threads;
     }
 

--- a/lib/thread.cpp
+++ b/lib/thread.cpp
@@ -40,7 +40,18 @@ namespace MR
       if (__number_of_threads)
         return __number_of_threads;
       auto opt = App::get_options ("nthreads");
-      __number_of_threads = opt.size() ? opt[0][0] : File::Config::get_int ("NumberOfThreads", std::thread::hardware_concurrency());
+      if (opt.size()) {
+        __number_of_threads = opt[0][0];
+        return __number_of_threads;
+      }
+
+      const char* from_env = getenv ("MRTRIX_NTHREADS");
+      if (from_env) {
+        __number_of_threads = to<size_t> (from_env);
+        return __number_of_threads;
+      }
+
+      __number_of_threads = std::thread::hardware_concurrency();
       return __number_of_threads;
     }
 


### PR DESCRIPTION
This now also checks whether the MRTRIX_NTHREADS environment variable is
set, and if so will use that value instead of reading it from the config
file. However, the -nthreads option still take precedence.

Discussed on the forum:
http://community.mrtrix.org/t/control-multi-threading-on-a-cluster/632?u=jdtournier