### PR TITLE
Move memory aligned deque to core/types.h

### DIFF
--- a/core/types.h
+++ b/core/types.h
@@ -20,6 +20,7 @@
 #include <complex>
 #include <iostream>
 #include <vector>
+#include <deque>
 #include <cstddef>
 #include <memory>
 
@@ -242,6 +243,21 @@ namespace MR
       public:
         using ::std::vector<X>::vector;
         vector() { }
+    };
+
+  
+  template <typename X, int N=(alignof(X)>::MR::malloc_align)>
+    class deque : public ::std::deque<X, Eigen::aligned_allocator<X>> { NOMEMALIGN
+      public:
+        using ::std::deque<X,Eigen::aligned_allocator<X>>::deque;
+        deque() { }
+    };
+
+  template <typename X>
+    class deque<X,0> : public ::std::deque<X> { NOMEMALIGN
+      public:
+        using ::std::deque<X>::deque;
+        deque() { }
     };
 
 

--- a/src/dwi/tractography/GT/particle.h
+++ b/src/dwi/tractography/GT/particle.h
@@ -74,7 +74,15 @@ namespace MR {
               removeSuccessor();
             alive = false;
           }
+
+          // disable copy and assignment
+          Particle(const Particle&) = delete;
+          Particle& operator=(const Particle&) = delete;
           
+          // default move constructor and assignment
+          Particle(Particle&&) = default;
+          Particle& operator=(Particle&&) = default;
+
           
           // Getters and setters ----------------------------------------------------------
           

--- a/src/dwi/tractography/GT/particlepool.h
+++ b/src/dwi/tractography/GT/particlepool.h
@@ -97,14 +97,14 @@ namespace MR {
           void clear() {
             std::lock_guard<std::mutex> lock (mutex);
             pool.clear();
-            std::stack<Particle*, vector<Particle*> > e {};
+            std::stack<Particle*, deque<Particle*> > e {};
             avail.swap(e);
           }
           
         protected:
           std::mutex mutex;
-          std::deque<Particle, Eigen::aligned_allocator<Particle> > pool;
-          std::stack<Particle*, vector<Particle*> > avail;
+          deque<Particle> pool;
+          std::stack<Particle*, deque<Particle*> > avail;
           Math::RNG rng;
         };
 


### PR DESCRIPTION
Hopefully ensures Eigen 3.2 compatibility? (as discussed in #998)