### PR TITLE
tck2connectome: Fix -scale_invnodevol option

### DIFF
--- a/src/dwi/tractography/connectome/connectome.cpp
+++ b/src/dwi/tractography/connectome/connectome.cpp
@@ -117,7 +117,7 @@ void setup_metric (Metric& metric, Image<node_t>& nodes_data)
   } else if (get_options ("scale_invlength").size()) {
     metric.set_scale_invlength();
   }
-  if (get_options ("scale_invnnodevol").size())
+  if (get_options ("scale_invnodevol").size())
     metric.set_scale_invnodevol (nodes_data);
   auto opt = get_options ("scale_file");
   if (opt.size())


### PR DESCRIPTION
In response to [this thread](http://community.mrtrix.org/t/tck2connectome-option-not-working-scale-invnodevol/680).

Will add more test data for `tck2connectome` after 0.3.16 is merged to master, since it appears that due to my ongoing battles with git submodules, the `master` branch on `test_data` is no longer pointing to the same commit as `master` in the main repo.