### PR TITLE
Scripts: Better handling of scripts invoking other scripts

### DIFF
--- a/bin/dwi2response
+++ b/bin/dwi2response
@@ -31,10 +31,6 @@ common_options.add_argument('-grad', help='Pass the diffusion gradient table in 
 common_options.add_argument('-fslgrad', nargs=2, metavar=('bvecs', 'bvals'), help='Pass the diffusion gradient table in FSL bvecs/bvals format')
 app.cmdline.flagMutuallyExclusiveOptions( [ 'grad', 'fslgrad' ] )
 
-# Set default parameters; certain algorithms will need to override these
-app.cmdline.set_defaults(single_shell=False)
-app.cmdline.set_defaults(needs_bzero=False)
-
 # Import the command-line settings for all algorithms found in the relevant directory
 algorithm.initialise()
 
@@ -60,7 +56,7 @@ if app.args.lmax:
       app.error('Value of lmax must be even')
   except:
     app.error('Parameter lmax must be a number')
-  if app.args.single_shell and not len(lmax) == 1:
+  if alg.isSingleShell() and not len(lmax) == 1:
     app.error('Can only specify a single lmax value for single-shell algorithms')
 shell_option = ''
 if app.args.shell:
@@ -68,11 +64,11 @@ if app.args.shell:
     shell_values = [ int(x) for x in app.args.shell.split(',') ]
   except:
     app.error('-shell option should provide a comma-separated list of b-values')
-  if app.args.single_shell and not len(shell_values) == 1:
+  if alg.isSingleShell() and not len(shell_values) == 1:
     app.error('Can only specify a single b-value shell for single-shell algorithms')
   shell_option = ' -shell ' + app.args.shell
 singleshell_option = ''
-if app.args.single_shell:
+if alg.isSingleShell():
   singleshell_option = ' -singleshell -no-bzero'
 
 grad_import_option = ''
@@ -86,11 +82,11 @@ elif not image.headerField(path.fromUser(app.args.input, False), 'dwgrad'):
 app.makeTempDir()
 
 # Get standard input data into the temporary directory
-if app.args.single_shell or shell_option:
+if alg.isSingleShell() or shell_option:
   run.command('mrconvert ' + path.fromUser(app.args.input, True) + ' - -stride 0,0,0,1' + grad_import_option + ' | dwiextract - ' + path.toTemp('dwi.mif', True) + shell_option + singleshell_option)
 else: # Don't want to discard b=0 in multi-shell algorithms, which dwiextract will do
   run.command('mrconvert ' + path.fromUser(app.args.input, True) + ' ' + path.toTemp('dwi.mif', True) + ' -stride 0,0,0,1' + grad_import_option)
-if app.args.needs_bzero:
+if alg.needsBZero():
   run.command('mrconvert ' + path.fromUser(app.args.input, True) + ' - -stride 0,0,0,1' + grad_import_option + ' | dwiextract - ' + path.toTemp('bzero.mif', True) + " -bzero")
 if app.args.mask:
   run.command('mrconvert ' + path.fromUser(app.args.mask, True) + ' ' + path.toTemp('mask.mif', True) + ' -datatype bit')
@@ -98,7 +94,7 @@ if app.args.mask:
 alg.getInputs()
 
 app.gotoTempDir()
-  
+
 
 # Generate a brain mask (if necessary)
 # Otherwise, check that the mask provided is appropriate

--- a/lib/mrtrix3/dwi2response/dhollander.py
+++ b/lib/mrtrix3/dwi2response/dhollander.py
@@ -21,11 +21,18 @@ def checkOutputPaths():
   app.checkOutputPath(app.args.out_sfwm)
   app.checkOutputPath(app.args.out_gm)
   app.checkOutputPath(app.args.out_csf)
-  
-  
-  
+
+
+
 def getInputs():
   pass
+
+
+
+def isSingleShell():
+  return False
+def needsBZero():
+  return False
 
 
 

--- a/lib/mrtrix3/dwi2response/fa.py
+++ b/lib/mrtrix3/dwi2response/fa.py
@@ -10,8 +10,6 @@ def initialise(base_parser, subparsers):
   options.add_argument('-number', type=int, default=300, help='The number of highest-FA voxels to use')
   options.add_argument('-threshold', type=float, help='Apply a hard FA threshold, rather than selecting the top voxels')
   parser.flagMutuallyExclusiveOptions( [ 'number', 'threshold' ] )
-  parser.set_defaults(single_shell=True)
-  parser.set_defaults(needs_bzero=True)
 
 
 
@@ -23,6 +21,13 @@ def checkOutputPaths():
 
 def getInputs():
   pass
+
+
+
+def isSingleShell():
+  return True
+def needsBZero():
+  return True
 
 
 

--- a/lib/mrtrix3/dwi2response/manual.py
+++ b/lib/mrtrix3/dwi2response/manual.py
@@ -29,6 +29,13 @@ def getInputs():
 
 
 
+def isSingleShell():
+  return False
+def needsBZero():
+  return False
+
+
+
 def execute():
   import os, shutil
   from mrtrix3 import app, image, path, run

--- a/lib/mrtrix3/dwi2response/msmt_5tt.py
+++ b/lib/mrtrix3/dwi2response/msmt_5tt.py
@@ -46,7 +46,7 @@ def execute():
   # Get shell information
   shells = [ int(round(float(x))) for x in image.headerField('dwi.mif', 'shells').split() ]
   if len(shells) < 3:
-    app.warn('Less than three b-value shells; response functions will not be applicable in MSMT-CSD algorithm')
+    app.warn('Less than three b-value shells; response functions will not be applicable in resolving three tissues using MSMT-CSD algorithm')
 
   # Get lmax information (if provided)
   wm_lmax = [ ]
@@ -75,7 +75,7 @@ def execute():
   recursive_cleanup_option=''
   if not app._cleanup:
     recursive_cleanup_option = ' -nocleanup'
-  run.command('dwi2response ' + app.args.wm_algo + ' dwi.mif wm_ss_response.txt -mask wm_mask.mif -voxels wm_sf_mask.mif -quiet -tempdir ' + app._tempDir + recursive_cleanup_option)
+  run.command('dwi2response ' + app.args.wm_algo + ' dwi.mif wm_ss_response.txt -mask wm_mask.mif -voxels wm_sf_mask.mif -tempdir ' + app._tempDir + recursive_cleanup_option)
 
   # Check for empty masks
   wm_voxels  = int(image.statistic('wm_sf_mask.mif', 'count', 'wm_sf_mask.mif'))

--- a/lib/mrtrix3/dwi2response/msmt_5tt.py
+++ b/lib/mrtrix3/dwi2response/msmt_5tt.py
@@ -33,6 +33,13 @@ def getInputs():
 
 
 
+def isSingleShell():
+  return False
+def needsBZero():
+  return False
+
+
+
 def execute():
   import math, os, shutil
   from mrtrix3 import app, image, path, run

--- a/lib/mrtrix3/dwi2response/tax.py
+++ b/lib/mrtrix3/dwi2response/tax.py
@@ -9,7 +9,6 @@ def initialise(base_parser, subparsers):
   options.add_argument('-peak_ratio', type=float, default=0.1, help='Second-to-first-peak amplitude ratio threshold')
   options.add_argument('-max_iters', type=int, default=20, help='Maximum number of iterations')
   options.add_argument('-convergence', type=float, default=0.5, help='Percentile change in any RF coefficient required to continue iterating')
-  parser.set_defaults(single_shell=True)
 
 
 
@@ -21,6 +20,13 @@ def checkOutputPaths():
 
 def getInputs():
   pass
+
+
+
+def isSingleShell():
+  return True
+def needsBZero():
+  return False
 
 
 

--- a/lib/mrtrix3/dwi2response/tournier.py
+++ b/lib/mrtrix3/dwi2response/tournier.py
@@ -10,7 +10,6 @@ def initialise(base_parser, subparsers):
   options.add_argument('-sf_voxels', type=int, default=300, help='Number of single-fibre voxels to use when calculating response function')
   options.add_argument('-dilate', type=int, default=1, help='Number of mask dilation steps to apply when deriving voxel mask to test in the next iteration')
   options.add_argument('-max_iters', type=int, default=10, help='Maximum number of iterations')
-  parser.set_defaults(single_shell=True)
 
 
 
@@ -22,6 +21,13 @@ def checkOutputPaths():
 
 def getInputs():
   pass
+
+
+
+def isSingleShell():
+  return True
+def needsBZero():
+  return False
 
 
 
@@ -104,6 +110,6 @@ def execute():
     app.console('Exiting after maximum ' + str(app.args.max_iters) + ' iterations')
     run.function(shutil.copyfile, 'iter' + str(app.args.max_iters-1) + '_RF.txt', 'response.txt')
     run.function(shutil.move, 'iter' + str(app.args.max_iters-1) + '_SF.mif', 'voxels.mif')
-    
+
   run.function(shutil.copyfile, 'response.txt', path.fromUser(app.args.output, False))
 


### PR DESCRIPTION
Some discussion already in #785.

Needed some gymnastics to get it working on Windows on Python2. Basically, even once you find the shebang, neither `/usr/bin/env` nor `/usr/bin/env.exe` works, and determining the MSYS2 root directory is not as easy as one would think (`os.path.abspath()` just inserts the *current* drive letter to the start of the string). So instead I just bypass `env`, and use `distutils.spawn.find_executable()` as is already used elsewhere.

Needs testing across OS's and Python2/3.