### PR TITLE
Feature/cpp modernize

### DIFF
--- a/cmd/afdconnectivity.cpp
+++ b/cmd/afdconnectivity.cpp
@@ -83,9 +83,9 @@ void usage ()
 }
 
 
-typedef float value_type;
-typedef DWI::Tractography::Mapping::SetDixel SetDixel;
-typedef DWI::Tractography::SIFT::FixelBase FixelBase;
+using value_type = float;
+using DWI::Tractography::Mapping::SetDixel;
+using DWI::Tractography::SIFT::FixelBase;
 
 
 

--- a/cmd/amp2sh.cpp
+++ b/cmd/amp2sh.cpp
@@ -87,7 +87,7 @@ void usage ()
 #define RICIAN_POWER 2.25
 
 
-typedef float value_type;
+using value_type = float;
 
 class Amp2SHCommon {
   public:

--- a/cmd/dirflip.cpp
+++ b/cmd/dirflip.cpp
@@ -52,10 +52,8 @@ void usage ()
 }
 
 
-typedef double value_type;
-typedef Eigen::Vector3d vector3_type;
-
-
+using value_type = double;
+using vector3_type = Eigen::Vector3d;
 
 
 class Shared {

--- a/cmd/dirgen.cpp
+++ b/cmd/dirgen.cpp
@@ -94,7 +94,7 @@ class Energy {
       return p == 1 ? x : fast_pow (x*x, p/2);
     }
 
-    typedef double value_type;
+    using value_type = double;
 
     size_t size () const { return 3 * ndir; }
 

--- a/cmd/dirmerge.cpp
+++ b/cmd/dirmerge.cpp
@@ -44,9 +44,9 @@ ARGUMENTS
 }
 
 
-typedef double value_type;
-typedef std::array<value_type,3> Direction;
-typedef std::vector<Direction> DirectionSet;
+using value_type = double;
+using Direction = std::array<value_type,3>;
+using DirectionSet = std::vector<Direction>;
 
 struct OutDir {
   Direction d;

--- a/cmd/dirorder.cpp
+++ b/cmd/dirorder.cpp
@@ -44,7 +44,7 @@ void usage ()
 }
 
 
-typedef double value_type;
+using value_type = double;
 
 
   template <typename value_type>

--- a/cmd/dirsplit.cpp
+++ b/cmd/dirsplit.cpp
@@ -47,10 +47,8 @@ OPTIONS
   + Option ("cartesian", "Output the directions in Cartesian coordinates [x y z] instead of [az el].");
 }
 
-
-typedef double value_type;
-typedef Eigen::Vector3d vector3_type;
-
+using value_type = double;
+using vector3_type = Eigen::Vector3d;
 
 
 class Shared {

--- a/cmd/dwi2adc.cpp
+++ b/cmd/dwi2adc.cpp
@@ -44,7 +44,7 @@ void usage ()
 
 
 
-typedef float value_type;
+using value_type = float;
 
 
 

--- a/cmd/dwi2noise.cpp
+++ b/cmd/dwi2noise.cpp
@@ -62,7 +62,7 @@ void usage ()
 }
 
 
-typedef float value_type;
+using value_type = float;
 
 void run ()
 {

--- a/cmd/dwi2tensor.cpp
+++ b/cmd/dwi2tensor.cpp
@@ -25,7 +25,7 @@ using namespace MR;
 using namespace App;
 using namespace std;
 
-typedef float value_type;
+using value_type = float;
 
 #define DEFAULT_NITER 2
 

--- a/cmd/dwidenoise.cpp
+++ b/cmd/dwidenoise.cpp
@@ -86,7 +86,7 @@ void usage ()
 }
 
 
-typedef float value_type;
+using value_type = float;
 
 
 template <class ImageType>

--- a/cmd/dwiextract.cpp
+++ b/cmd/dwiextract.cpp
@@ -26,7 +26,7 @@ using namespace MR;
 using namespace App;
 using namespace std;
 
-typedef float value_type;
+using value_type = float;
 
 void usage ()
 {

--- a/cmd/fixel2tsf.cpp
+++ b/cmd/fixel2tsf.cpp
@@ -65,7 +65,7 @@ void usage ()
 
 }
 
-typedef DWI::Tractography::Mapping::SetVoxelDir SetVoxelDir;
+using SetVoxelDir = DWI::Tractography::Mapping::SetVoxelDir;
 
 
 void run ()

--- a/cmd/fixel2voxel.cpp
+++ b/cmd/fixel2voxel.cpp
@@ -94,8 +94,8 @@ void usage ()
 class OpBase
 {
   protected:
-    typedef Sparse::Image<FixelMetric> in_type;
-    typedef Image<float> out_type;
+    using in_type = Sparse::Image<FixelMetric>;
+    using out_type = Image<float>;
 
   public:
     OpBase (const bool weighted) :

--- a/cmd/fixelcfestats.cpp
+++ b/cmd/fixelcfestats.cpp
@@ -38,7 +38,7 @@ using namespace App;
 using namespace MR::DWI::Tractography::Mapping;
 using Sparse::FixelMetric;
 
-typedef float value_type;
+using value_type = float;
 
 #define DEFAULT_PERMUTATIONS 5000
 #define DEFAULT_CFE_DH 0.1
@@ -236,7 +236,7 @@ void run() {
   if (num_tracks < 1000000)
     WARN ("more than 1 million tracks should be used to ensure robust fixel-fixel connectivity");
   {
-    typedef DWI::Tractography::Mapping::SetVoxelDir SetVoxelDir;
+    using SetVoxelDir = DWI::Tractography::Mapping::SetVoxelDir;
     DWI::Tractography::Mapping::TrackLoader loader (track_file, num_tracks, "pre-computing fixel-fixel connectivity");
     DWI::Tractography::Mapping::TrackMapperBase mapper (input_header);
     mapper.set_upsample_ratio (DWI::Tractography::Mapping::determine_upsample_ratio (input_header, properties, 0.333f));

--- a/cmd/fod2dec.cpp
+++ b/cmd/fod2dec.cpp
@@ -79,7 +79,7 @@ void usage ()
     + Argument ("value").type_float();
 }
 
-typedef float value_type;
+using value_type = float;
 const value_type UNIT = 1.0 / std::sqrt(3.0);
 
 class DecTransform {

--- a/cmd/label2mesh.cpp
+++ b/cmd/label2mesh.cpp
@@ -64,7 +64,7 @@ void run ()
     throw Exception ("Input image must have an integer data type");
   auto labels = labels_header.get_image<uint32_t>();
 
-  typedef Eigen::Array<int, 3, 1> voxel_corner_t;
+  using voxel_corner_t = Eigen::Array<int, 3, 1>;
 
   std::vector<voxel_corner_t> lower_corners, upper_corners;
 

--- a/cmd/labelconvert.cpp
+++ b/cmd/labelconvert.cpp
@@ -98,7 +98,7 @@ void run ()
   bool user_warn = false;
   for (auto l = Loop (in) (in, out); l; ++l) {
     const node_t orig = in.value();
-    if (orig >= 0 && orig < mapping.size())
+    if (orig < mapping.size())
       out.value() = mapping[orig];
     else
       user_warn = true;

--- a/cmd/maskfilter.cpp
+++ b/cmd/maskfilter.cpp
@@ -99,7 +99,7 @@ void usage ()
 }
 
 
-typedef bool value_type;
+using value_type = bool;
 
 void run () {
 

--- a/cmd/mrcalc.cpp
+++ b/cmd/mrcalc.cpp
@@ -136,8 +136,8 @@ OPTIONS
 }
 
 
-typedef float real_type;
-typedef cfloat complex_type;
+using real_type = float;
+using complex_type = cfloat;
 
 
 /**********************************************************************

--- a/cmd/mrcat.cpp
+++ b/cmd/mrcat.cpp
@@ -52,7 +52,7 @@ OPTIONS
 }
 
 
-typedef float value_type;
+using value_type = float;
 
 
 void run () {

--- a/cmd/mrcheckerboardmask.cpp
+++ b/cmd/mrcheckerboardmask.cpp
@@ -13,7 +13,7 @@
  *
  */
 
-#include <math.h> 
+#include <cmath>
 #include "command.h"
 #include "image.h"
 #include "image_helpers.h"

--- a/cmd/mrclusterstats.cpp
+++ b/cmd/mrclusterstats.cpp
@@ -115,7 +115,7 @@ void write_output (const VectorType& data,
 
 
 
-typedef Stats::TFCE::value_type value_type;
+using value_type = Stats::TFCE::value_type;
 
 
 void run() {

--- a/cmd/mrmath.cpp
+++ b/cmd/mrmath.cpp
@@ -72,7 +72,7 @@ void usage ()
 }
 
 
-typedef float value_type;
+using value_type = float;
 
 
 class Mean {

--- a/cmd/mrmetric.cpp
+++ b/cmd/mrmetric.cpp
@@ -73,7 +73,7 @@ template <class InType1, class InType2, class MaskType1, class MaskType2>
                             ssize_t& n_voxels,
                             Eigen::VectorXd& sos) {
 
-    typedef typename InType1::value_type value_type;
+    using value_type = typename InType1::value_type;
 
     if (use_mask1 or use_mask2)
       n_voxels = 0;
@@ -180,8 +180,8 @@ void usage ()
 
 }
 
-typedef double value_type;
-typedef Image<bool> MaskType;
+using value_type = double;
+using MaskType = Image<bool>;
 
 void run ()
 {
@@ -298,9 +298,9 @@ void run ()
     if (space == 3) {
       INFO ("space: average space");
 
-      typedef Image<value_type> ImageType1;
-      typedef Image<value_type> ImageType2;
-      typedef Header ImageTypeM;
+      using ImageType1 = Image<value_type>;
+      using ImageType2 = Image<value_type>;
+      using ImageTypeM = Header;
 
       n_voxels = 0;
       std::vector<Header> headers;
@@ -312,16 +312,16 @@ void run ()
 
       Header midway_image_header = compute_minimum_average_header (headers, 1, padding, init_transforms);
 
-      typedef Interp::LinearInterp<Image<value_type>, Interp::LinearInterpProcessingType::Value> LinearInterpolatorType1;
-      typedef Interp::LinearInterp<Image<value_type>, Interp::LinearInterpProcessingType::Value> LinearInterpolatorType2;
-      typedef Interp::SplineInterp<ImageType1, Math::UniformBSpline<typename ImageType1::value_type>, Math::SplineProcessingType::Value> CubicInterpolatorType1;
-      typedef Interp::SplineInterp<ImageType2, Math::UniformBSpline<typename ImageType2::value_type>, Math::SplineProcessingType::Value> CubicInterpolatorType2;
-      typedef Interp::Nearest<Image<bool>> MaskInterpolatorType1;
-      typedef Interp::Nearest<Image<bool>> MaskInterpolatorType2;
-      typedef Image<default_type> ProcessedImageType;
-      typedef Image<bool> ProcessedMaskType;
+      using LinearInterpolatorType1 = Interp::LinearInterp<Image<value_type>, Interp::LinearInterpProcessingType::Value>;
+      using LinearInterpolatorType2 = Interp::LinearInterp<Image<value_type>, Interp::LinearInterpProcessingType::Value>;
+      using CubicInterpolatorType1 = Interp::SplineInterp<ImageType1, Math::UniformBSpline<typename ImageType1::value_type>, Math::SplineProcessingType::Value>;
+      using CubicInterpolatorType2 = Interp::SplineInterp<ImageType2, Math::UniformBSpline<typename ImageType2::value_type>, Math::SplineProcessingType::Value>;
+      using MaskInterpolatorType1 = Interp::Nearest<Image<bool>>;
+      using MaskInterpolatorType2 = Interp::Nearest<Image<bool>>;
+      using ProcessedImageType = Image<default_type>;
+      using ProcessedMaskType = Image<bool>;
 
-      typedef Registration::Metric::Params <
+      using LinearParamType = Registration::Metric::Params <
                                Registration::Transform::Rigid,
                                ImageType1,
                                ImageType2,
@@ -336,8 +336,8 @@ void run ()
                                Interp::LinearInterp<ProcessedImageType, Interp::LinearInterpProcessingType::Value>,
                                ProcessedMaskType,
                                Interp::Nearest<ProcessedMaskType>
-                               > LinearParamType;
-      typedef Registration::Metric::Params <
+                               >;
+      using CubicParamType = Registration::Metric::Params <
                                Registration::Transform::Rigid,
                                ImageType1,
                                ImageType2,
@@ -352,7 +352,7 @@ void run ()
                                Interp::LinearInterp<ProcessedImageType, Interp::LinearInterpProcessingType::Value>,
                                ProcessedMaskType,
                                Interp::Nearest<ProcessedMaskType>
-                               > CubicParamType;
+                               >;
 
         ImageTypeM midway_image (midway_image_header);
 

--- a/cmd/mrregister.cpp
+++ b/cmd/mrregister.cpp
@@ -105,7 +105,7 @@ void usage ()
   + DataType::options();
 }
 
-typedef double value_type;
+using value_type = double;
 
 
 

--- a/cmd/mrstats.cpp
+++ b/cmd/mrstats.cpp
@@ -59,8 +59,8 @@ OPTIONS
 }
 
 
-typedef Stats::value_type value_type;
-typedef Stats::complex_type complex_type;
+using value_type = Stats::value_type;
+using complex_type = Stats::complex_type;
 
 class Volume_loop
 {

--- a/cmd/sh2amp.cpp
+++ b/cmd/sh2amp.cpp
@@ -57,7 +57,7 @@ void usage ()
 }
 
 
-typedef float value_type;
+using value_type = float;
 
 
 class SH2Amp

--- a/cmd/sh2peaks.cpp
+++ b/cmd/sh2peaks.cpp
@@ -76,7 +76,7 @@ void usage ()
 }
 
 
-typedef float value_type;
+using value_type = float;
 
 
 

--- a/cmd/sh2response.cpp
+++ b/cmd/sh2response.cpp
@@ -61,7 +61,7 @@ void usage ()
 
 
 
-typedef double value_type;
+using value_type = double;
 
 
 

--- a/cmd/shconv.cpp
+++ b/cmd/shconv.cpp
@@ -46,7 +46,7 @@ void usage ()
 
 
 
-typedef float value_type;
+using value_type = float;
 
 
 class SConvFunctor {

--- a/cmd/tcknormalise.cpp
+++ b/cmd/tcknormalise.cpp
@@ -42,8 +42,8 @@ void usage ()
 
 
 
-typedef float value_type;
-typedef Tractography::Streamline<value_type> TrackType;
+using value_type = float;
+using TrackType = Tractography::Streamline<value_type>;
 
 
 

--- a/cmd/tckresample.cpp
+++ b/cmd/tckresample.cpp
@@ -58,7 +58,7 @@ void usage ()
 
 
 
-typedef float value_type;
+using value_type = float;
 
 void run ()
 {

--- a/cmd/tcksample.cpp
+++ b/cmd/tcksample.cpp
@@ -82,8 +82,8 @@ void usage ()
 
 
 
-typedef float value_type;
-typedef Eigen::VectorXf vector_type;
+using value_type = float;
+using vector_type = Eigen::VectorXf;
 
 
 

--- a/cmd/tensor2metric.cpp
+++ b/cmd/tensor2metric.cpp
@@ -26,7 +26,7 @@ using namespace MR;
 using namespace App;
 using namespace std;
 
-typedef float value_type;
+using value_type = float;
 const char* modulate_choices[] = { "none", "fa", "eigval", NULL };
 
 void usage ()

--- a/cmd/tsfdivide.cpp
+++ b/cmd/tsfdivide.cpp
@@ -35,7 +35,7 @@ void usage ()
   + Argument ("output", "the output track scalar file").type_file_out();
 }
 
-typedef float value_type;
+using value_type = float;
 
 
 void run ()

--- a/cmd/tsfmult.cpp
+++ b/cmd/tsfmult.cpp
@@ -35,7 +35,7 @@ void usage ()
   + Argument ("output", "the output track scalar file").type_file_out();
 }
 
-typedef float value_type;
+using value_type = float;
 
 
 void run ()

--- a/cmd/tsfsmooth.cpp
+++ b/cmd/tsfsmooth.cpp
@@ -43,7 +43,7 @@ void usage ()
   + Argument ("sigma").type_float(1e-6);
 }
 
-typedef float value_type;
+using value_type = float;
 
 
 void run ()

--- a/cmd/tsfthreshold.cpp
+++ b/cmd/tsfthreshold.cpp
@@ -40,7 +40,7 @@ void usage ()
 
 }
 
-typedef float value_type;
+using value_type = float;
 
 
 void run ()

--- a/cmd/warp2metric.cpp
+++ b/cmd/warp2metric.cpp
@@ -55,7 +55,7 @@ void usage ()
 }
 
 
