### PR TITLE
tckgen: Rejection and GMWMI seeding fixes

### DIFF
--- a/docs/reference/commands/mrcalc.rst
+++ b/docs/reference/commands/mrcalc.rst
@@ -19,7 +19,7 @@ apply generic voxel-wise mathematical operations to images.
 
 This command will only compute per-voxel operations. Use 'mrmath' to compute summary statistics across images or along image axes.
 
-This command uses a stack-based syntax, with operators (specified using options) operating on the top-most entries (i.e. images or values) in the stack. Operands (values or images) are pushed onto the stack in the order they appear (as arguments) on the command-line, and operands (specified as options) operate on and consume the top-most entries in the stack, and push their output as a new entry on the stack. For example:
+This command uses a stack-based syntax, with operators (specified using options) operating on the top-most entries (i.e. images or values) in the stack. Operands (values or images) are pushed onto the stack in the order they appear (as arguments) on the command-line, and operators (specified as options) operate on and consume the top-most entries in the stack, and push their output as a new entry on the stack. For example:
 
     $ mrcalc a.mif 2 -mult r.mif
 

--- a/docs/reference/commands/tckgen.rst
+++ b/docs/reference/commands/tckgen.rst
@@ -91,7 +91,7 @@ Tractography seeding options
 
 -  **-seed_rejection image** seed from an image using rejection sampling (higher values = more probable to seed from)
 
--  **-seed_gmwmi seed_image** seed from the grey matter - white matter interface (only valid if using ACT framework)
+-  **-seed_gmwmi image** seed from the grey matter - white matter interface (only valid if using ACT framework). Input image should be a 3D seeding volume; seeds drawn within this image will be optimised to the interface using the 5TT image provided using the -act option.
 
 -  **-seed_dynamic fod_image** determine seed points dynamically using the SIFT model (must not provide any other seeding mechanism). Note that while this seeding mechanism improves the distribution of reconstructed streamlines density, it should NOT be used as a substitute for the SIFT method itself.
 

--- a/src/dwi/tractography/seeding/basic.cpp
+++ b/src/dwi/tractography/seeding/basic.cpp
@@ -149,8 +149,10 @@ namespace MR
           max (0.0)
         {
           auto vox = Image<float>::open (in);
-          std::vector<size_t> bottom (vox.ndim(), 0), top (vox.ndim(), 0);
-          std::fill_n (bottom.begin(), 3, std::numeric_limits<size_t>::max());
+          if (!(vox.ndim() == 3 || (vox.ndim() == 4 && vox.size(3) == 1)))
+            throw Exception ("Seed image must be a 3D image");
+          std::vector<size_t> bottom (3, std::numeric_limits<size_t>::max());
+          std::vector<size_t> top    (3, 0);
 
           for (auto i = Loop (0,3) (vox); i; ++i) {
             const float value = vox.value();
@@ -186,7 +188,7 @@ namespace MR
           auto buf = Image<float>::scratch (header);
           volume *= buf.spacing(0) * buf.spacing(1) * buf.spacing(2);
 
-          copy (sub, buf);
+          copy (sub, buf, 0, 3);
 #ifdef REJECTION_SAMPLING_USE_INTERPOLATION
           interp = Interp::Linear<Image<float>> (buf);
 #else

--- a/src/dwi/tractography/seeding/seeding.cpp
+++ b/src/dwi/tractography/seeding/seeding.cpp
@@ -53,8 +53,10 @@ namespace MR
       + Option ("seed_rejection", "seed from an image using rejection sampling (higher values = more probable to seed from)").allow_multiple()
         + Argument ("image").type_image_in()
 
-      + Option ("seed_gmwmi", "seed from the grey matter - white matter interface (only valid if using ACT framework)").allow_multiple()
-        + Argument ("seed_image").type_image_in()
+      + Option ("seed_gmwmi", "seed from the grey matter - white matter interface (only valid if using ACT framework). "
+                              "Input image should be a 3D seeding volume; seeds drawn within this image will be optimised to the "
+                              "interface using the 5TT image provided using the -act option.").allow_multiple()
+        + Argument ("image").type_image_in()
 
       + Option ("seed_dynamic", "determine seed points dynamically using the SIFT model (must not provide any other seeding mechanism). "
                                 "Note that while this seeding mechanism improves the distribution of reconstructed streamlines density, "


### PR DESCRIPTION
- Prevent segfault when initialising a rejection seeder using a 4D image.
- Clarify usage of -seed_gmwmi option.

Fixes #867.