### PR TITLE
Detect lustre to avoid memory mapping files

### DIFF
--- a/core/file/mmap.cpp
+++ b/core/file/mmap.cpp
@@ -111,7 +111,7 @@ namespace MR
 
         if (fsbuf.f_type == 0xff534d42 /* CIFS */|| fsbuf.f_type == 0x6969 /* NFS */ || 
             fsbuf.f_type == 0x65735546 /* FUSE */ || fsbuf.f_type == 0x517b /* SMB */ || 
-            fsbuf.f_type == 0x47504653 /* GPFS */
+            fsbuf.f_type == 0x47504653 /* GPFS */ || fsbuf.f_type == 0xbd00bd0 /* LUSTRE */
 
 #ifdef MRTRIX_MACOSX
             || fsbuf.f_type == 0x0017 /* OSXFUSE */


### PR DESCRIPTION
Memory mapping of files on lustre has caused the 0% cpu use process stall, as discussed in the FAQ.  This edit just adds the lustre file system ID to the list recognized network file systems to opt for delayed write-back.