### PR TITLE
dwi2mask: use DWI::get_valid_DW_scheme()

### DIFF
--- a/cmd/dwi2mask.cpp
+++ b/cmd/dwi2mask.cpp
@@ -65,7 +65,7 @@ OPTIONS
 void run () {
 
   auto input = Image<float>::open (argument[0]).with_direct_io (3);
-  auto grad = DWI::get_DW_scheme (input);
+  auto grad = DWI::get_valid_DW_scheme (input);
 
   if (input.ndim() != 4)
     throw Exception ("input DWI image must be 4D");


### PR DESCRIPTION
This ensures the rights checks are done on the gradient scheme before
use, and produces a more informative error message when not found.

See also:
http://community.mrtrix.org/t/gradient-encoding-matrix-does-not-represent-a-hardi-sequence/549/10?u=jdtournier