### PR TITLE
mrview view tool: buttons to copy voxel and scanner location to clipboard

### DIFF
--- a/src/gui/mrview/tool/view.cpp
+++ b/src/gui/mrview/tool/view.cpp
@@ -82,22 +82,22 @@ namespace MR
               return Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsUserCheckable;
             }
 
-            QModelIndex index (int row, int column, const QModelIndex& parent = QModelIndex()) const 
-            { 
+            QModelIndex index (int row, int column, const QModelIndex& parent = QModelIndex()) const
+            {
               (void) parent; // to suppress warnings about unused parameters
-              return createIndex (row, column); 
+              return createIndex (row, column);
             }
 
             QModelIndex parent (const QModelIndex&) const { return QModelIndex(); }
 
-            int rowCount (const QModelIndex& parent = QModelIndex()) const 
+            int rowCount (const QModelIndex& parent = QModelIndex()) const
             {
               (void) parent; // to suppress warnings about unused parameters
               return planes.size();
             }
 
-            int columnCount (const QModelIndex& parent = QModelIndex()) const 
-            { 
+            int columnCount (const QModelIndex& parent = QModelIndex()) const
+            {
               (void) parent; // to suppress warnings about unused parameters
               return 1;
             }
@@ -114,7 +114,7 @@ namespace MR
                 p.plane[n] = -p.plane[n];
               if (p.name[0] == '-')
                 p.name = p.name.substr (1);
-              else 
+              else
                 p.name = "-" + p.name;
               emit dataChanged (index, index);
             }
@@ -156,7 +156,7 @@ namespace MR
 
 
 
-        View::View (Dock* parent) : 
+        View::View (Dock* parent) :
           Base (parent)
         {
           VBoxLayout* main_box = new VBoxLayout (this);
@@ -164,7 +164,7 @@ namespace MR
           HBoxLayout* hlayout  = new HBoxLayout;
           hlayout->setContentsMargins (0, 0, 0, 0);
           hlayout->setSpacing (0);
-          
+
           hide_button = new QPushButton ("Hide main image",this);
           hide_button->setToolTip (tr ("Hide all main images"));
           hide_button->setIcon (QIcon (":/hide.svg"));
@@ -172,9 +172,9 @@ namespace MR
           hide_button->setChecked (!window().get_image_visibility());
           connect (hide_button, SIGNAL (clicked(bool)), this, SLOT (hide_image_slot (bool)));
           hlayout->addWidget (hide_button, 1);
-          
+
           main_box->addLayout (hlayout, 0);
-          
+
           // FoV
           QGroupBox* group_box = new QGroupBox ("FOV");
           main_box->addWidget (group_box);
@@ -217,6 +217,13 @@ namespace MR
           connect (voxel_z, SIGNAL (valueChanged()), this, SLOT (onSetVoxel()));
           layout->addWidget (voxel_z, 0, 3);
 
+          copy_voxel_button = new QPushButton ("copy",this);
+          copy_voxel_button->setMinimumWidth(30);
+          copy_voxel_button->setToolTip (tr ("copy voxel to clipboard"));
+          copy_voxel_button->setCheckable (false);
+          connect (copy_voxel_button, SIGNAL (clicked()), this, SLOT (copy_voxel_slot ()));
+          layout->addWidget (copy_voxel_button, 0, 4);
+
           layout->addWidget (new QLabel (tr("Position: ")), 1, 0);
 
           focus_x = new AdjustButton (this);
@@ -233,6 +240,13 @@ namespace MR
           focus_z->setMinimumWidth(focus_button_width);
           connect (focus_z, SIGNAL (valueChanged()), this, SLOT (onSetFocus()));
           layout->addWidget (focus_z, 1, 3);
+
+          copy_focus_button = new QPushButton ("copy",this);
+          copy_focus_button->setMinimumWidth(30);
+          copy_focus_button->setToolTip (tr ("copy position to clipboard"));
+          copy_focus_button->setCheckable (false);
+          connect (copy_focus_button, SIGNAL (clicked()), this, SLOT (copy_focus_slot ()));
+          layout->addWidget (copy_focus_button, 1, 4);
 
           // Volume
           volume_box = new QGroupBox ("Volume");
@@ -325,7 +339,7 @@ namespace MR
           clip_box->setLayout (vlayout);
           hlayout = new HBoxLayout;
           vlayout->addLayout (hlayout);
-          
+
 
           clip_planes_model = new ClipPlaneModel (this);
           connect (clip_planes_model, SIGNAL (dataChanged (const QModelIndex&, const QModelIndex&)),
@@ -342,7 +356,7 @@ namespace MR
           clip_planes_list_view->setToolTip ("Right-click for more options");
           connect (clip_planes_list_view, SIGNAL (customContextMenuRequested (const QPoint&)),
               this, SLOT (clip_planes_right_click_menu_slot (const QPoint&)));
-          connect (clip_planes_list_view->selectionModel(), 
+          connect (clip_planes_list_view->selectionModel(),
               SIGNAL (selectionChanged (const QItemSelection, const QItemSelection)),
               this, SLOT (clip_planes_selection_changed_slot()));
           hlayout->addWidget (clip_planes_list_view, 1);
@@ -353,19 +367,19 @@ namespace MR
           toolbar->setMovable (false);
           toolbar->setIconSize (QSize (16, 16));
           hlayout->addWidget (toolbar);
-          
+
           clip_highlight_check_box = new QCheckBox ("Highlight selected clip planes");
           clip_highlight_check_box->setToolTip ("Helps to identify selected clip planes that can be interacted with.");
           clip_highlight_check_box->setChecked (true);
           connect (clip_highlight_check_box, SIGNAL (toggled(bool)), this, SLOT(clip_planes_toggle_highlight_slot()));
           vlayout->addWidget (clip_highlight_check_box);
-          
+
           clip_intersectionmode_check_box = new QCheckBox ("Intersection mode");
           clip_intersectionmode_check_box->setToolTip ("Generated volume is the intersection of individual clipped volumes, rather than the union.");
           clip_intersectionmode_check_box->setChecked (false);
           connect (clip_intersectionmode_check_box, SIGNAL (toggled(bool)), this, SLOT(clip_planes_toggle_intersectionmode_slot()));
           vlayout->addWidget (clip_intersectionmode_check_box);
-          
+
 
 
           // clip planes handling:
@@ -458,7 +472,7 @@ namespace MR
 
 
 
-        void View::showEvent (QShowEvent*) 
+        void View::showEvent (QShowEvent*)
         {
           connect (&window(), SIGNAL (imageChanged()), this, SLOT (onImageChanged()));
           connect (&window(), SIGNAL (imageVisibilityChanged(bool)), this, SLOT (onImageVisibilityChanged(bool)));
@@ -482,14 +496,14 @@ namespace MR
 
 
 
-        void View::closeEvent (QCloseEvent*) 
+        void View::closeEvent (QCloseEvent*)
         {
           window().disconnect (this);
         }
 
 
 
-        void View::onImageChanged () 
+        void View::onImageChanged ()
         {
           const auto image = window().image();
 
@@ -547,9 +561,36 @@ namespace MR
           window().set_image_visibility(!flag);
         }
 
+        void View::copy_focus_slot ()
+        {
+          if(!window().image())
+            return;
+
+          auto focus (window().focus());
+          std::cout << str(focus[0]) << ", " << str(focus[1]) << ", " << str(focus[2]) << std::endl;
+
+          QClipboard *clip = QApplication::clipboard();
+          QString input = QString::fromStdString(str(focus[0])+", "+str(focus[1])+", "+str(focus[2]));
+          clip->setText(input);
+        }
+
+        void View::copy_voxel_slot ()
+        {
+          if(!window().image())
+            return;
+
+          auto focus (window().focus());
+          focus = window().image()->transform().scanner2voxel.cast<float>() * focus;
+          std::cout << str(focus[0]) << ", " << str(focus[1]) << ", " << str(focus[2]) << std::endl;
+
+          QClipboard *clip = QApplication::clipboard();
+          QString input = QString::fromStdString(str(focus[0])+", "+str(focus[1])+", "+str(focus[2]));
+          clip->setText(input);
+        }
 
 
-        void View::onFocusChanged () 
+
+        void View::onFocusChanged ()
         {
           if(!window().image())
             return;
@@ -567,7 +608,7 @@ namespace MR
 
 
 
-        void View::onFOVChanged () 
+        void View::onFOVChanged ()
         {
           fov->setValue (window().FOV());
           fov->setRate (FOV_RATE_MULTIPLIER * fov->value());
@@ -577,7 +618,7 @@ namespace MR
 
 
 
-        void View::onSetFocus () 
+        void View::onSetFocus ()
         {
           try {
             window().set_focus (Eigen::Vector3f { focus_x->value(), focus_y->value(), focus_z->value() } );
@@ -621,7 +662,7 @@ namespace MR
 
 
 
-        void View::onModeChanged () 
+        void View::onModeChanged ()
         {
           const Mode::Base* mode = window().get_current_mode();
           transparency_box->setVisible (mode->features & Mode::ShaderTransparency);
@@ -636,14 +677,14 @@ namespace MR
 
 
 
-        void View::onSetTransparency () 
+        void View::onSetTransparency ()
         {
-          assert (window().image()); 
+          assert (window().image());
           window().image()->transparent_intensity = transparent_intensity->value();
           window().image()->opaque_intensity = opaque_intensity->value();
           window().image()->alpha = get_alpha_from_slider (opacity->value());
-          window().image()->lessthan = lower_threshold->value(); 
-          window().image()->greaterthan = upper_threshold->value(); 
+          window().image()->lessthan = lower_threshold->value();
+          window().image()->greaterthan = upper_threshold->value();
           window().updateGL();
         }
 
@@ -651,7 +692,7 @@ namespace MR
 
 
 
-        void View::onPlaneChanged () 
+        void View::onPlaneChanged ()
         {
           plane_combobox->setCurrentIndex (window().plane());
         }
@@ -660,7 +701,7 @@ namespace MR
 
 
 
-        void View::onSetPlane (int index) 
+        void View::onSetPlane (int index)
         {
           window().set_plane (index);
           window().updateGL();
@@ -669,7 +710,7 @@ namespace MR
 
 
 
-        void View::onCheckThreshold (bool) 
+        void View::onCheckThreshold (bool)
         {
           assert (window().image());
           assert (threshold_box->isEnabled());
@@ -684,14 +725,14 @@ namespace MR
 
 
 
-        void View::set_transparency_from_image () 
+        void View::set_transparency_from_image ()
         {
           if (!std::isfinite (window().image()->transparent_intensity) ||
               !std::isfinite (window().image()->opaque_intensity) ||
               !std::isfinite (window().image()->alpha) ||
               !std::isfinite (window().image()->lessthan) ||
               !std::isfinite (window().image()->greaterthan)) { // reset:
-            if (!std::isfinite (window().image()->intensity_min()) || 
+            if (!std::isfinite (window().image()->intensity_min()) ||
                 !std::isfinite (window().image()->intensity_max()))
               return;
 
@@ -715,7 +756,7 @@ namespace MR
 
           transparent_intensity->setValue (window().image()->transparent_intensity);
           opaque_intensity->setValue (window().image()->opaque_intensity);
-          opacity->setValue (get_slider_value_from_alpha (window().image()->alpha)); 
+          opacity->setValue (get_slider_value_from_alpha (window().image()->alpha));
           lower_threshold->setValue (window().image()->lessthan);
           upper_threshold->setValue (window().image()->greaterthan);
           lower_threshold_check_box->setChecked (window().image()->use_discard_lower());
@@ -779,19 +820,19 @@ namespace MR
 
 
 
-        void View::clip_planes_add_axial_slot () 
+        void View::clip_planes_add_axial_slot ()
         {
           clip_planes_model->add (*(window().image()), 2);
           window().updateGL();
         }
 
-        void View::clip_planes_add_sagittal_slot () 
+        void View::clip_planes_add_sagittal_slot ()
         {
           clip_planes_model->add (*(window().image()), 0);
           window().updateGL();
         }
 
-        void View::clip_planes_add_coronal_slot () 
+        void View::clip_planes_add_coronal_slot ()
         {
           clip_planes_model->add (*(window().image()), 1);
           window().updateGL();
@@ -799,10 +840,10 @@ namespace MR
 
 
 
-        void View::clip_planes_reset_axial_slot () 
+        void View::clip_planes_reset_axial_slot ()
         {
           QModelIndexList indices = clip_planes_list_view->selectionModel()->selectedIndexes();
-          for (int i = 0; i < indices.size(); ++i) 
+          for (int i = 0; i < indices.size(); ++i)
             clip_planes_model->reset (indices[i], *(window().image()), 2);
           window().updateGL();
         }
@@ -811,7 +852,7 @@ namespace MR
         void View::clip_planes_reset_sagittal_slot ()
         {
           QModelIndexList indices = clip_planes_list_view->selectionModel()->selectedIndexes();
-          for (int i = 0; i < indices.size(); ++i) 
+          for (int i = 0; i < indices.size(); ++i)
             clip_planes_model->reset (indices[i], *(window().image()), 0);
           window().updateGL();
         }
@@ -820,7 +861,7 @@ namespace MR
         void View::clip_planes_reset_coronal_slot ()
         {
           QModelIndexList indices = clip_planes_list_view->selectionModel()->selectedIndexes();
-          for (int i = 0; i < indices.size(); ++i) 
+          for (int i = 0; i < indices.size(); ++i)
             clip_planes_model->reset (indices[i], *(window().image()), 1);
           window().updateGL();
         }
@@ -828,10 +869,10 @@ namespace MR
 
 
 
-        void View::clip_planes_invert_slot () 
+        void View::clip_planes_invert_slot ()
         {
           QModelIndexList indices = clip_planes_list_view->selectionModel()->selectedIndexes();
-          for (int i = 0; i < indices.size(); ++i) 
+          for (int i = 0; i < indices.size(); ++i)
             clip_planes_model->invert (indices[i]);
           window().updateGL();
         }
@@ -848,7 +889,7 @@ namespace MR
         }
 
 
-        void View::clip_planes_clear_slot () 
+        void View::clip_planes_clear_slot ()
         {
           clip_planes_model->clear();
           window().updateGL();
@@ -868,7 +909,7 @@ namespace MR
               if (clip_planes_model->planes[i].active) {
                 std::pair<GL::vec4,bool> item;
                 item.first = clip_planes_model->planes[i].plane;
-                item.second = selection->isSelected (clip_planes_model->index (i,0)); 
+                item.second = selection->isSelected (clip_planes_model->index (i,0));
                 ret.push_back (item);
               }
             }
@@ -882,7 +923,7 @@ namespace MR
           vector<GL::vec4*> ret;
           if (clip_box->isChecked()) {
             QModelIndexList indices = clip_planes_list_view->selectionModel()->selectedIndexes();
-            for (int i = 0; i < indices.size(); ++i) 
+            for (int i = 0; i < indices.size(); ++i)
               if (clip_planes_model->planes[indices[i].row()].active)
                 ret.push_back (&clip_planes_model->planes[indices[i].row()].plane);
           }
@@ -899,7 +940,7 @@ namespace MR
           return clip_intersectionmode_check_box->isChecked();
         }
 
-        void View::clip_planes_selection_changed_slot () 
+        void View::clip_planes_selection_changed_slot ()
         {
           bool selected = clip_planes_list_view->selectionModel()->selectedIndexes().size();
           clip_planes_reset_submenu->setEnabled (selected);
@@ -914,12 +955,12 @@ namespace MR
         {
           window().updateGL();
         }
-        
+
         void View::clip_planes_toggle_highlight_slot ()
         {
           window().updateGL();
         }
-        
+
         void View::clip_planes_toggle_intersectionmode_slot ()
         {
           window().updateGL();

--- a/src/gui/mrview/tool/view.h
+++ b/src/gui/mrview/tool/view.h
@@ -33,7 +33,7 @@ namespace MR
       {
 
 
-        class ClipPlane 
+        class ClipPlane
         { MEMALIGN (ClipPlane)
           public:
             GL::vec4 plane;
@@ -80,6 +80,8 @@ namespace MR
             void onCheckThreshold (bool);
             void onModeChanged ();
             void hide_image_slot (bool flag);
+            void copy_focus_slot ();
+            void copy_voxel_slot ();
             void clip_planes_right_click_menu_slot (const QPoint& pos);
             void clip_planes_selection_changed_slot ();
             void clip_planes_toggle_shown_slot();
@@ -102,6 +104,8 @@ namespace MR
 
           private:
             QPushButton *hide_button;
+            QPushButton *copy_focus_button;
+            QPushButton *copy_voxel_button;
             AdjustButton *focus_x, *focus_y, *focus_z;
             AdjustButton *voxel_x, *voxel_y, *voxel_z;
             SpinBox *vol_index, *vol_group;


### PR DESCRIPTION
Added two buttons to the view tool that allow to copy x,y,z voxel or scanner coordinates to the clipboard and write them to stdout. Could be used as a poor man's annotation tool.

![2017-03-29t10_14_35 080200 0100_hooowx](https://cloud.githubusercontent.com/assets/10046944/24447350/8ba153a6-1468-11e7-8a39-af759893d4fa.png)
