### PR TITLE
mrcalc: use 0+1j notation rather than 0+1i

### DIFF
--- a/testing/tests/mrcalc
+++ b/testing/tests/mrcalc
@@ -1,4 +1,4 @@
 mrcalc mrcalc/in.mif 2 -mult -neg -exp 10 -add - | testing_diff_data - mrcalc/out1.mif -frac 1e-5
 mrcalc mrcalc/in.mif 1.224 -div -cos mrcalc/in.mif -abs -sqrt -log -atanh -sub - | testing_diff_data - mrcalc/out2.mif -frac 1e-5
 mrcalc mrcalc/in.mif 0.2 -gt mrcalc/in.mif mrcalc/in.mif -1.123 -mult 0.9324 -add -exp -neg -if - | testing_diff_data - mrcalc/out3.mif -frac 1e-5
-mrcalc mrcalc/in.mif 0+1i -mult -exp mrcalc/in.mif -mult 1.34+5.12i -mult - | testing_diff_data - mrcalc/out4.mif -frac 1e-5
+mrcalc mrcalc/in.mif 0+1j -mult -exp mrcalc/in.mif -mult 1.34+5.12j -mult - | testing_diff_data - mrcalc/out4.mif -frac 1e-5


### PR DESCRIPTION
Due to issues with handling of complex numbers on MacOSX - see #430. Just reported to me by a user, might as well fix it...
