### PR TITLE
Eigen OpenMP handling

### DIFF
--- a/configure
+++ b/configure
@@ -42,9 +42,9 @@ OPTIONS
 
     -verbose     enable more informative output.
 
-    -dev         enable the extended development build process
+    -dev         enable the extended development build process.
 
-    -R           used to generate an R module (implies -noshared)
+    -R           used to generate an R module (implies -noshared).
 
 
 ENVIRONMENT VARIABLES
@@ -776,6 +776,8 @@ except ( LinkError, RuntimeError ) as e:
   This shouldn't happen!''' + configure_log_hint)
 except:
   error ('unexpected exception!' + configure_log_hint)
+
+eigen_cflags += [ '-D'+'EIGEN_DONT_PARALLELIZE', ]
 
 
 

--- a/configure
+++ b/configure
@@ -816,6 +816,32 @@ except:
 
 
 
+# add openmp flags if required and available
+
+if openmp:
+  cpp_flags += [ '-fopenmp' ]
+  ld_flags  += [ '-fopenmp' ]
+  report ('Checking for OpenMP support: ')
+  try:
+    compile ('''
+    #include <Eigen/Core>
+    int main()
+    {
+      Eigen::initParallel();
+      Eigen::setNbThreads(4);
+      return (Eigen::nbThreads() == 4) ? 0 : 1;
+    }
+    ''', cpp_flags + eigen_cflags, ld_flags)
+    report ('ok\n')
+  except (CompileError, LinkError):
+    error ('OpenMP not found for this compiler/system.')
+  except:
+    error ('OpenMP not working as expected.')
+
+
+
+
+
 # shared library generation:
 if not noshared:
   report ('Checking shared library generation: ')
@@ -1168,31 +1194,6 @@ if asserts:
 elif not debug:
   cpp_flags += [ '-DNDEBUG' ]
 
-
-
-
-
-# add openmp flags as required
-
-if openmp:
-  cpp_flags += [ '-fopenmp' ]
-  ld_flags  += [ '-fopenmp' ]
-  report ('Checking for OpenMP support: ')
-  try:
-    compile ('''
-    #include <Eigen/Core>
-    int main()
-    {
-      Eigen::initParallel();
-      Eigen::setNbThreads(4);
-      return (Eigen::nbThreads() == 4) ? 0 : 1;
-    }
-    ''', cpp_flags + eigen_cflags, ld_flags)
-    report ('ok\n')
-  except (CompileError, LinkError):
-    error ('OpenMP not found for this compiler/system.')
-  except:
-    error ('OpenMP not working as expected.')
 
 
 

--- a/configure
+++ b/configure
@@ -1176,8 +1176,23 @@ elif not debug:
 
 if openmp:
   cpp_flags += [ '-fopenmp' ]
-  ld_flags += [ '-fopenmp' ]
-  ld_lib_flags += [ '-fopenmp' ]
+  ld_flags  += [ '-fopenmp' ]
+  report ('Checking for OpenMP support: ')
+  try:
+    compile ('''
+    #include <Eigen/Core>
+    int main()
+    {
+      Eigen::initParallel();
+      Eigen::setNbThreads(4);
+      return (Eigen::nbThreads() == 4) ? 0 : 1;
+    }
+    ''', cpp_flags + eigen_cflags, ld_flags)
+    report ('ok\n')
+  except (CompileError, LinkError):
+    error ('OpenMP not found for this compiler/system.')
+  except:
+    error ('OpenMP not working as expected.')
 
 
 

--- a/configure
+++ b/configure
@@ -788,6 +788,32 @@ if not openmp:
 
 
 
+# add openmp flags if required and available
+
+if openmp:
+  cpp_flags += [ '-fopenmp' ]
+  ld_flags  += [ '-fopenmp' ]
+  report ('Checking for OpenMP support: ')
+  try:
+    compile ('''
+    #include <Eigen/Core>
+    int main()
+    {
+      Eigen::initParallel();
+      Eigen::setNbThreads(4);
+      return (Eigen::nbThreads() == 4) ? 0 : 1;
+    }
+    ''', cpp_flags + eigen_cflags, ld_flags)
+    report ('ok\n')
+  except (CompileError, LinkError):
+    error ('OpenMP not found for this compiler/system.')
+  except:
+    error ('OpenMP not working as expected.')
+
+
+
+
+
 # Test that JSON for Modern C++ will compile, since it enforces its own requirements
 
 report('Checking JSON for Modern C++ requirements: ')
@@ -812,31 +838,6 @@ except ( CompileError, LinkError ):
 except:
   error ('unexpected exception!' + configure_log_hint)
 
