### PR TITLE
More fixes for scripts run.command() in 0.3.16

### DIFF
--- a/lib/mrtrix3/file.py
+++ b/lib/mrtrix3/file.py
@@ -3,7 +3,7 @@
 
 
 # These functions can (and should in some instances) be called upon any file / directory
-#   that is no longer required by the script. If the script has been instructed to retain 
+#   that is no longer required by the script. If the script has been instructed to retain
 #   all temporaries, the resource will be retained; if not, it will be deleted (in particular
 #   to dynamically free up storage space used by the script).
 def delTempFile(path):
@@ -68,3 +68,33 @@ def newTempFile(suffix):
   app.debug(full_path)
   return full_path
 
+
+
+# Wait until a particular file not only exists, but also does not have any
+#   other process operating on it (so hopefully whatever created it has
+#   finished its work)
+# Using open() rather than os.path.exists() ensures that not only has the file
+#   appeared in the directory listing, but the data are there and a file handle
+#   can be obtained.
+# Initially, checks for the file once every 1/1000th of a second; this gradually
+#   increases if the file still doesn't exist, until the program is only checking
+#   for the file once a minute.
+def waitFor(path):
+  import time
+  from mrtrix3 import app
+  try:
+    open(path)
+    return
+  except:
+    pass
+  app.console('Waiting for finalization of new file \"' + path + '\"')
+  delay = 1.0/1024.0
+  while True:
+    try:
+      with open(path):
+        pass
+      return
+    except IOError:
+      time.sleep(delay)
+      delay = max(60.0, delay*2.0)
+  app.debug('File \"' + path + '\" appears to be complete')

--- a/lib/mrtrix3/run.py
+++ b/lib/mrtrix3/run.py
@@ -1,5 +1,3 @@
-_env = None
-
 import os
 _mrtrix_bin_path = os.path.abspath(os.path.join(os.path.abspath(os.path.dirname(os.path.abspath(__file__))), os.pardir, os.pardir, 'bin'))
 # Remember to remove the '.exe' from Windows binary executables
@@ -14,16 +12,7 @@ def command(cmd, exitOnError=True):
   import inspect, os, subprocess, sys, tempfile
   from mrtrix3 import app
 
-  global _env, _mrtrix_exe_list
-
-  if not _env:
-    _env = os.environ.copy()
-    # Prevent _any_ SGE-compatible commands from running in SGE mode;
-    #   this is a simpler solution than trying to monitor a queued job
-    # If one day somebody wants to use this scripting framework to execute queued commands,
-    #   an alternative solution will need to be found
-    if os.environ.get('SGE_ROOT'):
-      del _env['SGE_ROOT']
+  global _mrtrix_exe_list
 
   # Vectorise the command string, preserving anything encased within quotation marks
   # TODO Use shlex.split()?
@@ -145,7 +134,7 @@ def command(cmd, exitOnError=True):
       handle_err = file_err.fileno()
     # Set off the processes
     try:
-      process = subprocess.Popen (command, stdin=handle_in, stdout=handle_out, stderr=handle_err, env=_env)
+      process = subprocess.Popen (command, stdin=handle_in, stdout=handle_out, stderr=handle_err)
       _processes.append(process)
       tempfiles.append( ( file_out, file_err ) )
     # FileNotFoundError not defined in Python 2.7

--- a/lib/mrtrix3/run.py
+++ b/lib/mrtrix3/run.py
@@ -363,7 +363,7 @@ def _shebang(item):
   if data.translate(None, textchars):
     app.debug('File \"' + item + '\": Not a text file')
     return []
-  data = data.decode('utf-8')
+  data = str(data.decode('utf-8'))
   # Try to find the shebang line
   for line in data.splitlines():
     line = line.strip()

--- a/lib/mrtrix3/run.py
+++ b/lib/mrtrix3/run.py
@@ -342,7 +342,6 @@ def versionMatch(item):
 #   shebang at the start of the file to alter the subprocess call
 def _shebang(item):
   import os
-  import sys
   from mrtrix3 import app
   from distutils.spawn import find_executable
   # If a complete path has been provided rather than just a file name, don't perform any additional file search
@@ -369,7 +368,8 @@ def _shebang(item):
   for line in data.splitlines():
     line = line.strip()
     if len(line) > 2 and line[0:2] == '#!':
-      shebang = line[2:].split(' ')
+      # Need to strip first in case there's a gap between the shebang symbol and the interpreter path
+      shebang = line[2:].strip().split(' ')
       if app.isWindows():
         # On Windows, /usr/bin/env can't be easily found, and any direct interpreter path will have a similar issue.
         #   Instead, manually find the right interpreter to call using distutils

--- a/lib/mrtrix3/run.py
+++ b/lib/mrtrix3/run.py
@@ -10,6 +10,7 @@ _processes = [ ]
 def command(cmd, exitOnError=True):
 
   import inspect, os, subprocess, sys, tempfile
+  from distutils.spawn import find_executable
   from mrtrix3 import app
 
   global _mrtrix_exe_list
@@ -64,6 +65,11 @@ def command(cmd, exitOnError=True):
       shebang = _shebang(item)
       if len(shebang):
         new_cmdsplit.extend(shebang)
+        if not is_mrtrix_exe:
+          # If a shebang is found, and this call is therefore invoking an
+          #   interpreter, can't rely on the interpreter finding the script
+          #   from PATH; need to find the full path ourselves.
+          item = find_executable(item)
       next_is_exe = False
     if item == '|':
       if is_mrtrix_exe:
@@ -336,6 +342,7 @@ def versionMatch(item):
 #   shebang at the start of the file to alter the subprocess call
 def _shebang(item):
   import os
+  import sys
   from mrtrix3 import app
   from distutils.spawn import find_executable
   # If a complete path has been provided rather than just a file name, don't perform any additional file search
@@ -357,6 +364,7 @@ def _shebang(item):
   if data.translate(None, textchars):
     app.debug('File \"' + item + '\": Not a text file')
     return []
+  data = data.decode('utf-8')
   # Try to find the shebang line
   for line in data.splitlines():
     line = line.strip()


### PR DESCRIPTION
Following on from discussion in #920.

I thought that perhaps there was some sort of network file system race condition that was causing the annoying `standard_space_roi` missing file issue in `5ttgen fsl` (hence function `file.waitFor()`). It now appears as though it's `sh` not finding the script, yet giving a 0 return code. Differences in `subprocess` between Python versions may have contributed to the prior confusion in diagnosing - on top of the `sh` error message not being found until the `-debug` option was used.

Independently of the `standard_space_roi` issue, this function can also be used to wait for the `run_first_all` output rather than globally disabling SGE.

Need to confirm that this still works on Windows.