### PR TITLE
fixelcfestats: New option -mask

### DIFF
--- a/cmd/fixelcfestats.cpp
+++ b/cmd/fixelcfestats.cpp
@@ -308,14 +308,6 @@ void run() {
     gaussian_const1 = 1.0 / (smooth_std_dev *  std::sqrt (2.0 * Math::pi));
   }
 
-  for (size_t f = 0; f != num_fixels; ++f) {
-    mask.index(0) = f;
-    if (!mask.value()) {
-      TRACE;
-      throw Exception ("False value in mask");
-    }
-  }
-
   {
     ProgressBar progress ("normalising and thresholding fixel-fixel connectivity matrix", num_fixels);
     for (index_type fixel = 0; fixel < num_fixels; ++fixel) {

--- a/cmd/fixelcfestats.cpp
+++ b/cmd/fixelcfestats.cpp
@@ -408,7 +408,7 @@ void run() {
           data (fixel, subject) = value;
         }
       } else {
-        data.col (subject) = subject_data_vector;
+        data.col (subject) = Eigen::Map<Eigen::Matrix<value_type, Eigen::Dynamic, 1> > (subject_data_vector.data(), mask_fixels);
       }
       progress++;
     }

--- a/cmd/fixelcfestats.cpp
+++ b/cmd/fixelcfestats.cpp
@@ -55,6 +55,13 @@ void usage ()
 
   SYNOPSIS = "Fixel-based analysis using connectivity-based fixel enhancement and non-parametric permutation testing";
 
+  DESCRIPTION
+  + "Note that if the -mask option is used, the output fixel directory will still contain the same set of fixels as that "
+    "present in the input fixel template, in order to retain fixel correspondence. However a consequence of this is that "
+    "all fixels in the template will be initialy visible when the output fixel directory is loaded in mrview. Those fixels "
+    "outside the processing mask will immediately disappear from view as soon as any data-file-based fixel colouring or "
+    "thresholding is applied.";
+
   REFERENCES
   + "Raffelt, D.; Smith, RE.; Ridgway, GR.; Tournier, JD.; Vaughan, DN.; Rose, S.; Henderson, R.; Connelly, A." // Internal
     "Connectivity-based fixel enhancement: Whole-brain statistical analysis of diffusion MRI measures in the presence of crossing fibres. \n"

--- a/docs/reference/commands/fixelcfestats.rst
+++ b/docs/reference/commands/fixelcfestats.rst
@@ -94,7 +94,7 @@ Raffelt, D.; Smith, RE.; Ridgway, GR.; Tournier, JD.; Vaughan, DN.; Rose, S.; He
 
 
 
-**Author:** David Raffelt (david.raffelt@florey.edu.au)
+**Author:** David Raffelt (david.raffelt@florey.edu.au) and Robert E. Smith (robert.smith@florey.edu.au)
 
 **Copyright:** Copyright (c) 2008-2017 the MRtrix3 contributors.
 

--- a/docs/reference/commands/fixelcfestats.rst
+++ b/docs/reference/commands/fixelcfestats.rst
@@ -62,6 +62,8 @@ Additional options for fixelcfestats
 
 -  **-angle value** the max angle threshold for assigning streamline tangents to fixels (Default: 45 degrees)
 
+-  **-mask file** provide a fixel data file containing a mask of those fixels to be used during processing
+
 Standard options
 ^^^^^^^^^^^^^^^^
 

--- a/docs/reference/commands/fixelcfestats.rst
+++ b/docs/reference/commands/fixelcfestats.rst
@@ -22,6 +22,11 @@ Usage
 -  *tracks*: the tracks used to determine fixel-fixel connectivity
 -  *out_fixel_directory*: the output directory where results will be saved. Will be created if it does not exist
 
+Description
+-----------
+
+Note that if the -mask option is used, the output fixel directory will still contain the same set of fixels as that present in the input fixel template, in order to retain fixel correspondence. However a consequence of this is that all fixels in the template will be initialy visible when the output fixel directory is loaded in mrview. Those fixels outside the processing mask will immediately disappear from view as soon as any data-file-based fixel colouring or thresholding is applied.
+
 Options
 -------
 

--- a/lib/mrtrix3/app.py
+++ b/lib/mrtrix3/app.py
@@ -7,13 +7,11 @@
 # - cmdline.addCitation(), cmdline.addDescription(), cmdline.setCopyright() as needed
 # - Add arguments and options to 'cmdline' as needed
 # - parse()
-# - checkOutputFile() as needed
+# - checkOutputPath() as needed
 # - makeTempDir() if the script requires a temporary directory
 # - gotoTempDir() if the script is using a temporary directory
 # - complete()
 #
-# checkOutputFile() can be called at any time after parse() to check if an intended output
-#   file already exists
 
 
 

--- a/src/gui/mrview/tool/fixel/base_fixel.cpp
+++ b/src/gui/mrview/tool/fixel/base_fixel.cpp
@@ -118,35 +118,37 @@ namespace MR
                "void main() {\n";
 
           if (fixel.use_discard_lower())
-            source += "  if (v_threshold[0] < lower) return;\n";
+            source += "  if (v_threshold[0] < lower || isnan(v_threshold[0])) return;\n";
           if (fixel.use_discard_upper())
