### PR TITLE
Fix segfault in global tractography.

### DIFF
--- a/cmd/tckglobal.cpp
+++ b/cmd/tckglobal.cpp
@@ -74,7 +74,7 @@ void usage ()
   + "Example use: "
   
   + " $ tckglobal dwi.mif wmr.txt -riso csfr.txt -riso gmr.txt -mask mask.mif \n"
-    "   -niter 1e8 -fod fod.mif -fiso fiso.mif tracks.tck "
+    "   -niter 1e9 -fod fod.mif -fiso fiso.mif tracks.tck "
   
   + "in which dwi.mif is the input image, wmr.txt is an anisotropic, multi-shell response function for WM, "
     "and csfr.txt and gmr.txt are isotropic response functions for CSF and GM. The output tractogram is "

--- a/src/dwi/tractography/GT/externalenergy.cpp
+++ b/src/dwi/tractography/GT/externalenergy.cpp
@@ -138,10 +138,14 @@ namespace MR {
         
         void ExternalEnergyComputer::acceptChanges()
         {
+          assert (changes_vox.size() == changes_tod.size());
+          assert (changes_vox.size() == changes_eext.size());
+          assert (!fiso.valid() || changes_vox.size() == changes_fiso.size());
+
           for (size_t k = 0; k != changes_vox.size(); ++k) 
           {
             assign_pos_of(changes_vox[k], 0, 3).to(tod, eext);
-            assert(!is_out_of_bounds(tod));
+            assert(!is_out_of_bounds(tod, 0, 3));
             tod.row(3) = changes_tod[k];
             eext.value() = changes_eext[k];
             if (fiso.valid()) {
@@ -196,7 +200,7 @@ namespace MR {
           if (w == 0.0)
             return;
           assign_pos_of(vox, 0, 3).to(tod);
-          if (is_out_of_bounds(tod))
+          if (is_out_of_bounds(tod, 0, 3))
             return;
           t = w * d;
           for (size_t k = 0; k != changes_vox.size(); ++k) {
@@ -213,12 +217,14 @@ namespace MR {
         
         double ExternalEnergyComputer::eval()
         {
+          assert (changes_vox.size() == changes_tod.size());
+
           dE = 0.0;
           double e;
           for (size_t k = 0; k != changes_vox.size(); ++k) 
           {
             assign_pos_of(changes_vox[k], 0, 3).to(dwi, eext);
-            assert(!is_out_of_bounds(dwi));
+            assert(!is_out_of_bounds(dwi, 0, 3));
             y = dwi.row(3);
             t = changes_tod[k];
             e = calcEnergy();
@@ -229,7 +235,7 @@ namespace MR {
           }
           return dE / stats.getText();
         }
-        
+
         
         double ExternalEnergyComputer::calcEnergy()
         {

--- a/src/dwi/tractography/GT/particlegrid.cpp
+++ b/src/dwi/tractography/GT/particlegrid.cpp
@@ -23,20 +23,15 @@ namespace MR {
         void ParticleGrid::add(const Point_t &pos, const Point_t &dir)
         {
           Particle* p = pool.create(pos, dir);
-          unsigned int gidx = pos2idx(pos);
+          size_t gidx = pos2idx(pos);
           grid[gidx].push_back(p);
         }
         
         void ParticleGrid::shift(Particle *p, const Point_t& pos, const Point_t& dir)
         {
-          unsigned int gidx0 = pos2idx(p->getPosition());
-          unsigned int gidx1 = pos2idx(pos);
-          for (ParticleVectorType::iterator it = grid[gidx0].begin(); it != grid[gidx0].end(); ++it) {
-            if (*it == p) {
-              grid[gidx0].erase(it);
-              break;
-            }
-          }
+          size_t gidx0 = pos2idx(p->getPosition());
+          size_t gidx1 = pos2idx(pos);
+          std::remove (grid[gidx0].begin(), grid[gidx0].end(), p);
           p->setPosition(pos);
           p->setDirection(dir);
           grid[gidx1].push_back(p);
@@ -44,13 +39,8 @@ namespace MR {
         
         void ParticleGrid::remove(Particle* p)
         {
-          unsigned int gidx0 = pos2idx(p->getPosition());
-          for (ParticleVectorType::iterator it = grid[gidx0].begin(); it != grid[gidx0].end(); ++it) {
-            if (*it == p) {
-              grid[gidx0].erase(it);
-              break;
-            }
-          }
+          size_t gidx0 = pos2idx(p->getPosition());
+          std::remove (grid[gidx0].begin(), grid[gidx0].end(), p);
           pool.destroy(p);
         }
         

--- a/src/dwi/tractography/GT/particlegrid.h
+++ b/src/dwi/tractography/GT/particlegrid.h
@@ -44,16 +44,16 @@ namespace MR {
           ParticleGrid(const HeaderType& image)
           {
             DEBUG("Initialise particle grid.");
-            dims[0] = Math::ceil<size_t>( image.size(0) * image.spacing(0) / (2*Particle::L) );
-            dims[1] = Math::ceil<size_t>( image.size(1) * image.spacing(1) / (2*Particle::L) );
-            dims[2] = Math::ceil<size_t>( image.size(2) * image.spacing(2) / (2*Particle::L) );
+            dims[0] = Math::ceil<size_t>( image.size(0) * image.spacing(0) / (2.0*Particle::L) );
+            dims[1] = Math::ceil<size_t>( image.size(1) * image.spacing(1) / (2.0*Particle::L) );
+            dims[2] = Math::ceil<size_t>( image.size(2) * image.spacing(2) / (2.0*Particle::L) );
             grid.resize(dims[0]*dims[1]*dims[2]);
             
             // Initialise scanner-to-grid transform
-            Eigen::DiagonalMatrix<default_type, 3> newspacing (2*Particle::L, 2*Particle::L, 2*Particle::L);
-            Eigen::Vector3 shift (image.spacing(0)/2 - Particle::L, 
-                                  image.spacing(1)/2 - Particle::L, 
-                                  image.spacing(2)/2 - Particle::L);
+            Eigen::DiagonalMatrix<default_type, 3> newspacing (2.0*Particle::L, 2.0*Particle::L, 2.0*Particle::L);
+            Eigen::Vector3 shift (image.spacing(0)/2.0 - Particle::L,
+                                  image.spacing(1)/2.0 - Particle::L,
+                                  image.spacing(2)/2.0 - Particle::L);
             T_s2g = image.transform() * newspacing;
             T_s2g = T_s2g.inverse().translate(shift);
           }
@@ -106,6 +106,7 @@ namespace MR {
           inline void pos2xyz(const Point_t& pos, size_t& x, size_t& y, size_t& z) const
           {
             Point_t gpos = T_s2g.cast<float>() * pos;
+            assert (gpos[0]>=-0.5 && gpos[1]>=-0.5 && gpos[2]>=-0.5);
             x = Math::round<size_t>(gpos[0]);
             y = Math::round<size_t>(gpos[1]);
             z = Math::round<size_t>(gpos[2]);

--- a/src/dwi/tractography/GT/particlepool.h
+++ b/src/dwi/tractography/GT/particlepool.h
@@ -97,14 +97,14 @@ namespace MR {
           void clear() {
             std::lock_guard<std::mutex> lock (mutex);
             pool.clear();
-            std::stack<Particle*> e {};
+            std::stack<Particle*, vector<Particle*> > e {};
             avail.swap(e);
           }
           
         protected:
           std::mutex mutex;
-          std::deque<Particle> pool;
-          std::stack<Particle*> avail;
+          std::deque<Particle, Eigen::aligned_allocator<Particle> > pool;
+          std::stack<Particle*, vector<Particle*> > avail;
           Math::RNG rng;
         };
 


### PR DESCRIPTION
As reported in #992, the recent merge of #785 accidentally introduced a segfault in `tckglobal`. This pull requests fixes this.

The error was caused by two issues:
- The new `row` method for image access interfered with an out-of-bounds check on the third dimension (DWI volumes) in the data energy computation. This was easily fixed by limiting the bounds check to the spatial dimensions.
- The memory alignment issues required a dedicated aligned allocator in `std::deque` and `std::stack` members of the object pool used to store track segments. This was fixed in 860c474 by setting the appropriate template arguments.

Today's commits clean up the code without affecting performance.