### PR TITLE
mrconvert fix axis insertion #977

### DIFF
--- a/core/adapter/permute_axes.h
+++ b/core/adapter/permute_axes.h
@@ -22,8 +22,8 @@ namespace MR
   namespace Adapter
   {
 
-    template <class ImageType> 
-      class PermuteAxes : 
+    template <class ImageType>
+      class PermuteAxes :
         public Base<PermuteAxes<ImageType>,ImageType>
     { MEMALIGN (PermuteAxes<ImageType>)
         public:
@@ -35,16 +35,27 @@ namespace MR
         using base_type::parent;
 
         PermuteAxes (const ImageType& original, const vector<int>& axes) :
-          base_type (original), 
+          base_type (original),
             axes_ (axes) {
               for (int i = 0; i < static_cast<int> (parent().ndim()); ++i) {
-                for (size_t a = 0; a < axes_.size(); ++a)
+                for (size_t a = 0; a < axes_.size(); ++a) {
+                  if (axes_[a] >= parent().ndim())
+                    throw Exception ("axis " + str(axes_[a]) + " exceeds image dimensionality");
                   if (axes_[a] == i)
                     goto next_axis;
+                }
                 if (parent().size (i) != 1)
                   throw Exception ("omitted axis \"" + str (i) + "\" has dimension greater than 1");
 next_axis:
                 continue;
+              }
+
+              int non_existent_index = -1;
+              for (auto& a : axes_) {
+                if (a < 0) {
+                  a = non_existent_index--;
+                  non_existent_axes.push_back (0);
+                }
               }
             }
 
@@ -63,11 +74,16 @@ next_axis:
 
           void reset () { parent().reset(); }
 
-        ssize_t get_index (size_t axis) const { return axes_[axis] < 0 ? 0 : parent().index (axes_[axis]); }
-          void move_index (size_t axis, ssize_t increment) { parent().index (axes_[axis]) += increment; }
+          ssize_t get_index (size_t axis) const { const auto a = axes_[axis]; return a < 0 ? non_existent_axes[-1-a] : parent().index (a); }
+          void move_index (size_t axis, ssize_t increment) {
+            const auto a = axes_[axis];
+            if (a < 0) non_existent_axes[-1-a] += increment;
+            else parent().index (a) += increment;
+          }
 
         private:
-          const vector<int> axes_;
+          vector<int> axes_;
+          vector<size_t> non_existent_axes;
 
       };
 


### PR DESCRIPTION
PermuteAxes keeps track of indices of non-existent axes to allow looping. 
Added dimensionality out of bounds check.