-            source += "  if (v_threshold[0] > upper) return;\n";
+            source += "  if (v_threshold[0] > upper || isnan(v_threshold[0])) return;\n";
 
           switch (scale_type) {
             case Unity:
-              source += "   vec4 line_offset = length_mult * vec4 (v_dir[0], 0);\n";
+              source += "  vec4 line_offset = length_mult * vec4 (v_dir[0], 0);\n";
               break;
             case Value:
-              source += "   vec4 line_offset = length_mult * v_scale[0] * vec4 (v_dir[0], 0);\n";
+              source += "  if (isnan(v_scale[0])) return;\n"
+                        "  vec4 line_offset = length_mult * v_scale[0] * vec4 (v_dir[0], 0);\n";
               break;
           }
 
           switch (color_type) {
             case CValue:
               if (!ColourMap::maps[colourmap].special) {
-                source += "    float amplitude = clamp (";
+                source += "  if (isnan(v_colour[0])) return;\n"
+                          "  float amplitude = clamp (";
                 if (fixel.scale_inverted())
                   source += "1.0 -";
                 source += " scale * (v_colour[0] - offset), 0.0, 1.0);\n";
               }
               source +=
-                std::string ("    vec3 color;\n") +
+                std::string ("  vec3 color;\n") +
                 ColourMap::maps[colourmap].glsl_mapping +
-                "   fColour = color;\n";
+                "  fColour = color;\n";
               break;
             case Direction:
               source +=
-                "   fColour = normalize (abs (v_dir[0]));\n";
+                "  fColour = normalize (abs (v_dir[0]));\n";
               break;
             default:
               break;

--- a/src/stats/cfe.h
+++ b/src/stats/cfe.h
@@ -61,9 +61,9 @@ namespace MR
                              const connectivity_value_type connectivity_value) :
               fixel_index (fixel_index),
               connectivity_value (connectivity_value) { }
-          index_type index() const { return fixel_index; }
-          connectivity_value_type value() const { return connectivity_value; }
-          void normalise (const connectivity_value_type norm_factor) { connectivity_value *= norm_factor; }
+          FORCE_INLINE index_type index() const { return fixel_index; }
+          FORCE_INLINE connectivity_value_type value() const { return connectivity_value; }
+          FORCE_INLINE void normalise (const connectivity_value_type norm_factor) { connectivity_value *= norm_factor; }
         private:
           const index_type fixel_index;
           connectivity_value_type connectivity_value;

--- a/src/stats/cfe.h
+++ b/src/stats/cfe.h
@@ -55,7 +55,7 @@ namespace MR
       // A class to store fixel index / connectivity value pairs
       //   only after the connectivity matrix has been thresholded / normalised
       class NormMatrixElement
-      {
+      { NOMEMALIGN
         public:
           NormMatrixElement (const index_type fixel_index,
                              const connectivity_value_type connectivity_value) :

--- a/src/stats/cfe.h
+++ b/src/stats/cfe.h
@@ -43,7 +43,7 @@ namespace MR
       @{ */
 
 
-      class connectivity { MEMALIGN(connectivity)
+      class connectivity { NOMEMALIGN
         public:
           connectivity () : value (0.0) { }
           connectivity (const connectivity_value_type v) : value (v) { }
@@ -61,6 +61,7 @@ namespace MR
         public:
           TrackProcessor (Image<uint32_t>& fixel_indexer,
                           const vector<direction_type>& fixel_directions,
+                          Image<bool>& fixel_mask,
                           vector<uint16_t>& fixel_TDI,
                           vector<std::map<uint32_t, connectivity> >& connectivity_matrix,
                           const value_type angular_threshold);
@@ -70,6 +71,7 @@ namespace MR
         private:
           Image<uint32_t> fixel_indexer;
           const vector<direction_type>& fixel_directions;
+          Image<bool> fixel_mask;
           vector<uint16_t>& fixel_TDI;
           vector<std::map<uint32_t, connectivity> >& connectivity_matrix;
           const value_type angular_threshold_dp;


### PR DESCRIPTION
Had a go since there were [multiple requests](http://community.mrtrix.org/t/how-to-restrict-fixelcfestats-to-subset-of-tracts/845). Untested, but it's easier for me to get it installed on a server to test if I push to the online repo, so might as well post here straight away in case anybody is curious.

Wasn't a single unique solution. What I've gone with is:

- Despite using `-mask` option, output fixel image will still contain the same set of fixels as the input fixel template.

- When constructing the fixel-fixel connectivity matrix, streamlines may still be assigned to a fixel that is outside the mask, if the streamline is most collinear with that fixel. However connectivity to that fixel will not contribute in any way to the analysis.

- Only fixels within the mask are involved in data smoothing, GLM, CFE.

Benefit of keeping all fixels is that you keep fixel correspondence across different experiments from the same template. You can still see those fixels, but they should disappear as soon as any quantitative value is loaded (should; need to check). Cropping the output would have made the set of fixels within the analysis mask more immediately obvious; but you can just `fixelcrop` after the fact if you want.

Closes #987.