-
-
-
-
-# add openmp flags if required and available
-
-if openmp:
-  cpp_flags += [ '-fopenmp' ]
-  ld_flags  += [ '-fopenmp' ]
-  report ('Checking for OpenMP support: ')
-  try:
-    compile ('''
-    #include <Eigen/Core>
-    int main()
-    {
-      Eigen::initParallel();
-      Eigen::setNbThreads(4);
-      return (Eigen::nbThreads() == 4) ? 0 : 1;
-    }
-    ''', cpp_flags + eigen_cflags, ld_flags)
-    report ('ok\n')
-  except (CompileError, LinkError):
-    error ('OpenMP not found for this compiler/system.')
-  except:
-    error ('OpenMP not working as expected.')
 
 
 

--- a/configure
+++ b/configure
@@ -46,6 +46,8 @@ OPTIONS
 
     -R           used to generate an R module (implies -noshared).
 
+    -openmp      enable OpenMP compiler flags.
+
 
 ENVIRONMENT VARIABLES
 
@@ -139,6 +141,7 @@ noshared = False
 static = False
 verbose = False
 R_module = False
+openmp = False
 sh_basis_def = None
 dev = False
 
@@ -158,6 +161,7 @@ for arg in sys.argv[1:]:
     R_module = True
     #noshared = True
     nogui = True
+  elif '-openmp'.startswith (arg): openmp = True
   else:
     print (usage_string)
     sys.exit (1)
@@ -777,7 +781,8 @@ except ( LinkError, RuntimeError ) as e:
 except:
   error ('unexpected exception!' + configure_log_hint)
 
-eigen_cflags += [ '-D'+'EIGEN_DONT_PARALLELIZE', ]
+if not openmp:
+  eigen_cflags += [ '-DEIGEN_DONT_PARALLELIZE' ]
 
 
 
@@ -1142,9 +1147,6 @@ if R_module:
 
 
 
-
-
-
 # add debugging or profiling flags if requested:
 
 cpp_flags += [ '-Wall' ]
@@ -1168,7 +1170,19 @@ elif not debug:
 
 
 
-#
+
+
+# add openmp flags as required
+
+if openmp:
+  cpp_flags += [ '-fopenmp' ]
+  ld_flags += [ '-fopenmp' ]
+  ld_lib_flags += [ '-fopenmp' ]
+
+
+
+
+
 # set macro for non-orthonormal SH basis if requested:
 if sh_basis_def is not None:
   cpp_flags += [ sh_basis_def ]

--- a/core/types.h
+++ b/core/types.h
@@ -49,7 +49,6 @@ namespace MR {
   }
 }
 
-#define EIGEN_DONT_PARALLELIZE
 #define EIGEN_DENSEBASE_PLUGIN "eigen_plugins/dense_base.h"
 #define EIGEN_MATRIXBASE_PLUGIN "eigen_plugins/dense_base.h"
 #define EIGEN_ARRAYBASE_PLUGIN "eigen_plugins/dense_base.h"

--- a/core/types.h
+++ b/core/types.h
@@ -49,6 +49,10 @@ namespace MR {
   }
 }
 
+#ifdef EIGEN_HAS_OPENMP
+# undef EIGEN_HAS_OPENMP
+#endif
+
 #define EIGEN_DENSEBASE_PLUGIN "eigen_plugins/dense_base.h"
 #define EIGEN_MATRIXBASE_PLUGIN "eigen_plugins/dense_base.h"
 #define EIGEN_ARRAYBASE_PLUGIN "eigen_plugins/dense_base.h"


### PR DESCRIPTION
As explained on [this page](https://eigen.tuxfamily.org/dox/TopicMultiThreading.html), Eigen handles multi-threading through OpenMP. This functionality can be disabled with macro `EIGEN_DONT_PARALLELIZE`, which we had activated in `core/types.h` because we typically have many, relatively small (voxelwise) operations that are more efficiently parallelized using image-level threading primitives.

However, there are two issues with this approach. First of all, `EIGEN_DONT_PARALLELIZE` is a one-off flag read only upon the first inclusion of `Eigen/Core`. The current implementation is therefore unpredictable because it depends on the header include order. For instance,
```
#include types.h
#include <Eigen/Core>
```
will deactivate Eigen parallelism, whereas
```
#include <Eigen/Core>
#include types.h
```
will not. It is therefore safer to define `EIGEN_DONT_PARALLELIZE` as a compiler flag, as done in 6df61fa. The reason why this hasn't been an issue so far, is because the OpenMP flags are not set in the default build configuration, hence making the `EIGEN_DONT_PARALLELIZE` macro mute anyway.

Secondly, in applications involving large matrices it may be useful to rely on the Eigen OpenMP parallelization. I have added the necessary compiler flag in 99c5aef, which can be activated with
```
./configure -openmp
```

However, this would then activate OpenMP for *all* commands, including the many operations that are already parallelized at the voxel or track level. Therefore, I have undefined the Eigen macro `EIGEN_HAS_OPENMP` by default. The developer can then de-/activate Eigen parallelism as desired using
```
#define EIGEN_HAS_OPENMP

// parallel Eigen code

#undef EIGEN_HAS_OPENMP
```

Before we merge, this needs to be properly tested on different systems. All works well on my Ubuntu 16.04; I'll test on my Mac later tonight.