### PR TITLE
Mrview cmdline parsing

### DIFF
--- a/cmd/mrview.cpp
+++ b/cmd/mrview.cpp
@@ -64,24 +64,6 @@ void run ()
 {
   GUI::MRView::Window window;
   window.show();
-  qApp->processEvents();
-
-  if (argument.size()) {
-    std::vector<std::unique_ptr<MR::Header>> list;
-
-    for (size_t n = 0; n < argument.size(); ++n) {
-      try {
-        list.push_back (std::unique_ptr<MR::Header> (new MR::Header (MR::Header::open (argument[n]))));
-      }
-      catch (Exception& e) {
-        e.display();
-      }
-    }
-
-    if (list.size())
-      window.add_images (list);
-  }
-
   window.process_commandline_options();
 
   if (qApp->exec())

--- a/src/gui/mrview/tool/connectome/connectome.cpp
+++ b/src/gui/mrview/tool/connectome/connectome.cpp
@@ -831,7 +831,7 @@ namespace MR
             + Option ("connectome.init", "Initialise the connectome tool using a parcellation image.")
             +   Argument ("image").type_image_in()
 
-            + Option ("connectome.load", "Load a matrix file into the connectome tool.")
+            + Option ("connectome.load", "Load a matrix file into the connectome tool.").allow_multiple()
             +   Argument ("path").type_file_in();
 
         }

--- a/src/gui/mrview/tool/overlay.cpp
+++ b/src/gui/mrview/tool/overlay.cpp
@@ -692,14 +692,14 @@ namespace MR
             + Option ("overlay.load", "Loads the specified image on the overlay tool.").allow_multiple()
             +   Argument ("image").type_image_in()
 
-            + Option ("overlay.opacity", "Sets the overlay opacity to floating value [0-1].")
+            + Option ("overlay.opacity", "Sets the overlay opacity to floating value [0-1].").allow_multiple()
             +   Argument ("value").type_float (0.0, 1.0)
 
-            + Option ("overlay.interpolation_on", "Enables overlay image interpolation.")
+            + Option ("overlay.interpolation_on", "Enables overlay image interpolation.").allow_multiple()
 
-            + Option ("overlay.interpolation_off", "Disables overlay image interpolation.")
+            + Option ("overlay.interpolation_off", "Disables overlay image interpolation.").allow_multiple()
 
-            + Option ("overlay.colourmap", "Sets the colourmap of the overlay as indexed in the colourmap dropdown menu.")
+            + Option ("overlay.colourmap", "Sets the colourmap of the overlay as indexed in the colourmap dropdown menu.").allow_multiple()
             +   Argument ("index").type_integer();
             
         }

--- a/src/gui/mrview/tool/screen_capture.cpp
+++ b/src/gui/mrview/tool/screen_capture.cpp
@@ -462,13 +462,13 @@ namespace MR
           options
             + OptionGroup ("Screen Capture tool options")
 
-            + Option ("capture.folder", "Set the output folder for the screen capture tool.")
+            + Option ("capture.folder", "Set the output folder for the screen capture tool.").allow_multiple()
             +   Argument ("path").type_text()
 
-            + Option ("capture.prefix", "Set the output file prefix for the screen capture tool.")
+            + Option ("capture.prefix", "Set the output file prefix for the screen capture tool.").allow_multiple()
             +   Argument ("string").type_text()
 
-            + Option ("capture.grab", "Start the screen capture process.");
+            + Option ("capture.grab", "Start the screen capture process.").allow_multiple();
         }
 
         bool Capture::process_commandline_option (const MR::App::ParsedOption& opt) 

--- a/src/gui/mrview/tool/vector.cpp
+++ b/src/gui/mrview/tool/vector.cpp
@@ -733,7 +733,7 @@ namespace MR
           options
             + OptionGroup ("Vector plot tool options")
 
-            + Option ("vector.load", "Load the specified MRtrix sparse image file (.msf) into the fixel tool.")
+            + Option ("vector.load", "Load the specified MRtrix sparse image file (.msf) into the fixel tool.").allow_multiple()
             +   Argument ("image").type_image_in();
         }
 

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -1922,15 +1922,15 @@ namespace MR
         options
           + OptionGroup ("View options")
 
-          + Option ("mode", "Switch to view mode specified by the integer index. as per the view menu.")
+          + Option ("mode", "Switch to view mode specified by the integer index. as per the view menu.").allow_multiple()
           +   Argument ("index").type_integer()
 
-          + Option ("load", "Load image specified and make it current.")
+          + Option ("load", "Load image specified and make it current.").allow_multiple()
           +   Argument ("image").type_image_in()
 
-          + Option ("reset", "Reset the view according to current image. This resets the FOV, projection, and focus.")
+          + Option ("reset", "Reset the view according to current image. This resets the FOV, projection, and focus.").allow_multiple()
 