-typedef float value_type;
+using value_type = float;
 
 
 void run ()

--- a/cmd/warpcorrect.cpp
+++ b/cmd/warpcorrect.cpp
@@ -38,7 +38,7 @@ void usage ()
 }
 
 
-typedef float value_type;
+using value_type = float;
 
 
 void run ()

--- a/lib/adapter/base.h
+++ b/lib/adapter/base.h
@@ -37,7 +37,7 @@ namespace MR
             parent_ (parent) {
             }
 
-          typedef typename ImageType::value_type value_type;
+          using value_type = typename ImageType::value_type;
 
           template <class U> 
             const Base& operator= (const U& V) { return parent_ = V; }

--- a/lib/adapter/extract.h
+++ b/lib/adapter/extract.h
@@ -29,7 +29,7 @@ namespace MR
         using Base<ImageType>::ndim;
         using Base<ImageType>::spacing;
         using Base<ImageType>::parent;
-        typedef typename ImageType::value_type value_type;
+        using value_type = typename ImageType::value_type;
 
         Extract1D (const ImageType& original, const size_t axis, const std::vector<int>& indices) :
           Base<ImageType> (original),
@@ -110,7 +110,7 @@ namespace MR
         using Base<ImageType>::ndim;
         using Base<ImageType>::spacing;
         using Base<ImageType>::parent;
-        typedef typename ImageType::value_type value_type;
+        using value_type = typename ImageType::value_type;
 
         Extract (const ImageType& original, const std::vector<std::vector<int>>& indices) :
           Base<ImageType> (original),

--- a/lib/adapter/gaussian1D.h
+++ b/lib/adapter/gaussian1D.h
@@ -44,7 +44,7 @@ namespace MR
           compute_kernel();
         }
 
