### PR TITLE
Remove Anaconda from PATH.

### DIFF
--- a/configure
+++ b/configure
@@ -205,6 +205,23 @@ if nogui: report (' [command-line only]')
 report ('\n\n')
 
 
+# remove any mention of anaconda from PATH:
+path = os.environ['PATH']
+if path.endswith ('\\'):
+  path = path[:-1]
+cleanpath = [];
+oldpath = path.split(':')
+for entry in oldpath:
+  if 'anaconda' not in entry.lower():
+    cleanpath += [ entry ]
+if not oldpath == cleanpath:
+  report ('WARNING: Anaconda removed from PATH to avoid conflicts\n\n')
+path = os.pathsep.join(cleanpath)
+
+os.environ['PATH'] = path
+
+
+
 
 
 global cpp, cpp_cmd, ld, ld_args, ld_cmd
@@ -1218,9 +1235,6 @@ for line in config_report.splitlines():
   cache.write ('# ' + line + '\n')
 cache.write ('\n\n')
 
-path = os.environ['PATH']
-if path.endswith ('\\'):
-  path = path[:-1]
 cache.write ("PATH = r'" + path + "'\n")
 
 commit ('obj_suffix', obj_suffix)


### PR DESCRIPTION
Let the configure script strip out any mentions of Anaconda python in the PATH. This should fix recurring installation issues on both macOS and Linux (cf. issue #936 and [this](http://community.mrtrix.org/t/compilation-on-linux/123), [this](http://community.mrtrix.org/t/loading-freesurfer-6-mgz-files-crashes-mrview-mrconvert/826/11), [this](http://community.mrtrix.org/t/permission-denied-when-using-mrconvert-and-dwi2response/873/8), or [this](http://community.mrtrix.org/t/error-processing-project-file-tmp-tmpexdmto-qt-pro/288/3) forum post)