### PR TITLE
Prevent estimation of optimal threshold when user specifies value

### DIFF
--- a/cmd/mrmesh.cpp
+++ b/cmd/mrmesh.cpp
@@ -58,7 +58,7 @@ void run ()
     Surface::Algo::image2mesh_blocky (input, mesh);
 
   } else {
-    default_type threshold = 0.0f;
+    default_type threshold = 0.0;
     auto input = Image<float>::open (argument[0]);
     auto opt = get_options("threshold");
     if ( opt.size() ) {

--- a/cmd/mrmesh.cpp
+++ b/cmd/mrmesh.cpp
@@ -58,9 +58,14 @@ void run ()
     Surface::Algo::image2mesh_blocky (input, mesh);
 
   } else {
-
+    default_type threshold = 0.0f;
     auto input = Image<float>::open (argument[0]);
-    const default_type threshold = get_option_value ("threshold", Filter::estimate_optimal_threshold (input));
+    auto opt = get_options("threshold");
+    if ( opt.size() ) {
+      threshold = (default_type) opt[0][0];
+    } else {
+      threshold = Filter::estimate_optimal_threshold (input);
+    }
     Surface::Algo::image2mesh_mc (input, mesh, threshold);
 
   }


### PR DESCRIPTION
In the original code, the optimal threshold was always being calculated,
even when the user specified the threshold on the command line.  Now,
check that the threshold flag was not given before calculating the
optimal threshold.  Saves some processing time and prevents the user
from being worried that their value was not being honored.