### PR TITLE
replace make_shared()

### DIFF
--- a/build
+++ b/build
@@ -1091,7 +1091,7 @@ def update_user_docs ():
 #                              SCRIPT VERSION                             #
 ###########################################################################
 
-with open (os.path.join(script_dir,'_version.py'),'w') as vfile:
+with open (os.path.join(mrtrix_dir[-1], script_dir, '_version.py'),'w') as vfile:
   vfile.write('__version__ = "'+get_git_version (mrtrix_dir[-1])+'"\n')
 
 

--- a/check_memalign
+++ b/check_memalign
@@ -7,7 +7,7 @@ echo "" >> $LOG
 
 retval=0
 
-for f in $(find . -type f -name '*.h' -o -name '*.cpp' | grep -v '_moc.cpp'); do 
+for f in $(find cmd core src -type f -name '*.h' -o -name '*.cpp' | grep -v '_moc.cpp'); do 
 
 # files to ignore:
   [[ "$f" -ef "src/gui/shview/icons.h" || 
@@ -66,14 +66,8 @@ for f in $(find . -type f -name '*.h' -o -name '*.cpp' | grep -v '_moc.cpp'); do
     perl -pe 's|/\*.*?\*/||g' | \
 # remove quoted strings:
     perl -pe 's/(")(\\"|.)*?"//g' | \
-# remove any text within a template declaration (i.e. within <>):
-    perl -pe 's|<[^{};<]*?>||g' | \
-# and do it multiple times to handle nested declarations:
-    perl -pe 's|<[^{};<]*?>||g' | \
-    perl -pe 's|<[^{};<]*?>||g' | \
-    perl -pe 's|<[^{};<]*?>||g' | \
 # match for the parts we're interested in and output just the bits that match:
-    grep -Eo '(?<!::)std::vector\>' 
+    grep -Po '(?<!::)std::vector\b' 
   )
 
 
@@ -92,14 +86,8 @@ for f in $(find . -type f -name '*.h' -o -name '*.cpp' | grep -v '_moc.cpp'); do
     perl -pe 's|/\*.*?\*/||g' | \
 # remove quoted strings:
     perl -pe 's/(")(\\"|.)*?"//g' | \
-# remove any text within a template declaration (i.e. within <>):
-    perl -pe 's|<[^{};<]*?>||g' | \
-# and do it multiple times to handle nested declarations:
-    perl -pe 's|<[^{};<]*?>||g' | \
-    perl -pe 's|<[^{};<]*?>||g' | \
-    perl -pe 's|<[^{};<]*?>||g' | \
 # match for the parts we're interested in and output just the bits that match:
-    grep -Eo '(?<!::)std::make_shared\>' 
+    grep -Po '(?<!::)std::make_shared\b' 
   )
 
 # if anything is left after that, show it:
@@ -120,8 +108,9 @@ else
   echo "FAIL"
   
   echo "" >> $LOG
-  echo "Please add MEMALIGN() macro to the class declarations identified above
-and replace all occurrences of std::vector with MR::vector" >> $LOG
+  echo "Please add MEMALIGN() macro to the class declarations identified above,
+replace all occurrences of std::vector with MR::vector,
+and avoid use of std::make_shared" >> $LOG
   exit 1
 fi
 

--- a/check_memalign
+++ b/check_memalign
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 LOG=memalign.log
 echo -n "Checking memory alignment for Eigen 3.3 compatibility... "
@@ -74,6 +74,32 @@ for f in $(find . -type f -name '*.h' -o -name '*.cpp' | grep -v '_moc.cpp'); do
     perl -pe 's|<[^{};<]*?>||g' | \
 # match for the parts we're interested in and output just the bits that match:
     grep -Eo '(?<!::)std::vector\>' 
+  )
+
+
+# detect any instances of std::make_shared:
+  res="$res"$( \
+    cat $f | \
+# remove C preprocessor macros:
+    grep -v '^#' | \
+# remove C++ single-line comments:
+    perl -pe 's|//.*$||' | \
+# remove all newlines to make file one long line:
+    tr '\n' ' ' | \
+# remove any duplicate spaces:
+    perl -pe 's|\s+| |g' | \
+# remove C-style comments:
+    perl -pe 's|/\*.*?\*/||g' | \
+# remove quoted strings:
+    perl -pe 's/(")(\\"|.)*?"//g' | \
+# remove any text within a template declaration (i.e. within <>):
+    perl -pe 's|<[^{};<]*?>||g' | \
+# and do it multiple times to handle nested declarations:
+    perl -pe 's|<[^{};<]*?>||g' | \
+    perl -pe 's|<[^{};<]*?>||g' | \
+    perl -pe 's|<[^{};<]*?>||g' | \
+# match for the parts we're interested in and output just the bits that match:
+    grep -Eo '(?<!::)std::make_shared\>' 
   )
 
 # if anything is left after that, show it:

