### PR TITLE
docs: removed dirty page from display issues

### DIFF
--- a/docs/troubleshooting/FAQ.rst
+++ b/docs/troubleshooting/FAQ.rst
@@ -296,3 +296,17 @@ used in these figures, which I'll explain here in full.
       trick I used in this manuscript was to rotate the hue of the termination
       screenshot by 180 degrees: this provides a pseudo-random coloring of the
       termination points that contrasts well against the tracks.
+
+
+Linux: very slow performance when writing large images
+--------------------------------------------------
+This might be due to the Linux Disk Caching or the kernel's handling of `dirty pages <https://lonesysadmin.net/2013/12/22/better-linux-disk-caching-performance-vm-dirty_ratio/>`__.
+
+On Ubuntu, you can get your current dirty page handling settings with ``sysctl -a | grep dirty``. 
+Those settings can be modified in ``/etc/sysctl.conf`` by adding the following two lines to ``/etc/sysctl.conf``::
+
+    vm.dirty_background_ratio = 60
+    vm.dirty_ratio = 80
+
+``vm.dirty_background_ratio`` is a percentage fraction of your RAM and should be larger than the image to be written. 
+After changing ``/etc/sysctl.conf``, execute ``sysctl -p`` to configure the new kernel parameters at runtime. Depending on your system, these changes might not be persistent after reboot.

--- a/docs/troubleshooting/display_issues.rst
+++ b/docs/troubleshooting/display_issues.rst
@@ -232,45 +232,6 @@ system-wide or user config file to disable these advanced terminal features:
     TerminalColor: 0
 
 
-Hanging on network file system when writing images
---------------------------------------------------
-
-When any *MRtrix3* command must read or write image data, there are two
-primary mechanisms by which this is performed:
-
-1. `Memory mapping <https://en.wikipedia.org/wiki/Memory-mapped_file>`_:
-The operating system provides access to the contents of the file as
-though it were simply a block of data in memory, without needing to
-explicitly load all of the image data into RAM.
-
-2. Preload / delayed write-back: When opening an existing image, the
-entire image contents are loaded into a block of RAM. If an image is
-modified, or a new image created, this occurs entirely within RAM, with
-the image contents written to disk storage only at completion of the
-command.
-
-This design ensures that loading images for processing is as fast as
-possible and does not incur unnecessary RAM requirements, and writing
-files to disk is as efficient as possible as all data is written as a
-single contiguous block.
-
-Memory mapping will be used wherever possible. However one circumstance
-where this should *not* be used is when *write access* is required for
-the target file, and it is stored on a *network file system*: in this
-case, the command typically slows to a crawl (e.g. progressbar stays at
-0% indefinitely), as the memory-mapping implementation repeatedly
-performs small data writes and attempts to keep the entire image data
-synchronised.
-
-*MRtrix3* will now *test* the type of file system that a target image is
-stored on; and if it is a network-based system, it will *not* use
-memory-mapping for images that may be written to. *However*, if you
-experience the aforementioned slowdown in such a circumstance, it is
-possible that the particular configuration you are using is not being
-correctly detected or identified. If you are unfortunate enough to
-encounter this issue, please report to the developers the hardware
-configuration and file system type in use.
-
 
 Conflicts with previous versions of Qt
 --------------------------------------
@@ -285,30 +246,4 @@ manifest in many ways, but the two most obvious one are:
 -  ``./configure`` reports the correct version of Qt, but ``./build``
    fails with various error messages (typically related to redefined
    macros, with previous definitions elsewhere in the code).
-
-
-
-Compiler error during build
----------------------------
-
-If you encounter an error during the build process that resembles the following::
-
-    ERROR: (#/#) [CC] release/cmd/command.o
-    
-    /usr/bin/g++-4.8 -c -std=c++11 -pthread -fPIC -I/home/user/mrtrix3/eigen -Wall -O2 -DNDEBUG -Isrc -Icmd -I./lib -Icmd cmd/command.cpp -o release/cmd/command.o
-    
-    failed with output
-    
-    g++-4.8: internal compiler error: Killed (program cc1plus)
-    Please submit a full bug report,
-    with preprocessed source if appropriate.
-    See for instructions.
-
-
-This is most typically caused by the compiler running out of RAM. This
-can be solved either through installing more RAM into your system, or
-by restricting the number of threads to be used during compilation::
-
-    NUMBER_OF_PROCESSORS=1 ./build
-
 

--- a/docs/troubleshooting/display_issues.rst
+++ b/docs/troubleshooting/display_issues.rst
@@ -271,20 +271,6 @@ correctly detected or identified. If you are unfortunate enough to
 encounter this issue, please report to the developers the hardware
 configuration and file system type in use.
 
-Linux: very slow performance when writing large images
---------------------------------------------------
-This might be due to the Linux Disk Caching or the kernel's handling of 
-_`dirty pages <https://lonesysadmin.net/2013/12/22/better-linux-disk-caching-performance-vm-dirty_ratio/>`__.
-
-On Ubuntu, you can get your current dirty page handling settings with ``sysctl -a | grep dirty``. 
-Those settings can be modified in ``/etc/sysctl.conf`` by adding the following two lines to ``/etc/sysctl.conf``::
-
-    vm.dirty_background_ratio = 60
-    vm.dirty_ratio = 80
-
-``vm.dirty_background_ratio`` is a percentage fraction of your RAM and should be larger than the image to be written. 
-After changing ``/etc/sysctl.conf``, execute ``sysctl -p`` to configure the new kernel parameters at runtime. Depending on your system, these changes might not be persistent after reboot.
-
 
 Conflicts with previous versions of Qt
 --------------------------------------


### PR DESCRIPTION
The section `Linux: very slow performance when writing large images` does not make sense in [troubleshooting/Display issues](https://mrtrix.readthedocs.io/en/latest/troubleshooting/display_issues.html) so I moved it to the FAQs.

Edit: Did the same for `Compiler error during build` and `Hanging on network file system when writing images`.

As a side node: I tried to edit it in the doctest branch but it seems to be way behind `master` and has a lot of conflicts after merging with master. 

