### PR TITLE
allocator alignment: use std::max_align_t rather than configure test

### DIFF
--- a/configure
+++ b/configure
@@ -745,47 +745,6 @@ except:
 
 
 
-# check Eigen3 memory alignment:
-
-report('Detecting allocator memory alignment: ')
-try:
-  memalign = compile ('''
-#include <iostream>
-#include <limits>
-
-int main (int argc, char* argv[])
-{
-  size_t default_align = std::numeric_limits<size_t>::max();
-  for (size_t n = 0; n < 100; ++n) {
-    struct alignas(64) X { double c[8]; };
-    X* x = new X;
-    size_t align = reinterpret_cast<size_t>(x) & 63U;
-    if (align && align < default_align)
-      default_align = align;
-  }
-  std::cout << default_align << "\\n";
-  return 0;
-}
-
-''', cpp_flags, ld_flags)
-
-  cpp_flags += [ '-DMRTRIX_ALLOC_MEM_ALIGN='+memalign ]
-  report (memalign + ' byte\n')
-except CompileError:
-  error (''' error compiling application!
-
-  This shouldn't happen!''' + configure_log_hint)
-except LinkError:
-  error (''' error linking application!
-
-  This shouldn't happen!''' + configure_log_hint)
-except RuntimeError:
-  error (''' error running application
-
-  This shouldn't happen!''' + configure_log_hint)
-except:
-  error ('unexpected exception!' + configure_log_hint)
-
 
 
 # Test that JSON for Modern C++ will compile, since it enforces its own requirements

--- a/core/types.h
+++ b/core/types.h
@@ -144,10 +144,10 @@ inline void __aligned_free (void* ptr) { if (ptr) std::free (*(reinterpret_cast<
 
 
 #define MEMALIGN(...) public: \
-  FORCE_INLINE void* operator new (std::size_t size) { return (alignof(__VA_ARGS__)>MRTRIX_ALLOC_MEM_ALIGN) ? __aligned_malloc (size) : ::operator new (size); } \
-  FORCE_INLINE void* operator new[] (std::size_t size) { return (alignof(__VA_ARGS__)>MRTRIX_ALLOC_MEM_ALIGN) ? __aligned_malloc (size) : ::operator new[] (size); } \
-  FORCE_INLINE void operator delete (void* ptr) { if (alignof(__VA_ARGS__)>MRTRIX_ALLOC_MEM_ALIGN) __aligned_free (ptr); else ::operator delete (ptr); } \
-  FORCE_INLINE void operator delete[] (void* ptr) { if (alignof(__VA_ARGS__)>MRTRIX_ALLOC_MEM_ALIGN) __aligned_free (ptr); else ::operator delete[] (ptr); }
+  FORCE_INLINE void* operator new (std::size_t size) { return (alignof(__VA_ARGS__)>alignof(std::max_align_t)) ? __aligned_malloc (size) : ::operator new (size); } \
+  FORCE_INLINE void* operator new[] (std::size_t size) { return (alignof(__VA_ARGS__)>alignof(std::max_align_t)) ? __aligned_malloc (size) : ::operator new[] (size); } \
+  FORCE_INLINE void operator delete (void* ptr) { if (alignof(__VA_ARGS__)>alignof(std::max_align_t)) __aligned_free (ptr); else ::operator delete (ptr); } \
+  FORCE_INLINE void operator delete[] (void* ptr) { if (alignof(__VA_ARGS__)>alignof(std::max_align_t)) __aligned_free (ptr); else ::operator delete[] (ptr); }
 
 
 /*! \def CHECK_MEM_ALIGN
@@ -165,7 +165,7 @@ inline void __aligned_free (void* ptr) { if (ptr) std::free (*(reinterpret_cast<
  * \sa MEMALIGN
  */
 #define CHECK_MEM_ALIGN(...) \
-    static_assert ( (alignof(__VA_ARGS__) <= MRTRIX_ALLOC_MEM_ALIGN ) || __has_custom_new_operator<__VA_ARGS__>::value, \
+    static_assert ( (alignof(__VA_ARGS__) <= alignof(std::max_align_t) ) || __has_custom_new_operator<__VA_ARGS__>::value, \
         "class requires over-alignment, but no operator new defined! Please insert MEMALIGN() into class definition.")
 
 
@@ -206,7 +206,7 @@ namespace MR
       std::integral_constant<bool, std::is_arithmetic<ValueType>::value || is_complex<ValueType>::value> { NOMEMALIGN };
 
 
-  template <typename X, int N=(alignof(X)>MRTRIX_ALLOC_MEM_ALIGN)>
+  template <typename X, int N=(alignof(X)>alignof(std::max_align_t))>
     class vector : public ::std::vector<X, Eigen::aligned_allocator<X>> { NOMEMALIGN
       public:
         using ::std::vector<X,Eigen::aligned_allocator<X>>::vector;


### PR DESCRIPTION
As discussed in #912.