### PR TITLE
mrconvert: don't set PE scheme if PhaseEncoding::set_scheme throws an exception

### DIFF
--- a/cmd/mrconvert.cpp
+++ b/cmd/mrconvert.cpp
@@ -90,16 +90,16 @@ DESCRIPTION
 
   + OptionGroup ("Options to modify generic header entries")
 
-  + Option ("clear_property", 
+  + Option ("clear_property",
             "remove the specified key from the image header altogether.").allow_multiple()
   + Argument ("key").type_text()
 
-  + Option ("set_property", 
+  + Option ("set_property",
             "set the value of the specified key in the image header.").allow_multiple()
   + Argument ("key").type_text()
   + Argument ("value").type_text()
 
-  + Option ("append_property", 
+  + Option ("append_property",
             "append the given value to the specified key in the image header (this adds the value specified as a new line in the header value).").allow_multiple()
   + Argument ("key").type_text()
   + Argument ("value").type_text()
@@ -288,11 +288,11 @@ void run ()
   }
 
   opt = get_options ("set_property");
-  for (size_t n = 0; n < opt.size(); ++n) 
+  for (size_t n = 0; n < opt.size(); ++n)
     header_out.keyval()[opt[n][0].as_text()] = opt[n][1].as_text();
 
   opt = get_options ("append_property");
-  for (size_t n = 0; n < opt.size(); ++n) 
+  for (size_t n = 0; n < opt.size(); ++n)
     add_line (header_out.keyval()[opt[n][0].as_text()], opt[n][1].as_text());
 
 
@@ -342,7 +342,7 @@ void run ()
           }
         } catch (...) {
           WARN ("Phase encoding scheme of input file does not match number of image volumes; omitting information from output image");
-          PhaseEncoding::set_scheme (header_out, pe_scheme);
+          PhaseEncoding::set_scheme (header_out, Eigen::MatrixXd());
         }
       }
     }


### PR DESCRIPTION
This makes sure that the output file does not contain a PE table if a bogus phase-encode scheme is present in the input image. `mrconvert` warns that the output file's PE table is removed but currently, a bogus PE table could trigger [this](https://github.com/MRtrix3/mrtrix3/blob/master/core/phase_encoding.h#L65) exception instead.