--- a/cmd/dirmerge.cpp
+++ b/cmd/dirmerge.cpp
@@ -44,7 +44,7 @@ ARGUMENTS
 
 using value_type = double;
 using Direction = std::array<value_type,3>;
-using DirectionSet = std::vector<Direction>;
+using DirectionSet = vector<Direction>;
 
 
 struct OutDir { MEMALIGN(OutDir)

--- a/cmd/fod2fixel.cpp
+++ b/cmd/fod2fixel.cpp
@@ -190,11 +190,11 @@ void Segmented_FOD_receiver::commit ()
 
   const auto index_filepath = Path::join (fixel_directory_path, index_path);
 
-  std::unique_ptr<IndexImage> index_image (nullptr);
-  std::unique_ptr<DataImage> dir_image (nullptr);
-  std::unique_ptr<DataImage> afd_image (nullptr);
-  std::unique_ptr<DataImage> peak_image (nullptr);
-  std::unique_ptr<DataImage> disp_image (nullptr);
+  std::unique_ptr<IndexImage> index_image;
+  std::unique_ptr<DataImage> dir_image;
+  std::unique_ptr<DataImage> afd_image;
+  std::unique_ptr<DataImage> peak_image;
+  std::unique_ptr<DataImage> disp_image;
 
   auto index_header (H);
   index_header.keyval()[Fixel::n_fixels_key] = str(n_fixels);
@@ -202,7 +202,7 @@ void Segmented_FOD_receiver::commit ()
   index_header.size(3) = 2;
   index_header.datatype() = DataType::from<uint32_t>();
   index_header.datatype().set_byte_order_native();
-  index_image = std::unique_ptr<IndexImage> (new IndexImage (IndexImage::create (index_filepath, index_header)));
+  index_image = make_unique<IndexImage> (IndexImage::create (index_filepath, index_header));
 
   auto fixel_data_header (H);
   fixel_data_header.ndim() = 3;
@@ -214,7 +214,7 @@ void Segmented_FOD_receiver::commit ()
   if (dir_path.size()) {
     auto dir_header (fixel_data_header);
     dir_header.size(1) = 3;
-    dir_image = std::unique_ptr<DataImage> (new DataImage (DataImage::create (Path::join(fixel_directory_path, dir_path), dir_header)));
+    dir_image = make_unique<DataImage> (DataImage::create (Path::join(fixel_directory_path, dir_path), dir_header));
     dir_image->index(1) = 0;
     Fixel::check_fixel_size (*index_image, *dir_image);
   }
@@ -222,7 +222,7 @@ void Segmented_FOD_receiver::commit ()
   if (afd_path.size()) {
     auto afd_header (fixel_data_header);
     afd_header.size(1) = 1;
-    afd_image = std::unique_ptr<DataImage> (new DataImage (DataImage::create (Path::join(fixel_directory_path, afd_path), afd_header)));
+    afd_image = make_unique<DataImage> (DataImage::create (Path::join(fixel_directory_path, afd_path), afd_header));
     afd_image->index(1) = 0;
     Fixel::check_fixel_size (*index_image, *afd_image);
   }
@@ -230,7 +230,7 @@ void Segmented_FOD_receiver::commit ()
   if (peak_path.size()) {
     auto peak_header(fixel_data_header);
     peak_header.size(1) = 1;
-    peak_image = std::unique_ptr<DataImage> (new DataImage (DataImage::create (Path::join(fixel_directory_path, peak_path), peak_header)));
+    peak_image = make_unique<DataImage> (DataImage::create (Path::join(fixel_directory_path, peak_path), peak_header));
     peak_image->index(1) = 0;
     Fixel::check_fixel_size (*index_image, *peak_image);
   }
@@ -238,7 +238,7 @@ void Segmented_FOD_receiver::commit ()
   if (disp_path.size()) {
     auto disp_header (fixel_data_header);
     disp_header.size(1) = 1;
-    disp_image = std::unique_ptr<DataImage> (new DataImage (DataImage::create (Path::join(fixel_directory_path, disp_path), disp_header)));
+    disp_image = make_unique<DataImage> (DataImage::create (Path::join(fixel_directory_path, disp_path), disp_header));
     disp_image->index(1) = 0;
     Fixel::check_fixel_size (*index_image, *disp_image);
   }

--- a/cmd/meshconvert.cpp
+++ b/cmd/meshconvert.cpp
@@ -72,7 +72,7 @@ void run ()
   auto opt = get_options ("transform");
   if (opt.size()) {
     auto H = Header::open (opt[0][1]);
-    std::unique_ptr<Surface::Filter::VertexTransform> transform (new Surface::Filter::VertexTransform (H));
+    auto transform = make_unique<Surface::Filter::VertexTransform> (H);
     switch (int(opt[0][0])) {
       case 0: transform->set_first2real(); break;
       case 1: transform->set_real2first(); break;

--- a/cmd/tckstats.cpp
+++ b/cmd/tckstats.cpp
@@ -180,7 +180,7 @@ void run ()
     stdev += i->get_weight() * Math::pow2 (i->get_length() - mean_length);
   stdev = std::sqrt (stdev / (((count - 1) / float(count)) * sum_weights));
 
-  std::vector<std::string> fields;
+  vector<std::string> fields;
   auto opt = get_options ("output");
   for (size_t n = 0; n < opt.size(); ++n)
     fields.push_back (opt[n][0]);

--- a/core/adapter/replicate.h
+++ b/core/adapter/replicate.h
@@ -74,7 +74,7 @@ namespace MR
       protected:
         using base_type::parent;
         Header header_;
-        std::vector<ssize_t> pos_;
+        vector<ssize_t> pos_;
 
     };
 

--- a/core/filter/dilate.h
+++ b/core/filter/dilate.h
@@ -73,7 +73,7 @@ namespace MR
           std::shared_ptr<ProgressBar> progress (message.size() ? new ProgressBar (message, npass + 1) : nullptr);
 
           for (unsigned int pass = 0; pass < npass; pass++) {
-            out = std::make_shared<Image<bool>> (Image<bool>::scratch (input));
+            out = make_shared<Image<bool>> (Image<bool>::scratch (input));
             for (auto l = Loop (*in) (*in, *out); l; ++l)
               out->value() = dilate (*in);
             if (pass < npass - 1)

--- a/core/filter/erode.h
+++ b/core/filter/erode.h
@@ -66,13 +66,13 @@ namespace MR
         template <class InputImageType, class OutputImageType>
         void operator() (InputImageType& input, OutputImageType& output)
         {
-          std::shared_ptr <Image<bool> > in = std::make_shared<Image<bool> > (Image<bool>::scratch (input));
+          std::shared_ptr <Image<bool> > in = make_shared<Image<bool> > (Image<bool>::scratch (input));
           copy (input, *in);
           std::shared_ptr <Image<bool> > out;
           std::shared_ptr<ProgressBar> progress (message.size() ? new ProgressBar (message, npass + 1) : nullptr);
 
           for (unsigned int pass = 0; pass < npass; pass++) {
-            out = std::make_shared<Image<bool> > (Image<bool>::scratch (input));
+            out = make_shared<Image<bool> > (Image<bool>::scratch (input));
             for (auto l = Loop (*in) (*in, *out); l; ++l)
              out->value() = erode (*in);
 

--- a/core/filter/smooth.h
+++ b/core/filter/smooth.h
@@ -122,7 +122,7 @@ namespace MR
         template <class InputImageType, class OutputImageType, typename ValueType = float>
         void operator() (InputImageType& input, OutputImageType& output)
         {
-          std::shared_ptr <Image<ValueType> > in (std::make_shared<Image<ValueType> > (Image<ValueType>::scratch (input)));
+          std::shared_ptr <Image<ValueType> > in (make_shared<Image<ValueType> > (Image<ValueType>::scratch (input)));
           threaded_copy (input, *in);
           std::shared_ptr <Image<ValueType> > out;
 
@@ -138,7 +138,7 @@ namespace MR
           for (size_t dim = 0; dim < 3; dim++) {
             if (stdev[dim] > 0) {
               DEBUG ("creating scratch image for smoothing image along dimension " + str(dim));
-              out = std::make_shared<Image<ValueType> > (Image<ValueType>::scratch (input));
+              out = make_shared<Image<ValueType> > (Image<ValueType>::scratch (input));
               Adapter::Gaussian1D<Image<ValueType> > gaussian (*in, stdev[dim], dim, extent[dim], zero_boundary);
               threaded_copy (gaussian, *out, 0, input.ndim(), 2);
               in = out;

--- a/core/header.cpp
+++ b/core/header.cpp
@@ -288,7 +288,7 @@ namespace MR
     H.reset_intensity_scaling();
     H.sanitise();
     H.format_ = "scratch image";
-    H.io = std::unique_ptr<ImageIO::Scratch> (new ImageIO::Scratch (H)); 
+    H.io = make_unique<ImageIO::Scratch> (H); 
     return H;
   }
 

--- a/core/thread_queue.h
+++ b/core/thread_queue.h
@@ -629,7 +629,7 @@ namespace MR
 
     template <class T> class Queue<__Batch<T>> { NOMEMALIGN
       private:
-        using BatchType = std::vector<T>;
+        using BatchType = vector<T>;
         using BatchQueue = Queue<BatchType>;
 
       public:

--- a/core/types.h
+++ b/core/types.h
@@ -250,6 +250,11 @@ namespace MR
       return std::shared_ptr<X> (new X (std::forward<Args> (args)...));
     }
 
+  template <typename X, typename... Args>
+    inline std::unique_ptr<X> make_unique (Args&&... args) {
+      return std::unique_ptr<X> (new X (std::forward<Args> (args)...));
+    }
+
 }
 
 namespace std

--- a/core/types.h
+++ b/core/types.h
@@ -21,6 +21,7 @@
 #include <iostream>
 #include <vector>
 #include <cstddef>
+#include <memory>
 
 #define NOMEMALIGN
 
@@ -242,6 +243,12 @@ namespace MR
         using ::std::vector<X>::vector;
         vector() { }
     };
+
+
+  template <typename X, typename... Args>
+    inline std::shared_ptr<X> make_shared (Args&&... args) {
+      return std::shared_ptr<X> (new X (std::forward<Args> (args)...));
+    }
 
 }
 

--- a/src/dwi/tractography/GT/mhsampler.h
+++ b/src/dwi/tractography/GT/mhsampler.h
@@ -42,7 +42,7 @@ namespace MR {
                     EnergyComputer* e, Image<bool>& m)
             : props(p), stats(s), pGrid(pgrid), E(e), T(dwi), 
               dims{size_t(dwi.size(0)), size_t(dwi.size(1)), size_t(dwi.size(2))}, 
-              mask(m), lock(std::make_shared<SpatialLock<float>>(5*Particle::L)), 
+              mask(m), lock(make_shared<SpatialLock<float>>(5*Particle::L)), 
               sigpos(Particle::L / 8.), sigdir(0.2)
           {
             DEBUG("Initialise Metropolis Hastings sampler.");

--- a/src/dwi/tractography/GT/particlegrid.h
+++ b/src/dwi/tractography/GT/particlegrid.h
@@ -38,7 +38,7 @@ namespace MR {
         { MEMALIGN(ParticleGrid)
         public:
           
-          using ParticleVectorType = std::vector<Particle*>;
+          using ParticleVectorType = vector<Particle*>;
           
           template <class HeaderType>
           ParticleGrid(const HeaderType& image)

--- a/src/dwi/tractography/SIFT/gradient_sort.h
+++ b/src/dwi/tractography/SIFT/gradient_sort.h
@@ -79,7 +79,7 @@ namespace MR
       class MT_gradient_vector_sorter
       { MEMALIGN(MT_gradient_vector_sorter)
 
-          using VecType = std::vector<Cost_fn_gradient_sort>;
+          using VecType = vector<Cost_fn_gradient_sort>;
           using VecItType = VecType::iterator;
 
           class Comparator { NOMEMALIGN

--- a/src/dwi/tractography/resampling/resampling.cpp
+++ b/src/dwi/tractography/resampling/resampling.cpp
@@ -74,7 +74,7 @@ namespace MR {
           using value_type = float;
           using point_type = Eigen::Vector3f;
 
-          point_type get_pos (const std::vector<default_type>& s)
+          point_type get_pos (const vector<default_type>& s)
           {
             if (s.size() != 3)
               throw Exception ("position expected as a comma-seperated list of 3 values");

--- a/src/dwi/tractography/tracking/generated_track.h
+++ b/src/dwi/tractography/tracking/generated_track.h
@@ -38,7 +38,7 @@ namespace MR
 
           public:
 
-            using BaseType = std::vector<Eigen::Vector3f>;
+            using BaseType = vector<Eigen::Vector3f>;
 
             enum class status_t { INVALID, SEED_REJECTED, TRACK_REJECTED, ACCEPTED };
 

--- a/src/gui/mrview/tool/odf/item.cpp
+++ b/src/gui/mrview/tool/odf/item.cpp
@@ -116,7 +116,7 @@ namespace MR
           const vector<size_t>& volumes = (*shells)[index].get_volumes();
           for (size_t row = 0; row != volumes.size(); ++row)
             shell_dirs.row (row) = grad.row (volumes[row]).head<3>().cast<float>();
-          std::unique_ptr<MR::DWI::Directions::Set> new_dirs (new MR::DWI::Directions::Set (shell_dirs));
+          auto new_dirs = make_unique<MR::DWI::Directions::Set> (shell_dirs);
           std::swap (dirs, new_dirs);
           shell_index = index;
           dir_type = DixelPlugin::dir_t::DW_SCHEME;
@@ -125,13 +125,13 @@ namespace MR
         void ODF_Item::DixelPlugin::set_header() {
           if (!header_dirs.rows())
             throw Exception ("No direction scheme defined in header");
-          std::unique_ptr<MR::DWI::Directions::Set> new_dirs (new MR::DWI::Directions::Set (header_dirs));
+          auto new_dirs = make_unique<MR::DWI::Directions::Set> (header_dirs);
           std::swap (dirs, new_dirs);
           dir_type = DixelPlugin::dir_t::HEADER;
         }
 
         void ODF_Item::DixelPlugin::set_internal (const size_t n) {
-          std::unique_ptr<MR::DWI::Directions::Set> new_dirs (new MR::DWI::Directions::Set (n));
+          auto new_dirs = make_unique<MR::DWI::Directions::Set> (n);
           std::swap (dirs, new_dirs);
           dir_type = DixelPlugin::dir_t::INTERNAL;
         }
@@ -144,7 +144,7 @@ namespace MR
 
         void ODF_Item::DixelPlugin::set_from_file (const std::string& path)
         {
-          std::unique_ptr<MR::DWI::Directions::Set> new_dirs (new MR::DWI::Directions::Set (path));
+          auto new_dirs = make_unique<MR::DWI::Directions::Set> (path);
           std::swap (dirs, new_dirs);
           dir_type = DixelPlugin::dir_t::FILE;
         }

--- a/src/gui/mrview/tool/odf/model.cpp
+++ b/src/gui/mrview/tool/odf/model.cpp
@@ -35,7 +35,7 @@ namespace MR
           vector<std::unique_ptr<MR::Header>> hlist;
           for (size_t i = 0; i < list.size(); ++i) {
             try {
-              std::unique_ptr<MR::Header> header (new MR::Header (MR::Header::open (list[i])));
+              auto header = make_unique<MR::Header> (MR::Header::open (list[i]));
               switch (type) {
                 case odf_type_t::SH:
                   Math::SH::check (*header);
@@ -61,7 +61,7 @@ namespace MR
           if (hlist.size()) {
             beginInsertRows (QModelIndex(), items.size(), items.size()+hlist.size());
             for (size_t i = 0; i < hlist.size(); ++i)
-              items.push_back (std::unique_ptr<ODF_Item> (new ODF_Item (std::move (*hlist[i]), type, scale, hide_negative_lobes, colour_by_direction)));
+              items.push_back (make_unique<ODF_Item> (std::move (*hlist[i]), type, scale, hide_negative_lobes, colour_by_direction));
             endInsertRows();
           }
 

--- a/src/gui/mrview/tool/overlay.cpp
+++ b/src/gui/mrview/tool/overlay.cpp
@@ -201,7 +201,7 @@ namespace MR
             return;
           vector<std::unique_ptr<MR::Header>> list;
           for (size_t n = 0; n < overlay_names.size(); ++n)
-            list.push_back (std::unique_ptr<MR::Header> (new MR::Header (MR::Header::open (overlay_names[n]))));
+            list.push_back (make_unique<MR::Header> (MR::Header::open (overlay_names[n])));
 
           add_images (list);
         }
@@ -233,7 +233,7 @@ namespace MR
             QList<QUrl> urlList = mimeData->urls();
             for (int i = 0; i < urlList.size() && i < max_files; ++i) {
               try {
-                list.push_back (std::unique_ptr<MR::Header> (new MR::Header (MR::Header::open (urlList.at (i).path().toUtf8().constData()))));
+                list.push_back (make_unique<MR::Header> (MR::Header::open (urlList.at (i).path().toUtf8().constData())));
               }
               catch (Exception& e) {
                 e.display();
@@ -707,7 +707,7 @@ namespace MR
         {
           if (opt.opt->is ("overlay.load")) {
             vector<std::unique_ptr<MR::Header>> list;
-            try { list.push_back (std::unique_ptr<MR::Header> (new MR::Header (MR::Header::open (opt[0])))); }
+            try { list.push_back (make_unique<MR::Header> (MR::Header::open (opt[0]))); }
             catch (Exception& e) { e.display(); }
             add_images (list);
             return true;

--- a/src/gui/mrview/tool/roi_editor/roi.cpp
+++ b/src/gui/mrview/tool/roi_editor/roi.cpp
@@ -296,7 +296,7 @@ namespace MR
             return;
           vector<std::unique_ptr<MR::Header>> list;
           for (size_t n = 0; n < names.size(); ++n)
-            list.push_back (std::unique_ptr<MR::Header> (new MR::Header (MR::Header::open (names[n]))));
+            list.push_back (make_unique<MR::Header> (MR::Header::open (names[n])));
 
           load (list);
           in_insert_mode = false;
@@ -316,7 +316,7 @@ namespace MR
             QList<QUrl> urlList = mimeData->urls();
             for (int i = 0; i < urlList.size() && i < max_files; ++i) {
               try {
-                list.push_back (std::unique_ptr<MR::Header> (new MR::Header (MR::Header::open (urlList.at (i).path().toUtf8().constData()))));
+                list.push_back (make_unique<MR::Header> (MR::Header::open (urlList.at (i).path().toUtf8().constData())));
               }
               catch (Exception& e) {
                 e.display();
@@ -893,7 +893,7 @@ namespace MR
         {
           if (opt.opt->is ("roi.load")) {
             vector<std::unique_ptr<MR::Header>> list;
-            try { list.push_back (std::unique_ptr<MR::Header> (new MR::Header (MR::Header::open (opt[0])))); }
+            try { list.push_back (make_unique<MR::Header> (MR::Header::open (opt[0]))); }
             catch (Exception& e) { e.display(); }
             load (list);
             return true;

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -145,7 +145,7 @@ namespace MR
           QList<QUrl> urlList = mimeData->urls();
           for (int i = 0; i < urlList.size() && i < 32; ++i) {
             try {
-              list.push_back (std::unique_ptr<MR::Header> (new MR::Header (MR::Header::open (urlList.at (i).path().toUtf8().constData()))));
+              list.push_back (make_unique<MR::Header> (MR::Header::open (urlList.at (i).path().toUtf8().constData())));
             }
             catch (Exception& e) {
               e.display();
@@ -736,7 +736,7 @@ namespace MR
 
           vector<std::unique_ptr<MR::Header>> list;
           for (size_t n = 0; n < MR::App::argument.size(); ++n) {
-            try { list.push_back (std::unique_ptr<MR::Header> (new MR::Header (MR::Header::open (MR::App::argument[n])))); }
+            try { list.push_back (make_unique<MR::Header> (MR::Header::open (MR::App::argument[n]))); }
             catch (Exception& e) { e.display(); }
           }
           add_images (list);
@@ -795,7 +795,7 @@ namespace MR
         vector<std::unique_ptr<MR::Header>> list;
         for (size_t n = 0; n < image_list.size(); ++n) {
           try {
-            list.push_back (std::unique_ptr<MR::Header> (new MR::Header (MR::Header::open (image_list[n]))));
+            list.push_back (make_unique<MR::Header> (MR::Header::open (image_list[n])));
           }
           catch (Exception& E) {
             E.display();
@@ -815,7 +815,7 @@ namespace MR
 
         try {
           vector<std::unique_ptr<MR::Header>> list;
-          list.push_back (std::unique_ptr<MR::Header> (new MR::Header (MR::Header::open (folder))));
+          list.push_back (make_unique<MR::Header> (MR::Header::open (folder)));
           add_images (list);
         }
         catch (Exception& E) {
@@ -1884,7 +1884,7 @@ namespace MR
 
           if (opt.opt->is ("load")) {
             vector<std::unique_ptr<MR::Header>> list;
-            try { list.push_back (std::unique_ptr<MR::Header> (new MR::Header (MR::Header::open (opt[0])))); }
+            try { list.push_back (make_unique<MR::Header> (MR::Header::open (opt[0]))); }
             catch (Exception& e) { e.display(); }
             add_images (list);
             return;

--- a/src/registration/linear.h
+++ b/src/registration/linear.h
@@ -86,11 +86,11 @@ namespace MR
       }
       size_t stage_iterations, gd_max_iter;
       default_type scale_factor;
-      std::vector<OptimiserAlgoType> optimisers;
+      vector<OptimiserAlgoType> optimisers;
       OptimiserAlgoType optimiser_default, optimiser_first, optimiser_last;
       default_type loop_density;
       ssize_t fod_lmax;
-      std::vector<std::string> diagnostics_images;
+      vector<std::string> diagnostics_images;
     } ;
 
     class Linear

--- a/src/registration/metric/evaluate.h
+++ b/src/registration/metric/evaluate.h
@@ -91,8 +91,8 @@ namespace MR
                 DEBUG ("Reorienting FODs...");
                 std::shared_ptr<Image<default_type> > im1_image_reoriented;
                 std::shared_ptr<Image<default_type> > im2_image_reoriented;
-                im1_image_reoriented = std::make_shared<Image<default_type>>(Image<default_type>::scratch (params.im1_image));
-                im2_image_reoriented = std::make_shared<Image<default_type>>(Image<default_type>::scratch (params.im2_image));
+                im1_image_reoriented = make_shared<Image<default_type>>(Image<default_type>::scratch (params.im1_image));
+                im2_image_reoriented = make_shared<Image<default_type>>(Image<default_type>::scratch (params.im2_image));
                 {
                    LogLevelLatch log_level (0);
                   Registration::Transform::reorient (params.im1_image, *im1_image_reoriented, params.transformation.get_transform_half(), directions);
@@ -215,8 +215,8 @@ namespace MR
                 DEBUG ("Reorienting FODs...");
                 std::shared_ptr<Image<default_type> > im1_image_reoriented;
                 std::shared_ptr<Image<default_type> > im2_image_reoriented;
-                im1_image_reoriented = std::make_shared<Image<default_type>>(Image<default_type>::scratch (params.im1_image));
-                im2_image_reoriented = std::make_shared<Image<default_type>>(Image<default_type>::scratch (params.im2_image));
+                im1_image_reoriented = make_shared<Image<default_type>>(Image<default_type>::scratch (params.im1_image));
+                im2_image_reoriented = make_shared<Image<default_type>>(Image<default_type>::scratch (params.im2_image));
                 {
                    LogLevelLatch log_level (0);
                   Registration::Transform::reorient (params.im1_image, *im1_image_reoriented, params.transformation.get_transform_half(), directions);

--- a/src/registration/nonlinear.h
+++ b/src/registration/nonlinear.h
@@ -151,19 +151,19 @@ namespace MR
               field_header.ndim() = 4;
               field_header.size(3) = 3;
 
-              im1_to_mid_new = std::make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
-              im2_to_mid_new = std::make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
-              im1_update = std::make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
-              im2_update = std::make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
-              im1_update_new = std::make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
-              im2_update_new = std::make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
+              im1_to_mid_new = make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
+              im2_to_mid_new = make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
+              im1_update = make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
+              im2_update = make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
+              im1_update_new = make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
+              im2_update_new = make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
 
               if (!is_initialised) {
                 if (level == 0) {
-                  im1_to_mid = std::make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
-                  im2_to_mid = std::make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
-                  mid_to_im1 = std::make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
-                  mid_to_im2 = std::make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
+                  im1_to_mid = make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
+                  im2_to_mid = make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
+                  mid_to_im1 = make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
+                  mid_to_im2 = make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
                 } else {
                   DEBUG ("Upsampling fields");
                   {
@@ -307,22 +307,22 @@ namespace MR
             field_header.ndim() = 4;
             field_header.size(3) = 3;
 
-            im1_to_mid = std::make_shared<Image<default_type>> (Image<default_type>::scratch (field_header));
+            im1_to_mid = make_shared<Image<default_type>> (Image<default_type>::scratch (field_header));
             input_warps.index(4) = 0;
             threaded_copy (input_warps, *im1_to_mid, 0, 4);
             Registration::Warp::deformation2displacement (*im1_to_mid, *im1_to_mid);
 
-            mid_to_im1 = std::make_shared<Image<default_type>> (Image<default_type>::scratch (field_header));
+            mid_to_im1 = make_shared<Image<default_type>> (Image<default_type>::scratch (field_header));
             input_warps.index(4) = 1;
             threaded_copy (input_warps, *mid_to_im1, 0, 4);
             Registration::Warp::deformation2displacement (*mid_to_im1, *mid_to_im1);
 
-            im2_to_mid = std::make_shared<Image<default_type>> (Image<default_type>::scratch (field_header));
+            im2_to_mid = make_shared<Image<default_type>> (Image<default_type>::scratch (field_header));
             input_warps.index(4) = 2;
             threaded_copy (input_warps, *im2_to_mid, 0, 4);
             Registration::Warp::deformation2displacement (*im2_to_mid, *im2_to_mid);
 
-            mid_to_im2 = std::make_shared<Image<default_type>> (Image<default_type>::scratch (field_header));
+            mid_to_im2 = make_shared<Image<default_type>> (Image<default_type>::scratch (field_header));
             input_warps.index(4) = 3;
             threaded_copy (input_warps, *mid_to_im2, 0, 4);
             Registration::Warp::deformation2displacement (*mid_to_im2, *mid_to_im2);
@@ -449,7 +449,7 @@ namespace MR
         protected:
 
           std::shared_ptr<Image<default_type> > reslice (Image<default_type>& image, Header& header) {
-            std::shared_ptr<Image<default_type> > temp = std::make_shared<Image<default_type> > (Image<default_type>::scratch (header));
+            std::shared_ptr<Image<default_type> > temp = make_shared<Image<default_type> > (Image<default_type>::scratch (header));
             Filter::reslice<Interp::Linear> (image, *temp);
             return temp;
           }

--- a/src/registration/warp/compose.h
+++ b/src/registration/warp/compose.h
@@ -175,8 +175,8 @@ namespace MR
         } else {
           scale_factor = std::pow (2, std::ceil (std::log ((max_norm * step) / (min_vox_size / 2.0)) / std::log (2.0)));
 
-          std::shared_ptr<Image<default_type>> scaled_update = std::make_shared<Image<default_type> >(Image<default_type>::scratch (update));
-          std::shared_ptr<Image<default_type>> composed = std::make_shared<Image<default_type> >(Image<default_type>::scratch (update));
+          std::shared_ptr<Image<default_type>> scaled_update = make_shared<Image<default_type> >(Image<default_type>::scratch (update));
+          std::shared_ptr<Image<default_type>> composed = make_shared<Image<default_type> >(Image<default_type>::scratch (update));
 
           // Scaling
           default_type scaled_step = step / scale_factor; // apply the step size and scale factor at once

--- a/src/surface/freesurfer.cpp
+++ b/src/surface/freesurfer.cpp
@@ -58,11 +58,11 @@ namespace MR
         if (num_entries > 0) {
 
           const int32_t orig_lut_name_length = get_BE<int32_t> (in);
-          std::unique_ptr<char> orig_lut_name (new char[orig_lut_name_length]);
+          std::unique_ptr<char[]> orig_lut_name (new char[orig_lut_name_length]);
           in.read (orig_lut_name.get(), orig_lut_name_length);
           for (int32_t i = 0; i != num_entries; ++i) {
             const int32_t struct_name_length = get_BE<int32_t> (in);
-            std::unique_ptr<char> struct_name (new char[struct_name_length]);
+            std::unique_ptr<char[]> struct_name (new char[struct_name_length]);
             in.read (struct_name.get(), struct_name_length);
             const int32_t r    = get_BE<int32_t> (in);
             const int32_t g    = get_BE<int32_t> (in);
@@ -81,7 +81,7 @@ namespace MR
 
           num_entries = get_BE<int32_t> (in);
           const int32_t orig_lut_name_length = get_BE<int32_t> (in);
-          std::unique_ptr<char> orig_lut_name (new char[orig_lut_name_length]);
+          std::unique_ptr<char[]> orig_lut_name (new char[orig_lut_name_length]);
           in.read (orig_lut_name.get(), orig_lut_name_length);
 
           const int32_t num_entries_to_read = get_BE<int32_t> (in);
@@ -92,7 +92,7 @@ namespace MR
             if (lut.find (structure) != lut.end())
               throw Exception ("Error reading FreeSurfer annotation file \"" + Path::basename (path) + "\": Duplicate structure index");
             const int32_t struct_name_length = get_BE<int32_t> (in);
-            std::unique_ptr<char> struct_name (new char[struct_name_length]);
+            std::unique_ptr<char[]> struct_name (new char[struct_name_length]);
             in.read (struct_name.get(), struct_name_length);
             const int32_t r    = get_BE<int32_t> (in);
             const int32_t g    = get_BE<int32_t> (in);


### PR DESCRIPTION
To address #957.

Adds a new convenience call `MR::make_shared<X>()` to replace `std::make_shared<X>()`, which will allocate using the proper operator new, rather than placement new (presumably the reason why alignment requirements weren't being respected). 

Also fixes `check_memalign` to properly detect instances of `std::vector` (not sure why it wasn't working before...), and adds test for `std::make_shared`. 

I also added an equivalent `MR::make_unique<X>()` convenience call to create `std::unique_ptr<T>` pointers. 