### PR TITLE
file.waitfor(): Make more robust

### DIFF
--- a/lib/mrtrix3/file.py
+++ b/lib/mrtrix3/file.py
@@ -83,7 +83,13 @@ def newTempFile(suffix):
 #   increases if the file still doesn't exist, until the program is only checking
 #   for the file once a minute.
 def waitFor(path):
-  import fcntl, os, time
+  import os, time
+  
+  try:
+    import fcntl
+    do_fcntl = True
+  except ImportError:
+    do_fcntl = False
   from mrtrix3 import app
   if not os.path.exists(path):
     delay = 1.0/1024.0
@@ -97,8 +103,9 @@ def waitFor(path):
     return
   try:
     with open(path, 'rb+') as f:
-      fcntl.lockf(f, fcntl.LOCK_EX)
-      fcntl.lockf(f, fcntl.LOCK_UN)
+      if do_fcntl:
+        fcntl.lockf(f, fcntl.LOCK_EX)
+        fcntl.lockf(f, fcntl.LOCK_UN)
     app.debug('File \"' + path + '\" immediately ready')
     return
   except:
@@ -108,8 +115,9 @@ def waitFor(path):
   while True:
     try:
       with open(path, 'rb+') as f:
-        fcntl.lockf(f, fcntl.LOCK_EX)
-        fcntl.lockf(f, fcntl.LOCK_UN)
+        if do_fcntl:
+          fcntl.lockf(f, fcntl.LOCK_EX)
+          fcntl.lockf(f, fcntl.LOCK_UN)
       app.debug('File \"' + path + '\" appears to have been finalized')
       return
     except (IOError, OSError):

--- a/lib/mrtrix3/file.py
+++ b/lib/mrtrix3/file.py
@@ -73,24 +73,48 @@ def newTempFile(suffix):
 # Wait until a particular file not only exists, but also does not have any
 #   other process operating on it (so hopefully whatever created it has
 #   finished its work)
-# Using open() rather than os.path.exists() ensures that not only has the file
-#   appeared in the directory listing, but the data are there and a file handle
-#   can be obtained. Additionally, an exclusive file lock is obtained.
-# 'r+' mode is used since it includes write access (which may fail if some other
-#   process also has write access to that file), but will _not_ create a new file
-#   if the file is somehow deleted between os.path.exists() and open().
+# This functionality is achieved in different ways, depending on the capabilities
+#   of the system:
+#   - On Windows, two processes cannot open the same file in read mode. Therefore,
+#     try to open the file in 'rb+' mode, which requests write access but does not
+#     create a new file if none exists
+#   - If command fuser is available, parse its output and look for any processes
+#     that have write access to the file.
+#   - If neither of those applies, no additional safety check can be performed.
 # Initially, checks for the file once every 1/1000th of a second; this gradually
 #   increases if the file still doesn't exist, until the program is only checking
 #   for the file once a minute.
 def waitFor(path):
   import os, time
-  
-  try:
-    import fcntl
-    do_fcntl = True
-  except ImportError:
-    do_fcntl = False
   from mrtrix3 import app
+
+  def inUse(path):
+    import subprocess
+    from distutils.spawn import find_executable
+    if app.isWindows():
+      if not os.access(path, os.W_OK):
+        return None
+      try:
+        with open(path, 'rb+') as f:
+          pass
+        return False
+      except:
+        return True
+    if not find_executable('fuser'):
+      return None
+    # Apparently the 'F' for open with write access only appears in the verbose output
+    proc = subprocess.Popen(['fuser', '-v', path], shell=False, stdin=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
+    (stdout, stderr) = proc.communicate()
+    # fuser writes process IDs to stdout, and all other info to stderr - even when tabulated together in the verbose output
+    # Need to first remove the leading printout, which is the path being queried
+    stderr = stderr.decode('utf-8').lstrip(':')
+    # Now look for a line where a 'F' appears in the ACCESS field
+    for line in stderr.splitlines():
+      line = line.split()
+      if len(line) == 3 and 'F' in line[1]:
+        return True
+    return False
+
   if not os.path.exists(path):
     delay = 1.0/1024.0
     app.console('Waiting for creation of new file \"' + path + '\"')
@@ -98,29 +122,20 @@ def waitFor(path):
       time.sleep(delay)
       delay = max(60.0, delay*2.0)
     app.debug('File \"' + path + '\" appears to have been created')
-  if not os.access(path, os.W_OK):
-    app.warn('User does not have write access to file \"' + path + '\"; unable to verify file is complete')
+  init_test = inUse(path)
+  if init_test is None:
+    app.warn('Unable to test for finalization of new file \"' + path + '\"')
     return
-  try:
-    with open(path, 'rb+') as f:
-      if do_fcntl:
-        fcntl.lockf(f, fcntl.LOCK_EX)
-        fcntl.lockf(f, fcntl.LOCK_UN)
+  if not init_test:
     app.debug('File \"' + path + '\" immediately ready')
     return
-  except:
-    pass
   app.console('Waiting for finalization of new file \"' + path + '\"')
   delay = 1.0/1024.0
   while True:
-    try:
-      with open(path, 'rb+') as f:
-        if do_fcntl:
-          fcntl.lockf(f, fcntl.LOCK_EX)
-          fcntl.lockf(f, fcntl.LOCK_UN)
-      app.debug('File \"' + path + '\" appears to have been finalized')
-      return
-    except (IOError, OSError):
+    if inUse(path):
       time.sleep(delay)
       delay = max(60.0, delay*2.0)
+    else:
+      app.debug('File \"' + path + '\" appears to have been finalized')
+      return
 


### PR DESCRIPTION
Resurgence of [this post](http://community.mrtrix.org/t/5ttgen/133/17) made me have another look at the newer solution to the `5ttgen` `run_first_all` problem, and I suspect what I had wasn't good enough.

The theory was to wait until a valid file handle can be obtained for the file the script is waiting for. That way it would happily wait for any SGE jobs to complete, rather than trying to disable SGE altogether. Trouble is, I think that a read handle could be obtained even if some other process had not yet completed writing the file data.

New approach is based on [this post](https://www.calazan.com/how-to-check-if-a-file-is-locked-in-python/): Try to get a file handle that includes write permissions, since that shouldn't be permitted if another process has its own write file handle.

Another option I looked into is `fcntl.flock()`, but it looks like those are merely *advisory* locks...

Haven't tested; would very much appreciate a test from anyone who has SGE up and running on their system. Or if anybody has a better idea for how to achieve a similar result, since there's still an outside chance of a race condition with this one.