### PR TITLE
Threads: check that casting uint8_t to std::atomic<uint8_t> is safe

### DIFF
--- a/core/raw.h
+++ b/core/raw.h
@@ -175,6 +175,9 @@ namespace MR
 
     template <> 
       inline void store_native<bool> (const bool value, void* data, size_t i) {
+        // bit of a hack - assume lock-free atomic operations on bytes, and that
+        // atomic<uint8_t> genuinely is one byte. Both now checked in thread
+        // initialisation (in Thread::__Backend() constructor)
         std::atomic<uint8_t>* at = reinterpret_cast<std::atomic<uint8_t>*> (as<uint8_t>(data) + (i/8));
         uint8_t prev = *at, new_value;
         do {

--- a/core/thread.cpp
+++ b/core/thread.cpp
@@ -13,6 +13,7 @@
 
 
 #include <thread>
+#include <atomic>
 
 #include "app.h"
 #include "thread.h"
@@ -64,6 +65,13 @@ namespace MR
     __Backend::__Backend () :
       refcount (0) {
         DEBUG ("initialising threads...");
+
+        std::atomic<uint8_t> a;
+        if (!a.is_lock_free()) 
+          WARN ("atomic operations on uint8_t are not lock-free - this may introduce instabilities in operation!");
+
+        if (sizeof (a) != sizeof (uint8_t)) 
+          WARN ("size of atomic<uint8_t> differs from that of uint8_t - this may introduce instabilities in operation!");
 
         previous_print_func = print;
         previous_report_to_user_func = report_to_user_func;


### PR DESCRIPTION
Required for thread-safe access to bitwise data - but this cast is a bit
of a hack and makes assumptions about the implementation. These
assumptions are now explicitly checked when the multi-threaded backend
is initialised - only issues warnings for now.