### PR TITLE
MGH / MGZ formats: Always big-endian

### DIFF
--- a/lib/file/mgh.h
+++ b/lib/file/mgh.h
@@ -88,7 +88,7 @@ extern "C" {
     float ti;         /*!< milliseconds */
     float fov;        /*!< IGNORE THIS FIELD (data is inconsistent) */
 
-    std::vector<std::string> tags; /*!< variable length char strings */
+    std::vector<std::tuple<int32_t,int64_t,std::string>> tags; /*!< variable length char strings */
 
   };
 

--- a/lib/file/mgh.h
+++ b/lib/file/mgh.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (c) 2008-2016 the MRtrix3 contributors
- * 
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
- * 
+ *
  * MRtrix is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * 
+ *
  * For more details, see www.mrtrix.org
- * 
+ *
  */
 
 #ifndef _MGH_HEADER_
@@ -19,6 +19,8 @@
 
 #include <vector>
 #include <string>
+
+#include "types.h"
 
 /*=================*/
 #ifdef  __cplusplus
@@ -47,22 +49,22 @@ extern "C" {
     int32_t type;          /*!< data type of the image buffer; can be one of the following: UCHAR, SHORT, INT, or FLOAT (specified as 0, 4, 1, or 3, respectively) */
     int32_t dof;           /*!< degrees of freedom (where appropriate) */
     int16_t goodRASFlag;   /*!< if true, the direction cosines, which will be detailed next, are in the header; if false, a CORONAL orientation will be assumed */
-    float   spacing_x;     /*!< spacing in the X direction (ranging [0...width]) - default is 1 */
-    float   spacing_y;     /*!< spacing in the Y direction (ranging [0...height]) - default is 1 */
-    float   spacing_z;     /*!< spacing in the Z direction (ranging [0...depth]) - default is 1 */
+    MR::float32 spacing_x;     /*!< spacing in the X direction (ranging [0...width]) - default is 1 */
+    MR::float32 spacing_y;     /*!< spacing in the Y direction (ranging [0...height]) - default is 1 */
+    MR::float32 spacing_z;     /*!< spacing in the Z direction (ranging [0...depth]) - default is 1 */
 
-    float x_r; /* default is -1 */
-    float x_a; /* default is 0  */
-    float x_s; /* default is 0  */
-    float y_r; /* default is 0  */
-    float y_a; /* default is 0  */
-    float y_s; /* default is -1 */
-    float z_r; /* default is 0  */
-    float z_a; /* default is 1  */
-    float z_s; /* default is 0  */
-    float c_r; /* default is 0  */
-    float c_a; /* default is 0  */
-    float c_s; /* default is 0  */
+    MR::float32 x_r; /* default is -1 */
+    MR::float32 x_a; /* default is 0  */
+    MR::float32 x_s; /* default is 0  */
+    MR::float32 y_r; /* default is 0  */
+    MR::float32 y_a; /* default is 0  */
+    MR::float32 y_s; /* default is -1 */
+    MR::float32 z_r; /* default is 0  */
+    MR::float32 z_a; /* default is 1  */
+    MR::float32 z_s; /* default is 0  */
+    MR::float32 c_r; /* default is 0  */
+    MR::float32 c_a; /* default is 0  */
+    MR::float32 c_s; /* default is 0  */
 
     /**** 90 bytes total - note that data starts at 284 ****/
 
@@ -79,20 +81,23 @@ extern "C" {
 #define MGH_TYPE_INT   1
 #define MGH_TYPE_FLOAT 3
 
-
-  struct mgh_other {
-
-    float tr;         /*!< milliseconds */
-    float flip_angle; /*!< radians */
-    float te;         /*!< milliseconds */
-    float ti;         /*!< milliseconds */
-    float fov;        /*!< IGNORE THIS FIELD (data is inconsistent) */
-
-    std::vector<std::tuple<int32_t,int64_t,std::string>> tags; /*!< variable length char strings */
-
+  struct mgh_tag
+  {
+    int32_t id;
+    int64_t size;
+    std::string content;
   };
 
-  typedef struct mgh_other mgh_other ;
+  struct mgh_other
+  {
+    MR::float32 tr;         /*!< milliseconds */
+    MR::float32 flip_angle; /*!< radians */
+    MR::float32 te;         /*!< milliseconds */
+    MR::float32 ti;         /*!< milliseconds */
+    MR::float32 fov;        /*!< IGNORE THIS FIELD (data is inconsistent) */
+
+    std::vector<mgh_tag> tags; /*!< variable length char strings */
+  };
 
 
   /*=================*/

--- a/lib/file/mgh_utils.cpp
+++ b/lib/file/mgh_utils.cpp
@@ -31,9 +31,9 @@ namespace MR
 
       namespace {
 
-        std::string tag_ID_to_string (int num)
+        std::string tag_ID_to_string (const int32_t tag)
         {
-          switch (num) {
+          switch (tag) {
             case 1: return "MGH_TAG_OLD_COLORTABLE";
             case 2: return "MGH_TAG_OLD_USEREALRAS";
             case 3: return "MGH_TAG_CMDLINE";
@@ -59,12 +59,12 @@ namespace MR
 
             default: break;
           }
-          return "MGH_TAG_" + str(num);
+          return "MGH_TAG_" + str(tag);
         }
 
 
 
-        int string_to_tag_ID (const std::string& key)
+        int32_t string_to_tag_ID (const std::string& key)
         {
           if (key.compare (0, 8, "MGH_TAG_") == 0) {
 
@@ -129,7 +129,7 @@ namespace MR
         DataType dtype;
         int32_t type = ByteOrder::BE (MGHH.type);
         switch (type) {
-          case MGH_TYPE_UCHAR: dtype = DataType::UInt8;   break;
+          case MGH_TYPE_UCHAR: dtype = DataType::UInt8;     break;
           case MGH_TYPE_SHORT: dtype = DataType::Int16BE;   break;
           case MGH_TYPE_INT:   dtype = DataType::Int32BE;   break;
           case MGH_TYPE_FLOAT: dtype = DataType::Float32BE; break;
@@ -204,7 +204,7 @@ namespace MR
       void read_tag (Header& H, const mgh_tag& tag)
       {
         if (tag.content.size())
-          add_line (H.keyval()["comments"], tag_ID_to_string(tag.id) + ": " + tag.content);
+          add_line (H.keyval()["comments"], tag_ID_to_string (ByteOrder::BE (tag.id)) + ": " + tag.content);
       }
 
 
@@ -313,7 +313,9 @@ namespace MR
             else {
               auto id = string_to_tag_ID (key);
               if (id) {
-                auto tag = prepare_tag (id, value.size());
+                mgh_tag tag;
+                tag.id = ByteOrder::BE (id);
+                tag.size = ByteOrder::BE (value.size());
                 tag.content = value;
                 MGHO.tags.push_back (tag);
               }

--- a/lib/file/mgh_utils.cpp
+++ b/lib/file/mgh_utils.cpp
@@ -126,13 +126,7 @@ namespace MR
 
         // Ignore FoV field
 
-/*
- * Although this code removes the wacky nullspace that these image files have
- * between the actual tag fields, greatly neatening the header "comments"
- * contents, FreeSurfer is subsequently unable to open that file. It seems as
- * though they expect literally a std::vector object at &MGHO.tags, rather
- * than a list of null-terminated strings...
-
+        // Do this manually to get rid of a lot of non-printable bytes
         for (const auto i : MGHO.tags) {
           std::string s;
           for (auto c : i) {
@@ -146,9 +140,6 @@ namespace MR
           if (s.size())
             add_line (H.keyval()["comments"], s);
         }
-*/
-        for (const auto i : MGHO.tags)
-          add_line (H.keyval()["comments"], i);
       }
 
 
@@ -262,10 +253,11 @@ namespace MR
       {
         File::OFStream out (path, std::ios_base::out | std::ios_base::app);
         out.write ((char*) &MGHO, 5 * sizeof (float));
-        for (std::vector<std::string>::const_iterator i = MGHO.tags.begin(); i != MGHO.tags.end(); ++i) {
-          //std::cerr << "Length " << i->size() << ", string: " << i->c_str() << "\n";
-          out.write (i->c_str(), i->size() + 1);
-        }
+        // Do *not* write metadata string fields; don't yet know
+        //   formatting expected by FreeSurfer (is more than just
+        //   null-terminated strings)
+        //for (std::vector<std::string>::const_iterator i = MGHO.tags.begin(); i != MGHO.tags.end(); ++i)
+        //  out.write (i->c_str(), i->size() + 1);
         out.close();
       }
 

--- a/lib/file/mgh_utils.cpp
+++ b/lib/file/mgh_utils.cpp
@@ -1,16 +1,16 @@
 /*
  * Copyright (c) 2008-2016 the MRtrix3 contributors
- * 
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
- * 
+ *
  * MRtrix is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * 
+ *
  * For more details, see www.mrtrix.org
- * 
+ *
  */
 
 #include <cctype>
@@ -27,6 +27,79 @@ namespace MR
   {
     namespace MGH
     {
+
+
+
+      namespace {
+
+        std::string tag_ID_to_string (int num)
+        {
+          switch (num) {
+            case 1: return "MGH_TAG_OLD_COLORTABLE";
+            case 2: return "MGH_TAG_OLD_USEREALRAS";
+            case 3: return "MGH_TAG_CMDLINE";
+            case 4: return "MGH_TAG_USEREALRAS";
+            case 5: return "MGH_TAG_COLORTABLE";
+
+            case 10: return "MGH_TAG_GCAMORPH_GEOM";
+            case 11: return "MGH_TAG_GCAMORPH_TYPE";
+            case 12: return "MGH_TAG_GCAMORPH_LABELS";
+
+            case 20: return "MGH_TAG_OLD_SURF_GEOM";
+            case 21: return "MGH_TAG_SURF_GEOM";
+
+            case 30: return "MGH_TAG_OLD_MGH_XFORM";
+            case 31: return "MGH_TAG_MGH_XFORM";
+            case 32: return "MGH_TAG_GROUP_AVG_SURFACE_AREA";
+            case 33: return "MGH_TAG_AUTO_ALIGN";
+
+            case 40: return "MGH_TAG_SCALAR_DOUBLE";
+            case 41: return "MGH_TAG_PEDIR";
+            case 42: return "MGH_TAG_MRI_FRAME";
+            case 43: return "MGH_TAG_FIELDSTRENGTH";
+
+            default: break;
+          }
+          return "MGH_TAG_" + str(num);
+        }
+
+
+
+        int string_to_tag_ID (const std::string& key)
+        {
+          if (key.compare (0, 8, "MGH_TAG_") == 0) {
+
+            auto id = key.substr (8);
+
+            if (id == "OLD_COLORTABLE") return 1;
+            if (id == "OLD_USEREALRAS") return 2;
+            if (id == "CMDLINE") return 3;
+            if (id == "USEREALRAS") return 4;
+            if (id == "COLORTABLE") return 5;
+
+            if (id == "GCAMORPH_GEOM") return 10;
+            if (id == "GCAMORPH_TYPE") return 11;
+            if (id == "GCAMORPH_LABELS") return 12;
+
+            if (id == "OLD_SURF_GEOM") return 20;
+            if (id == "SURF_GEOM") return 21;
+
+            if (id == "OLD_MGH_XFORM") return 30;
+            if (id == "MGH_XFORM") return 31;
+            if (id == "GROUP_AVG_SURFACE_AREA") return 32;
+            if (id == "AUTO_ALIGN") return 33;
+
+            if (id == "SCALAR_DOUBLE") return 40;
+            if (id == "PEDIR") return 41;
+            if (id == "MRI_FRAME") return 42;
+            if (id == "FIELDSTRENGTH") return 43;
+          }
+
+          return 0;
+        }
+
+      }
+
 
 
       bool read_header (Header& H, const mgh_header& MGHH)
@@ -196,16 +269,16 @@ namespace MR
         Raw::store<float> (H.spacing (axes[2]), &MGHH.spacing_z, is_BE);
 
         //const Math::Matrix<float>& M (H.transform());
-        Raw::store<float> (M(0,0), &MGHH.x_r, is_BE); 
-        Raw::store<float> (M(0,1), &MGHH.y_r, is_BE); 
+        Raw::store<float> (M(0,0), &MGHH.x_r, is_BE);
+        Raw::store<float> (M(0,1), &MGHH.y_r, is_BE);
         Raw::store<float> (M(0,2), &MGHH.z_r, is_BE);
 
-        Raw::store<float> (M(1,0), &MGHH.x_a, is_BE); 
-        Raw::store<float> (M(1,1), &MGHH.y_a, is_BE); 
+        Raw::store<float> (M(1,0), &MGHH.x_a, is_BE);
+        Raw::store<float> (M(1,1), &MGHH.y_a, is_BE);
         Raw::store<float> (M(1,2), &MGHH.z_a, is_BE);
-        
-        Raw::store<float> (M(2,0), &MGHH.x_s, is_BE); 
-        Raw::store<float> (M(2,1), &MGHH.y_s, is_BE); 
+
+        Raw::store<float> (M(2,0), &MGHH.x_s, is_BE);
+        Raw::store<float> (M(2,1), &MGHH.y_s, is_BE);
         Raw::store<float> (M(2,2), &MGHH.z_s, is_BE);
 
         for (size_t i = 0; i != 3; ++i) {
@@ -243,7 +316,7 @@ namespace MR
               Raw::store<float> (to<float> (i.substr (3)), &MGHO.ti, is_BE);
             else if (key.compare (0, 9, "[MGH TAG ") == 0) {
               auto pos = key.find ("]");
-              if (pos == key.npos) 
+              if (pos == key.npos)
                 continue;
               int32_t tag = ByteOrder::BE (to<int32_t> (key.substr (9, pos)));
               auto content = i.substr (pos+3);

--- a/lib/file/mgh_utils.cpp
+++ b/lib/file/mgh_utils.cpp
@@ -116,7 +116,7 @@ namespace MR
         if (Raw::fetch_<float> (&MGHO.tr, is_BE) != 0.0f)
           add_line (H.keyval()["comments"], "TR: "   + str (Raw::fetch_<float> (&MGHO.tr, is_BE)) + "ms");
         if (Raw::fetch_<float> (&MGHO.flip_angle, is_BE) != 0.0f)
-          add_line (H.keyval()["comments"], "Flip: " + str (Raw::fetch_<float> (&MGHO.flip_angle, is_BE) * 180.0 / Math::pi) + "deg");
+          add_line (H.keyval()["comments"], "Flip: " + str (Raw::fetch_<float> (&MGHO.flip_angle, is_BE)) + "deg");
         if (Raw::fetch_<float> (&MGHO.te, is_BE) != 0.0f)
           add_line (H.keyval()["comments"], "TE: "   + str (Raw::fetch_<float> (&MGHO.te, is_BE)) + "ms");
         if (Raw::fetch_<float> (&MGHO.ti, is_BE) != 0.0f)
@@ -135,7 +135,7 @@ namespace MR
 
       void write_header (mgh_header& MGHH, const Header& H)
       {
-        bool is_BE = H.datatype().is_big_endian();
+        const bool is_BE = true;
 
         const size_t ndim = H.ndim();
         if (ndim > 4)
@@ -212,8 +212,7 @@ namespace MR
 
       void write_other (mgh_other& MGHO, const Header& H)
       {
-
-        bool is_BE = H.datatype().is_big_endian();
+        const bool is_BE = true;
 
         const auto comments = H.keyval().find("comments");
         if (comments != H.keyval().end()) {
@@ -232,7 +231,6 @@ namespace MR
           }
         }
         Raw::store<float> (0.0, &MGHO.fov, is_BE);
-
       }
 
 

--- a/lib/file/mgh_utils.h
+++ b/lib/file/mgh_utils.h
@@ -31,13 +31,6 @@ namespace MR
     namespace MGH
     {
 
-      inline mgh_tag prepare_tag (int32_t id, int64_t size) {
-        mgh_tag tag;
-        tag.id = ByteOrder::BE (id);
-        tag.size = ByteOrder::BE (size);
-        return tag;
-      }
-
       void read_header  (Header& H, const mgh_header& MGHH);
       void read_other   (Header& H, const mgh_other& MGHO);
       void read_tag     (Header& H, const mgh_tag& tag);

--- a/lib/file/mgh_utils.h
+++ b/lib/file/mgh_utils.h
@@ -1,21 +1,22 @@
 /*
  * Copyright (c) 2008-2016 the MRtrix3 contributors
- * 
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/
- * 
+ *
  * MRtrix is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * 
+ *
  * For more details, see www.mrtrix.org
- * 
+ *
  */
 
 #ifndef __file_mgh_utils_h__
 #define __file_mgh_utils_h__
 
+#include "raw.h"
 #include "file/mgh.h"
 
 #define MGH_HEADER_SIZE 90
@@ -30,8 +31,17 @@ namespace MR
     namespace MGH
     {
 
-      bool read_header  (Header& H, const mgh_header& MGHH);
-      void read_other   (Header& H, const mgh_other& MGHO, const bool is_BE);
+      inline mgh_tag prepare_tag (int32_t id, int64_t size) {
+        mgh_tag tag;
+        tag.id = ByteOrder::BE (id);
+        tag.size = ByteOrder::BE (size);
+        return tag;
+      }
+
+      void read_header  (Header& H, const mgh_header& MGHH);
+      void read_other   (Header& H, const mgh_other& MGHO);
+      void read_tag     (Header& H, const mgh_tag& tag);
+
       void write_header (mgh_header& MGHH, const Header& H);
       void write_other  (mgh_other&  MGHO, const Header& H);
 

--- a/lib/file/mgh_utils.h
+++ b/lib/file/mgh_utils.h
@@ -35,8 +35,6 @@ namespace MR
       void write_header (mgh_header& MGHH, const Header& H);
       void write_other  (mgh_other&  MGHO, const Header& H);
 
-      void write_other_to_file (const std::string&, const mgh_other&);
-
     }
   }
 }

--- a/lib/formats/mgh.cpp
+++ b/lib/formats/mgh.cpp
@@ -43,41 +43,21 @@ namespace MR
 
         mgh_other MGHO;
         memcpy (&MGHO, fmap.address() + other_offset, other_floats_size);
-        MGHO.tags.clear();
+        File::MGH::read_other (H, MGHO, is_BE);
 
+        MGHO.tags.clear();
         uint8_t* p_current = fmap.address() + other_tags_offset;
 
         while (p_current < fmap.address() + fmap.size()) {
 
           int32_t tag = Raw::fetch_BE<int32_t> (p_current);
           int64_t size = Raw::fetch_BE<int64_t> (p_current+4);
-          if (size) 
-            add_line (H.keyval()["comments"], "[TAG "+str(tag) + "]: "   + (const char*) (p_current+12));
+          if (size & p_current[12]) 
+            add_line (H.keyval()["comments"], "[MGH TAG "+str(tag) + "]: "   + (const char*) (p_current+12));
 
           p_current += 12 + size;
         }
 
-        /*
-        if (other_tags_offset < fmap.size()) {
-          // It's memory-mapped, so should be able to use memcpy to do the initial grab
-          const size_t total_text_length = fmap.size() - other_tags_offset;
-          char* const tags = new char [total_text_length];
-          memcpy (tags, fmap.address() + other_tags_offset, total_text_length);
-
-          // Extract and separate null-terminated strings
-          size_t char_offset = 0;
-          while (char_offset < total_text_length) {
-            std::string line (tags + char_offset);
-            if (line.size())
-              MGHO.tags.push_back (line);
-            char_offset += line.size() + 1;
-          }
-
-          delete[] tags;
-        }
-*/
-
-        File::MGH::read_other (H, MGHO, is_BE);
 
       } // End reading other data beyond the end of the image data
 

--- a/lib/formats/mgh.cpp
+++ b/lib/formats/mgh.cpp
@@ -110,7 +110,14 @@ namespace MR
 
       File::resize (H.name(), MGH_DATA_OFFSET + footprint(H));
 
-      File::MGH::write_other_to_file (H.name(), MGHO);
+      out.open (H.name(), std::ios_base::out | std::ios_base::app);
+      out.write ((char*) &MGHO, 5 * sizeof (float));
+      for (const auto& tag : MGHO.tags) {
+        out.write (reinterpret_cast<const char*> (&std::get<0>(tag)), sizeof(int32_t));
+        out.write (reinterpret_cast<const char*> (&std::get<1>(tag)), sizeof(int64_t));
+        out.write (std::get<2>(tag).c_str(), std::get<2>(tag).size());
+      }
+      out.close();
 
       std::unique_ptr<ImageIO::Base> io_handler (new ImageIO::Default (H));
       io_handler->files.push_back (File::Entry (H.name(), MGH_DATA_OFFSET));

--- a/lib/formats/mgh.cpp
+++ b/lib/formats/mgh.cpp
@@ -97,8 +97,10 @@ namespace MR
       if (H.ndim() > 4)
         throw Exception ("MGH format cannot support more than 4 dimensions for image \"" + H.name() + "\"");
 
-      if (H.datatype().bytes() > 1)
+      if (H.datatype().bytes() > 1) {
         H.datatype().set_flag (DataType::BigEndian);
+        H.datatype().unset_flag (DataType::LittleEndian);
+      }
 
       mgh_header MGHH;
       mgh_other  MGHO;

--- a/lib/formats/mgh.cpp
+++ b/lib/formats/mgh.cpp
@@ -97,6 +97,9 @@ namespace MR
       if (H.ndim() > 4)
         throw Exception ("MGH format cannot support more than 4 dimensions for image \"" + H.name() + "\"");
 
+      if (H.datatype().bytes() > 1)
+        H.datatype().set_flag (DataType::BigEndian);
+
       mgh_header MGHH;
       mgh_other  MGHO;
       memset (&MGHH, 0x00, MGH_HEADER_SIZE);

--- a/lib/formats/mgz.cpp
+++ b/lib/formats/mgz.cpp
@@ -95,8 +95,10 @@ namespace MR
       if (H.ndim() > 4)
         throw Exception ("MGZ format cannot support more than 4 dimensions for image \"" + H.name() + "\"");
 
-      if (H.datatype().bytes() > 1)
+      if (H.datatype().bytes() > 1) {
         H.datatype().set_flag (DataType::BigEndian);
+        H.datatype().unset_flag (DataType::LittleEndian);
+      }
 
       std::unique_ptr<ImageIO::GZ> io_handler (new ImageIO::GZ (H, MGH_DATA_OFFSET));
 

--- a/lib/formats/mgz.cpp
+++ b/lib/formats/mgz.cpp
@@ -95,6 +95,9 @@ namespace MR
       if (H.ndim() > 4)
         throw Exception ("MGZ format cannot support more than 4 dimensions for image \"" + H.name() + "\"");
 
+      if (H.datatype().bytes() > 1)
+        H.datatype().set_flag (DataType::BigEndian);
+
       std::unique_ptr<ImageIO::GZ> io_handler (new ImageIO::GZ (H, MGH_DATA_OFFSET));
 
       File::MGH::write_header (*reinterpret_cast<mgh_header*> (io_handler->header()), H);

--- a/lib/formats/mgz.cpp
+++ b/lib/formats/mgz.cpp
@@ -41,7 +41,7 @@ namespace MR
 
       try {
 
-        mgh_other  MGHO;
+        mgh_other MGHO;
         memset (&MGHO, 0x00, 5 * sizeof(float));
         MGHO.tags.clear();
 

--- a/lib/image_io/gz.cpp
+++ b/lib/image_io/gz.cpp
@@ -96,6 +96,8 @@ namespace MR
             }
             last += BYTES_PER_ZCALL;
             zf.write (reinterpret_cast<const char*> (address), last - address);
+            if (lead_out)
+              zf.write (reinterpret_cast<const char*> (lead_out.get()), lead_out_size);
           }
         }
 

--- a/lib/image_io/gz.h
+++ b/lib/image_io/gz.h
@@ -29,19 +29,25 @@ namespace MR
     {
       public:
         GZ (GZ&&) = default;
-        GZ (const Header& header, size_t file_header_size) :
+        GZ (const Header& header, size_t file_header_size, size_t file_tailer_size = 0) :
           Base (header), 
           lead_in_size (file_header_size),
-          lead_in (file_header_size ? new uint8_t [file_header_size] : nullptr) { }
+          lead_out_size (file_tailer_size),
+          lead_in (file_header_size ? new uint8_t [file_header_size] : nullptr),
+          lead_out (file_tailer_size ? new uint8_t [file_tailer_size] : nullptr) { }
 
         uint8_t* header () {
           return lead_in.get();
         }
 
+        uint8_t* tailer () {
+          return lead_out.get();
+        }
+
       protected:
         int64_t  bytes_per_segment;
-        size_t   lead_in_size;
-        std::unique_ptr<uint8_t[]> lead_in;
+        size_t   lead_in_size, lead_out_size;
+        std::unique_ptr<uint8_t[]> lead_in, lead_out;
 
         virtual void load (const Header&, size_t);
         virtual void unload (const Header&);


### PR DESCRIPTION
Creating .mgh / .mgz images with little-endian encoding causes faults in other softwares; therefore enforce big-endianness regardless of header datatype.

Closes #952.