-          + Option ("fov", "Set the field of view, in mm.")
+          + Option ("fov", "Set the field of view, in mm.").allow_multiple()
           +   Argument ("value").type_float()
 
           + Option ("focus", "Either set the position of the crosshairs in scanner coordinates, "
@@ -1940,49 +1940,49 @@ namespace MR
 
           + Option ("voxel", "Set the position of the crosshairs in voxel coordinates, "
               "relative the image currently displayed. The new position should be supplied "
-              "as a comma-separated list of floating-point values.")
+              "as a comma-separated list of floating-point values.").allow_multiple()
           +   Argument ("x,y,z").type_sequence_float()
 
-          + Option ("plane", "Set the viewing plane, according to the mappping 0: sagittal; 1: coronal; 2: axial.")
+          + Option ("plane", "Set the viewing plane, according to the mappping 0: sagittal; 1: coronal; 2: axial.").allow_multiple()
           +   Argument ("index").type_integer (0,2)
 
-          + Option ("lock", "Set whether view is locked to image axes (0: no, 1: yes).")
+          + Option ("lock", "Set whether view is locked to image axes (0: no, 1: yes).").allow_multiple()
           +   Argument ("yesno").type_bool()
 
-          + Option ("select_image", "Switch to image number specified, with reference to the list of currently loaded images.")
+          + Option ("select_image", "Switch to image number specified, with reference to the list of currently loaded images.").allow_multiple()
           +   Argument ("index").type_integer (0)
 
-          + Option ("autoscale", "Reset the image scaling to automatically determined range.")
+          + Option ("autoscale", "Reset the image scaling to automatically determined range.").allow_multiple()
 
-          + Option ("interpolation", "Enable or disable image interpolation in main image.")
+          + Option ("interpolation", "Enable or disable image interpolation in main image.").allow_multiple()
           +   Argument ("boolean").type_bool ()
 
-          + Option ("colourmap", "Switch the image colourmap to that specified, as per the colourmap menu.")
+          + Option ("colourmap", "Switch the image colourmap to that specified, as per the colourmap menu.").allow_multiple()
           +   Argument ("index").type_integer (0)
 
-          + Option ("noannotations", "Hide all image annotation overlays")
+          + Option ("noannotations", "Hide all image annotation overlays").allow_multiple()
 
-          + Option ("comments", "Show of hide image comments overlay.")
+          + Option ("comments", "Show of hide image comments overlay.").allow_multiple()
           +   Argument ("boolean").type_bool ()
 
-          + Option ("voxelinfo", "Show or hide voxel information overlay")
+          + Option ("voxelinfo", "Show or hide voxel information overlay").allow_multiple()
           +   Argument ("boolean").type_bool ()
 
-          + Option ("orientationlabel", "Show or hide orientation label overlay.")
+          + Option ("orientationlabel", "Show or hide orientation label overlay.").allow_multiple()
           +   Argument ("boolean").type_bool ()
 
-          + Option ("colourbar", "Show or hide colourbar overlay.")
+          + Option ("colourbar", "Show or hide colourbar overlay.").allow_multiple()
           +   Argument ("boolean").type_bool ()
 
-          + Option ("intensity_range", "Set the image intensity range to that specified")
+          + Option ("intensity_range", "Set the image intensity range to that specified").allow_multiple()
           +   Argument ("min,max").type_sequence_int()
 
           + OptionGroup ("Window management options")
 
-          + Option ("size", "Set the size of the view area, in pixel units.")
+          + Option ("size", "Set the size of the view area, in pixel units.").allow_multiple()
           +   Argument ("width,height").type_sequence_int()
 
-          + Option ("position", "Set the position of the main window, in pixel units.")
+          + Option ("position", "Set the position of the main window, in pixel units.").allow_multiple()
           +   Argument ("x,y").type_sequence_int()
 
           + Option ("fullscreen", "Start fullscreen.")


### PR DESCRIPTION
This implements the changes I'd [suggested here](https://github.com/MRtrix3/mrtrix3/pull/875#issuecomment-271538907), in response to a discussion with @ansk. Basically, images provided as regular arguments will now be opened as if they had been supplied with the `-load` option, meaning any following options apply to the expected image, etc. 

One thing this does change is that the image initially displayed when the command is issued is the _last_ one specified, whereas currently this would be the first one. Not sure whether this is a big deal, but I don't think there's any way to avoid this given how we want this to work.

Also, to make something like this actually work:

    mrview a.mif -interp off b.mif -interp off

I needed to add `.allow_multiple()` to the `-interpolation` option. So I've now gone and made most options `.allow_multiple()` in the main viewer window (i.e. those defined in `src/gui/mrview/window.cpp`, but I reckon it might make sense to allow just about all options to appear multiple times from all the other tools too. Would be great if everyone could have a look at their tools and add `.allow_multiple()` to all options where it might make sense. If we do this, this could allow quite complex operations, like multiple screen captures all on the same command-line, etc. 

As always, feel free to make any suggestion, comment, etc. 