### PR TITLE
add current command-line to 'command_history' header entry

### DIFF
--- a/core/header.cpp
+++ b/core/header.cpp
@@ -161,10 +161,6 @@ namespace MR
       throw Exception ("no name supplied to open image!");
 
     Header H (template_header);
-    std::string cmd = App::argv[0];
-    for (int n = 1; n < App::argc; ++n)
-      cmd += std::string(" \"") + App::argv[n] + "\"";
-    add_line (H.keyval()["command_history"], cmd);
 
     try {
       INFO ("creating image \"" + image_name + "\"...");
@@ -172,6 +168,15 @@ namespace MR
       H.keyval()["mrtrix_version"] = App::mrtrix_version;
       if (App::project_version)
         H.keyval()["project_version"] = App::project_version;
+
+      std::string cmd = App::argv[0];
+      for (int n = 1; n < App::argc; ++n)
+        cmd += std::string(" \"") + App::argv[n] + "\"";
+      cmd += std::string ("  (version=") + App::mrtrix_version;
+      if (App::project_version)
+        cmd += std::string (", project=") + App::project_version;
+      cmd += ")";
+      add_line (H.keyval()["command_history"], cmd);
 
       H.sanitise();
 

--- a/core/header.cpp
+++ b/core/header.cpp
@@ -126,7 +126,7 @@ namespace MR
       }
 
       H.sanitise();
-      if (!do_not_realign_transform) 
+      if (!do_not_realign_transform)
         H.realign_transform();
 
     }
@@ -139,14 +139,14 @@ namespace MR
 
 
   namespace {
-    inline bool check_strides_match (const vector<ssize_t>& a, const vector<ssize_t>& b) 
+    inline bool check_strides_match (const vector<ssize_t>& a, const vector<ssize_t>& b)
     {
       size_t n = 0;
-      for (; n < std::min (a.size(), b.size()); ++n) 
-        if (a[n] != b[n]) return false; 
-      for (size_t i = n; i < a.size(); ++i) 
+      for (; n < std::min (a.size(), b.size()); ++n)
+        if (a[n] != b[n]) return false;
+      for (size_t i = n; i < a.size(); ++i)
         if (a[i] > 1) return false;
-      for (size_t i = n; i < b.size(); ++i) 
+      for (size_t i = n; i < b.size(); ++i)
         if (b[i] > 1) return false;
       return true;
     }
@@ -161,6 +161,10 @@ namespace MR
       throw Exception ("no name supplied to open image!");
 
     Header H (template_header);
+    std::string cmd = App::argv[0];
+    for (int n = 1; n < App::argc; ++n)
+      cmd += std::string(" \"") + App::argv[n] + "\"";
+    add_line (H.keyval()["command_history"], cmd);
 
     try {
       INFO ("creating image \"" + image_name + "\"...");
@@ -226,7 +230,7 @@ namespace MR
         size_t axis = 0;
         while (axis < limits.size()) {
           pos[axis]++;
-          if (pos[axis] < limits[axis]) 
+          if (pos[axis] < limits[axis])
             return true;
           pos[axis] = 0;
           axis++;
@@ -255,7 +259,7 @@ namespace MR
         H.axes_.resize (n + Pdim.size());
 
         for (size_t i = 0; i < Pdim.size(); ++i) {
-          while (H.stride(a)) 
+          while (H.stride(a))
             ++a;
           H.size(a) = Pdim[i];
           H.stride(a) = ++next_stride;
@@ -281,14 +285,14 @@ namespace MR
 
 
 
-  Header Header::scratch (const Header& template_header, const std::string& label) 
+  Header Header::scratch (const Header& template_header, const std::string& label)
   {
     Header H (template_header);
     H.name() = label;
     H.reset_intensity_scaling();
     H.sanitise();
     H.format_ = "scratch image";
-    H.io = make_unique<ImageIO::Scratch> (H); 
+    H.io = make_unique<ImageIO::Scratch> (H);
     return H;
   }
 
@@ -299,14 +303,14 @@ namespace MR
 
 
 
-  std::ostream& operator<< (std::ostream& stream, const Header& H) 
+  std::ostream& operator<< (std::ostream& stream, const Header& H)
   {
     stream << "\"" << H.name() << "\", " << H.datatype().specifier() << ", size [ ";
     for (size_t n = 0; n < H.ndim(); ++n) stream << H.size(n) << " ";
     stream << "], voxel size [ ";
-    for (size_t n = 0; n < H.ndim(); ++n) stream << H.spacing(n) << " "; 
+    for (size_t n = 0; n < H.ndim(); ++n) stream << H.spacing(n) << " ";
     stream << "], strides [ ";
-    for (size_t n = 0; n < H.ndim(); ++n) stream << H.stride(n) << " "; 
+    for (size_t n = 0; n < H.ndim(); ++n) stream << H.stride(n) << " ";
     stream << "]";
     return stream;
   }
@@ -364,10 +368,10 @@ namespace MR
 
     for (const auto& p : keyval()) {
       std::string key = "  " + p.first + ": ";
-      if (key.size() < 21) 
+      if (key.size() < 21)
         key.resize (21, ' ');
       const auto entries = split_lines (p.second);
-      if (entries.size() > 5) 
+      if (entries.size() > 5)
         desc += key + "[ " + str (entries.size()) + " entries ]\n";
       else {
         for (const auto value : entries) {
@@ -426,13 +430,13 @@ namespace MR
       size_t num_valid_vox = 0;
       for (size_t i = 0; i < 3; ++i) {
         if (std::isfinite(spacing(i))) {
-          ++num_valid_vox; 
+          ++num_valid_vox;
           mean_vox_size += spacing(i);
         }
       }
       mean_vox_size /= num_valid_vox;
-      for (size_t i = 0; i < 3; ++i) 
-        if (!std::isfinite(spacing(i))) 
+      for (size_t i = 0; i < 3; ++i)
+        if (!std::isfinite(spacing(i)))
           spacing(i) = mean_vox_size;
     }
   }


### PR DESCRIPTION
as suggested in #956.

All up for discussion. It's a simple addition, so why not. But it's not perfect, that history won't survive conversion to other formats - although it might (with a few modifications) work well with the MGH formats. 