-        typedef typename ImageType::value_type value_type;
+        using value_type = typename ImageType::value_type;
 
         value_type value ()
         {

--- a/lib/adapter/gradient1D.h
+++ b/lib/adapter/gradient1D.h
@@ -27,7 +27,7 @@ namespace MR
       class Gradient1D : public Base<ImageType> {
       public:
 
-        typedef typename ImageType::value_type value_type;
+        using value_type = typename ImageType::value_type;
 
         Gradient1D (const ImageType& parent,
                     size_t axis = 0,

--- a/lib/adapter/gradient3D.h
+++ b/lib/adapter/gradient3D.h
@@ -35,7 +35,7 @@ namespace MR
       class Gradient3D : public Gradient1D<ImageType> {
 
       public:
-        typedef typename ImageType::value_type value_type;
+        using value_type = typename ImageType::value_type;
 
         Gradient3D (const ImageType& parent,
                     bool wrt_scanner = false) :

--- a/lib/adapter/jacobian.h
+++ b/lib/adapter/jacobian.h
@@ -36,7 +36,7 @@ namespace MR
             wrt_scanner (wrt_scanner) { }
 
 
-          typedef typename WarpType::value_type value_type;
+          using value_type = typename WarpType::value_type;
 
 
           Eigen::Matrix<value_type, 3, 3> value ()

--- a/lib/adapter/median.h
+++ b/lib/adapter/median.h
@@ -38,8 +38,8 @@ namespace MR
             set_extent (extent);
           }
 
-        typedef typename ImageType::value_type value_type;
-        typedef Median voxel_type;
+        using value_type = typename ImageType::value_type;
+        using voxel_type = Median;
 
         void set_extent (const std::vector<int>& ext)
         {

--- a/lib/adapter/neighbourhood3D.h
+++ b/lib/adapter/neighbourhood3D.h
@@ -34,7 +34,7 @@ namespace MR
       class NeighbourhoodCoord : public Base<ImageType>
     {
       public:
-        typedef typename ImageType::value_type value_type;
+        using value_type = typename ImageType::value_type;
 
         using Base<ImageType>::name;
         using Base<ImageType>::spacing;

--- a/lib/adapter/normalise3D.h
+++ b/lib/adapter/normalise3D.h
@@ -37,8 +37,8 @@ namespace MR
             set_extent (extent);
           }
 
-        typedef typename ImageType::value_type value_type;
-        typedef Normalise3D voxel_type;
+        using value_type = typename ImageType::value_type;
+        using voxel_type = Normalise3D;
 
         void set_extent (const std::vector<int>& ext)
         {

--- a/lib/adapter/permute_axes.h
+++ b/lib/adapter/permute_axes.h
@@ -29,7 +29,7 @@ namespace MR
       public:
         using Base<ImageType>::size;
         using Base<ImageType>::parent;
-        typedef typename ImageType::value_type value_type;
+        using value_type = typename ImageType::value_type;
 
         PermuteAxes (const ImageType& original, const std::vector<int>& axes) :
           Base<ImageType> (original), 

--- a/lib/adapter/replicate.h
+++ b/lib/adapter/replicate.h
@@ -29,7 +29,7 @@ namespace MR
       class Replicate : public Base<ImageType>
     {
       public:
-        typedef typename ImageType::value_type value_type;
+        using value_type = typename ImageType::value_type;
 
         using Base<ImageType>::name;
         using Base<ImageType>::ndim;

--- a/lib/adapter/reslice.h
+++ b/lib/adapter/reslice.h
@@ -74,7 +74,7 @@ namespace MR
       class Reslice
     {
       public:
-        typedef typename ImageType::value_type value_type;
+        using value_type = typename ImageType::value_type;
 
         template <class HeaderType>
           Reslice (const ImageType& original,

--- a/lib/adapter/subset.h
+++ b/lib/adapter/subset.h
@@ -27,7 +27,7 @@ namespace MR
       class Subset : public Base<ImageType>
     {
       public:
-        typedef typename ImageType::value_type value_type;
+        using value_type = typename ImageType::value_type;
 
         using Base<ImageType>::name;
         using Base<ImageType>::spacing;

--- a/lib/adapter/warp.h
+++ b/lib/adapter/warp.h
@@ -50,7 +50,7 @@ namespace MR
       class Warp
     {
       public:
-        typedef typename ImageType::value_type value_type;
+        using value_type = typename ImageType::value_type;
 
           Warp (const ImageType& original,
                 const WarpType& warp,

--- a/lib/algo/histogram.h
+++ b/lib/algo/histogram.h
@@ -27,7 +27,7 @@ namespace MR
     template <class Set> class Histogram
     {
       public:
-        typedef typename Set::value_type value_type;
+        using value_type = typename Set::value_type;
 
         Histogram (Set& D, const size_t num_buckets=100) {
           if (num_buckets < 10)

--- a/lib/algo/min_max.h
+++ b/lib/algo/min_max.h
@@ -26,7 +26,7 @@ namespace MR
       template <class ImageType>
       class __MinMax {
         public:
-          typedef typename ImageType::value_type value_type;
+          using value_type = typename ImageType::value_type;
 
           __MinMax (value_type& overal_min, value_type& overal_max) :
             overal_min (overal_min), overal_max (overal_max),

--- a/lib/app.h
+++ b/lib/app.h
@@ -16,7 +16,7 @@
 #ifndef __app_h__
 #define __app_h__
 
-#include <string.h>
+#include <cstring>
 #include <string>
 #include <vector>
 #include <limits>

--- a/lib/bitset.h
+++ b/lib/bitset.h
@@ -19,7 +19,7 @@
 
 
 #include <atomic>
-#include <stdint.h>
+#include <cstdint>
 #include "mrtrix.h"
 
 

--- a/lib/cmdline_option.h
+++ b/lib/cmdline_option.h
@@ -57,7 +57,7 @@ namespace MR
       TracksOut
     } ArgType;
 
-    typedef int ArgFlags;
+    using ArgFlags = int;
     constexpr ArgFlags None = 0;
     constexpr ArgFlags Optional = 0x1;
     constexpr ArgFlags AllowMultiple = 0x2;

--- a/lib/debug.h
+++ b/lib/debug.h
@@ -18,7 +18,7 @@
 #define __debug_h__
 
 #include <iostream>
-#include <string.h>
+#include <cstring>
 
 namespace MR {
   namespace App {

--- a/lib/file/gz.h
+++ b/lib/file/gz.h
@@ -18,7 +18,7 @@
 
 #include <cassert>
 #include <cstring>
-#include <stdio.h>
+#include <cstdio>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>

--- a/lib/file/mmap.h
+++ b/lib/file/mmap.h
@@ -18,7 +18,7 @@
 
 #include <iostream>
 #include <cassert>
-#include <stdint.h>
+#include <cstdint>
 
 #include "types.h"
 #include "file/entry.h"

--- a/lib/file/utils.h
+++ b/lib/file/utils.h
@@ -16,7 +16,7 @@
 #ifndef __file_ops_h__
 #define __file_ops_h__
 
-#include <stdint.h>
+#include <cstdint>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>

--- a/lib/filter/dwi_brain_mask.h
+++ b/lib/filter/dwi_brain_mask.h
@@ -68,7 +68,7 @@ namespace MR
 
         template <class InputImageType, class OutputImageType>
         void operator() (InputImageType& input, OutputImageType& output) {
-            typedef typename InputImageType::value_type value_type;
+            using value_type = typename InputImageType::value_type;
 
             Header header (input);
             header.ndim() = 3;

--- a/lib/filter/optimal_threshold.h
+++ b/lib/filter/optimal_threshold.h
@@ -132,8 +132,8 @@ namespace MR
         class ImageCorrelationCostFunction {
 
           public:
-            typedef typename ImageType::value_type value_type;
-            typedef typename MaskType::value_type mask_value_type;
+            using value_type = typename ImageType::value_type;
+            using mask_value_type = typename MaskType::value_type;
 
             ImageCorrelationCostFunction (ImageType& input, MaskType& mask) :
                 input (input),
@@ -184,7 +184,7 @@ namespace MR
       template <class ImageType, class MaskType>
         typename ImageType::value_type estimate_optimal_threshold (ImageType& input, MaskType& mask)
         {
-          typedef typename ImageType::value_type input_value_type;
+          using input_value_type = typename ImageType::value_type;
 
           input_value_type min, max;
           min_max (input, min, max);
@@ -253,7 +253,7 @@ namespace MR
             void operator() (InputImageType& input, OutputImageType& output, MaskType& mask)
             {
               axes_.resize (4);
-              typedef typename InputImageType::value_type input_value_type;
+              using input_value_type = typename InputImageType::value_type;
 
               input_value_type optimal_threshold = estimate_optimal_threshold (input, mask);
               

--- a/lib/hash_map.h
+++ b/lib/hash_map.h
@@ -38,8 +38,7 @@
 namespace MR
 {
   template <class K, class V> struct UnorderedMap {
-    typedef
-    MRTRIX_HASH_MAP_TYPE <K,V> Type;
+    using Type = MRTRIX_HASH_MAP_TYPE <K,V>;
   };
 }
 

--- a/lib/image.h
+++ b/lib/image.h
@@ -37,7 +37,7 @@ namespace MR
   template <typename ValueType>
     class Image {
       public:
-        typedef ValueType value_type;
+        using value_type = ValueType;
         class Buffer;
 
         Image ();
@@ -278,7 +278,7 @@ namespace MR
     // lightweight struct to copy data into:
     template <typename ValueType>
       struct TmpImage {
-        typedef ValueType value_type;
+        using value_type = ValueType;
 
         const typename Image<ValueType>::Buffer& b;
         void* const data;

--- a/lib/image_helpers.h
+++ b/lib/image_helpers.h
@@ -442,7 +442,7 @@ namespace MR
     template <class ImageType> 
       class Value {
         public:
-          typedef typename ImageType::value_type value_type;
+          using value_type = typename ImageType::value_type;
           Value () = delete;
           Value (const Value&) = delete;
           FORCE_INLINE Value (Value&&) = default;

--- a/lib/image_io/base.h
+++ b/lib/image_io/base.h
@@ -17,7 +17,7 @@
 #define __image_io_base_h__
 
 #include <vector>
-#include <stdint.h>
+#include <cstdint>
 #include <unistd.h>
 #include <cassert>
 

--- a/lib/interp/base.h
+++ b/lib/interp/base.h
@@ -67,7 +67,7 @@ namespace MR
     template <class ImageType> class Base : public ImageType, public Transform
     {
       public:
-        typedef typename ImageType::value_type value_type;
+        using value_type = typename ImageType::value_type;
 
         //! construct an Interp object to obtain interpolated values using the
         //! parent ImageType class

--- a/lib/interp/cubic.h
+++ b/lib/interp/cubic.h
@@ -108,7 +108,7 @@ namespace MR
         using SplineBase = SplineInterpBase<ImageType, SplineType, Math::SplineProcessingType::Value>;
         EIGEN_MAKE_ALIGNED_OPERATOR_NEW  // avoid memory alignment errors in Eigen3;
 
-        typedef typename SplineBase::value_type value_type;
+        using value_type = typename SplineBase::value_type;
         using SplineBase::P;
         using SplineBase::H;
         using SplineBase::clamp;
@@ -224,7 +224,7 @@ namespace MR
         using SplineBase = SplineInterpBase<ImageType, SplineType, Math::SplineProcessingType::Derivative>;
         EIGEN_MAKE_ALIGNED_OPERATOR_NEW  // avoid memory alignment errors in Eigen3;
 
-        typedef typename SplineBase::value_type value_type;
+        using value_type = typename SplineBase::value_type;
         using SplineBase::P;
         using SplineBase::H;
         using SplineBase::clamp;
@@ -371,7 +371,7 @@ namespace MR
         using SplineBase = SplineInterpBase<ImageType, SplineType, Math::SplineProcessingType::ValueAndDerivative>;
         EIGEN_MAKE_ALIGNED_OPERATOR_NEW  // avoid memory alignment errors in Eigen3;
 
-        typedef typename SplineBase::value_type value_type;
+        using value_type = typename SplineBase::value_type;
         using SplineBase::P;
         using SplineBase::H;
         using SplineBase::clamp;

--- a/lib/interp/linear.h
+++ b/lib/interp/linear.h
@@ -70,13 +70,13 @@ namespace MR
     template <class C>
     struct value_type_of
     {
-      typedef C type;
+      using type = C;
     };
 
     template <class X>
     struct value_type_of<std::complex<X>>
     {
-      typedef X type;
+      using type = X;
     };
 
     enum LinearInterpProcessingType
@@ -95,7 +95,7 @@ namespace MR
     {
       public:
         using typename Base<ImageType>::value_type;
-        typedef typename value_type_of<value_type>::type coef_type;
+        using coef_type = typename value_type_of<value_type>::type;
 
         EIGEN_MAKE_ALIGNED_OPERATOR_NEW  // avoid memory alignment errors in Eigen3;
 
@@ -134,8 +134,8 @@ namespace MR
         using LinearBase = LinearInterpBase<ImageType, LinearInterpProcessingType::Value>;
         EIGEN_MAKE_ALIGNED_OPERATOR_NEW  // avoid memory alignment errors in Eigen3;
 
-        typedef typename LinearBase::value_type value_type;
-        typedef typename LinearBase::coef_type coef_type;
+        using value_type = typename LinearBase::value_type;
+        using coef_type = typename LinearBase::coef_type;
         using LinearBase::P;
         using LinearBase::clamp;
         using LinearBase::bounds;
@@ -261,8 +261,8 @@ namespace MR
         using LinearBase = LinearInterpBase<ImageType, LinearInterpProcessingType::Derivative>;
         EIGEN_MAKE_ALIGNED_OPERATOR_NEW  // avoid memory alignment errors in Eigen3;
 
-        typedef typename LinearBase::value_type value_type;
-        typedef typename LinearBase::coef_type coef_type;
+        using value_type = typename LinearBase::value_type;
+        using coef_type = typename LinearBase::coef_type;
         using LinearBase::P;
         using LinearBase::clamp;
         using LinearBase::bounds;
@@ -411,8 +411,8 @@ namespace MR
         using LinearBase = LinearInterpBase<ImageType, LinearInterpProcessingType::ValueAndDerivative>;
         EIGEN_MAKE_ALIGNED_OPERATOR_NEW  // avoid memory alignment errors in Eigen3;
 
-        typedef typename LinearBase::value_type value_type;
-        typedef typename LinearBase::coef_type coef_type;
+        using value_type = typename LinearBase::value_type;
+        using coef_type = typename LinearBase::coef_type;
         using LinearBase::P;
         using LinearBase::clamp;
         using LinearBase::bounds;

--- a/lib/math/SH.h
+++ b/lib/math/SH.h
@@ -85,7 +85,7 @@ namespace MR
         Eigen::Matrix<typename MatrixType::Scalar,Eigen::Dynamic, Eigen::Dynamic> init_transform (const MatrixType& dirs, const int lmax)
         {
           using namespace Eigen;
-          typedef typename MatrixType::Scalar value_type;
+          using value_type = typename MatrixType::Scalar;
           if (dirs.cols() != 2)
             throw Exception ("direction matrix should have 2 columns: [ azimuth elevation ]");
           Matrix<value_type,Dynamic,Dynamic> SHT (dirs.rows(), NforL (lmax));
@@ -160,7 +160,7 @@ namespace MR
       template <typename ValueType>
       class Transform {
         public:
-          typedef Eigen::Matrix<ValueType,Eigen::Dynamic,Eigen::Dynamic> matrix_type;
+          using matrix_type = Eigen::Matrix<ValueType,Eigen::Dynamic,Eigen::Dynamic>;
 
           template <class MatrixType>
             Transform (const MatrixType& dirs, int lmax) :
@@ -208,7 +208,7 @@ namespace MR
             typename VectorType::Scalar sin_azimuth,
             int lmax)
         {
-          typedef typename VectorType::Scalar value_type;
+          using value_type = typename VectorType::Scalar;
           value_type amplitude = 0.0;
           Eigen::Matrix<value_type,Eigen::Dynamic,1,0,64> AL (lmax+1);
           Legendre::Plm_sph (AL, lmax, 0, cos_elevation);
@@ -244,7 +244,7 @@ namespace MR
       template <class VectorType1, class VectorType2>
         inline typename VectorType1::Scalar value (const VectorType1& coefs, const VectorType2& unit_dir, int lmax)
         {
-          typedef typename VectorType1::Scalar value_type;
+          using value_type = typename VectorType1::Scalar;
           value_type rxy = std::sqrt ( pow2(unit_dir[1]) + pow2(unit_dir[0]) );
           value_type cp = (rxy) ? unit_dir[0]/rxy : 1.0;
           value_type sp = (rxy) ? unit_dir[1]/rxy : 0.0;
@@ -255,7 +255,7 @@ namespace MR
       template <class VectorType1, class VectorType2>
         inline VectorType1& delta (VectorType1& delta_vec, const VectorType2& unit_dir, int lmax)
         {
-          typedef typename VectorType1::Scalar value_type;
+          using value_type = typename VectorType1::Scalar;
           delta_vec.resize (NforL (lmax));
           value_type rxy = std::sqrt ( pow2(unit_dir[1]) + pow2(unit_dir[0]) );
           value_type cp = (rxy) ? unit_dir[0]/rxy : 1.0;
@@ -289,7 +289,7 @@ namespace MR
       template <class VectorType1, class VectorType2>
         inline VectorType1& SH2RH (VectorType1& RH, const VectorType2& sh)
         {
-          typedef typename VectorType2::Scalar value_type;
+          using value_type = typename VectorType2::Scalar;
           RH.resize (sh.size());
           int lmax = 2*sh.size() +1;
           Eigen::Matrix<value_type,Eigen::Dynamic,1,0,64> AL (lmax+1);
@@ -343,7 +343,7 @@ namespace MR
 
 
       namespace {
-        template <typename> struct __dummy { typedef int type; };
+        template <typename> struct __dummy { using type = int; };
       }
 
 
@@ -468,7 +468,7 @@ namespace MR
       template <typename ValueType> class PrecomputedAL
       {
         public:
-          typedef ValueType value_type;
+          using value_type = ValueType;
 
           PrecomputedAL () : lmax (0), ndir (0), nAL (0), inc (0.0) { }
           PrecomputedAL (int up_to_lmax, int num_dir = 512) {
@@ -587,7 +587,7 @@ namespace MR
             UnitVectorType& unit_init_dir,
             PrecomputedAL<typename VectorType::Scalar>* precomputer = nullptr)
         {
-          typedef typename VectorType::Scalar value_type;
+          using value_type = typename VectorType::Scalar;
           assert (std::isfinite (unit_init_dir[0]));
           for (int i = 0; i < 50; i++) {
             value_type az = std::atan2 (unit_init_dir[1], unit_init_dir[0]);
@@ -644,7 +644,7 @@ namespace MR
             typename VectorType::Scalar& d2SH_daz2,
             PrecomputedAL<typename VectorType::Scalar>* precomputer)
         {
-          typedef typename VectorType::Scalar value_type;
+          using value_type = typename VectorType::Scalar;
           value_type sel = std::sin (elevation);
           value_type cel = std::cos (elevation);
           bool atpole = sel < 1e-4;

--- a/lib/math/check_gradient.h
+++ b/lib/math/check_gradient.h
@@ -31,7 +31,7 @@ namespace MR {
           bool show_hessian = false,
           Eigen::Matrix<typename Function::value_type, Eigen::Dynamic, 1> conditioner = Eigen::Matrix<typename Function::value_type, Eigen::Dynamic, 1>())
       {
-        typedef typename Function::value_type value_type;
+        using value_type = typename Function::value_type;
         const size_t N = function.size();
         Eigen::Matrix<value_type, Eigen::Dynamic, 1> g (N);
 

--- a/lib/math/constrained_least_squares.h
+++ b/lib/math/constrained_least_squares.h
@@ -45,9 +45,9 @@ namespace MR
         class Problem {
           public:
 
-            typedef ValueType value_type;
-            typedef Eigen::Matrix<value_type,Eigen::Dynamic,Eigen::Dynamic> matrix_type;
-            typedef Eigen::Matrix<value_type,Eigen::Dynamic,1> vector_type;
+            using value_type = ValueType;
+            using matrix_type = Eigen::Matrix<value_type,Eigen::Dynamic,Eigen::Dynamic>;
+            using vector_type = Eigen::Matrix<value_type,Eigen::Dynamic,1>;
 
             Problem () { }
             //! set up constrained least-squares problem
@@ -130,9 +130,9 @@ namespace MR
         class Solver {
           public:
 
-            typedef ValueType value_type;
-            typedef Eigen::Matrix<value_type,Eigen::Dynamic,Eigen::Dynamic> matrix_type;
-            typedef Eigen::Matrix<value_type,Eigen::Dynamic,1> vector_type;
+            using value_type = ValueType;
+            using matrix_type = Eigen::Matrix<value_type,Eigen::Dynamic,Eigen::Dynamic>;
+            using vector_type = Eigen::Matrix<value_type,Eigen::Dynamic,1>;
 
             Solver (const Problem<value_type>& problem) :
               P (problem),

--- a/lib/math/cubic_spline.h
+++ b/lib/math/cubic_spline.h
@@ -30,8 +30,8 @@ namespace MR
     template <typename T> class CubicSpline
     {
       public:
-        typedef Eigen::Matrix<T, 4, 4> BasisMatrix;
-        typedef Eigen::Matrix<T, 1, 4> WeightVector;
+        using BasisMatrix = Eigen::Matrix<T, 4, 4>;
+        using WeightVector = Eigen::Matrix<T, 1, 4>;
         WeightVector weights, deriv_weights;
 
         void set (T position) {
@@ -91,7 +91,7 @@ namespace MR
     template <typename T> class HermiteSpline :
     public CubicSpline<T> {
       public:
-        typedef typename CubicSpline<T>::BasisMatrix BasisMatrix;
+        using BasisMatrix = typename CubicSpline<T>::BasisMatrix;
         static const BasisMatrix hermite_basis_mtrx;
         static const BasisMatrix hermite_derivative_basis_mtrx;
 
@@ -104,7 +104,7 @@ namespace MR
     template <typename T> class UniformBSpline :
     public CubicSpline<T> {
       public:
-        typedef typename CubicSpline<T>::BasisMatrix BasisMatrix;
+        using BasisMatrix = typename CubicSpline<T>::BasisMatrix;
         static const BasisMatrix uniform_bspline_basis_mtrx;
         static const BasisMatrix uniform_bspline_derivative_basis_mtrx;
 

--- a/lib/math/gradient_descent.h
+++ b/lib/math/gradient_descent.h
@@ -51,7 +51,7 @@ namespace MR
       class GradientDescent
       {
         public:
-          typedef typename Function::value_type value_type;
+          using value_type = typename Function::value_type;
 
           GradientDescent (Function& function, UpdateFunctor update_functor = LinearUpdate(), value_type step_size_upfactor = 3.0, value_type step_size_downfactor = 0.1, bool verbose = false) :
             func (function),

--- a/lib/math/gradient_descent_bb.h
+++ b/lib/math/gradient_descent_bb.h
@@ -49,7 +49,7 @@ namespace MR
       class GradientDescentBB
       {
         public:
-          typedef typename Function::value_type value_type;
+          using value_type = typename Function::value_type;
 
           GradientDescentBB (Function& function, UpdateFunctor update_functor = LinearUpdateBB(), bool verbose = false) :
             func (function),

--- a/lib/math/hermite.h
+++ b/lib/math/hermite.h
@@ -28,7 +28,7 @@ namespace MR
     template <typename T> class Hermite
     {
       public:
-        typedef T value_type;
+        using value_type = T;
 
         Hermite (value_type tension = 0.0) : t (T (0.5) *tension) { }
 

--- a/lib/math/legendre.h
+++ b/lib/math/legendre.h
@@ -110,7 +110,7 @@ namespace MR
       template <typename VectorType> 
         inline void Plm_sph (VectorType& array, const int lmax, const int m, const typename VectorType::Scalar x)
         {
-          typedef typename VectorType::Scalar value_type;
+          using value_type = typename VectorType::Scalar;
           value_type x2 = pow2 (x);
           if (m && x2 >= 1.0) {
             for (int n = m; n <= lmax; ++n)
@@ -141,7 +141,7 @@ namespace MR
       template <typename VectorType> 
         inline void Plm_sph_deriv (VectorType& array, const int lmax, const int m, const typename VectorType::Scalar x)
         {
-          typedef typename VectorType::Scalar value_type;
+          using value_type = typename VectorType::Scalar;
           value_type x2 = pow2 (x);
           if (x2 >= 1.0) {
             for (int n = m; n <= lmax; n++) 

--- a/lib/math/rng.h
+++ b/lib/math/rng.h
@@ -82,7 +82,7 @@ namespace MR
       class RNG::Uniform {
         public:
           RNG rng;
-          typedef ValueType result_type;
+          using result_type = ValueType;
           // static const ValueType max() const { return static_cast<ValueType>(1.0); }
           // static const ValueType min() const { return static_cast<ValueType>(0.0); }
           std::uniform_real_distribution<ValueType> dist;
@@ -93,7 +93,7 @@ namespace MR
       class RNG::Normal {
         public:
           RNG rng;
-          typedef ValueType result_type;
+          using result_type = ValueType;
           std::normal_distribution<ValueType> dist;
           ValueType operator() () { return dist (rng); }
       };

--- a/lib/math/sinc.h
+++ b/lib/math/sinc.h
@@ -26,7 +26,7 @@ namespace MR
     template <typename T = float> class Sinc
     {
       public:
-        typedef T value_type;
+        using value_type = T;
 
         Sinc (const size_t w) :
           window_size (w),

--- a/lib/math/stats/permutation.h
+++ b/lib/math/stats/permutation.h
@@ -22,7 +22,7 @@ namespace MR
     namespace Stats
     {
 
-      typedef float value_type;
+      using value_type = float;
 
 
       inline bool is_duplicate_vector (const std::vector<size_t>& v1, const std::vector<size_t>& v2)

--- a/lib/math/versor.h
+++ b/lib/math/versor.h
@@ -30,7 +30,7 @@ namespace MR {
     class Versor : public Eigen::Quaternion<ValueType>
     {
 
-        typedef ValueType value_type;
+        using value_type = ValueType;
 
       public:
         Versor () : Eigen::Quaternion<ValueType> (NAN, NAN, NAN, NAN) { }
@@ -79,8 +79,8 @@ namespace MR {
 
     };
 
-    typedef Versor<float>  Versorf;
-    typedef Versor<double> Versord;
+    using Versorf = Versor<float>;
+    using Versord = Versor<double>;
 
     template <typename value_type>
     inline std::ostream& operator<< (std::ostream& stream, const Versor<value_type>& v)

--- a/lib/sparse/image.h
+++ b/lib/sparse/image.h
@@ -106,8 +106,8 @@ namespace MR
         Image (const std::string& image_name, const Header& template_header) :
           ::MR::Image<uint64_t> (::MR::Image<uint64_t>::create (image_name, template_header)), io (nullptr) { check(); }
 
-        typedef uint64_t value_type;
-        typedef DataType sparse_data_type;
+        using value_type = uint64_t;
+        using sparse_data_type = DataType;
 
         Value<DataType> value () { return { *this, *io }; }
         const Value<DataType> value () const { return { *this, *io }; }

--- a/lib/stats.h
+++ b/lib/stats.h
@@ -32,8 +32,8 @@ namespace MR
     extern const char * field_choices[];
     extern const App::OptionGroup Options;
 
-    typedef float value_type;
-    typedef cfloat complex_type;
+    using value_type = float;
+    using complex_type = cfloat;
 
 
     class CalibrateHistogram

--- a/lib/stride.h
+++ b/lib/stride.h
@@ -59,7 +59,7 @@ namespace MR
   namespace Stride
   {
 
-    typedef std::vector<ssize_t> List;
+    using List = std::vector<ssize_t>;
 
     extern const App::OptionGroup Options;
 

--- a/lib/thread.h
+++ b/lib/thread.h
@@ -112,7 +112,7 @@ namespace MR
             __single_thread (Functor&& functor, const std::string& name = "unnamed") :
             __thread_base (name) { 
               DEBUG ("launching thread \"" + name + "\"...");
-              typedef typename std::remove_reference<Functor>::type F;
+              using F = typename std::remove_reference<Functor>::type;
               thread = std::async (std::launch::async, &F::execute, &functor);
             }
           __single_thread (const __single_thread&) = delete;
@@ -142,7 +142,7 @@ namespace MR
             __multi_thread (Functor& functor, size_t nthreads, const std::string& name = "unnamed") :
               __thread_base (name), functors ( (nthreads>0 ? nthreads-1 : 0), functor) { 
                 DEBUG ("launching " + str (nthreads) + " threads \"" + name + "\"...");
-                typedef typename std::remove_reference<Functor>::type F;
+                using F = typename std::remove_reference<Functor>::type;
                 threads.reserve (nthreads);
                 for (auto& f : functors) 
                   threads.push_back (std::async (std::launch::async, &F::execute, &f));
@@ -204,7 +204,7 @@ namespace MR
       template <class Functor>
         class __run {
           public:
-            typedef __single_thread type;
+            using type = __single_thread;
             type operator() (Functor& functor, const std::string& name) {
               return { functor, name };
             }
@@ -213,7 +213,7 @@ namespace MR
       template <class Functor>
         class __run<__Multi<Functor>> {
           public:
-            typedef __multi_thread<Functor> type;
+            using type = __multi_thread<Functor>;
             type operator() (__Multi<Functor>& functor, const std::string& name) {
               return { functor.functor, functor.num, name };
             }

--- a/lib/thread_queue.h
+++ b/lib/thread_queue.h
@@ -48,16 +48,16 @@ namespace MR
 
 
       // to handle batched / unbatched seamlessly:
-      template <class X> class __item { public: typedef X type; }; 
-      template <class X> class __item <__Batch<X>> { public: typedef X type; };
+      template <class X> class __item { public: using type = X; };
+      template <class X> class __item <__Batch<X>> { public: using type = X; };
 
       // to get multi/single job/functor seamlessly:
       template <class X>
         class __job
         {
           public:
-            typedef typename std::remove_reference<X>::type type;
-            typedef typename std::remove_reference<X>::type& member_type;
+            using type = typename std::remove_reference<X>::type;
+            using member_type = typename std::remove_reference<X>::type&;
             static X& functor (X& job) { return job; }
 
             template <class SingleFunctor>
@@ -70,8 +70,8 @@ namespace MR
         class __job <__Multi<X>>
         {
           public:
-            typedef typename std::remove_reference<X>::type type;
-            typedef typename std::remove_reference<X>::type member_type;
+            using type = typename std::remove_reference<X>::type;
+            using member_type = typename std::remove_reference<X>::type;
             static X& functor (__Multi<X>& job) { return job.functor; }
 
             template <class SingleFunctor>
@@ -639,8 +639,8 @@ namespace MR
     template <class T> class Queue<__Batch<T>>
     {
       private:
-        typedef std::vector<T> BatchType;
-        typedef Queue<BatchType> BatchQueue;
+        using BatchType = std::vector<T>;
+        using BatchQueue = Queue<BatchType>;
 
       public:
         Queue (const __Batch<T>& item_type, const std::string& description = "unnamed", size_t buffer_size = MRTRIX_QUEUE_DEFAULT_CAPACITY) :

--- a/lib/types.h
+++ b/lib/types.h
@@ -18,7 +18,7 @@
 
 #define EIGEN_DONT_PARALLELIZE
 
-#include <stdint.h>
+#include <cstdint>
 #include <complex>
 #include <iostream>
 #include <vector>

--- a/lib/types.h
+++ b/lib/types.h
@@ -111,10 +111,10 @@
 namespace MR
 {
 
-  typedef float  float32;
-  typedef double float64;
-  typedef std::complex<double> cdouble;
-  typedef std::complex<float> cfloat;
+  using float32 = float ;
+  using float64 = double;
+  using cdouble = std::complex<double>;
+  using cfloat = std::complex<float>;
 
   template <typename T>
     struct container_cast : public T {
@@ -124,13 +124,13 @@ namespace MR
     };
 
   //! the default type used throughout MRtrix
-  typedef double default_type;
+  using default_type = double;
 
   constexpr default_type NaN = std::numeric_limits<default_type>::quiet_NaN();
   constexpr default_type Inf = std::numeric_limits<default_type>::infinity();
 
   //! the type for the affine transform of an image:
-  typedef Eigen::Transform<default_type, 3, Eigen::AffineCompact> transform_type;
+  using transform_type = Eigen::Transform<default_type, 3, Eigen::AffineCompact>;
 
 
   //! check whether type is complex:
@@ -176,8 +176,8 @@ namespace std
 }
 
 namespace Eigen {
-  typedef Matrix<MR::default_type,3,1> Vector3;
-  typedef Matrix<MR::default_type,4,1> Vector4;
+  using Vector3 = Matrix<MR::default_type,3,1>;
+  using Vector4 = Matrix<MR::default_type,4,1>;
 }
 
 #endif

--- a/src/connectome/connectome.h
+++ b/src/connectome/connectome.h
@@ -26,9 +26,9 @@ namespace MR {
 namespace Connectome {
 
 
-typedef uint32_t node_t;
+using node_t = uint32_t;
 
-typedef Eigen::Matrix<default_type, Eigen::Dynamic, Eigen::Dynamic> matrix_type;
+using matrix_type = Eigen::Matrix<default_type, Eigen::Dynamic, Eigen::Dynamic>;
 
 
 void verify_matrix (matrix_type&, const node_t);

--- a/src/connectome/lut.h
+++ b/src/connectome/lut.h
@@ -41,7 +41,7 @@ class LUT_node
 
   public:
 
-    typedef Eigen::Array<uint8_t, 3, 1> RGB;
+    using RGB = Eigen::Array<uint8_t, 3, 1>;
 
     LUT_node (const std::string& n) :
       name (n),
@@ -96,7 +96,7 @@ class LUT : public std::multimap<node_t, LUT_node>
 {
     enum file_format { LUT_NONE, LUT_BASIC, LUT_FREESURFER, LUT_AAL, LUT_ITKSNAP, LUT_MRTRIX };
   public:
-    typedef std::multimap<node_t, LUT_node> map_type;
+    using map_type = std::multimap<node_t, LUT_node>;
     LUT () : exclusive (true) { }
     LUT (const std::string&);
     void load (const std::string&);

--- a/src/doc/examples/per_datum_multithreaded_processing.md
+++ b/src/doc/examples/per_datum_multithreaded_processing.md
@@ -35,7 +35,7 @@ void usage ()
 
 // It is a good idea to use typedef's to help with flexibility if types need to
 // be changed later on.
-typedef float value_type;
+using value_type = float;
 
 // This is the functor that will be invoked per-voxel. Note this could be a
 // simple function if the operation to be performed was independent of any

--- a/src/doc/examples/per_datum_processing.md
+++ b/src/doc/examples/per_datum_processing.md
@@ -34,7 +34,7 @@ void usage ()
 
 // It is a good idea to use typedef's to help with flexibility if types need to
 // be changed later on.
-typedef float value_type;
+using value_type = float;
 
 
 // This is where execution proper starts - the equivalent of main(). 

--- a/src/doc/examples/per_voxel_multithreaded_processing.md
+++ b/src/doc/examples/per_voxel_multithreaded_processing.md
@@ -44,7 +44,7 @@ void usage ()
 // dataset (I typically use float rather than double to keep RAM usage low),
 // the other for the values used in the computation itself (this often
 // needs to be higher precision to avoid rounding errors, etc).
-typedef float value_type;
+using value_type = float;
 typedef float compute_type;
 
 

--- a/src/dwi/bootstrap.h
+++ b/src/dwi/bootstrap.h
@@ -38,7 +38,7 @@ namespace MR {
             }
         };
 
-        typedef typename ImageType::value_type value_type;
+        using value_type = typename ImageType::value_type;
         using Adapter::Base<ImageType>::size;
         using Adapter::Base<ImageType>::index;
 

--- a/src/dwi/directions/set.h
+++ b/src/dwi/directions/set.h
@@ -21,7 +21,7 @@
 
 
 
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 
 #include "progressbar.h"

--- a/src/dwi/directions/set.h
+++ b/src/dwi/directions/set.h
@@ -33,7 +33,7 @@ namespace MR {
 
 
 
-      typedef unsigned int dir_t;
+      using dir_t = unsigned int;
 
 
 

--- a/src/dwi/fixel_map.h
+++ b/src/dwi/fixel_map.h
@@ -52,7 +52,7 @@ namespace MR
         EIGEN_MAKE_ALIGNED_OPERATOR_NEW  // avoid memory alignment errors in Eigen3;
 
         class MapVoxel;
-        typedef Image<MapVoxel*> VoxelAccessor;
+        using VoxelAccessor = Image<MapVoxel*>;
 
         virtual ~Fixel_map()
         {

--- a/src/dwi/fmls.cpp
+++ b/src/dwi/fmls.cpp
@@ -195,7 +195,7 @@ namespace MR {
         Eigen::Matrix<default_type, Eigen::Dynamic, 1> values (dirs.size());
         transform->SH2A (values, in);
 
-        typedef std::multimap<default_type, dir_t, Max_abs> map_type;
+        using map_type = std::multimap<default_type, dir_t, Max_abs>;
         map_type data_in_order;
         for (size_t i = 0; i != size_t(values.size()); ++i)
           data_in_order.insert (std::make_pair (values[i], i));

--- a/src/dwi/fmls.h
+++ b/src/dwi/fmls.h
@@ -187,8 +187,8 @@ namespace MR
       class FODQueueWriter
       {
 
-          typedef Image<float> FODImageType;
-          typedef Image<float> MaskImageType;
+          using FODImageType = Image<float>;
+          using MaskImageType = Image<float>;
 
         public:
           FODQueueWriter (const FODImageType& fod_image, const MaskImageType& mask_image = MaskImageType()) :

--- a/src/dwi/shells.h
+++ b/src/dwi/shells.h
@@ -157,7 +157,7 @@ namespace MR
 
       private:
 
-        typedef decltype(std::declval<const Eigen::MatrixXd>().col(0)) BValueList;
+        using BValueList = decltype(std::declval<const Eigen::MatrixXd>().col(0));
 
         // Functions for current b-value clustering implementation
         size_t clusterBvalues (const BValueList&, std::vector<size_t>&) const;

--- a/src/dwi/tensor.h
+++ b/src/dwi/tensor.h
@@ -77,7 +77,7 @@ namespace MR
     template <class MatrixType, class VectorTypeOut, class VectorTypeIn>
       inline void dwi2tensor (VectorTypeOut& dt, const MatrixType& binv, VectorTypeIn& dwi)
     {
-      typedef typename VectorTypeIn::Scalar T;
+      using T = typename VectorTypeIn::Scalar;
       for (ssize_t i = 0; i < dwi.size(); ++i)
         dwi[i] = dwi[i] > T(0.0) ? -std::log (dwi[i]) : T(0.0);
       dt = binv * dwi;
@@ -86,14 +86,14 @@ namespace MR
 
     template <class VectorType> inline typename VectorType::Scalar tensor2ADC (const VectorType& dt)
     {
-      typedef typename VectorType::Scalar T;
+      using T = typename VectorType::Scalar;
       return (dt[0]+dt[1]+dt[2]) / T (3.0);
     }
 
 
     template <class VectorType> inline typename VectorType::Scalar tensor2FA (const VectorType& dt)
     {
-      typedef typename VectorType::Scalar T;
+      using T = typename VectorType::Scalar;
       T trace = tensor2ADC (dt);
       T a[] = { dt[0]-trace, dt[1]-trace, dt[2]-trace };
       trace = dt[0]*dt[0] + dt[1]*dt[1] + dt[2]*dt[2] + T (2.0) * (dt[3]*dt[3] + dt[4]*dt[4] + dt[5]*dt[5]);
@@ -105,7 +105,7 @@ namespace MR
 
     template <class VectorType> inline typename VectorType::Scalar tensor2RA (const VectorType& dt)
     {
-      typedef typename VectorType::Scalar T;
+      using T = typename VectorType::Scalar;
       T trace = tensor2ADC (dt);
       T a[] = { dt[0]-trace, dt[1]-trace, dt[2]-trace };
       return trace ?

--- a/src/dwi/tractography/ACT/gmwmi.h
+++ b/src/dwi/tractography/ACT/gmwmi.h
@@ -50,7 +50,7 @@ namespace MR
         {
 
           protected:
-            typedef Interp::Linear<Image<float>> Interp;
+            using Interp = Interp::Linear<Image<float>>;
 
           public:
             GMWMI_finder (const Image<float>& buffer) :

--- a/src/dwi/tractography/GT/particle.h
+++ b/src/dwi/tractography/GT/particle.h
@@ -24,7 +24,7 @@ namespace MR {
     namespace Tractography {
       namespace GT {
         
-        typedef Eigen::Vector3f Point_t;
+        using Point_t = Eigen::Vector3f;
         
         /**
          * A particle is a segment of a track and consists of a position and a direction.

--- a/src/dwi/tractography/GT/particlegrid.h
+++ b/src/dwi/tractography/GT/particlegrid.h
@@ -39,7 +39,7 @@ namespace MR {
         {
         public:
           
-          typedef std::vector<Particle*> ParticleVectorType;
+          using ParticleVectorType = std::vector<Particle*>;
           
           template <class HeaderType>
           ParticleGrid(const HeaderType& image)

--- a/src/dwi/tractography/GT/spatiallock.h
+++ b/src/dwi/tractography/GT/spatiallock.h
@@ -34,8 +34,8 @@ namespace MR {
         class SpatialLock
         {
         public:
-          typedef T value_type;
-          typedef Eigen::Matrix<value_type, 3, 1> point_type;
+          using value_type = T;
+          using point_type = Eigen::Matrix<value_type, 3, 1>;
           
           SpatialLock() : _tx(0), _ty(0), _tz(0) { }
           SpatialLock(const value_type t) : _tx(t), _ty(t), _tz(t) { }

--- a/src/dwi/tractography/SIFT/gradient_sort.h
+++ b/src/dwi/tractography/SIFT/gradient_sort.h
@@ -82,14 +82,14 @@ namespace MR
       class MT_gradient_vector_sorter
       {
 
-          typedef std::vector<Cost_fn_gradient_sort> VecType;
-          typedef VecType::iterator VecItType;
+          using VecType = std::vector<Cost_fn_gradient_sort>;
+          using VecItType = VecType::iterator;
 
           class Comparator {
             public:
               bool operator() (const VecItType& a, const VecItType& b) const { return (a->get_gradient_per_unit_length() < b->get_gradient_per_unit_length()); }
           };
-          typedef std::set<VecItType, Comparator> SetType;
+          using SetType = std::set<VecItType, Comparator>;
 
 
         public:

--- a/src/dwi/tractography/SIFT/model.h
+++ b/src/dwi/tractography/SIFT/model.h
@@ -60,8 +60,8 @@ namespace MR
       {
 
         protected:
-        typedef typename Fixel_map<Fixel>::MapVoxel MapVoxel;
-        typedef typename Fixel_map<Fixel>::VoxelAccessor VoxelAccessor;
+          using MapVoxel = typename Fixel_map<Fixel>::MapVoxel;
+          using VoxelAccessor = typename Fixel_map<Fixel>::VoxelAccessor;
 
         public:
           template <class Set>

--- a/src/dwi/tractography/SIFT/model_base.h
+++ b/src/dwi/tractography/SIFT/model_base.h
@@ -127,8 +127,8 @@ namespace MR
         {
 
           protected:
-            typedef typename Fixel_map<Fixel>::MapVoxel MapVoxel;
-            typedef typename Fixel_map<Fixel>::VoxelAccessor VoxelAccessor;
+            using MapVoxel = typename Fixel_map<Fixel>::MapVoxel;
+            using VoxelAccessor = typename Fixel_map<Fixel>::VoxelAccessor;
 
           public:
             ModelBase (Image<float>& dwi, const DWI::Directions::FastLookupSet& dirs) :

--- a/src/dwi/tractography/SIFT/proc_mask.h
+++ b/src/dwi/tractography/SIFT/proc_mask.h
@@ -48,7 +48,7 @@ namespace MR
         // Private functor for performing ACT image regridding
         class ResampleFunctor
         {
-            typedef Eigen::Transform<float,3,Eigen::AffineCompact> transform_type;
+            using transform_type = Eigen::Transform<float,3,Eigen::AffineCompact>;
           public:
             ResampleFunctor (Image<float>&, Image<float>&, Image<float>&);
             ResampleFunctor (const ResampleFunctor&);

--- a/src/dwi/tractography/SIFT/sifter.h
+++ b/src/dwi/tractography/SIFT/sifter.h
@@ -48,9 +48,9 @@ namespace MR
       {
 
         protected:
-        typedef Model<Fixel> MapType;
-        typedef Fixel_map<Fixel>::MapVoxel MapVoxel;
-        typedef Fixel_map<Fixel>::VoxelAccessor VoxelAccessor;
+        using MapType = Model<Fixel>;
+        using MapVoxel = Fixel_map<Fixel>::MapVoxel;
+        using VoxelAccessor = Fixel_map<Fixel>::VoxelAccessor;
 
 
         public:

--- a/src/dwi/tractography/SIFT/track_contribution.h
+++ b/src/dwi/tractography/SIFT/track_contribution.h
@@ -19,7 +19,7 @@
 #define __dwi_tractography_sift_track_contribution_h__
 
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "header.h"
 #include "min_mem_array.h"

--- a/src/dwi/tractography/SIFT/track_index_range.h
+++ b/src/dwi/tractography/SIFT/track_index_range.h
@@ -36,8 +36,8 @@ namespace MR
 
 
 
-      typedef std::pair<track_t, track_t> TrackIndexRange;
-      typedef Thread::Queue< TrackIndexRange > TrackIndexRangeQueue;
+      using TrackIndexRange = std::pair<track_t, track_t>;
+      using TrackIndexRangeQueue = Thread::Queue< TrackIndexRange >;
 
 
 

--- a/src/dwi/tractography/SIFT/types.h
+++ b/src/dwi/tractography/SIFT/types.h
@@ -32,8 +32,8 @@ namespace MR
       {
 
 
-      typedef unsigned int track_t;
-      typedef unsigned int voxel_t;
+      using track_t = unsigned int;
+      using voxel_t = unsigned int;
 
 
       }

--- a/src/dwi/tractography/SIFT2/fixel.h
+++ b/src/dwi/tractography/SIFT2/fixel.h
@@ -41,7 +41,7 @@ namespace MR
       class Fixel : public SIFT::FixelBase
       {
 
-        typedef SIFT::track_t track_t;
+        using track_t = SIFT::track_t;
 
         public:
           Fixel () :

--- a/src/dwi/tractography/SIFT2/streamline_stats.h
+++ b/src/dwi/tractography/SIFT2/streamline_stats.h
@@ -18,7 +18,7 @@
 #define __dwi_tractography_sift2_streamline_stats_h__
 
 
-#include <assert.h>
+#include <cassert>
 #include <limits>
 
 #include "math/math.h"

--- a/src/dwi/tractography/connectome/connectome.h
+++ b/src/dwi/tractography/connectome/connectome.h
@@ -38,8 +38,8 @@ namespace Connectome {
 #define TCK2NODES_FORWARDSEARCH_DEFAULT_DIST 3.0
 
 
-typedef MR::Connectome::node_t node_t;
-typedef std::pair<node_t, node_t> NodePair;
+using node_t = MR::Connectome::node_t;
+using NodePair = std::pair<node_t, node_t>;
 
 class Tck2nodes_base;
 class Metric;

--- a/src/dwi/tractography/file.h
+++ b/src/dwi/tractography/file.h
@@ -214,7 +214,7 @@ namespace MR
           using __WriterBase__<ValueType>::update_counts;
           using __WriterBase__<ValueType>::open_success;
 
-          typedef Eigen::Matrix<ValueType,3,1> vector_type;
+          using vector_type = Eigen::Matrix<ValueType,3,1>;
 
           //! create a new track file with the specified properties
           WriterUnbuffered (const std::string& file, const Properties& properties) :
@@ -358,7 +358,7 @@ namespace MR
           using WriterUnbuffered<ValueType>::format_point;
           using WriterUnbuffered<ValueType>::weights_name;
           using WriterUnbuffered<ValueType>::write_weights;
-          typedef typename WriterUnbuffered<ValueType>::vector_type vector_type;
+          using vector_type = typename WriterUnbuffered<ValueType>::vector_type;
 
           //! create new RAM-buffered track file with specified properties
           /*! the capacity of the RAM buffer can be specified as a config file

--- a/src/dwi/tractography/file_base.h
+++ b/src/dwi/tractography/file_base.h
@@ -59,7 +59,7 @@ namespace MR
         class __WriterBase__
         {
           public:
-            typedef ValueType value_type;
+            using value_type = ValueType;
 
             __WriterBase__(const std::string& name) :
               count (0),

--- a/src/dwi/tractography/mapping/fixel_td_map.h
+++ b/src/dwi/tractography/mapping/fixel_td_map.h
@@ -40,8 +40,8 @@ namespace MR
       class Fixel_TD_map : public Fixel_map<Fixel>
       {
 
-          typedef typename Fixel_map<Fixel>::MapVoxel MapVoxel;
-          typedef typename Fixel_map<Fixel>::VoxelAccessor VoxelAccessor;
+          using MapVoxel = typename Fixel_map<Fixel>::MapVoxel;
+          using VoxelAccessor = typename Fixel_map<Fixel>::VoxelAccessor;
 
         public:
           Fixel_TD_map (const Header& H, const DWI::Directions::FastLookupSet& directions) :

--- a/src/dwi/tractography/mapping/gaussian/mapper.h
+++ b/src/dwi/tractography/mapping/gaussian/mapper.h
@@ -37,7 +37,7 @@ namespace MR {
           class TrackMapper : public Mapping::TrackMapperTWI
           {
 
-            typedef Mapping::TrackMapperTWI BaseMapper;
+            using BaseMapper = Mapping::TrackMapperTWI;
 
             public:
             template <class HeaderType>
@@ -154,7 +154,7 @@ namespace MR {
           template <class Cont>
             void TrackMapper::voxelise_precise (const Streamline<>& tck, Cont& out) const
             {
-              typedef Eigen::Vector3f PointF;
+              using PointF = Eigen::Vector3f;
 
               static const float accuracy = Math::pow2 (0.005 * std::min (info.spacing (0), std::min (info.spacing (1), info.spacing (2))));
 

--- a/src/dwi/tractography/mapping/gaussian/voxel.h
+++ b/src/dwi/tractography/mapping/gaussian/voxel.h
@@ -50,7 +50,7 @@ namespace MR {
 
           class Voxel : public Mapping::Voxel, public VoxelAddon
           {
-            typedef Mapping::Voxel Base;
+            using Base = Mapping::Voxel;
             public:
             Voxel (const int x, const int y, const int z) : Base (x, y, z) , VoxelAddon () { }
             Voxel (const Eigen::Vector3i& that) : Base (that), VoxelAddon() { }
@@ -71,7 +71,7 @@ namespace MR {
 
           class VoxelDEC : public Mapping::VoxelDEC, public VoxelAddon
           {
-            typedef Mapping::VoxelDEC Base;
+            using Base = Mapping::VoxelDEC;
             public:
             VoxelDEC () : Base (), VoxelAddon () { }
             VoxelDEC (const Eigen::Vector3i& V) : Base (V), VoxelAddon () { }
@@ -94,7 +94,7 @@ namespace MR {
 
           class Dixel : public Mapping::Dixel, public VoxelAddon
           {
-            typedef Mapping::Dixel Base;
+            using Base = Mapping::Dixel;
             public:
             Dixel () : Base (), VoxelAddon () { }
             Dixel (const Eigen::Vector3i& V) : Base (V), VoxelAddon () { }
@@ -115,7 +115,7 @@ namespace MR {
 
           class VoxelTOD : public Mapping::VoxelTOD, public VoxelAddon
           {
-            typedef Mapping::VoxelTOD Base;
+            using Base = Mapping::VoxelTOD;
             public:
             VoxelTOD () : Base (), VoxelAddon () { }
             VoxelTOD (const Eigen::Vector3i& V) : Base (V), VoxelAddon () { }
@@ -157,7 +157,7 @@ namespace MR {
           class SetVoxel : public std::set<Voxel>, public Mapping::SetVoxelExtras
           {
             public:
-              typedef Voxel VoxType;
+              using VoxType = Voxel;
               inline void insert (const Eigen::Vector3i& v, const float l, const float f)
               {
                 const Voxel temp (v, l, f);
@@ -171,7 +171,7 @@ namespace MR {
           class SetVoxelDEC : public std::set<VoxelDEC>, public Mapping::SetVoxelExtras
           {
             public:
-              typedef VoxelDEC VoxType;
+              using VoxType = VoxelDEC;
               inline void insert (const Eigen::Vector3i& v, const Eigen::Vector3f& d, const float l, const float f)
               {
                 const VoxelDEC temp (v, d, l, f);
@@ -185,7 +185,7 @@ namespace MR {
           class SetDixel : public std::set<Dixel>, public Mapping::SetVoxelExtras
           {
             public:
-              typedef Dixel VoxType;
+              using VoxType = Dixel;
               inline void insert (const Eigen::Vector3i& v, const size_t d, const float l, const float f)
               {
                 const Dixel temp (v, d, l, f);
@@ -199,7 +199,7 @@ namespace MR {
           class SetVoxelTOD : public std::set<VoxelTOD>, public Mapping::SetVoxelExtras
           {
             public:
-              typedef VoxelTOD VoxType;
+              using VoxType = VoxelTOD;
               inline void insert (const Eigen::Vector3i& v, const Eigen::VectorXf& t, const float l, const float f)
               {
                 const VoxelTOD temp (v, t, l, f);

--- a/src/dwi/tractography/mapping/mapper.h
+++ b/src/dwi/tractography/mapping/mapper.h
@@ -211,7 +211,7 @@ namespace MR {
         template <class Cont>
           void TrackMapperBase::voxelise_precise (const Streamline<>& tck, Cont& out) const
           {
-            typedef Eigen::Vector3f PointF;
+            using PointF = Eigen::Vector3f;
 
             const float accuracy = Math::pow2 (0.005 * std::min (info.spacing (0), std::min (info.spacing (1), info.spacing (2))));
 

--- a/src/dwi/tractography/mapping/voxel.h
+++ b/src/dwi/tractography/mapping/voxel.h
@@ -270,7 +270,7 @@ namespace MR {
         class SetVoxel : public std::set<Voxel>, public SetVoxelExtras
         {
           public:
-            typedef Voxel VoxType;
+            using VoxType = Voxel;
             inline void insert (const Voxel& v)
             {
               iterator existing = std::set<Voxel>::find (v);
@@ -293,7 +293,7 @@ namespace MR {
         class SetVoxelDEC : public std::set<VoxelDEC>, public SetVoxelExtras
         {
           public:
-            typedef VoxelDEC VoxType;
+            using VoxType = VoxelDEC;
             inline void insert (const VoxelDEC& v)
             {
               iterator existing = std::set<VoxelDEC>::find (v);
@@ -320,7 +320,7 @@ namespace MR {
         class SetVoxelDir : public std::set<VoxelDir>, public SetVoxelExtras
         {
           public:
-            typedef VoxelDir VoxType;
+            using VoxType = VoxelDir;
             inline void insert (const VoxelDir& v)
             {
               iterator existing = std::set<VoxelDir>::find (v);
@@ -345,7 +345,7 @@ namespace MR {
         class SetDixel : public std::set<Dixel>, public SetVoxelExtras
         {
           public:
-            typedef Dixel VoxType;
+            using VoxType = Dixel;
             inline void insert (const Dixel& v)
             {
               iterator existing = std::set<Dixel>::find (v);
@@ -373,7 +373,7 @@ namespace MR {
         class SetVoxelTOD : public std::set<VoxelTOD>, public SetVoxelExtras
         {
           public:
-            typedef VoxelTOD VoxType;
+            using VoxType = VoxelTOD;
             inline void insert (const VoxelTOD& v)
             {
               iterator existing = std::set<VoxelTOD>::find (v);

--- a/src/dwi/tractography/properties.cpp
+++ b/src/dwi/tractography/properties.cpp
@@ -22,7 +22,7 @@ namespace MR {
 
       void Properties::load_ROIs ()
       {
-        typedef std::multimap<std::string,std::string>::const_iterator iter;
+        using iter = std::multimap<std::string,std::string>::const_iterator;
 
         std::pair<iter,iter> range = roi.equal_range ("include");
         for (iter it = range.first; it != range.second; ++it) include.add (it->second);

--- a/src/dwi/tractography/resampling/arc.h
+++ b/src/dwi/tractography/resampling/arc.h
@@ -29,8 +29,8 @@ namespace MR {
 
         // Also handles resampling along a fixed line
         class Arc : public Base {
-            typedef float value_type;
-            typedef Eigen::Vector3f point_type;
+            using value_type = float;
+            using point_type = Eigen::Vector3f;
           private:
             class Plane {
               public:

--- a/src/dwi/tractography/resampling/resampling.cpp
+++ b/src/dwi/tractography/resampling/resampling.cpp
@@ -71,8 +71,8 @@ namespace MR {
 
 
         namespace {
-          typedef float value_type;
-          typedef Eigen::Vector3f point_type;
+          using value_type = float;
+          using point_type = Eigen::Vector3f;
           point_type get_pos (const std::vector<default_type>& s)
           {
             if (s.size() != 3)

--- a/src/dwi/tractography/roi.h
+++ b/src/dwi/tractography/roi.h
@@ -40,7 +40,7 @@ namespace MR
 
       class Mask : public Image<bool> {
         public:
-          typedef Eigen::Transform<float, 3, Eigen::AffineCompact> transform_type;
+          using transform_type = Eigen::Transform<float, 3, Eigen::AffineCompact>;
           Mask (const Mask&) = default;
           Mask (const std::string& name) :
               Image<bool> (__get_mask (name)),

--- a/src/dwi/tractography/scalar_file.h
+++ b/src/dwi/tractography/scalar_file.h
@@ -67,7 +67,7 @@ namespace MR
       template <typename T = float> class ScalarReader : public __ReaderBase__
       {
         public:
-          typedef T value_type;
+          using value_type = T;
 
           ScalarReader (const std::string& file, Properties& properties) {
             open (file, "track scalars", properties);
@@ -162,7 +162,7 @@ namespace MR
       class ScalarWriter : public __WriterBase__<T>
       {
         public:
-          typedef T value_type;
+          using value_type = T;
           using __WriterBase__<T>::count;
           using __WriterBase__<T>::count_offset;
           using __WriterBase__<T>::total_count;

--- a/src/dwi/tractography/seeding/basic.h
+++ b/src/dwi/tractography/seeding/basic.h
@@ -140,7 +140,7 @@ namespace MR
         class Rejection : public Base
         {
           public:
-            typedef Eigen::Transform<float, 3, Eigen::AffineCompact> transform_type;
+            using transform_type = Eigen::Transform<float, 3, Eigen::AffineCompact>;
             Rejection (const std::string&);
 
             EIGEN_MAKE_ALIGNED_OPERATOR_NEW  // avoid memory alignment errors in Eigen3;

--- a/src/dwi/tractography/seeding/dynamic.h
+++ b/src/dwi/tractography/seeding/dynamic.h
@@ -204,10 +204,10 @@ namespace MR
         {
           private:
 
-            typedef Fixel_TD_seed Fixel;
+            using Fixel = Fixel_TD_seed;
 
-            typedef Fixel_map<Fixel>::MapVoxel MapVoxel;
-            typedef Fixel_map<Fixel>::VoxelAccessor VoxelAccessor;
+            using MapVoxel = Fixel_map<Fixel>::MapVoxel;
+            using VoxelAccessor = Fixel_map<Fixel>::VoxelAccessor;
 
 
         public:

--- a/src/dwi/tractography/streamline.h
+++ b/src/dwi/tractography/streamline.h
@@ -34,8 +34,8 @@ namespace MR
         class Streamline : public std::vector<Eigen::Matrix<ValueType,3,1>>
       {
         public:
-          typedef Eigen::Matrix<ValueType,3,1> point_type;
-          typedef ValueType value_type;
+          using point_type = Eigen::Matrix<ValueType,3,1>;
+          using value_type = ValueType;
 
           Streamline () : index (-1), weight (1.0f) { }
 

--- a/src/dwi/tractography/tracking/exec.h
+++ b/src/dwi/tractography/tracking/exec.h
@@ -73,9 +73,9 @@ namespace MR
                   throw Exception ("Dynamic seeding requires setting the desired number of tracks using the -number option");
                 const size_t num_tracks = to<size_t>(max_num_tracks);
 
-                typedef Mapping::SetDixel SetDixel;
-                typedef Mapping::TrackMapperBase TckMapper;
-                typedef Seeding::WriteKernelDynamic Writer;
+                using SetDixel = Mapping::SetDixel;
+                using TckMapper = Mapping::TrackMapperBase;
+                using Writer = Seeding::WriteKernelDynamic;
 
                 DWI::Directions::FastLookupSet dirs (1281);
                 auto fod_data = Image<float>::open (fod_path);

--- a/src/dwi/tractography/tracking/generated_track.h
+++ b/src/dwi/tractography/tracking/generated_track.h
@@ -36,7 +36,7 @@ namespace MR
     class GeneratedTrack : public std::vector<Eigen::Vector3f>
     {
 
-        typedef std::vector<Eigen::Vector3f> BaseType;
+        using BaseType = std::vector<Eigen::Vector3f>;
 
       public:
         GeneratedTrack() : seed_index (0) { }

--- a/src/dwi/tractography/tracking/types.h
+++ b/src/dwi/tractography/tracking/types.h
@@ -48,7 +48,7 @@ namespace MR
         template <class ImageType>
           class Interpolator {
             public:
-              typedef Interp::Linear<ImageType> type;
+              using type = Interp::Linear<ImageType>;
           };
 
 

--- a/src/gui/dwi/render_frame.h
+++ b/src/gui/dwi/render_frame.h
@@ -40,7 +40,7 @@ namespace MR
       {
           Q_OBJECT
 
-          typedef Renderer::mode_t mode_t;
+          using mode_t = Renderer::mode_t;
 
         public:
           RenderFrame (QWidget* parent);

--- a/src/gui/dwi/renderer.h
+++ b/src/gui/dwi/renderer.h
@@ -45,9 +45,9 @@ namespace MR
       class Renderer
       {
 
-          typedef Eigen::MatrixXf matrix_t;
-          typedef Eigen::VectorXf vector_t;
-          typedef Eigen::Matrix3f tensor_t;
+          using matrix_t = Eigen::MatrixXf;
+          using vector_t = Eigen::VectorXf;
+          using tensor_t = Eigen::Matrix3f;
 
         public:
 
@@ -200,7 +200,7 @@ namespace MR
 
           class Dixel : public ModeBase
           {
-              typedef MR::DWI::Directions::dir_t dir_t;
+              using dir_t = MR::DWI::Directions::dir_t;
             public:
               Dixel (Renderer& parent) :
                   ModeBase (parent),

--- a/src/gui/mrview/colourmap.h
+++ b/src/gui/mrview/colourmap.h
@@ -50,7 +50,7 @@ namespace MR
         class Entry {
           public:
 
-            typedef std::function< Eigen::Array3f (float) > basic_map_fn;
+            using basic_map_fn = std::function< Eigen::Array3f (float) >;
 
             Entry (const char* name, const char* glsl_mapping, basic_map_fn basic_mapping,
                 const char* amplitude = NULL, bool special = false, bool is_colour = false) :

--- a/src/gui/mrview/tool/connectome/edge.h
+++ b/src/gui/mrview/tool/connectome/edge.h
@@ -39,7 +39,7 @@ namespace MR
       class Edge
       {
 
-          typedef MR::Connectome::node_t node_t;
+          using node_t = MR::Connectome::node_t;
 
         public:
           Edge (const node_t, const node_t, const Eigen::Vector3f&, const Eigen::Vector3f&);

--- a/src/gui/mrview/tool/connectome/file_data_vector.h
+++ b/src/gui/mrview/tool/connectome/file_data_vector.h
@@ -33,7 +33,7 @@ namespace MR
       class FileDataVector : public Eigen::VectorXf
       {
         public:
-          typedef Eigen::VectorXf base_t;
+          using base_t = Eigen::VectorXf;
           FileDataVector ();
           FileDataVector (const FileDataVector&);
           FileDataVector (FileDataVector&&);

--- a/src/gui/mrview/tool/connectome/types.h
+++ b/src/gui/mrview/tool/connectome/types.h
@@ -28,9 +28,9 @@ namespace MR
       namespace Tool
       {
 
-      typedef MR::Connectome::node_t   node_t;
-      typedef MR::Connectome::LUT_node LUT_node;
-      typedef MR::Connectome::LUT      LUT;
+      using MR::Connectome::node_t;
+      using MR::Connectome::LUT_node;
+      using MR::Connectome::LUT;
 
       enum class node_visibility_t { ALL, NONE, DEGREE, CONNECTOME, VECTOR_FILE, MATRIX_FILE };
       enum class node_geometry_t   { SPHERE, CUBE, OVERLAY, MESH };

--- a/src/gui/mrview/tool/fixel.h
+++ b/src/gui/mrview/tool/fixel.h
@@ -170,8 +170,8 @@ namespace MR
               }
         };
 
-        typedef MR::Sparse::Image<MR::Sparse::FixelMetric> FixelSparseImageType;
-        typedef MR::Image<float> FixelPackedImageType;
+        using FixelSparseImageType = MR::Sparse::Image<MR::Sparse::FixelMetric>;
+        using FixelPackedImageType = MR::Image<float>;
 
         // Subclassed specialisations of template wrapper
         // This is because loading of image data is dependent on particular buffer type

--- a/src/gui/mrview/tool/odf/type.h
+++ b/src/gui/mrview/tool/odf/type.h
@@ -35,7 +35,7 @@ namespace MR
 
 
         // TODO Remove
-        typedef GUI::DWI::Renderer::mode_t odf_type_t;
+        using odf_type_t = GUI::DWI::Renderer::mode_t;
 
 
 

--- a/src/gui/opengl/gl.h
+++ b/src/gui/opengl/gl.h
@@ -63,8 +63,8 @@ namespace MR
     {
 
 #if QT_VERSION >= 0x050400
-      typedef QOpenGLWidget Area;
-      typedef QSurfaceFormat Format;
+      using Area = QOpenGLWidget;
+      using Format = QSurfaceFormat;
       struct CheckContext {
 # ifndef NDEBUG
         CheckContext () : __context (nullptr) { }
@@ -87,7 +87,7 @@ namespace MR
           using QGLWidget::QGLWidget;
           QImage grabFramebuffer () { return QGLWidget::grabFrameBuffer(); }
       };
-      typedef QGLFormat Format;
+      using Format = QGLFormat;
       struct CheckContext {
         void grab_context () { }
         void check_context () const { }

--- a/src/gui/opengl/gl_core_3_3.cpp
+++ b/src/gui/opengl/gl_core_3_3.cpp
@@ -13,8 +13,8 @@
  * 
  */
 #include <algorithm>
-#include <string.h>
-#include <stddef.h>
+#include <cstring>
+#include <cstddef>
 #include "gui/opengl/gl_core_3_3.h"
 
 #if defined(__APPLE__)
@@ -32,7 +32,7 @@ static void* AppleGLGetProcAddress (const char* name)
 
 #if defined(__sgi) || defined (__sun)
 #include <dlfcn.h>
-#include <stdio.h>
+#include <cstdio>
 
 static void* SunGetProcAddress (const GLubyte* name)
 {

--- a/src/gui/opengl/gl_core_3_3.h
+++ b/src/gui/opengl/gl_core_3_3.h
@@ -84,16 +84,16 @@
 
 #endif /*GL_LOAD_GEN_BASIC_OPENGL_TYPEDEFS*/
 
-#include <stddef.h>
+#include <cstddef>
 #ifndef GLEXT_64_TYPES_DEFINED
 /* This code block is duplicated in glxext.h, so must be protected */
 #define GLEXT_64_TYPES_DEFINED
 /* Define int32_t, int64_t, and uint64_t types for UST/MSC */
 /* (as used in the GL_EXT_timer_query extension). */
 #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
-#include <inttypes.h>
+#include <cinttypes>
 #elif defined(__sun__) || defined(__digital__)
-#include <inttypes.h>
+#include <cinttypes>
 #if defined(__STDC__)
 #if defined(__arch64__) || defined(_LP64)
 typedef long int int64_t;
@@ -104,22 +104,22 @@ typedef unsigned long long int uint64_t;
 #endif /* __arch64__ */
 #endif /* __STDC__ */
 #elif defined( __VMS ) || defined(__sgi)
-#include <inttypes.h>
+#include <cinttypes>
 #elif defined(__SCO__) || defined(__USLC__)
-#include <stdint.h>
+#include <cstdint>
 #elif defined(__UNIXOS2__) || defined(__SOL64__)
 typedef long int int32_t;
 typedef long long int int64_t;
 typedef unsigned long long int uint64_t;
 #elif defined(_WIN32) && defined(__GNUC__)
-#include <stdint.h>
+#include <cstdint>
 #elif defined(_WIN32)
 typedef __int32 int32_t;
 typedef __int64 int64_t;
 typedef unsigned __int64 uint64_t;
 #else
 /* Fallback if nothing above works */
-#include <inttypes.h>
+#include <cinttypes>
 #endif
 #endif
 	typedef unsigned int GLenum;

--- a/src/gui/opengl/shader.h
+++ b/src/gui/opengl/shader.h
@@ -75,9 +75,9 @@ namespace MR
             friend class Program;
         };
 
-        typedef Object<gl::VERTEX_SHADER> Vertex;
-        typedef Object<gl::GEOMETRY_SHADER> Geometry;
-        typedef Object<gl::FRAGMENT_SHADER> Fragment;
+        using Vertex = Object<gl::VERTEX_SHADER>;
+        using Geometry = Object<gl::GEOMETRY_SHADER>;
+        using Fragment = Object<gl::FRAGMENT_SHADER>;
 
 
 

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -169,7 +169,7 @@ namespace MR
       auto init_seg = Image<uint8_t>::scratch (H);
 
       // For every voxel, stores those polygons that may intersect the voxel
-      typedef std::map< Vox, std::vector<size_t> > Vox2Poly;
+      using Vox2Poly = std::map< Vox, std::vector<size_t>>;
       Vox2Poly voxel2poly;
 
       // Map each polygon to the underlying voxels

--- a/src/mesh/mesh.h
+++ b/src/mesh/mesh.h
@@ -36,8 +36,8 @@ namespace MR
   {
 
 
-    typedef Eigen::Vector3 Vertex;
-    typedef std::vector<Vertex> VertexList;
+    using Vertex = Eigen::Vector3;
+    using VertexList = std::vector<Vertex>;
 
     class Vox : public Eigen::Array3i
     {
@@ -91,10 +91,10 @@ namespace MR
 
     template <> bool Polygon<3>::shares_edge (const Polygon<3>&) const;
 
-    typedef Polygon<3> Triangle;
-    typedef std::vector<Triangle> TriangleList;
-    typedef Polygon<4> Quad;
-    typedef std::vector<Quad> QuadList;
+    using Triangle = Polygon<3>;
+    using TriangleList = std::vector<Triangle>;
+    using Quad = Polygon<4>;
+    using QuadList = std::vector<Quad>;
 
 
 

--- a/src/mesh/mesh.h
+++ b/src/mesh/mesh.h
@@ -19,7 +19,7 @@
 
 #include <fstream>
 #include <vector>
-#include <stdint.h>
+#include <cstdint>
 
 #include "header.h"
 #include "image.h"

--- a/src/min_mem_array.h
+++ b/src/min_mem_array.h
@@ -20,9 +20,9 @@
 #define __min_mem_array_h__
 
 #include <algorithm>
-#include <assert.h>
-#include <stddef.h>
-#include <stdint.h>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
 
 
 namespace MR {

--- a/src/registration/linear.h
+++ b/src/registration/linear.h
@@ -170,7 +170,7 @@ namespace MR
           TransformType& transform,
           Im1ImageType& im1_image,
           Im2ImageType& im2_image) {
-            typedef Image<float> BogusMaskType;
+            using BogusMaskType = Image<float>;
             run_masked<MetricType, TransformType, Im1ImageType, Im2ImageType, BogusMaskType, BogusMaskType >
               (metric, transform, im1_image, im2_image, nullptr, nullptr);
           }
@@ -182,7 +182,7 @@ namespace MR
           Im1ImageType& im1_image,
           Im2ImageType& im2_image,
           std::unique_ptr<Im2MaskType>& im2_mask) {
-            typedef Image<float> BogusMaskType;
+            using BogusMaskType = Image<float>;
             run_masked<MetricType, TransformType, Im1ImageType, Im2ImageType, BogusMaskType, Im2MaskType >
               (metric, transform, im1_image, im2_image, nullptr, im2_mask);
           }
@@ -195,7 +195,7 @@ namespace MR
           Im1ImageType& im1_image,
           Im2ImageType& im2_image,
           std::unique_ptr<Im1MaskType>& im1_mask) {
-            typedef Image<float> BogusMaskType;
+            using BogusMaskType = Image<float>;
             run_masked<MetricType, TransformType, Im1ImageType, Im2ImageType, Im1MaskType, BogusMaskType >
               (metric, transform, im1_image, im2_image, im1_mask, nullptr);
           }
@@ -261,21 +261,21 @@ namespace MR
             //   // transform.debug();
             // }
 
-            typedef Header MidwayImageType;
-            typedef Im1ImageType ProcessedImageType;
-            typedef Image<bool> ProcessedMaskType;
+            using MidwayImageType = Header;
+            using ProcessedImageType = Im1ImageType;
+            using ProcessedMaskType = Image<bool>;
 
 #ifdef REGISTRATION_CUBIC_INTERP
             // typedef Interp::SplineInterp<Im1ImageType, Math::UniformBSpline<typename Im1ImageType::value_type>, Math::SplineProcessingType::ValueAndDerivative> Im1ImageInterpolatorType;
             // typedef Interp::SplineInterp<Im2ImageType, Math::UniformBSpline<typename Im2ImageType::value_type>, Math::SplineProcessingType::ValueAndDerivative> Im2ImageInterpolatorType;
             // typedef Interp::SplineInterp<ProcessedImageType, Math::UniformBSpline<typename ProcessedImageType::value_type>, Math::SplineProcessingType::ValueAndDerivative> ProcessedImageInterpolatorType;
 #else
-            typedef Interp::LinearInterp<Im1ImageType, Interp::LinearInterpProcessingType::ValueAndDerivative> Im1ImageInterpolatorType;
-            typedef Interp::LinearInterp<Im2ImageType, Interp::LinearInterpProcessingType::ValueAndDerivative> Im2ImageInterpolatorType;
-            typedef Interp::LinearInterp<ProcessedImageType, Interp::LinearInterpProcessingType::ValueAndDerivative> ProcessedImageInterpolatorType;
+            using Im1ImageInterpolatorType = Interp::LinearInterp<Im1ImageType, Interp::LinearInterpProcessingType::ValueAndDerivative>;
+            using Im2ImageInterpolatorType = Interp::LinearInterp<Im2ImageType, Interp::LinearInterpProcessingType::ValueAndDerivative>;
+            using ProcessedImageInterpolatorType = Interp::LinearInterp<ProcessedImageType, Interp::LinearInterpProcessingType::ValueAndDerivative>;
 #endif
 
-            typedef Metric::Params<TransformType,
+            using ParamType = Metric::Params<TransformType,
                                    Im1ImageType,
                                    Im2ImageType,
                                    MidwayImageType,
@@ -288,7 +288,7 @@ namespace MR
                                    ProcessedImageType,
                                    ProcessedImageInterpolatorType,
                                    ProcessedMaskType,
-                                   Interp::Nearest<ProcessedMaskType>> ParamType;
+                                   Interp::Nearest<ProcessedMaskType>>;
 
             Eigen::Matrix<typename TransformType::ParameterType, Eigen::Dynamic, 1> optimiser_weights = transform.get_optimiser_weights();
             const Eigen::Matrix<default_type, 4, 1> midspace_padding = Eigen::Matrix<default_type, 4, 1>(1.0, 1.0, 1.0, 1.0);

--- a/src/registration/metric/cross_correlation.h
+++ b/src/registration/metric/cross_correlation.h
@@ -160,7 +160,7 @@ namespace MR
         public:
           /** requires_precompute:
           type_trait to distinguish metric types that require a call to precompute before the operator() is called */
-          typedef int requires_precompute;
+          using requires_precompute = int;
 
 
 
@@ -189,18 +189,18 @@ namespace MR
             default_type precompute (ParamType& parameters) {
               DEBUG ("precomputing cross correlation data...");
 
-              typedef decltype(parameters.im1_image) Im1Type;
-              typedef decltype(parameters.im2_image) Im2Type;
-              typedef decltype(parameters.midway_image) MidwayImageType;
-              typedef decltype(parameters.im1_mask) Im1MaskType;
-              typedef decltype(parameters.im2_mask) Im2MaskType;
-              typedef typename ParamType::Im1InterpType Im1ImageInterpolatorType;
-              typedef typename ParamType::Im2InterpType Im2ImageInterpolatorType;
-              typedef typename ParamType::ProcessedImageType PImageType;
+              using Im1Type = decltype(parameters.im1_image);
+              using Im2Type = decltype(parameters.im2_image);
+              using MidwayImageType = decltype(parameters.midway_image);
+              using Im1MaskType = decltype(parameters.im1_mask);
+              using Im2MaskType = decltype(parameters.im2_mask);
+              using Im1ImageInterpolatorType = typename ParamType::Im1InterpType;
+              using Im2ImageInterpolatorType = typename ParamType::Im2InterpType;
+              using PImageType = typename ParamType::ProcessedImageType;
               // typedef Interp::LinearInterp<Im1MaskType, Interp::LinearInterpProcessingType::Value> Im1MaskInterpolatorType;
               // typedef Interp::LinearInterp<Im2MaskType, Interp::LinearInterpProcessingType::Value> Im2MaskInterpolatorType;
-              typedef typename ParamType::Mask1InterpolatorType Im1MaskInterpolatorType;
-              typedef typename ParamType::Mask2InterpolatorType Im2MaskInterpolatorType;
+              using Im1MaskInterpolatorType = typename ParamType::Mask1InterpolatorType;
+              using Im2MaskInterpolatorType = typename ParamType::Mask2InterpolatorType;
 
               assert (parameters.midway_image.ndim() == 3);
               mean1 = 0.0;

--- a/src/registration/metric/difference_robust.h
+++ b/src/registration/metric/difference_robust.h
@@ -78,7 +78,7 @@ namespace MR
 
           /** requires_initialisation:
           type_trait to distinguish metric types that require a call to init before the operator() is called */
-          typedef int requires_initialisation;
+          using requires_initialisation = int;
 
           void init (const Im1Type& im1, const Im2Type& im2) {
             assert (im1.ndim() == 4);

--- a/src/registration/metric/evaluate.h
+++ b/src/registration/metric/evaluate.h
@@ -33,27 +33,27 @@ namespace MR
       namespace {
         template<class T>
         struct Void2 {
-          typedef void type;
+          using type = void;
         };
 
         template <class MetricType, typename U = void>
         struct metric_requires_precompute {
-          typedef int no;
+          using no = int;
         };
 
         template <class MetricType>
         struct metric_requires_precompute<MetricType, typename Void2<typename MetricType::requires_precompute>::type> {
-          typedef int yes;
+          using yes = int;
         };
 
         template <class MetricType, typename U = void>
         struct metric_requires_initialisation {
-          typedef int no;
+          using no = int;
         };
 
         template <class MetricType>
         struct metric_requires_initialisation<MetricType, typename Void2<typename MetricType::requires_initialisation>::type> {
-          typedef int yes;
+          using yes = int;
         };
       }
       //! \endcond
@@ -62,8 +62,8 @@ namespace MR
         class Evaluate {
           public:
 
-            typedef typename ParamType::TransformParamType TransformParamType;
-            typedef default_type value_type;
+            using TransformParamType = typename ParamType::TransformParamType;
+            using value_type = default_type;
 
             template <class U = MetricType>
             Evaluate (const MetricType& metric_, ParamType& parameters, typename metric_requires_initialisation<U>::yes = 0) :

--- a/src/registration/metric/mean_squared.h
+++ b/src/registration/metric/mean_squared.h
@@ -181,7 +181,7 @@ namespace MR
               }
 
             //type_trait to indicate return type of operator()
-            typedef int is_vector_type;
+            using is_vector_type = int;
 
             template <class Params>
               Eigen::Matrix<default_type, Eigen::Dynamic, 1> operator() (Params& params,

--- a/src/registration/metric/normalised_cross_correlation.h
+++ b/src/registration/metric/normalised_cross_correlation.h
@@ -96,7 +96,7 @@ namespace MR
           out.index(1) = mask.index(1);
           out.index(2) = mask.index(2);
           out.index(3) = 0;
-          typedef typename ImageType3::value_type value_type;
+          using value_type = typename ImageType3::value_type;
           in1.index(0) = mask.index(0);
           in1.index(1) = mask.index(1);
           in1.index(2) = mask.index(2);
@@ -210,23 +210,23 @@ namespace MR
 
           public:
             /** typedef int is_neighbourhood: type_trait to distinguish voxel-wise and neighbourhood based metric types */
-            typedef int is_neighbourhood;
+            using is_neighbourhood = int;
             /** requires_precompute int is_neighbourhood: type_trait to distinguish metric types that require a call to precompute before the operator() is called */
-            typedef int requires_precompute;
+            using requires_precompute = int;
 
             template <class ParamType>
               default_type precompute(ParamType& parameters) {
                 INFO("precomputing cross correlation data...");
                 throw Exception ("TODO");
 
-                typedef decltype(parameters.im1_image) Im1Type;
-                typedef decltype(parameters.im2_image) Im2Type;
-                typedef decltype(parameters.im1_mask) Im1MaskType;
-                typedef decltype(parameters.im2_mask) Im2MaskType;
-                typedef typename ParamType::ProcessedValueType ProcessedImageValueType;
-                typedef typename ParamType::ProcessedMaskType ProcessedMaskType;
-                typedef typename ParamType::ProcessedMaskInterpType ProcessedMaskInterpolatorType;
-                typedef typename ParamType::ProcessedImageInterpType CCInterpType;
+                using Im1Type = decltype(parameters.im1_image);
+                using Im2Type = decltype(parameters.im2_image);
+                using Im1MaskType = decltype(parameters.im1_mask);
+                using Im2MaskType = decltype(parameters.im2_mask);
+                using ProcessedImageValueType = typename ParamType::ProcessedValueType;
+                using ProcessedMaskType = typename ParamType::ProcessedMaskType;
+                using ProcessedMaskInterpolatorType = typename ParamType::ProcessedMaskInterpType;
+                using CCInterpType = typename ParamType::ProcessedImageInterpType;
 
                 Header midway_header (parameters.midway_image);
                 midway_v2s = MR::Transform (midway_header).voxel2scanner;

--- a/src/registration/metric/params.h
+++ b/src/registration/metric/params.h
@@ -44,18 +44,18 @@ namespace MR
       class Params {
         public:
 
-          typedef typename TransformType::ParameterType TransformParamType;
-          typedef typename Im1ImageInterpType::value_type Im1ValueType;
-          typedef typename Im2ImageInterpType::value_type Im2ValueType;
-          typedef Im1ImageInterpType Im1InterpType;
-          typedef Im2ImageInterpType Im2InterpType;
-          typedef Im1MaskInterpolatorType Mask1InterpolatorType;
-          typedef Im2MaskInterpolatorType Mask2InterpolatorType;
-          typedef typename ProcImageInterpolatorType::value_type ProcessedValueType;
-          typedef ProcImageType ProcessedImageType;
-          typedef ProcMaskType ProcessedMaskType;
-          typedef ProcImageInterpolatorType ProcessedImageInterpType;
-          typedef ProcessedMaskInterpolatorType ProcessedMaskInterpType;
+          using TransformParamType = typename TransformType::ParameterType;
+          using Im1ValueType = typename Im1ImageInterpType::value_type;
+          using Im2ValueType = typename Im2ImageInterpType::value_type;
+          using Im1InterpType = Im1ImageInterpType;
+          using Im2InterpType = Im2ImageInterpType;
+          using Mask1InterpolatorType = Im1MaskInterpolatorType;
+          using Mask2InterpolatorType = Im2MaskInterpolatorType;
+          using ProcessedValueType = typename ProcImageInterpolatorType::value_type;
+          using ProcessedImageType = ProcImageType;
+          using ProcessedMaskType = ProcMaskType;
+          using ProcessedImageInterpType = ProcImageInterpolatorType;
+          using ProcessedMaskInterpType = ProcessedMaskInterpolatorType;
 
           Params (TransformType& transform,
                   Im1ImageType& im1_image,

--- a/src/registration/metric/thread_kernel.h
+++ b/src/registration/metric/thread_kernel.h
@@ -31,37 +31,37 @@ namespace MR
       namespace {
         template<class T>
         struct Void {
-          typedef void type;
+          using type = void;
         };
 
         template <class MetricType, typename U = void>
         struct is_neighbourhood_metric {
-          typedef int no;
+          using no = int;
         };
 
         template <class MetricType>
         struct is_neighbourhood_metric<MetricType, typename Void<typename MetricType::is_neighbourhood>::type> {
-          typedef int yes;
+          using yes = int;
         };
 
         template <class MetricType, typename U = void>
         struct use_processed_image {
-          typedef int no;
+          using no = int;
         };
 
         template <class MetricType>
         struct use_processed_image<MetricType, typename Void<typename MetricType::requires_precompute>::type> {
-          typedef int yes;
+          using yes = int;
         };
 
         template <class MetricType, typename U = void>
         struct cost_is_vector {
-          typedef int no;
+          using no = int;
         };
 
         template <class MetricType>
         struct cost_is_vector<MetricType, typename Void<typename MetricType::is_vector_type>::type> {
-          typedef int yes;
+          using yes = int;
         };
       }
       //! \endcond

--- a/src/registration/transform/affine.h
+++ b/src/registration/transform/affine.h
@@ -81,10 +81,10 @@ namespace MR
       class Affine : public Base  {
         public:
 
-          typedef typename Base::ParameterType ParameterType;
-          typedef AffineUpdate UpdateType;
-          typedef AffineRobustEstimator RobustEstimatorType;
-          typedef int has_robust_estimator;
+          using ParameterType = typename Base::ParameterType;
+          using UpdateType = AffineUpdate;
+          using RobustEstimatorType = AffineRobustEstimator;
+          using has_robust_estimator = int;
 
           EIGEN_MAKE_ALIGNED_OPERATOR_NEW  // avoid memory alignment errors in Eigen3;
 

--- a/src/registration/transform/base.h
+++ b/src/registration/transform/base.h
@@ -83,7 +83,7 @@ namespace MR
       class Base  {
         public:
 
-          typedef default_type ParameterType;
+          using ParameterType = default_type;
           Base (size_t number_of_parameters) :
             number_of_parameters(number_of_parameters),
             optimiser_weights (number_of_parameters) {

--- a/src/registration/transform/rigid.h
+++ b/src/registration/transform/rigid.h
@@ -70,10 +70,10 @@ namespace MR
           
           EIGEN_MAKE_ALIGNED_OPERATOR_NEW  // avoid memory alignment errors in Eigen3;
 
-          typedef typename Base::ParameterType ParameterType;
-          typedef RigidLinearNonSymmetricUpdate UpdateType;
-          typedef RigidRobustEstimator RobustEstimatorType;
-          typedef int has_robust_estimator;
+          using ParameterType = typename Base::ParameterType;
+          using UpdateType = RigidLinearNonSymmetricUpdate;
+          using RobustEstimatorType = RigidRobustEstimator;
+          using has_robust_estimator = int;
 
           Rigid () : Base (12) {
             default_type w1 (MR::File::Config::get_float ("reg_gdweight_matrix", 0.0003f));

--- a/src/registration/transform/search.h
+++ b/src/registration/transform/search.h
@@ -51,10 +51,10 @@ namespace MR
     namespace RotationSearch
     {
 
-      typedef transform_type TrafoType;
-      typedef Eigen::Matrix<default_type, 3, 3> MatType;
-      typedef Eigen::Matrix<default_type, 3, 1> VecType;
-      typedef Eigen::Quaternion<default_type> QuatType;
+      using TrafoType = transform_type;
+      using MatType = Eigen::Matrix<default_type, 3, 3>;
+      using VecType = Eigen::Matrix<default_type, 3, 1>;
+      using QuatType = Eigen::Quaternion<default_type>;
 
       template <class MetricType = Registration::Metric::MeanSquaredNoGradient>
         class ExhaustiveRotationSearch {
@@ -89,7 +89,7 @@ namespace MR
 
             EIGEN_MAKE_ALIGNED_OPERATOR_NEW  // avoid memory alignment errors in Eigen3;
 
-            typedef Metric::Params<Registration::Transform::Rigid,
+            using ParamType = Metric::Params<Registration::Transform::Rigid,
                                      Image<default_type>,
                                      Image<default_type>,
                                      Header,
@@ -103,7 +103,7 @@ namespace MR
                                      Image<default_type>,
                                      Interp::LinearInterp<Image<default_type>, Interp::LinearInterpProcessingType::Value>,
                                      Image<default_type>,
-                                     Interp::Nearest<Image<default_type>>> ParamType;
+                                     Interp::Nearest<Image<default_type>>>;
 
             void write_images (const std::string& im1_path, const std::string& im2_path) {
               Image<default_type> image1_midway;

--- a/src/stats/cfe.h
+++ b/src/stats/cfe.h
@@ -26,8 +26,8 @@ namespace MR
     namespace CFE
     {
 
-      typedef float value_type;
-      typedef DWI::Tractography::Mapping::SetVoxelDir SetVoxelDir;
+      using value_type = float;
+      using SetVoxelDir = DWI::Tractography::Mapping::SetVoxelDir;
 
 
       /** \addtogroup Statistics

--- a/src/stats/cluster.h
+++ b/src/stats/cluster.h
@@ -25,7 +25,7 @@ namespace MR
     namespace Cluster
     {
 
-      typedef float value_type;
+      using value_type = float;
 
 
       /** \addtogroup Statistics

--- a/src/stats/permtest.h
+++ b/src/stats/permtest.h
@@ -29,7 +29,7 @@ namespace MR
     namespace PermTest
     {
 
-      typedef float value_type;
+      using value_type = float;
 
 
 

--- a/src/stats/tfce.h
+++ b/src/stats/tfce.h
@@ -26,7 +26,7 @@ namespace MR
     namespace TFCE
     {
 
-      typedef float value_type;
+      using value_type = float;
 
 
       /** \addtogroup Statistics

--- a/testing/cmd/testing_diff_tsf.cpp
+++ b/testing/cmd/testing_diff_tsf.cpp
@@ -46,7 +46,7 @@ void usage ()
     + Argument ("tolerance").type_float (0.0);
 }
 
-typedef float value_type;
+using value_type = float;
 
 void run ()
 {


### PR DESCRIPTION
Made changes to modernise aspects of the code as well as removed a comparison thats always true.

- replaced C Standard Library includes with C++ Standard Library includes.
- removed comparison that is always true (unsigned ints are always greater than or equal to zero)
- replaced typdef aliases which are a C++03 method with using aliases which are C++11 and above.

The last commit is a significant change, feel free to remove it. 