### PR TITLE
Fix mrview cmdline processing

### DIFF
--- a/cmd/mrview.cpp
+++ b/cmd/mrview.cpp
@@ -64,7 +64,6 @@ void run ()
 {
   GUI::MRView::Window window;
   window.show();
-  window.process_commandline_options();
 
   if (qApp->exec())
     throw Exception ("error running Qt application");

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -231,7 +231,7 @@ namespace MR
         tool_has_focus (nullptr),
         best_FPS (NAN),
         show_FPS (false),
-        current_arg (1) {
+        current_arg (nullptr) {
           main = this;
           GUI::App::set_main_window (this);
           GUI::Dialog::init();
@@ -705,7 +705,8 @@ namespace MR
           if(!tools_colourbar_position)
             WARN ("invalid specifier \"" + cbar_pos + "\" for config file entry \"MRViewToolsColourBarPosition\"");
 
-          QTimer::singleShot (10, this, SLOT(process_commandline_options()));
+          current_arg = MR::App::argv+1;
+          QTimer::singleShot (10, this, SLOT(process_commandline_option_slot()));
         }
 
 
@@ -1700,7 +1701,43 @@ namespace MR
       }
 
 
-      void Window::process_commandline_options ()
+      void Window::process_commandline_option_slot ()
+      {
+        if (current_arg >= MR::App::argv + MR::App::argc)
+          return;
+
+        const MR::App::Option* opt_p = match_option (*current_arg);
+
+        if (opt_p) {
+          if (current_arg + int (opt_p->size()) >= MR::App::argv+MR::App::argc)
+            throw Exception (std::string ("not enough parameters to option \"-") + opt_p->id + "\"");
+          ++current_arg;
+          const MR::App::ParsedOption opt (ParsedOption (opt_p, current_arg));
+          current_arg += opt_p->size();
+          try {
+            process_commandline_option (opt);
+          }
+          catch (Exception& E) {
+            E.display();
+            qApp->quit();
+          }
+        }
+        else {
+          std::vector<std::unique_ptr<MR::Header>> list;
+          try { list.push_back (std::unique_ptr<MR::Header> (new MR::Header (MR::Header::open (*current_arg)))); }
+          catch (Exception& e) { e.display(); }
+          add_images (list);
+          ++current_arg;
+        }
+
+
+        QTimer::singleShot (10, this, SLOT(process_commandline_option_slot()));
+        glarea->update();
+      }
+
+
+
+      void Window::process_commandline_option (const MR::App::ParsedOption& opt)
       {
 #undef TOOL
 #define TOOL(classname, name, description) \
@@ -1708,267 +1745,236 @@ namespace MR
         if (stub.compare (0, stub.size(), std::string (opt.opt->id), 0, stub.size()) == 0) { \
           create_tool (tool_group->actions()[tool_id], false); \
           if (dynamic_cast<Tool::__Action__*>(tool_group->actions()[tool_id])->dock->tool->process_commandline_option (opt)) \
-            return; \
+          return; \
         } \
         ++tool_id;
 
-        if (current_arg >= MR::App::argc)
-          return;
-        QTimer::singleShot (10, this, SLOT(process_commandline_options()));
-
-
-        glarea->update();
-
-        try {
-
-          const MR::App::Option* opt_p = match_option (MR::App::argv[current_arg]);
-          if (opt_p) {
-            if (current_arg + int (opt_p->size()) >= MR::App::argc)
-              throw Exception (std::string ("not enough parameters to option \"-") + opt_p->id + "\"");
-
-            const MR::App::ParsedOption opt (ParsedOption (opt_p, MR::App::argv+current_arg+1));
-            current_arg += 1+opt_p->size();
-
-            // see whether option is claimed by any tools:
-            size_t tool_id = 0;
-            std::string stub;
+        // see whether option is claimed by any tools:
+        size_t tool_id = 0;
+        std::string stub;
 #include "gui/mrview/tool/list.h"
 
 
-            // process general options:
-            if (opt.opt->is ("mode")) {
-              int n = int(opt[0]) - 1;
-              if (n < 0 || n >= mode_group->actions().size())
-                throw Exception ("invalid mode index \"" + str(n) + "\" in batch command");
-              select_mode_slot (mode_group->actions()[n]);
-              return;
-            }
-
-            if (opt.opt->is ("size")) {
-              std::vector<int> glsize = opt[0];
-              if (glsize.size() != 2)
-                throw Exception ("invalid argument \"" + std::string(opt.args[0]) + "\" to view.size batch command");
-              QSize oldsize = glarea->size();
-              QSize winsize = size();
-              resize (winsize.width() - oldsize.width() + glsize[0], winsize.height() - oldsize.height() + glsize[1]);
-              return;
-            }
-
-            if (opt.opt->is ("reset")) {
-              reset_view_slot();
-              return;
-            }
-
-            else if (opt.opt->is ("fov")) {
-              float fov = opt[0];
-              set_FOV (fov);
-              glarea->update();
-              return;
-            }
-
-            if (opt.opt->is ("focus")) {
-              try {
-                auto pos = parse_floats (opt[0]);
-                if (pos.size() != 3)
-                  throw Exception ("-focus option expects a comma-separated list of 3 floating-point values");
-                set_focus (Eigen::Vector3f { float(pos[0]), float(pos[1]), float(pos[2]) });
-              }
-              catch (Exception& E) {
-                try {
-                  show_crosshairs_action->setChecked (to<bool> (opt[0]));
-                }
-                catch (Exception& E2) {
-                  throw Exception ("-focus option expects a boolean or a comma-separated list of 3 floating-point values");
-                }
-              }
-              glarea->update();
-              return;
-            }
-
-            if (opt.opt->is ("voxel")) {
-              if (image()) {
-                std::vector<default_type> pos = parse_floats (opt[0]);
-                if (pos.size() != 3)
-                  throw Exception ("-voxel option expects a comma-separated list of 3 floating-point values");
-                set_focus (image()->transform().voxel2scanner.cast<float>() *  Eigen::Vector3f { float(pos[0]), float(pos[1]), float(pos[2]) });
-                glarea->update();
-              }
-              return;
-            }
-
-            if (opt.opt->is ("volume")) {
-              if (image()) {
-                auto pos = parse_ints (opt[0]);
-                for (size_t n = 0; n < std::min (pos.size(), image()->image.ndim()); ++n) {
-                  if (pos[n] < 0 || pos[n] >= image()->image.size(n+3))
-                    throw Exception ("volume index outside of image dimensions"); 
-                  set_image_volume (n+3, pos[n]);
-                  set_image_navigation_menu();
-                }
-                glarea->update();
-              }
-              return;
-            }
-
-            if (opt.opt->is ("fov")) {
-              float fov = opt[0];
-              set_FOV (fov);
-              glarea->update();
-              return;
-            }
-
-            if (opt.opt->is ("plane")) {
-              int n = opt[0];
-              set_plane (n);
-              glarea->update();
-              return;
-            }
-
-            if (opt.opt->is ("lock")) {
-              bool n = opt[0];
-              snap_to_image_action->setChecked (n);
-              snap_to_image_slot();
-              return;
-            }
-
-            if (opt.opt->is ("select_image")) {
-              int n = int(opt[0]) - 1;
-              if (n < 0 || n >= image_group->actions().size())
-                throw Exception ("invalid image index requested for option -select_image");
-              image_select_slot (image_group->actions()[n]);
-              return;
-            }
-
-            if (opt.opt->is ("load")) {
-              std::vector<std::unique_ptr<MR::Header>> list;
-              try { list.push_back (std::unique_ptr<MR::Header> (new MR::Header (MR::Header::open (opt[0])))); }
-              catch (Exception& e) { e.display(); }
-              add_images (list);
-              return;
-            }
-
-            if (opt.opt->is ("autoscale")) {
-              image_reset_slot();
-              return;
-            }
-
-            if (opt.opt->is ("colourmap")) {
-              int n = int(opt[0]) - 1;
-              if (n < 0 || n >= static_cast<int>(colourmap_button->colourmap_actions.size()))
-                throw Exception ("invalid image colourmap index \"" + str(n+1) + "\" requested in batch command");
-              colourmap_button->set_colourmap_index(n);
-              return;
-            }
-
-            if (opt.opt->is ("interpolation")) {
-              try {
-                image_interpolate_action->setChecked (to<bool> (opt[0]));
-              }
-              catch (Exception& E) {
-                throw Exception ("-interpolation option expects a boolean");
-              }
-              image_interpolate_slot();
-            }
-
-            if (opt.opt->is ("intensity_range")) {
-              if (image()) {
-                std::vector<default_type> param = parse_floats (opt[0]);
-                if (param.size() != 2)
-                  throw Exception ("-intensity_range options expects comma-separated list of two floating-point values");
-                image()->set_windowing (param[0], param[1]);
-                glarea->update();
-              }
-              return;
-            }
-
-            if (opt.opt->is ("position")) {
-              std::vector<int> pos = opt[0];
-              if (pos.size() != 2)
-                throw Exception ("invalid argument \"" + std::string(opt[0]) + "\" to -position option");
-              move (pos[0], pos[1]);
-              return;
-            }
-
-            if (opt.opt->is ("fullscreen")) {
-              full_screen_action->setChecked (true);
-              full_screen_slot();
-              return;
-            }
-
-            if (opt.opt->is ("noannotations")) {
-              toggle_annotations_slot ();
-              return;
-            }
-
-            if (opt.opt->is ("comments")) {
-              try {
-                show_comments_action->setChecked (to<bool> (opt[0]));
-              }
-              catch (Exception& E) {
-                throw Exception ("-comments option expects a boolean");
-              }
-              glarea->update();
-              return;
-            }
-
-            if (opt.opt->is ("voxelinfo")) {
-              try {
-                show_voxel_info_action->setChecked (to<bool> (opt[0]));
-              }
-              catch (Exception& E) {
-                throw Exception ("-voxelinfo option expects a boolean");
-              }
-              glarea->update();
-              return;
-            }
-
-            if (opt.opt->is ("orientationlabel")) {
-              try {
-                show_orientation_labels_action->setChecked (to<bool> (opt[0]));
-              }
-              catch (Exception& E) {
-                throw Exception ("-orientationlabel option expects a boolean");
-              }
-              glarea->update();
-              return;
-            }
-
-            if (opt.opt->is ("colourbar")) {
-              try {
-                show_colourbar_action->setChecked (to<bool> (opt[0]));
-              }
-              catch (Exception& E) {
-                throw Exception ("-colourbar option expects a boolean");
-              }
-              glarea->update();
-              return;
-            }
-
-            if (opt.opt->is ("fps")) {
-              show_FPS = true;
-              return;
-            }
-
-            if (opt.opt->is ("exit")) {
-              qApp->processEvents();
-              qApp->quit();
-            }
-
-            assert ("shouldn't reach here!" && false);
-          }
-          else {
-            std::vector<std::unique_ptr<MR::Header>> list;
-            try { list.push_back (std::unique_ptr<MR::Header> (new MR::Header (MR::Header::open (MR::App::argv[current_arg])))); }
-            catch (Exception& e) { e.display(); }
-            add_images (list);
-            ++current_arg;
-          }
+        // process general options:
+        if (opt.opt->is ("mode")) {
+          int n = int(opt[0]) - 1;
+          if (n < 0 || n >= mode_group->actions().size())
+            throw Exception ("invalid mode index \"" + str(n) + "\" in batch command");
+          select_mode_slot (mode_group->actions()[n]);
+          return;
         }
-        catch (Exception& E) {
-          E.display();
+
+        if (opt.opt->is ("size")) {
+          std::vector<int> glsize = opt[0];
+          if (glsize.size() != 2)
+            throw Exception ("invalid argument \"" + std::string(opt.args[0]) + "\" to view.size batch command");
+          QSize oldsize = glarea->size();
+          QSize winsize = size();
+          resize (winsize.width() - oldsize.width() + glsize[0], winsize.height() - oldsize.height() + glsize[1]);
+          return;
+        }
+
+        if (opt.opt->is ("reset")) {
+          reset_view_slot();
+          return;
+        }
+
+        else if (opt.opt->is ("fov")) {
+          float fov = opt[0];
+          set_FOV (fov);
+          glarea->update();
+          return;
+        }
+
+        if (opt.opt->is ("focus")) {
+          try {
+            auto pos = parse_floats (opt[0]);
+            if (pos.size() != 3)
+              throw Exception ("-focus option expects a comma-separated list of 3 floating-point values");
+            set_focus (Eigen::Vector3f { float(pos[0]), float(pos[1]), float(pos[2]) });
+          }
+          catch (Exception& E) {
+            try {
+              show_crosshairs_action->setChecked (to<bool> (opt[0]));
+            }
+            catch (Exception& E2) {
+              throw Exception ("-focus option expects a boolean or a comma-separated list of 3 floating-point values");
+            }
+          }
+          glarea->update();
+          return;
+        }
+
+        if (opt.opt->is ("voxel")) {
+          if (image()) {
+            std::vector<default_type> pos = parse_floats (opt[0]);
+            if (pos.size() != 3)
+              throw Exception ("-voxel option expects a comma-separated list of 3 floating-point values");
+            set_focus (image()->transform().voxel2scanner.cast<float>() *  Eigen::Vector3f { float(pos[0]), float(pos[1]), float(pos[2]) });
+            glarea->update();
+          }
+          return;
+        }
+
+        if (opt.opt->is ("volume")) {
+          if (image()) {
+            auto pos = parse_ints (opt[0]);
+            for (size_t n = 0; n < std::min (pos.size(), image()->image.ndim()); ++n) {
+              if (pos[n] < 0 || pos[n] >= image()->image.size(n+3))
+                throw Exception ("volume index outside of image dimensions"); 
+              set_image_volume (n+3, pos[n]);
+              set_image_navigation_menu();
+            }
+            glarea->update();
+          }
+          return;
+        }
+
+        if (opt.opt->is ("fov")) {
+          float fov = opt[0];
+          set_FOV (fov);
+          glarea->update();
+          return;
+        }
+
+        if (opt.opt->is ("plane")) {
+          int n = opt[0];
+          set_plane (n);
+          glarea->update();
+          return;
+        }
+
+        if (opt.opt->is ("lock")) {
+          bool n = opt[0];
+          snap_to_image_action->setChecked (n);
+          snap_to_image_slot();
+          return;
+        }
+
+        if (opt.opt->is ("select_image")) {
+          int n = int(opt[0]) - 1;
+          if (n < 0 || n >= image_group->actions().size())
+            throw Exception ("invalid image index requested for option -select_image");
+          image_select_slot (image_group->actions()[n]);
+          return;
+        }
+
+        if (opt.opt->is ("load")) {
+          std::vector<std::unique_ptr<MR::Header>> list;
+          try { list.push_back (std::unique_ptr<MR::Header> (new MR::Header (MR::Header::open (opt[0])))); }
+          catch (Exception& e) { e.display(); }
+          add_images (list);
+          return;
+        }
+
+        if (opt.opt->is ("autoscale")) {
+          image_reset_slot();
+          return;
+        }
+
+        if (opt.opt->is ("colourmap")) {
+          int n = int(opt[0]) - 1;
+          if (n < 0 || n >= static_cast<int>(colourmap_button->colourmap_actions.size()))
+            throw Exception ("invalid image colourmap index \"" + str(n+1) + "\" requested in batch command");
+          colourmap_button->set_colourmap_index(n);
+          return;
+        }
+
+        if (opt.opt->is ("interpolation")) {
+          try {
+            image_interpolate_action->setChecked (to<bool> (opt[0]));
+          }
+          catch (Exception& E) {
+            throw Exception ("-interpolation option expects a boolean");
+          }
+          image_interpolate_slot();
+        }
+
+        if (opt.opt->is ("intensity_range")) {
+          if (image()) {
+            std::vector<default_type> param = parse_floats (opt[0]);
+            if (param.size() != 2)
+              throw Exception ("-intensity_range options expects comma-separated list of two floating-point values");
+            image()->set_windowing (param[0], param[1]);
+            glarea->update();
+          }
+          return;
+        }
+
+        if (opt.opt->is ("position")) {
+          std::vector<int> pos = opt[0];
+          if (pos.size() != 2)
+            throw Exception ("invalid argument \"" + std::string(opt[0]) + "\" to -position option");
+          move (pos[0], pos[1]);
+          return;
+        }
+
+        if (opt.opt->is ("fullscreen")) {
+          full_screen_action->setChecked (true);
+          full_screen_slot();
+          return;
+        }
+
+        if (opt.opt->is ("noannotations")) {
+          toggle_annotations_slot ();
+          return;
+        }
+
+        if (opt.opt->is ("comments")) {
+          try {
+            show_comments_action->setChecked (to<bool> (opt[0]));
+          }
+          catch (Exception& E) {
+            throw Exception ("-comments option expects a boolean");
+          }
+          glarea->update();
+          return;
+        }
+
+        if (opt.opt->is ("voxelinfo")) {
+          try {
+            show_voxel_info_action->setChecked (to<bool> (opt[0]));
+          }
+          catch (Exception& E) {
+            throw Exception ("-voxelinfo option expects a boolean");
+          }
+          glarea->update();
+          return;
+        }
+
+        if (opt.opt->is ("orientationlabel")) {
+          try {
+            show_orientation_labels_action->setChecked (to<bool> (opt[0]));
+          }
+          catch (Exception& E) {
+            throw Exception ("-orientationlabel option expects a boolean");
+          }
+          glarea->update();
+          return;
+        }
+
+        if (opt.opt->is ("colourbar")) {
+          try {
+            show_colourbar_action->setChecked (to<bool> (opt[0]));
+          }
+          catch (Exception& E) {
+            throw Exception ("-colourbar option expects a boolean");
+          }
+          glarea->update();
+          return;
+        }
+
+        if (opt.opt->is ("fps")) {
+          show_FPS = true;
+          return;
+        }
+
+        if (opt.opt->is ("exit")) {
+          qApp->processEvents();
           qApp->quit();
         }
 
+        assert ("shouldn't reach here!" && false);
       }
 
 

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -1683,7 +1683,6 @@ namespace MR
         ++tool_id;
 
         glarea->update();
-        qApp->processEvents();
 
         try {
           for (int arg = 1; arg < MR::App::argc; ++arg) {
@@ -1764,6 +1763,20 @@ namespace MR
                 continue;
               }
 
+              if (opt.opt->is ("volume")) {
+                if (image()) {
+                  auto pos = parse_ints (opt[0]);
+                  for (size_t n = 0; n < std::min (pos.size(), image()->image.ndim()); ++n) {
+                    if (pos[n] < 0 || pos[n] >= image()->image.size(n+3))
+                      throw Exception ("volume index outside of image dimensions"); 
+                    set_image_volume (n+3, pos[n]);
+                    set_image_navigation_menu();
+                  }
+                  glarea->update();
+                }
+                continue;
+              }
+
               if (opt.opt->is ("fov")) {
                 float fov = opt[0];
                 set_FOV (fov);
@@ -1802,7 +1815,10 @@ namespace MR
               }
 
               if (opt.opt->is ("autoscale")) {
-                image_reset_slot();
+                if (image()) {
+                  image()->display_range = NaN;
+                  glarea->update();
+                }
                 continue;
               }
 
@@ -1944,6 +1960,10 @@ namespace MR
               "relative the image currently displayed. The new position should be supplied "
               "as a comma-separated list of floating-point values.").allow_multiple()
           +   Argument ("x,y,z").type_sequence_float()
+
+          + Option ("volume", "Set the volume index for the image displayed, "
+              "as a comma-separated list of integers.").allow_multiple()
+          +   Argument ("idx").type_sequence_int()
 
           + Option ("plane", "Set the viewing plane, according to the mappping 0: sagittal; 1: coronal; 2: axial.").allow_multiple()
           +   Argument ("index").type_integer (0,2)

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -230,7 +230,8 @@ namespace MR
         snap_to_image_axes_and_voxel (true),
         tool_has_focus (nullptr),
         best_FPS (NAN),
-        show_FPS (false) {
+        show_FPS (false),
+        current_arg (1) {
           main = this;
           GUI::App::set_main_window (this);
           GUI::Dialog::init();
@@ -703,6 +704,8 @@ namespace MR
           tools_colourbar_position = parse_colourmap_position_str(cbar_pos);
           if(!tools_colourbar_position)
             WARN ("invalid specifier \"" + cbar_pos + "\" for config file entry \"MRViewToolsColourBarPosition\"");
+
+          QTimer::singleShot (10, this, SLOT(process_commandline_options()));
         }
 
 
@@ -970,6 +973,11 @@ namespace MR
       void Window::updateGL ()
       {
         glarea->update();
+      }
+
+      void Window::drawGL ()
+      {
+        glarea->repaint();
       }
 
 
@@ -1678,260 +1686,267 @@ namespace MR
           tool_group->actions()[tool_id]->setChecked (true); \
           select_tool_slot (tool_group->actions()[tool_id]); \
           if (dynamic_cast<Tool::__Action__*>(tool_group->actions()[tool_id])->dock->tool->process_commandline_option (opt)) \
-          continue; \
+            return; \
         } \
         ++tool_id;
+
+        if (current_arg >= MR::App::argc)
+          return;
+        QTimer::singleShot (10, this, SLOT(process_commandline_options()));
+
 
         glarea->update();
 
         try {
-          for (int arg = 1; arg < MR::App::argc; ++arg) {
-            qApp->processEvents();
 
-            const MR::App::Option* opt_p = match_option (MR::App::argv[arg]);
-            if (opt_p) {
-              if (arg + int (opt_p->size()) >= MR::App::argc)
-                throw Exception (std::string ("not enough parameters to option \"-") + opt_p->id + "\"");
+          const MR::App::Option* opt_p = match_option (MR::App::argv[current_arg]);
+          if (opt_p) {
+            if (current_arg + int (opt_p->size()) >= MR::App::argc)
+              throw Exception (std::string ("not enough parameters to option \"-") + opt_p->id + "\"");
 
-              const MR::App::ParsedOption opt (ParsedOption (opt_p, MR::App::argv+arg+1));
-              arg += opt_p->size();
+            const MR::App::ParsedOption opt (ParsedOption (opt_p, MR::App::argv+current_arg+1));
+            current_arg += 1+opt_p->size();
 
-              // see whether option is claimed by any tools:
-              size_t tool_id = 0;
-              std::string stub;
+            // see whether option is claimed by any tools:
+            size_t tool_id = 0;
+            std::string stub;
 #include "gui/mrview/tool/list.h"
 
 
-              // process general options:
-              if (opt.opt->is ("mode")) {
-                int n = int(opt[0]) - 1;
-                if (n < 0 || n >= mode_group->actions().size())
-                  throw Exception ("invalid mode index \"" + str(n) + "\" in batch command");
-                select_mode_slot (mode_group->actions()[n]);
-                continue;
-              }
-
-              if (opt.opt->is ("size")) {
-                std::vector<int> glsize = opt[0];
-                if (glsize.size() != 2)
-                  throw Exception ("invalid argument \"" + std::string(opt.args[0]) + "\" to view.size batch command");
-                QSize oldsize = glarea->size();
-                QSize winsize = size();
-                resize (winsize.width() - oldsize.width() + glsize[0], winsize.height() - oldsize.height() + glsize[1]);
-                continue;
-              }
-
-              if (opt.opt->is ("reset")) {
-                reset_view_slot();
-                continue;
-              }
-
-              else if (opt.opt->is ("fov")) {
-                float fov = opt[0];
-                set_FOV (fov);
-                glarea->update();
-                continue;
-              }
-
-              if (opt.opt->is ("focus")) {
-                try {
-                  auto pos = parse_floats (opt[0]);
-                  if (pos.size() != 3)
-                    throw Exception ("-focus option expects a comma-separated list of 3 floating-point values");
-                  set_focus (Eigen::Vector3f { float(pos[0]), float(pos[1]), float(pos[2]) });
-                }
-                catch (Exception& E) {
-                  try {
-                    show_crosshairs_action->setChecked (to<bool> (opt[0]));
-                  }
-                  catch (Exception& E2) {
-                    throw Exception ("-focus option expects a boolean or a comma-separated list of 3 floating-point values");
-                  }
-                }
-                glarea->update();
-                continue;
-              }
-
-              if (opt.opt->is ("voxel")) {
-                if (image()) {
-                  std::vector<default_type> pos = parse_floats (opt[0]);
-                  if (pos.size() != 3)
-                    throw Exception ("-voxel option expects a comma-separated list of 3 floating-point values");
-                  set_focus (image()->transform().voxel2scanner.cast<float>() *  Eigen::Vector3f { float(pos[0]), float(pos[1]), float(pos[2]) });
-                  glarea->update();
-                }
-                continue;
-              }
-
-              if (opt.opt->is ("volume")) {
-                if (image()) {
-                  auto pos = parse_ints (opt[0]);
-                  for (size_t n = 0; n < std::min (pos.size(), image()->image.ndim()); ++n) {
-                    if (pos[n] < 0 || pos[n] >= image()->image.size(n+3))
-                      throw Exception ("volume index outside of image dimensions"); 
-                    set_image_volume (n+3, pos[n]);
-                    set_image_navigation_menu();
-                  }
-                  glarea->update();
-                }
-                continue;
-              }
-
-              if (opt.opt->is ("fov")) {
-                float fov = opt[0];
-                set_FOV (fov);
-                glarea->update();
-                continue;
-              }
-
-              if (opt.opt->is ("plane")) {
-                int n = opt[0];
-                set_plane (n);
-                glarea->update();
-                continue;
-              }
-
-              if (opt.opt->is ("lock")) {
-                bool n = opt[0];
-                snap_to_image_action->setChecked (n);
-                snap_to_image_slot();
-                continue;
-              }
-
-              if (opt.opt->is ("select_image")) {
-                int n = int(opt[0]) - 1;
-                if (n < 0 || n >= image_group->actions().size())
-                  throw Exception ("invalid image index requested for option -select_image");
-                image_select_slot (image_group->actions()[n]);
-                continue;
-              }
-
-              if (opt.opt->is ("load")) {
-                std::vector<std::unique_ptr<MR::Header>> list;
-                try { list.push_back (std::unique_ptr<MR::Header> (new MR::Header (MR::Header::open (opt[0])))); }
-                catch (Exception& e) { e.display(); }
-                add_images (list);
-                continue;
-              }
-
-              if (opt.opt->is ("autoscale")) {
-                if (image()) {
-                  image()->display_range = NaN;
-                  glarea->update();
-                }
-                continue;
-              }
-
-              if (opt.opt->is ("colourmap")) {
-                int n = int(opt[0]) - 1;
-                if (n < 0 || n >= static_cast<int>(colourmap_button->colourmap_actions.size()))
-                  throw Exception ("invalid image colourmap index \"" + str(n+1) + "\" requested in batch command");
-                colourmap_button->set_colourmap_index(n);
-                continue;
-              }
-
-              if (opt.opt->is ("interpolation")) {
-                try {
-                  image_interpolate_action->setChecked (to<bool> (opt[0]));
-                }
-                catch (Exception& E) {
-                  throw Exception ("-interpolation option expects a boolean");
-                }
-                image_interpolate_slot();
-              }
-
-              if (opt.opt->is ("intensity_range")) {
-                if (image()) {
-                  std::vector<default_type> param = parse_floats (opt[0]);
-                  if (param.size() != 2)
-                    throw Exception ("-intensity_range options expects comma-separated list of two floating-point values");
-                  image()->set_windowing (param[0], param[1]);
-                  glarea->update();
-                }
-                continue;
-              }
-
-              if (opt.opt->is ("position")) {
-                std::vector<int> pos = opt[0];
-                if (pos.size() != 2)
-                  throw Exception ("invalid argument \"" + std::string(opt[0]) + "\" to -position option");
-                move (pos[0], pos[1]);
-                continue;
-              }
-
-              if (opt.opt->is ("fullscreen")) {
-                full_screen_action->setChecked (true);
-                full_screen_slot();
-                continue;
-              }
-
-              if (opt.opt->is ("noannotations")) {
-                toggle_annotations_slot ();
-              }
-
-              if (opt.opt->is ("comments")) {
-                try {
-                  show_comments_action->setChecked (to<bool> (opt[0]));
-                }
-                catch (Exception& E) {
-                  throw Exception ("-comments option expects a boolean");
-                }
-                glarea->update();
-              }
-
-              if (opt.opt->is ("voxelinfo")) {
-                try {
-                  show_voxel_info_action->setChecked (to<bool> (opt[0]));
-                }
-                catch (Exception& E) {
-                  throw Exception ("-voxelinfo option expects a boolean");
-                }
-                glarea->update();
-              }
-
-              if (opt.opt->is ("orientationlabel")) {
-                try {
-                  show_orientation_labels_action->setChecked (to<bool> (opt[0]));
-                }
-                catch (Exception& E) {
-                  throw Exception ("-orientationlabel option expects a boolean");
-                }
-                glarea->update();
-              }
-
-              if (opt.opt->is ("colourbar")) {
-                try {
-                  show_colourbar_action->setChecked (to<bool> (opt[0]));
-                }
-                catch (Exception& E) {
-                  throw Exception ("-colourbar option expects a boolean");
-                }
-                glarea->update();
-              }
-
-              if (opt.opt->is ("fps")) {
-                show_FPS = true;
-                continue;
-              }
-
-              if (opt.opt->is ("exit")) {
-                qApp->processEvents();
-                qApp->quit();
-              }
-
+            // process general options:
+            if (opt.opt->is ("mode")) {
+              int n = int(opt[0]) - 1;
+              if (n < 0 || n >= mode_group->actions().size())
+                throw Exception ("invalid mode index \"" + str(n) + "\" in batch command");
+              select_mode_slot (mode_group->actions()[n]);
+              return;
             }
-            else {
+
+            if (opt.opt->is ("size")) {
+              std::vector<int> glsize = opt[0];
+              if (glsize.size() != 2)
+                throw Exception ("invalid argument \"" + std::string(opt.args[0]) + "\" to view.size batch command");
+              QSize oldsize = glarea->size();
+              QSize winsize = size();
+              resize (winsize.width() - oldsize.width() + glsize[0], winsize.height() - oldsize.height() + glsize[1]);
+              return;
+            }
+
+            if (opt.opt->is ("reset")) {
+              reset_view_slot();
+              return;
+            }
+
+            else if (opt.opt->is ("fov")) {
+              float fov = opt[0];
+              set_FOV (fov);
+              glarea->update();
+              return;
+            }
+
+            if (opt.opt->is ("focus")) {
+              try {
+                auto pos = parse_floats (opt[0]);
+                if (pos.size() != 3)
+                  throw Exception ("-focus option expects a comma-separated list of 3 floating-point values");
+                set_focus (Eigen::Vector3f { float(pos[0]), float(pos[1]), float(pos[2]) });
+              }
+              catch (Exception& E) {
+                try {
+                  show_crosshairs_action->setChecked (to<bool> (opt[0]));
+                }
+                catch (Exception& E2) {
+                  throw Exception ("-focus option expects a boolean or a comma-separated list of 3 floating-point values");
+                }
+              }
+              glarea->update();
+              return;
+            }
+
+            if (opt.opt->is ("voxel")) {
+              if (image()) {
+                std::vector<default_type> pos = parse_floats (opt[0]);
+                if (pos.size() != 3)
+                  throw Exception ("-voxel option expects a comma-separated list of 3 floating-point values");
+                set_focus (image()->transform().voxel2scanner.cast<float>() *  Eigen::Vector3f { float(pos[0]), float(pos[1]), float(pos[2]) });
+                glarea->update();
+              }
+              return;
+            }
+
+            if (opt.opt->is ("volume")) {
+              if (image()) {
+                auto pos = parse_ints (opt[0]);
+                for (size_t n = 0; n < std::min (pos.size(), image()->image.ndim()); ++n) {
+                  if (pos[n] < 0 || pos[n] >= image()->image.size(n+3))
+                    throw Exception ("volume index outside of image dimensions"); 
+                  set_image_volume (n+3, pos[n]);
+                  set_image_navigation_menu();
+                }
+                glarea->update();
+              }
+              return;
+            }
+
+            if (opt.opt->is ("fov")) {
+              float fov = opt[0];
+              set_FOV (fov);
+              glarea->update();
+              return;
+            }
+
+            if (opt.opt->is ("plane")) {
+              int n = opt[0];
+              set_plane (n);
+              glarea->update();
+              return;
+            }
+
+            if (opt.opt->is ("lock")) {
+              bool n = opt[0];
+              snap_to_image_action->setChecked (n);
+              snap_to_image_slot();
+              return;
+            }
+
+            if (opt.opt->is ("select_image")) {
+              int n = int(opt[0]) - 1;
+              if (n < 0 || n >= image_group->actions().size())
+                throw Exception ("invalid image index requested for option -select_image");
+              image_select_slot (image_group->actions()[n]);
+              return;
+            }
+
+            if (opt.opt->is ("load")) {
               std::vector<std::unique_ptr<MR::Header>> list;
-              try { list.push_back (std::unique_ptr<MR::Header> (new MR::Header (MR::Header::open (MR::App::argv[arg])))); }
+              try { list.push_back (std::unique_ptr<MR::Header> (new MR::Header (MR::Header::open (opt[0])))); }
               catch (Exception& e) { e.display(); }
               add_images (list);
+              return;
             }
+
+            if (opt.opt->is ("autoscale")) {
+              image_reset_slot();
+              return;
+            }
+
+            if (opt.opt->is ("colourmap")) {
+              int n = int(opt[0]) - 1;
+              if (n < 0 || n >= static_cast<int>(colourmap_button->colourmap_actions.size()))
+                throw Exception ("invalid image colourmap index \"" + str(n+1) + "\" requested in batch command");
+              colourmap_button->set_colourmap_index(n);
+              return;
+            }
+
+            if (opt.opt->is ("interpolation")) {
+              try {
+                image_interpolate_action->setChecked (to<bool> (opt[0]));
+              }
+              catch (Exception& E) {
+                throw Exception ("-interpolation option expects a boolean");
+              }
+              image_interpolate_slot();
+            }
+
+            if (opt.opt->is ("intensity_range")) {
+              if (image()) {
+                std::vector<default_type> param = parse_floats (opt[0]);
+                if (param.size() != 2)
+                  throw Exception ("-intensity_range options expects comma-separated list of two floating-point values");
+                image()->set_windowing (param[0], param[1]);
+                glarea->update();
+              }
+              return;
+            }
+
+            if (opt.opt->is ("position")) {
+              std::vector<int> pos = opt[0];
+              if (pos.size() != 2)
+                throw Exception ("invalid argument \"" + std::string(opt[0]) + "\" to -position option");
+              move (pos[0], pos[1]);
+              return;
+            }
+
+            if (opt.opt->is ("fullscreen")) {
+              full_screen_action->setChecked (true);
+              full_screen_slot();
+              return;
+            }
+
+            if (opt.opt->is ("noannotations")) {
+              toggle_annotations_slot ();
+              return;
+            }
+
+            if (opt.opt->is ("comments")) {
+              try {
+                show_comments_action->setChecked (to<bool> (opt[0]));
+              }
+              catch (Exception& E) {
+                throw Exception ("-comments option expects a boolean");
+              }
+              glarea->update();
+              return;
+            }
+
+            if (opt.opt->is ("voxelinfo")) {
+              try {
+                show_voxel_info_action->setChecked (to<bool> (opt[0]));
+              }
+              catch (Exception& E) {
+                throw Exception ("-voxelinfo option expects a boolean");
+              }
+              glarea->update();
+              return;
+            }
+
+            if (opt.opt->is ("orientationlabel")) {
+              try {
+                show_orientation_labels_action->setChecked (to<bool> (opt[0]));
+              }
+              catch (Exception& E) {
+                throw Exception ("-orientationlabel option expects a boolean");
+              }
+              glarea->update();
+              return;
+            }
+
+            if (opt.opt->is ("colourbar")) {
+              try {
+                show_colourbar_action->setChecked (to<bool> (opt[0]));
+              }
+              catch (Exception& E) {
+                throw Exception ("-colourbar option expects a boolean");
+              }
+              glarea->update();
+              return;
+            }
+
+            if (opt.opt->is ("fps")) {
+              show_FPS = true;
+              return;
+            }
+
+            if (opt.opt->is ("exit")) {
+              qApp->processEvents();
+              qApp->quit();
+            }
+
+            assert ("shouldn't reach here!" && false);
+          }
+          else {
+            std::vector<std::unique_ptr<MR::Header>> list;
+            try { list.push_back (std::unique_ptr<MR::Header> (new MR::Header (MR::Header::open (MR::App::argv[current_arg])))); }
+            catch (Exception& e) { e.display(); }
+            add_images (list);
+            ++current_arg;
           }
         }
         catch (Exception& E) {
           E.display();
           qApp->quit();
         }
+
       }
 
 

--- a/src/gui/mrview/window.h
+++ b/src/gui/mrview/window.h
@@ -319,6 +319,7 @@ namespace MR
           void set_image_navigation_menu ();
 
           void closeEvent (QCloseEvent* event) override;
+          void create_tool (QAction* action, bool show);
 
           template <class Event> void grab_mouse_state (Event* event);
           template <class Event> void update_mouse_state (Event* event);

--- a/src/gui/mrview/window.h
+++ b/src/gui/mrview/window.h
@@ -82,7 +82,6 @@ namespace MR
           ~Window();
 
           void add_images (std::vector<std::unique_ptr<MR::Header>>& list);
-          void process_commandline_options ();
 
           const QPoint& mouse_position () const { return mouse_position_; }
           const QPoint& mouse_displacement () const { return mouse_displacement_; }
@@ -175,6 +174,7 @@ namespace MR
         public slots:
           void on_scaling_changed ();
           void updateGL ();
+          void drawGL ();
 
         private slots:
           void image_open_slot ();
@@ -216,6 +216,7 @@ namespace MR
           void about_slot ();
           void aboutQt_slot ();
 
+          void process_commandline_options ();
 
 
         private:
@@ -327,6 +328,7 @@ namespace MR
           std::vector<double> render_times;
           double best_FPS, best_FPS_time;
           bool show_FPS;
+          int current_arg;
 
           friend class ImageBase;
           friend class Mode::Base;

--- a/src/gui/mrview/window.h
+++ b/src/gui/mrview/window.h
@@ -216,7 +216,7 @@ namespace MR
           void about_slot ();
           void aboutQt_slot ();
 
-          void process_commandline_options ();
+          void process_commandline_option_slot ();
 
 
         private:
@@ -321,6 +321,8 @@ namespace MR
           void closeEvent (QCloseEvent* event) override;
           void create_tool (QAction* action, bool show);
 
+          void process_commandline_option (const MR::App::ParsedOption& opt);
+
           template <class Event> void grab_mouse_state (Event* event);
           template <class Event> void update_mouse_state (Event* event);
 
@@ -329,7 +331,7 @@ namespace MR
           std::vector<double> render_times;
           double best_FPS, best_FPS_time;
           bool show_FPS;
-          int current_arg;
+          char* const* current_arg;
 
           friend class ImageBase;
           friend class Mode::Base;


### PR DESCRIPTION
This fixes issues when trying to run a complex set of operations in MRView from the command-line, and adds a new option `-volume` to set the volume currently shown. The main problem was that screen updates were not guaranteed to happen after each option was processed, leading to funny issues for later options, outdated/blank screenshots, etc. 

This came about because I was trying to do this:
```ShellSession
mrview -capture.folder . -capture.prefix screenshot- image.mif -size 256,256 -noannot -fov 120 \
    -vol 0 -autoscale -capture.grab \
    -vol 1 -autoscale -capture.grab \
    -vol 2 -autoscale -capture.grab \
    -vol 3 -autoscale -capture.grab \
    -vol 4 -autoscale -capture.grab \
    -vol 5 -autoscale -capture.grab \
    -exit
```
which now works with these changes. :grin:

One outstanding issue though is that any tool-specific option will cause the corresponding dock widget to show up, screwing up the window size. One way around it is to set the docks to floating in the config (i.e. add `MRViewDockFloating: 1` to the config file), but it's a bit ugly. It would be better to create the tool, but leave it hidden when started from the command-line... 