### PR TITLE
dwiextract: preserve DW scheme information exactly as per input

### DIFF
--- a/cmd/dwiextract.cpp
+++ b/cmd/dwiextract.cpp
@@ -51,7 +51,9 @@ void run()
 {
   auto input_image = Image<float>::open (argument[0]);
 
-  Eigen::MatrixXd grad = DWI::get_valid_DW_scheme (input_image);
+  Eigen::MatrixXd grad_unprocessed = DWI::get_DW_scheme (input_image);
+  Eigen::MatrixXd grad = grad_unprocessed;
+  DWI::validate_DW_scheme (grad, input_image);
 
   // Want to support non-shell-like data if it's just a straight extraction
   //   of all dwis or all bzeros i.e. don't initialise the Shells class
@@ -88,7 +90,7 @@ void run()
 
   Eigen::MatrixXd new_grad (volumes.size(), grad.cols());
   for (size_t i = 0; i < volumes.size(); i++)
-    new_grad.row (i) = grad.row (volumes[i]);
+    new_grad.row (i) = grad_unprocessed.row (volumes[i]);
   DWI::set_DW_scheme (header, new_grad);
 
   auto output_image = Image<float>::create (argument[1], header);

--- a/src/dwi/gradient.cpp
+++ b/src/dwi/gradient.cpp
@@ -213,9 +213,8 @@ namespace MR
 
 
 
-    Eigen::MatrixXd get_valid_DW_scheme (const Header& header, bool nofail)
+    void validate_DW_scheme (Eigen::MatrixXd& grad, const Header& header, bool nofail)
     {
-      auto grad = get_DW_scheme (header);
       if (grad.rows() == 0) 
         throw Exception ("no diffusion encoding information found in image \"" + header.name() + "\"");
 
@@ -245,7 +244,6 @@ namespace MR
         if (!nofail)
           throw Exception (e, "unable to get valid diffusion gradient table for image \"" + header.name() + "\"");
       }
-      return grad;
     }
 
 

--- a/src/dwi/gradient.h
+++ b/src/dwi/gradient.h
@@ -200,13 +200,24 @@ namespace MR
     void export_grad_commandline (const Header& header);
 
 
+    /*! \brief validate the DW encoding matrix \a grad and
+     * check that it matches the DW header in \a header 
+     *
+     * This ensures the dimensions match the corresponding DWI data, applies
+     * b-value scaling if specified, and normalises the gradient vectors. */
+    void validate_DW_scheme (Eigen::MatrixXd& grad, const Header& header, bool nofail = false);
 
     /*! \brief get the DW encoding matrix as per get_DW_scheme(), and
      * check that it matches the DW header in \a header 
      *
      * This is the version that should be used in any application that
      * processes the DWI raw data. */
-    Eigen::MatrixXd get_valid_DW_scheme (const Header& header, bool nofail = false);
+    inline Eigen::MatrixXd get_valid_DW_scheme (const Header& header, bool nofail = false) 
+    {
+      auto grad = get_DW_scheme (header);
+      validate_DW_scheme (grad, header, nofail);
+      return grad;
+    }
 
 
     //! \brief get the matrix mapping SH coefficients to amplitudes


### PR DESCRIPTION
As discussed in #878. Basically, get a processed version of the DW info to allow the shell selection to work as expected, but write back the unmodified version of the relevant DW info to the output.
