### PR TITLE
shview fixes for multi-shell isotropic case

### DIFF
--- a/cmd/shview.cpp
+++ b/cmd/shview.cpp
@@ -35,14 +35,14 @@ void usage ()
 
   ARGUMENTS
   + Argument ("coefs",
-              "a text file containing the even spherical harmonics coefficients to display.")
+              "a text file containing the even order spherical harmonics coefficients to display.")
   .optional()
   .type_file_in();
 
   OPTIONS
   + Option ("response",
-            "assume SH coefficients file only contains even, m=0 terms. Used to "
-            "display the response function as produced by estimate_response");
+            "assume SH coefficients file only contains m=0 terms (zonal harmonics). "
+            "Used to display the response function as produced by estimate_response");
 
   REQUIRES_AT_LEAST_ONE_ARGUMENT = false;
 }

--- a/src/gui/shview/render_window.cpp
+++ b/src/gui/shview/render_window.cpp
@@ -220,11 +220,11 @@ namespace MR
         render_frame = new RenderFrame (this);
         setCentralWidget (render_frame);
 
-        render_frame->set_lmax (8);
+        render_frame->set_lmax (0);
         render_frame->set_normalise (true);
         render_frame->set_LOD (5);
 
-        lmax_group->actions() [render_frame->get_lmax() /2]->setChecked (true);
+        lmax_group->actions() [render_frame->get_lmax()/2]->setChecked (true);
         lod_group->actions() [render_frame->get_LOD()-3]->setChecked (true);
       }
 
@@ -339,7 +339,9 @@ namespace MR
 
           is_response = values.cols() < 15;
           response_action->setChecked (is_response);
-          lmax_group->actions()[is_response ? values.cols()-1 : Math::SH::LforN (values.cols())/2]->setChecked (true);
+
+          render_frame->set_lmax (is_response ? (values.cols()-1)*2 : Math::SH::LforN (values.cols()));
+          lmax_group->actions()[render_frame->get_lmax()/2]->setChecked (true);
 
           name = Path::basename (filename);
           set_values (0);

--- a/src/gui/shview/render_window.cpp
+++ b/src/gui/shview/render_window.cpp
@@ -337,9 +337,6 @@ namespace MR
           if (values.cols() == 0 || values.rows() == 0)
             throw Exception ("invalid matrix of SH coefficients");
 
-          if (values.cols() == 1)
-            values.transposeInPlace();
-
           is_response = values.cols() < 15;
           response_action->setChecked (is_response);
           int lmax = is_response ? values.cols()-2 : (Math::SH::LforN (values.cols())/2)-1;

--- a/src/gui/shview/render_window.cpp
+++ b/src/gui/shview/render_window.cpp
@@ -178,8 +178,8 @@ namespace MR
         lmax_menu->addSeparator();
 
         lmax_group = new QActionGroup (this);
-        for (int n = 0; n < 8; n++) {
-          int num = 2* (n+1);
+        for (int n = 0; n <= 8; n++) {
+          int num = 2*n;
           QString label = QString::number (num);
           QAction* lmax_action = new QAction (label, this);
           lmax_action->setCheckable (true);
@@ -224,14 +224,14 @@ namespace MR
         render_frame->set_normalise (true);
         render_frame->set_LOD (5);
 
-        lmax_group->actions() [ (render_frame->get_lmax() /2)-1]->setChecked (true);
+        lmax_group->actions() [render_frame->get_lmax() /2]->setChecked (true);
         lod_group->actions() [render_frame->get_LOD()-3]->setChecked (true);
       }
 
       Window::~Window()
       {
         render_frame->makeCurrent();
-        QList<QAction*> lmax = lod_group->actions();
+        QList<QAction*> lmax = lmax_group->actions();
         for (QAction* action : lmax)
           delete action;
         QList<QAction*> lods = lod_group->actions();
@@ -294,7 +294,7 @@ namespace MR
       {
         QList<QAction*> actions = lmax_group->actions();
         int index = actions.indexOf (lmax_group->checkedAction());
-        if (index < 7) {
+        if (index < 8) {
           actions[index+1]->setChecked (true);
           lmax_slot();
         }
@@ -339,8 +339,7 @@ namespace MR
 
           is_response = values.cols() < 15;
           response_action->setChecked (is_response);
-          int lmax = is_response ? values.cols()-2 : (Math::SH::LforN (values.cols())/2)-1;
-          lmax_group->actions()[lmax]->setChecked (true);
+          lmax_group->actions()[is_response ? values.cols()-1 : Math::SH::LforN (values.cols())/2]->setChecked (true);
 
           name = Path::basename (filename);
           set_values (0);


### PR DESCRIPTION
This ended up actually being a removal of an old feature, which supposedly intentionally allowed a column vector.  In the single-shell days, the only reasonable interpretation was to treat the column vector as a row.  The fix introduces a segfault upon loading a multi-shell isotropic response (so not ready to merge yet); I'll quickly check if I can spot why...

(for reference: this is about one of the issues mentioned in #619)