### PR TITLE
Further shview enhancements

### DIFF
--- a/src/gui/dwi/render_frame.cpp
+++ b/src/gui/dwi/render_frame.cpp
@@ -34,8 +34,6 @@ namespace MR
 
         constexpr float DistDefault = 0.3f;
         constexpr float DistInc = 0.005f;
-        constexpr float DistMin = 0.1f;
-        constexpr float DistMax = 10.0f;
 
         constexpr float ScaleInc = 1.05f;
 
@@ -315,8 +313,6 @@ namespace MR
           }
           else if (event->buttons() == Qt::RightButton) {
             distance *= 1.0 - DistInc*dy;
-            if (distance < DistMin) distance = DistMin;
-            if (distance > DistMax) distance = DistMax;
             update();
           }
         }

--- a/src/gui/dwi/render_frame.cpp
+++ b/src/gui/dwi/render_frame.cpp
@@ -189,12 +189,8 @@ namespace MR
           if (std::isfinite (values[0])) {
             gl::Disable (gl::BLEND);
 
-            if (!std::isfinite (scale)) {
-              if (values[0] != 0.0)
-                scale = 2.0f / values[0];
-              else 
-                scale = 2.0f / values.norm();
-            }
+            if (!std::isfinite (scale)) 
+              scale = 2.0f / values.norm();
 
             renderer.set_mode (mode);
 

--- a/src/gui/dwi/render_frame.cpp
+++ b/src/gui/dwi/render_frame.cpp
@@ -56,7 +56,7 @@ namespace MR
 
       RenderFrame::RenderFrame (QWidget* parent) :
         GL::Area (parent),
-        view_angle (AngleDefault), distance (DistDefault), line_width (1.0), scale (NaN), 
+        view_angle (AngleDefault), distance (DistDefault), scale (NaN), 
         lmax_computed (0), lod_computed (0), mode (mode_t::SH), recompute_mesh (true), recompute_amplitudes (true),
         show_axes (true), hide_neg_values (true), color_by_dir (true), use_lighting (true),
         glfont (get_font (parent)), projection (this, glfont),
@@ -239,7 +239,6 @@ namespace MR
         }
 
         if (show_axes) {
-          gl::LineWidth (line_width);
           gl::BlendFunc (gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA);
           gl::Enable (gl::BLEND);
           gl::Enable (gl::LINE_SMOOTH);

--- a/src/gui/dwi/render_frame.cpp
+++ b/src/gui/dwi/render_frame.cpp
@@ -44,10 +44,10 @@ namespace MR
 
       RenderFrame::RenderFrame (QWidget* parent) :
         GL::Area (parent),
-        view_angle (40.0), distance (0.3), line_width (1.0), scale (1.0), 
+        view_angle (40.0), distance (0.3), line_width (1.0), scale (NaN), 
         lmax_computed (0), lod_computed (0), mode (mode_t::SH), recompute_mesh (true), recompute_amplitudes (true),
         show_axes (true), hide_neg_values (true), color_by_dir (true), use_lighting (true),
-        normalise (false), font (parent->font()), projection (this, font),
+        font (parent->font()), projection (this, font),
         orientation (Math::Versorf::unit()),
         focus (0.0, 0.0, 0.0), OS (0), OS_x (0), OS_y (0),
         renderer ((QGLWidget*)this)
@@ -179,9 +179,12 @@ namespace MR
           if (std::isfinite (values[0])) {
             gl::Disable (gl::BLEND);
 
-            float final_scale = scale;
-            if (normalise && std::isfinite (values[0]) && values[0] != 0.0)
-              final_scale /= values[0];
+            if (!std::isfinite (scale)) {
+              if (std::isfinite (values[0]) && values[0] != 0.0)
+                scale = 2.0f / values[0];
+              else 
+                scale = 2.0f / values.norm();
+            }
 
             renderer.set_mode (mode);
 
@@ -194,7 +197,7 @@ namespace MR
               recompute_mesh = false;
             }
 
-            renderer.start (projection, *lighting, final_scale, use_lighting, color_by_dir, hide_neg_values);
+            renderer.start (projection, *lighting, scale, use_lighting, color_by_dir, hide_neg_values);
 
             if (recompute_amplitudes) {
               Eigen::Matrix<float, Eigen::Dynamic, 1> r_del_daz;

--- a/src/gui/dwi/render_frame.cpp
+++ b/src/gui/dwi/render_frame.cpp
@@ -272,25 +272,15 @@ namespace MR
       }
 
 
-
-
-
-
-
-
-      void RenderFrame::mouseDoubleClickEvent (QMouseEvent* event)
-      {
-        if (event->modifiers() == Qt::NoModifier) {
-          if (event->buttons() == Qt::LeftButton) {
-            orientation = DefaultOrientation;
-            update();
-          }
-          else if (event->buttons() == Qt::MidButton) {
-            focus.setZero();
-            update();
-          }
-        }
+      void RenderFrame::reset_view () {
+        orientation = DefaultOrientation;
+        focus.setZero();
+        update();
       }
+
+
+
+
 
 
       void RenderFrame::mousePressEvent (QMouseEvent* event)

--- a/src/gui/dwi/render_frame.cpp
+++ b/src/gui/dwi/render_frame.cpp
@@ -43,6 +43,8 @@ namespace MR
     {
 
       namespace {
+        const Math::Versorf DefaultOrientation = Eigen::AngleAxisf (Math::pi_4, Eigen::Vector3f (0.0f, 0.0f, 1.0f)) * 
+                                                     Eigen::AngleAxisf (Math::pi/3.0f, Eigen::Vector3f (1.0f, 0.0f, 0.0f));
         QFont get_font (QWidget* parent) {
           QFont f = parent->font();
           f.setPointSize (MR::File::Config::get_int ("FontSize", 10));
@@ -56,7 +58,7 @@ namespace MR
         lmax_computed (0), lod_computed (0), mode (mode_t::SH), recompute_mesh (true), recompute_amplitudes (true),
         show_axes (true), hide_neg_values (true), color_by_dir (true), use_lighting (true),
         glfont (get_font (parent)), projection (this, glfont),
-        orientation (Eigen::AngleAxisf (Math::pi_4, Eigen::Vector3f (0.0f, 0.0f, 1.0f)) * Eigen::AngleAxisf (Math::pi/3.0f, Eigen::Vector3f (1.0f, 0.0f, 0.0f))),
+        orientation (DefaultOrientation),
         focus (0.0, 0.0, 0.0), OS (0), OS_x (0), OS_y (0),
         renderer ((QGLWidget*)this)
       {
@@ -280,7 +282,7 @@ namespace MR
       {
         if (event->modifiers() == Qt::NoModifier) {
           if (event->buttons() == Qt::LeftButton) {
-            orientation = Math::Versorf::unit();
+            orientation = DefaultOrientation;
             update();
           }
           else if (event->buttons() == Qt::MidButton) {

--- a/src/gui/dwi/render_frame.cpp
+++ b/src/gui/dwi/render_frame.cpp
@@ -48,7 +48,7 @@ namespace MR
         lmax_computed (0), lod_computed (0), mode (mode_t::SH), recompute_mesh (true), recompute_amplitudes (true),
         show_axes (true), hide_neg_values (true), color_by_dir (true), use_lighting (true),
         font (parent->font()), projection (this, font),
-        orientation (Math::Versorf::unit()),
+        orientation (Eigen::AngleAxisf (Math::pi_4, Eigen::Vector3f (0.0f, 0.0f, 1.0f)) * Eigen::AngleAxisf (Math::pi/3.0f, Eigen::Vector3f (1.0f, 0.0f, 0.0f))),
         focus (0.0, 0.0, 0.0), OS (0), OS_x (0), OS_y (0),
         renderer ((QGLWidget*)this)
       {

--- a/src/gui/dwi/render_frame.cpp
+++ b/src/gui/dwi/render_frame.cpp
@@ -28,8 +28,6 @@
 #define DIST_MAX 10.0
 
 #define SCALE_INC 1.05
-#define SCALE_MIN 0.01
-#define SCALE_MAX 10.0
 
 #define ANGLE_INC 0.1
 #define ANGLE_MIN 1.0
@@ -332,8 +330,6 @@ namespace MR
         int scroll = event->delta() / 120;
         for (int n = 0; n < scroll; n++) scale *= SCALE_INC;
         for (int n = 0; n > scroll; n--) scale /= SCALE_INC;
-        if (scale > SCALE_MAX) scale = SCALE_MAX;
-        if (scale < SCALE_MIN) scale = SCALE_MIN;
         update();
       }
 

--- a/src/gui/dwi/render_frame.h
+++ b/src/gui/dwi/render_frame.h
@@ -134,7 +134,7 @@ namespace MR
           void screenshot (int oversampling, const std::string& image_name);
 
         protected:
-          float view_angle, distance, line_width, scale;
+          float view_angle, distance, scale;
           int lmax_computed, lod_computed;
           mode_t mode;
           bool recompute_mesh, recompute_amplitudes, show_axes, hide_neg_values, color_by_dir, use_lighting, normalise;

--- a/src/gui/dwi/render_frame.h
+++ b/src/gui/dwi/render_frame.h
@@ -115,6 +115,10 @@ namespace MR
             recompute_mesh = recompute_amplitudes = true;
             update();
           }
+          void set_text (const std::string& text_to_display) {
+            text = text_to_display;
+            update();
+          }
 
           int  get_LOD () const { return lod_computed; }
           int  get_lmax () const { return lmax_computed; }
@@ -136,7 +140,7 @@ namespace MR
           std::unique_ptr<MR::DWI::Directions::Set> dirs;
 
           QPoint last_pos;
-          GL::Font font;
+          GL::Font glfont;
           Projection projection;
           Math::Versorf orientation;
           Eigen::Vector3f focus;
@@ -152,6 +156,8 @@ namespace MR
 
           Renderer renderer;
           Eigen::VectorXf values;
+
+          std::string text;
 
         protected:
           virtual void initializeGL () override;

--- a/src/gui/dwi/render_frame.h
+++ b/src/gui/dwi/render_frame.h
@@ -86,6 +86,7 @@ namespace MR
           void reset_scale () {
             set_scale (NaN);
           }
+          void reset_view ();
           void set_lmax (int lmax) {
             assert (mode == mode_t::SH);
             if (lmax != lmax_computed) 
@@ -163,7 +164,6 @@ namespace MR
           virtual void initializeGL () override;
           virtual void resizeGL (int w, int h) override;
           virtual void paintGL () override;
-          void mouseDoubleClickEvent (QMouseEvent* event) override;
           void mousePressEvent (QMouseEvent* event) override;
           void mouseMoveEvent (QMouseEvent* event) override;
           void wheelEvent (QWheelEvent* event) override;

--- a/src/gui/dwi/render_frame.h
+++ b/src/gui/dwi/render_frame.h
@@ -79,9 +79,12 @@ namespace MR
             use_lighting = yesno;
             update();
           }
-          void set_normalise (bool yesno = true) {
-            normalise = yesno;
+          void set_scale (float new_scale) {
+            scale = new_scale;
             update();
+          }
+          void reset_scale () {
+            set_scale (NaN);
           }
           void set_lmax (int lmax) {
             assert (mode == mode_t::SH);

--- a/src/gui/mrview/tool/odf/preview.cpp
+++ b/src/gui/mrview/tool/odf/preview.cpp
@@ -116,6 +116,7 @@ namespace MR
           if (lock_orientation_to_image_box->isChecked()) {
             const Projection* proj = window().get_current_mode()->get_current_projection();
             if (!proj) return;
+            render_frame->reset_view();
             render_frame->set_rotation (proj->modelview());
           }
         }

--- a/src/gui/mrview/tool/odf/preview.h
+++ b/src/gui/mrview/tool/odf/preview.h
@@ -39,11 +39,6 @@ namespace MR
             {
               public:
                 RenderFrame (QWidget* parent);
-                
-                void set_scale (float sc) {
-                  scale = sc;
-                  update();
-                }
 
                 void set_colour (const QColor& c) {
                   renderer.set_colour (c);

--- a/src/gui/opengl/font.cpp
+++ b/src/gui/opengl/font.cpp
@@ -52,7 +52,7 @@ namespace MR
 
 
 
-      void Font::initGL () 
+      void Font::initGL (bool with_shadow) 
       {
         const int first_char = ' ', last_char = '~', default_char = '?';
         DEBUG ("loading font into OpenGL texture...");
@@ -85,29 +85,31 @@ namespace MR
           font_width[c] = metric.width (c);
           const int current_font_width = font_width[c] + 2;
 
-          // blur along x:
-          for (int row = 0; row < font_height; ++row) {
-            for (int col = 0; col < current_font_width; ++col) {
-              const int tex_idx = 2 * (current_x + col + row*tex_width);
-              const int pix_idx = 4 * (col + row*max_font_width);
-              float val = 0.0f;
-              for (int x = -1; x <= 1; ++x)
-                if (col+x >= 0 && col+x < current_font_width) 
-                  val += std::exp (-x*x/2.0f) * pix_data[pix_idx+4*x];
-              tex_data[tex_idx] = val;
+          if (with_shadow) {
+            // blur along x:
+            for (int row = 0; row < font_height; ++row) {
+              for (int col = 0; col < current_font_width; ++col) {
+                const int tex_idx = 2 * (current_x + col + row*tex_width);
+                const int pix_idx = 4 * (col + row*max_font_width);
+                float val = 0.0f;
+                for (int x = -1; x <= 1; ++x)
+                  if (col+x >= 0 && col+x < current_font_width) 
+                    val += std::exp (-x*x/2.0f) * pix_data[pix_idx+4*x];
+                tex_data[tex_idx] = val;
+              }
             }
-          }
 
-          // blur along y and store as alpha component:
-          for (int row = 0; row < font_height; ++row) {
-            for (int col = 0; col < current_font_width; ++col) {
-              const int tex_idx = 2 * (current_x + col + row*tex_width);
-              const int pix_idx = 4 * (col + row*max_font_width);
-              float val = 0.0f;
-              for (int x = -1; x <= 1; ++x) 
-                if (row+x >= 0 && row+x < font_height) 
-                  val += std::exp (-x*x/2.0) * tex_data[tex_idx+2*tex_width*x];
-              tex_data[tex_idx+1] = pix_data[pix_idx] ? 1.0f : 0.005f*val;
+            // blur along y and store as alpha component:
+            for (int row = 0; row < font_height; ++row) {
+              for (int col = 0; col < current_font_width; ++col) {
+                const int tex_idx = 2 * (current_x + col + row*tex_width);
+                const int pix_idx = 4 * (col + row*max_font_width);
+                float val = 0.0f;
+                for (int x = -1; x <= 1; ++x) 
+                  if (row+x >= 0 && row+x < font_height) 
+                    val += std::exp (-x*x/2.0) * tex_data[tex_idx+2*tex_width*x];
+                tex_data[tex_idx+1] = pix_data[pix_idx] ? 1.0f : 0.005f*val;
+              }
             }
           }
 
@@ -117,6 +119,8 @@ namespace MR
               const int tex_idx = 2 * (current_x + col + row*tex_width);
               const int pix_idx = 4 * (col + row*max_font_width);
               tex_data[tex_idx] = pix_data[pix_idx] / 255.0f;
+              if (!with_shadow)
+                tex_data[tex_idx+1] = tex_data[tex_idx];
             }
           }
 

--- a/src/gui/opengl/font.h
+++ b/src/gui/opengl/font.h
@@ -27,11 +27,11 @@ namespace MR
 
       class Font {
         public:
-          Font (const QFont& font) :
+          Font (const QFont font) :
             metric (font),
             font (font) { } 
 
-          void initGL ();
+          void initGL (bool with_shadow = true);
 
           const QFontMetrics metric;
 
@@ -59,7 +59,7 @@ namespace MR
           void render (const std::string& text, int x, int y) const;
 
         protected:
-          const QFont& font;
+          const QFont font;
           GL::Texture tex;
           GL::VertexBuffer vertex_buffer[2];
           GL::VertexArrayObject vertex_array_object;

--- a/src/gui/opengl/lighting.cpp
+++ b/src/gui/opengl/lighting.cpp
@@ -22,6 +22,18 @@ namespace MR
   {
     namespace GL
     {
+      namespace {
+
+        constexpr float DefaultAmbient = 0.6f;
+        constexpr float DefaultDiffuse = 0.5f;
+        constexpr float DefaultSpecular = 0.2f;
+        constexpr float DefaultShine = 2.0f;
+        constexpr float DefaultBackgroundColor[3] = { 1.0f, 1.0f, 1.0f };
+        constexpr float DefaultLightPosition[3] = { 1.0f, 1.0f, 3.0f };
+
+      }
+
+
 
       void Lighting::load_defaults ()
       {
@@ -29,32 +41,32 @@ namespace MR
         //CONF default: 1,1,1 (white)
         //CONF The default colour to use for the background in OpenGL panels, notably
         //CONF the SH viewer.
-        File::Config::get_RGB ("BackgroundColor", background_color, 1.0, 1.0, 1.0);
+        File::Config::get_RGB ("BackgroundColor", background_color, DefaultBackgroundColor[0], DefaultBackgroundColor[1], DefaultBackgroundColor[2]);
 
         //CONF option: LightPosition
         //CONF default: 1,1,3
         //CONF The default position vector to use for the light in OpenGL
         //CONF renders.
-        File::Config::get_RGB ("LightPosition", lightpos, 1.0, 1.0, 3.0);
+        File::Config::get_RGB ("LightPosition", lightpos, DefaultLightPosition[0], DefaultLightPosition[1], DefaultBackgroundColor[2]);
 
         Eigen::Map<Eigen::Vector3f> (lightpos).normalize();
 
         //CONF option: AmbientIntensity
         //CONF default: 0.6
         //CONF The default intensity for the ambient light in OpenGL renders.
-        ambient = File::Config::get_float ("AmbientIntensity", 0.6);
+        ambient = File::Config::get_float ("AmbientIntensity", DefaultAmbient);
         //CONF option: DiffuseIntensity
         //CONF default: 0.3
         //CONF The default intensity for the diffuse light in OpenGL renders.
-        diffuse = File::Config::get_float ("DiffuseIntensity", 0.3);
+        diffuse = File::Config::get_float ("DiffuseIntensity", DefaultDiffuse);
         //CONF option: SpecularIntensity
         //CONF default: 0.4
         //CONF The default intensity for the specular light in OpenGL renders.
-        specular = File::Config::get_float ("SpecularIntensity", 0.4);
+        specular = File::Config::get_float ("SpecularIntensity", DefaultSpecular);
         //CONF option: SpecularExponent
         //CONF default: 1
         //CONF The default exponent for the specular light in OpenGL renders.
-        shine = File::Config::get_float ("SpecularExponent", 1.0);
+        shine = File::Config::get_float ("SpecularExponent", DefaultShine);
       }
 
 

--- a/src/gui/opengl/lighting.cpp
+++ b/src/gui/opengl/lighting.cpp
@@ -24,10 +24,10 @@ namespace MR
     {
       namespace {
 
-        constexpr float DefaultAmbient = 0.6f;
+        constexpr float DefaultAmbient = 0.5f;
         constexpr float DefaultDiffuse = 0.5f;
-        constexpr float DefaultSpecular = 0.2f;
-        constexpr float DefaultShine = 2.0f;
+        constexpr float DefaultSpecular = 0.5f;
+        constexpr float DefaultShine = 5.0f;
         constexpr float DefaultBackgroundColor[3] = { 1.0f, 1.0f, 1.0f };
         constexpr float DefaultLightPosition[3] = { 1.0f, 1.0f, 3.0f };
 
@@ -38,13 +38,11 @@ namespace MR
       void Lighting::load_defaults ()
       {
         //CONF option: BackgroundColor
-        //CONF default: 1,1,1 (white)
         //CONF The default colour to use for the background in OpenGL panels, notably
         //CONF the SH viewer.
         File::Config::get_RGB ("BackgroundColor", background_color, DefaultBackgroundColor[0], DefaultBackgroundColor[1], DefaultBackgroundColor[2]);
 
         //CONF option: LightPosition
-        //CONF default: 1,1,3
         //CONF The default position vector to use for the light in OpenGL
         //CONF renders.
         File::Config::get_RGB ("LightPosition", lightpos, DefaultLightPosition[0], DefaultLightPosition[1], DefaultBackgroundColor[2]);
@@ -52,19 +50,15 @@ namespace MR
         Eigen::Map<Eigen::Vector3f> (lightpos).normalize();
 
         //CONF option: AmbientIntensity
-        //CONF default: 0.6
         //CONF The default intensity for the ambient light in OpenGL renders.
         ambient = File::Config::get_float ("AmbientIntensity", DefaultAmbient);
         //CONF option: DiffuseIntensity
-        //CONF default: 0.3
         //CONF The default intensity for the diffuse light in OpenGL renders.
         diffuse = File::Config::get_float ("DiffuseIntensity", DefaultDiffuse);
         //CONF option: SpecularIntensity
-        //CONF default: 0.4
         //CONF The default intensity for the specular light in OpenGL renders.
         specular = File::Config::get_float ("SpecularIntensity", DefaultSpecular);
         //CONF option: SpecularExponent
-        //CONF default: 1
         //CONF The default exponent for the specular light in OpenGL renders.
         shine = File::Config::get_float ("SpecularExponent", DefaultShine);
       }

--- a/src/gui/opengl/lighting.h
+++ b/src/gui/opengl/lighting.h
@@ -27,18 +27,15 @@ namespace MR
 
       class Lighting : public QObject
       {
-          Q_OBJECT
+        Q_OBJECT
 
         public:
-          Lighting (QObject* parent) : 
+
+          Lighting (QObject* parent) :
             QObject (parent), 
-            ambient (0.5),
-            diffuse (0.7), 
-            specular (0.7),
-            shine (0.5),
             set_background (false) {
-            load_defaults();
-          }
+              load_defaults();
+            }
 
           float ambient, diffuse, specular, shine;
           float light_color[3], lightpos[3], background_color[3];

--- a/src/gui/shview/render_window.cpp
+++ b/src/gui/shview/render_window.cpp
@@ -124,7 +124,7 @@ namespace MR
         colour_by_direction_action->setStatusTip (tr ("Colour surface according to direction"));
         connect (colour_by_direction_action, SIGNAL (triggered (bool)), this, SLOT (colour_by_direction_slot (bool)));
 
-        response_action = new QAction ("Treat as &response", this);
+        response_action = new QAction ("Treat as response (&zonal SH)", this);
         response_action->setCheckable (true);
         response_action->setChecked (is_response_coefs);
         response_action->setShortcut (tr ("Z"));

--- a/src/gui/shview/render_window.cpp
+++ b/src/gui/shview/render_window.cpp
@@ -124,18 +124,24 @@ namespace MR
         colour_by_direction_action->setStatusTip (tr ("Colour surface according to direction"));
         connect (colour_by_direction_action, SIGNAL (triggered (bool)), this, SLOT (colour_by_direction_slot (bool)));
 
-        QAction* reset_scale_action = new QAction ("&Reset scaling", this);
-        reset_scale_action->setCheckable (false);
-        reset_scale_action->setShortcut (tr ("Esc"));
-        reset_scale_action->setStatusTip (tr ("reset intensity scaling based on ODF currently displayed"));
-        connect (reset_scale_action, SIGNAL (triggered ()), this, SLOT (reset_scale_slot ()));
-
         response_action = new QAction ("Treat as &response", this);
         response_action->setCheckable (true);
         response_action->setChecked (is_response_coefs);
         response_action->setShortcut (tr ("R"));
         response_action->setStatusTip (tr ("Assume each row of values consists only of\nthe m=0 (axially symmetric) even SH coefficients"));
         connect (response_action, SIGNAL (triggered (bool)), this, SLOT (response_slot (bool)));
+
+        QAction* reset_scale_action = new QAction ("Reset &scaling", this);
+        reset_scale_action->setCheckable (false);
+        reset_scale_action->setShortcut (tr ("Esc"));
+        reset_scale_action->setStatusTip (tr ("reset intensity scaling based on ODF currently displayed"));
+        connect (reset_scale_action, SIGNAL (triggered ()), this, SLOT (reset_scale_slot ()));
+
+        QAction* reset_view_action = new QAction ("&Reset View", this);
+        reset_view_action->setCheckable (false);
+        reset_view_action->setShortcut (tr ("Home"));
+        reset_view_action->setStatusTip (tr ("reset viewing direction and focus position"));
+        connect (reset_view_action, SIGNAL (triggered ()), this, SLOT (reset_view_slot ()));
 
         QAction* manual_colour_action = new QAction ("&Manual colour", this);
         manual_colour_action->setShortcut (tr ("M"));
@@ -158,6 +164,7 @@ namespace MR
         QMenu* lmax_menu = settings_menu->addMenu (tr ("&Harmonic order"));
         QMenu* lod_menu = settings_menu->addMenu (tr ("Level of &detail"));
         settings_menu->addSeparator();
+        settings_menu->addAction (reset_view_action);
         settings_menu->addAction (reset_scale_action);
         settings_menu->addAction (manual_colour_action);
         settings_menu->addAction (advanced_lighting_action);
@@ -260,31 +267,43 @@ namespace MR
       {
         render_frame->set_use_lighting (is_checked);
       }
+
       void Window::show_axes_slot (bool is_checked)
       {
         render_frame->set_show_axes (is_checked);
       }
+
       void Window::hide_negative_lobes_slot (bool is_checked)
       {
         render_frame->set_hide_neg_values (is_checked);
       }
+
       void Window::colour_by_direction_slot (bool is_checked)
       {
         render_frame->set_color_by_dir (is_checked);
       }
+
       void Window::reset_scale_slot ()
       {
         render_frame->reset_scale ();
       }
+
+      void Window::reset_view_slot ()
+      {
+        render_frame->reset_view ();
+      }
+
       void Window::response_slot (bool is_checked)
       {
         is_response = is_checked;
         set_values (current);
       }
+
       void Window::lmax_slot ()
       {
         render_frame->set_lmax (lmax_group->checkedAction()->data().toInt());
       }
+
       void Window::lod_slot ()
       {
         render_frame->set_LOD (lod_group->checkedAction()->data().toInt());

--- a/src/gui/shview/render_window.cpp
+++ b/src/gui/shview/render_window.cpp
@@ -224,6 +224,8 @@ namespace MR
 
         lmax_group->actions() [render_frame->get_lmax()/2]->setChecked (true);
         lod_group->actions() [render_frame->get_LOD()-3]->setChecked (true);
+
+        render_frame->set_text ("no data loaded");
       }
 
       Window::~Window()
@@ -354,7 +356,7 @@ namespace MR
       void Window::set_values (int row)
       {
         Eigen::Matrix<float, Eigen::Dynamic, 1> val;
-        std::string title;
+        std::string title, text;
 
         if (values.rows()) {
           current = row;
@@ -372,9 +374,12 @@ namespace MR
             val = values.row (current);
           if (is_response) title += " (response)";
           title = name + " [ " + str (current) + " ]";
+          render_frame->set_text ("row " + str(current));
         }
-        else 
+        else {
           name.clear();
+          render_frame->set_text ("no data loaded");
+        }
 
         render_frame->set (val);
         setWindowTitle (QString (title.c_str()));

--- a/src/gui/shview/render_window.cpp
+++ b/src/gui/shview/render_window.cpp
@@ -223,7 +223,7 @@ namespace MR
         render_frame->set_LOD (5);
 
         lmax_group->actions() [render_frame->get_lmax()/2]->setChecked (true);
-        lod_group->actions() [render_frame->get_LOD()-3]->setChecked (true);
+        lod_group->actions() [render_frame->get_LOD()-1]->setChecked (true);
 
         render_frame->set_text ("no data loaded");
       }

--- a/src/gui/shview/render_window.cpp
+++ b/src/gui/shview/render_window.cpp
@@ -356,7 +356,7 @@ namespace MR
       void Window::set_values (int row)
       {
         Eigen::Matrix<float, Eigen::Dynamic, 1> val;
-        std::string title, text;
+        std::string title;
 
         if (values.rows()) {
           current = row;
@@ -372,9 +372,15 @@ namespace MR
           }
           else 
             val = values.row (current);
-          if (is_response) title += " (response)";
-          title = name + " [ " + str (current) + " ]";
-          render_frame->set_text ("row " + str(current));
+          title = name;
+          if (is_response)
+            title += " (response)";
+          if (values.rows() > 1) {
+            title += " [ " + str (current+1) + "/" + str(values.rows()) + " ]";
+            render_frame->set_text ("row " + str(current+1) + " of " + str(values.rows()));
+          } else {
+            render_frame->set_text ("");
+          }
         }
         else {
           name.clear();

--- a/src/gui/shview/render_window.cpp
+++ b/src/gui/shview/render_window.cpp
@@ -124,12 +124,11 @@ namespace MR
         colour_by_direction_action->setStatusTip (tr ("Colour surface according to direction"));
         connect (colour_by_direction_action, SIGNAL (triggered (bool)), this, SLOT (colour_by_direction_slot (bool)));
 
-        QAction* normalise_action = new QAction ("&Normalise", this);
-        normalise_action->setCheckable (true);
-        normalise_action->setChecked (true);
-        normalise_action->setShortcut (tr ("N"));
-        normalise_action->setStatusTip (tr ("Normalise surface intensity"));
-        connect (normalise_action, SIGNAL (triggered (bool)), this, SLOT (normalise_slot (bool)));
+        QAction* reset_scale_action = new QAction ("&Reset scaling", this);
+        reset_scale_action->setCheckable (false);
+        reset_scale_action->setShortcut (tr ("Esc"));
+        reset_scale_action->setStatusTip (tr ("reset intensity scaling based on ODF currently displayed"));
+        connect (reset_scale_action, SIGNAL (triggered ()), this, SLOT (reset_scale_slot ()));
 
         response_action = new QAction ("Treat as &response", this);
         response_action->setCheckable (true);
@@ -154,7 +153,7 @@ namespace MR
         settings_menu->addAction (show_axes_action);
         settings_menu->addAction (hide_negative_lobes_action);
         settings_menu->addAction (colour_by_direction_action);
-        settings_menu->addAction (normalise_action);
+        settings_menu->addAction (reset_scale_action);
         settings_menu->addAction (response_action);
         settings_menu->addSeparator();
         QMenu* lmax_menu = settings_menu->addMenu (tr ("&Harmonic order"));
@@ -221,7 +220,6 @@ namespace MR
         setCentralWidget (render_frame);
 
         render_frame->set_lmax (0);
-        render_frame->set_normalise (true);
         render_frame->set_LOD (5);
 
         lmax_group->actions() [render_frame->get_lmax()/2]->setChecked (true);
@@ -272,9 +270,9 @@ namespace MR
       {
         render_frame->set_color_by_dir (is_checked);
       }
-      void Window::normalise_slot (bool is_checked)
+      void Window::reset_scale_slot ()
       {
-        render_frame->set_normalise (is_checked);
+        render_frame->reset_scale ();
       }
       void Window::response_slot (bool is_checked)
       {

--- a/src/gui/shview/render_window.cpp
+++ b/src/gui/shview/render_window.cpp
@@ -127,7 +127,7 @@ namespace MR
         response_action = new QAction ("Treat as &response", this);
         response_action->setCheckable (true);
         response_action->setChecked (is_response_coefs);
-        response_action->setShortcut (tr ("R"));
+        response_action->setShortcut (tr ("Z"));
         response_action->setStatusTip (tr ("Assume each row of values consists only of\nthe m=0 (axially symmetric) even SH coefficients"));
         connect (response_action, SIGNAL (triggered (bool)), this, SLOT (response_slot (bool)));
 
@@ -139,7 +139,7 @@ namespace MR
 
         QAction* reset_view_action = new QAction ("&Reset View", this);
         reset_view_action->setCheckable (false);
-        reset_view_action->setShortcut (tr ("Home"));
+        reset_view_action->setShortcut (tr ("R"));
         reset_view_action->setStatusTip (tr ("reset viewing direction and focus position"));
         connect (reset_view_action, SIGNAL (triggered ()), this, SLOT (reset_view_slot ()));
 

--- a/src/gui/shview/render_window.cpp
+++ b/src/gui/shview/render_window.cpp
@@ -153,12 +153,12 @@ namespace MR
         settings_menu->addAction (show_axes_action);
         settings_menu->addAction (hide_negative_lobes_action);
         settings_menu->addAction (colour_by_direction_action);
-        settings_menu->addAction (reset_scale_action);
         settings_menu->addAction (response_action);
         settings_menu->addSeparator();
         QMenu* lmax_menu = settings_menu->addMenu (tr ("&Harmonic order"));
         QMenu* lod_menu = settings_menu->addMenu (tr ("Level of &detail"));
         settings_menu->addSeparator();
+        settings_menu->addAction (reset_scale_action);
         settings_menu->addAction (manual_colour_action);
         settings_menu->addAction (advanced_lighting_action);
 

--- a/src/gui/shview/render_window.h
+++ b/src/gui/shview/render_window.h
@@ -58,6 +58,7 @@ namespace MR
           void hide_negative_lobes_slot (bool is_checked);
           void colour_by_direction_slot (bool is_checked);
           void reset_scale_slot ();
+          void reset_view_slot ();
           void response_slot (bool is_checked);
           void previous_slot ();
           void next_slot ();

--- a/src/gui/shview/render_window.h
+++ b/src/gui/shview/render_window.h
@@ -57,7 +57,7 @@ namespace MR
           void show_axes_slot (bool is_checked);
           void hide_negative_lobes_slot (bool is_checked);
           void colour_by_direction_slot (bool is_checked);
-          void normalise_slot (bool is_checked);
+          void reset_scale_slot ();
           void response_slot (bool is_checked);
           void previous_slot ();
           void next_slot ();


### PR DESCRIPTION
Following #885, this adds modifications suggested in #619:

- scale is now set once at load time, and only modified on demand by pressing the Esc key (or using the 'reset scaling' menu entry). This allows comparison of ODFs / responses across different rows (useful for multi-shell handling, etc). 

- Scaling is set according to norm of SH coefficient vector of currently displayed ODF, rather than _l_=0 term as previously (should be more robust to different types of ODFs). 

- Font rendering on viewport is now possible. The text "no data loaded" is shown initially, and set to "row _n_" once data are shown. Should be possible to set the actual b-value if we eventually decide to support that. 

- initial view is now oblique: 45° to X-Y, 30° above transverse plane. Makes it easier to appreciate response functions without needing to interact with the projection. 

I've not tested whether MRView will still work correctly with these changes - some of these changes involve the `DWI::renderer` and `DWI::render_frame` code, which is common to both `shview` and the `mrview` ODF tool. I don't anticipate any particular issues, but I would appreciate thorough testing before merging...  :wink: