### PR TITLE
fix compilation error on g++ 7.1 due to legacy code

### DIFF
--- a/core/fixel/legacy/image.h
+++ b/core/fixel/legacy/image.h
@@ -73,7 +73,7 @@ namespace MR
           friend std::ostream& operator<< (std::ostream& stream, const Value& value) {
             stream << "Position [ ";
             for (size_t n = 0; n < value.offsets.ndim(); ++n)
-              stream << value.offsets[n] << " ";
+              stream << value.offsets.index(n) << " ";
             stream << "], offset = " << value.offsets.value() << ", " << value.size() << " elements";
             return stream;
           }


### PR DESCRIPTION
as discussed on the [community forum](http://community.mrtrix.org/t/building-failure-windows/1004?u=jdtournier). 