### PR TITLE
mrconvert PE export with -coord option

### DIFF
--- a/cmd/mrconvert.cpp
+++ b/cmd/mrconvert.cpp
@@ -316,8 +316,9 @@ void run ()
       if (*maxval >= header_in.size(axis))
         throw Exception ("coordinate position " + str(*maxval) + " for axis " + str(axis) + " provided with -coord option is out of range of input image");
 
+      header_out.size (axis) = pos[axis].size();
       if (axis == 3) {
-        const auto grad = DWI::get_DW_scheme (header_out);
+        const auto grad = DWI::get_DW_scheme (header_in);
         if (grad.rows()) {
           if ((ssize_t)grad.rows() != header_in.size(3)) {
             WARN ("Diffusion encoding of input file does not match number of image volumes; omitting gradient information from output image");
@@ -331,7 +332,7 @@ void run ()
         }
         Eigen::MatrixXd pe_scheme;
         try {
-          pe_scheme = PhaseEncoding::parse_scheme (header_out);
+          pe_scheme = PhaseEncoding::get_scheme (header_in);
           if (pe_scheme.rows()) {
             Eigen::MatrixXd extract_scheme (pos[3].size(), pe_scheme.cols());
             for (size_t vol = 0; vol != pos[3].size(); ++vol)


### PR DESCRIPTION
Currently, 
```
mrconvert -coord 3 0,1 in.mif -export_pe_table acqp.txt out.mif
```
fails with error:
```
mrconvert: [ERROR] malformed PE scheme in image "out.mif" - number of rows does not equal number of volumes
```
This pull request fixes this, and also facilitates jointly importing and exporting PE and/or gradient tables.
