### PR TITLE
Dicom split series by image type

### DIFF
--- a/core/file/dicom/image.cpp
+++ b/core/file/dicom/image.cpp
@@ -43,6 +43,10 @@ namespace MR {
         // process image-specific or per-frame items here:
         if (is_toplevel) {
           switch (item.group) {
+            case 0x0008U: 
+              if (item.element == 0x0008U) 
+                image_type = join (item.get_string(), " ");
+              return;
             case 0x0018U: 
               switch (item.element) {
                 case 0x0050U: 

--- a/core/file/dicom/image.h
+++ b/core/file/dicom/image.h
@@ -31,21 +31,21 @@ namespace MR {
         public:
           Frame () { 
             acq_dim[0] = acq_dim[1] = dim[0] = dim[1] = instance = series_num = acq = sequence = UINT_MAX;
-            position_vector[0] = position_vector[1] = position_vector[2] = NAN;
-            orientation_x[0] = orientation_x[1] = orientation_x[2] = NAN;
-            orientation_y[0] = orientation_y[1] = orientation_y[2] = NAN;
-            orientation_z[0] = orientation_z[1] = orientation_z[2] = NAN;
-            distance = NAN;
-            pixel_size[0] = pixel_size[1] = slice_thickness = slice_spacing = NAN; 
+            position_vector[0] = position_vector[1] = position_vector[2] = NaN;
+            orientation_x[0] = orientation_x[1] = orientation_x[2] = NaN;
+            orientation_y[0] = orientation_y[1] = orientation_y[2] = NaN;
+            orientation_z[0] = orientation_z[1] = orientation_z[2] = NaN;
+            distance = NaN;
+            pixel_size[0] = pixel_size[1] = slice_thickness = slice_spacing = NaN; 
             scale_intercept = 0.0;
             scale_slope = 1.0;
-            bvalue = G[0] = G[1] = G[2] = NAN;
+            bvalue = G[0] = G[1] = G[2] = NaN;
             data = bits_alloc = data_size = frame_offset = 0;
             DW_scheme_wrt_image = false;
             transfer_syntax_supported = true;
             pe_axis = 3;
             pe_sign = 0;
-            pixel_bandwidth = bandwidth_per_pixel_phase_encode = echo_time = NAN;
+            pixel_bandwidth = bandwidth_per_pixel_phase_encode = echo_time = NaN;
             echo_train_length = 0;
           }
 
@@ -53,7 +53,7 @@ namespace MR {
           Eigen::Vector3 position_vector, orientation_x, orientation_y, orientation_z, G;
           default_type distance, pixel_size[2], slice_thickness, slice_spacing, scale_slope, scale_intercept, bvalue;
           size_t data, bits_alloc, data_size, frame_offset;
-          std::string filename;
+          std::string filename, image_type;
           bool DW_scheme_wrt_image, transfer_syntax_supported;
           size_t pe_axis;
           int pe_sign;
@@ -64,6 +64,8 @@ namespace MR {
           bool operator< (const Frame& frame) const {
             if (series_num != frame.series_num) 
               return series_num < frame.series_num;
+            if (image_type != frame.image_type)
+              return image_type < frame.image_type;
             if (acq != frame.acq) 
               return acq < frame.acq;
             assert (std::isfinite (distance));

--- a/core/file/dicom/mapper.cpp
+++ b/core/file/dicom/mapper.cpp
@@ -118,7 +118,7 @@ namespace MR {
         if (std::isfinite (frame.echo_time))
           H.keyval()["EchoTime"] = str (0.001 * frame.echo_time, 6);
 
-        size_t nchannels = frames.size() ? 1 : frame.data_size / (frame.dim[0] * frame.dim[1] * (frame.bits_alloc/8));
+        size_t nchannels = image.frames.size() ? 1 : image.data_size / (frame.dim[0] * frame.dim[1] * (frame.bits_alloc/8));
         if (nchannels > 1) 
           INFO ("data segment is larger than expected from image dimensions - interpreting as multi-channel data");
 

--- a/core/file/dicom/mapper.cpp
+++ b/core/file/dicom/mapper.cpp
@@ -113,11 +113,12 @@ namespace MR {
         }
 
         const Image& image (*(*series[0])[0]);
+        const Frame& frame (*frames[0]);
 
-        if (std::isfinite (image.echo_time))
-          H.keyval()["EchoTime"] = str (0.001 * image.echo_time, 6);
+        if (std::isfinite (frame.echo_time))
+          H.keyval()["EchoTime"] = str (0.001 * frame.echo_time, 6);
 
-        size_t nchannels = image.frames.size() ? 1 : image.data_size / (image.dim[0] * image.dim[1] * (image.bits_alloc/8));
+        size_t nchannels = frames.size() ? 1 : frame.data_size / (frame.dim[0] * frame.dim[1] * (frame.bits_alloc/8));
         if (nchannels > 1) 
           INFO ("data segment is larger than expected from image dimensions - interpreting as multi-channel data");
 
@@ -132,12 +133,12 @@ namespace MR {
         }
 
         H.stride(0) = ++current_axis;
-        H.size(0) = image.dim[0];
-        H.spacing(0) = image.pixel_size[0];
+        H.size(0) = frame.dim[0];
+        H.spacing(0) = frame.pixel_size[0];
 
         H.stride(1) = ++current_axis;
-        H.size(1) = image.dim[1];
-        H.spacing(1) = image.pixel_size[1];
+        H.size(1) = frame.dim[1];
+        H.spacing(1) = frame.pixel_size[1];
 
         H.stride(2) = ++current_axis;
         H.size(2) = dim[1];
@@ -150,42 +151,41 @@ namespace MR {
         }
 
 
-        if (image.bits_alloc == 8) 
+        if (frame.bits_alloc == 8) 
           H.datatype() = DataType::UInt8;
-        else if (image.bits_alloc == 16) {
+        else if (frame.bits_alloc == 16) {
           H.datatype() = DataType::UInt16;
           if (image.is_BE) 
             H.datatype() = DataType::UInt16 | DataType::BigEndian;
           else 
             H.datatype() = DataType::UInt16 | DataType::LittleEndian;
         }
-        else throw Exception ("unexpected number of allocated bits per pixel (" + str (image.bits_alloc) 
+        else throw Exception ("unexpected number of allocated bits per pixel (" + str (frame.bits_alloc) 
             + ") in file \"" + H.name() + "\"");
 
-        H.set_intensity_scaling (image.scale_slope, image.scale_intercept);
+        H.set_intensity_scaling (frame.scale_slope, frame.scale_intercept);
 
 
         // If multi-frame, take the transform information from the sorted frames; the first entry in the
         // vector should be the first slice of the first volume
         {
           transform_type M;
-          const Frame* frame (image.frames.size() ? image.frames[0].get() : &static_cast<const Frame&> (image));
 
-          M(0,0) = -frame->orientation_x[0];
-          M(1,0) = -frame->orientation_x[1];
-          M(2,0) = +frame->orientation_x[2];
+          M(0,0) = -frame.orientation_x[0];
+          M(1,0) = -frame.orientation_x[1];
+          M(2,0) = +frame.orientation_x[2];
 
-          M(0,1) = -frame->orientation_y[0];
-          M(1,1) = -frame->orientation_y[1];
-          M(2,1) = +frame->orientation_y[2];
+          M(0,1) = -frame.orientation_y[0];
+          M(1,1) = -frame.orientation_y[1];
+          M(2,1) = +frame.orientation_y[2];
 
-          M(0,2) = -frame->orientation_z[0];
-          M(1,2) = -frame->orientation_z[1];
-          M(2,2) = +frame->orientation_z[2];
+          M(0,2) = -frame.orientation_z[0];
+          M(1,2) = -frame.orientation_z[1];
+          M(2,2) = +frame.orientation_z[2];
 
-          M(0,3) = -frame->position_vector[0];
-          M(1,3) = -frame->position_vector[1];
-          M(2,3) = +frame->position_vector[2];
+          M(0,3) = -frame.position_vector[0];
+          M(1,3) = -frame.position_vector[1];
+          M(2,3) = +frame.position_vector[2];
 
           H.transform() = M;
           std::string dw_scheme = Frame::get_DW_scheme (frames, dim[1], M);
@@ -206,24 +206,24 @@ namespace MR {
           if (H.size (2) != 1)
             throw Exception ("DICOM mosaic contains multiple slices in image \"" + H.name() + "\"");
 
-          H.size(0) = image.acq_dim[0];
-          H.size(1) = image.acq_dim[1];
+          H.size(0) = frame.acq_dim[0];
+          H.size(1) = frame.acq_dim[1];
           H.size(2) = image.images_in_mosaic;
 
-          if (image.dim[0] % image.acq_dim[0] || image.dim[1] % image.acq_dim[1]) {
-            WARN ("acquisition matrix [ " + str (image.acq_dim[0]) + " " + str (image.acq_dim[1]) 
-                + " ] does not fit into DICOM mosaic [ " + str (image.dim[0]) + " " + str (image.dim[1]) 
+          if (frame.dim[0] % frame.acq_dim[0] || frame.dim[1] % frame.acq_dim[1]) {
+            WARN ("acquisition matrix [ " + str (frame.acq_dim[0]) + " " + str (frame.acq_dim[1]) 
+                + " ] does not fit into DICOM mosaic [ " + str (frame.dim[0]) + " " + str (frame.dim[1]) 
                 + " ] -  adjusting matrix size to suit");
-            H.size(0) = image.dim[0] / size_t (float(image.dim[0]) / float(image.acq_dim[0]));
-            H.size(1) = image.dim[1] / size_t (float(image.dim[1]) / float(image.acq_dim[1]));
+            H.size(0) = frame.dim[0] / size_t (float(frame.dim[0]) / float(frame.acq_dim[0]));
+            H.size(1) = frame.dim[1] / size_t (float(frame.dim[1]) / float(frame.acq_dim[1]));
           }
 
-          float xinc = H.spacing(0) * (image.dim[0] - H.size(0)) / 2.0;
-          float yinc = H.spacing(1) * (image.dim[1] - H.size(1)) / 2.0;
+          float xinc = H.spacing(0) * (frame.dim[0] - H.size(0)) / 2.0;
+          float yinc = H.spacing(1) * (frame.dim[1] - H.size(1)) / 2.0;
           for (size_t i = 0; i < 3; i++) 
             H.transform()(i,3) += xinc * H.transform()(i,0) + yinc * H.transform()(i,1);
 
-          io_handler.reset (new MR::ImageIO::Mosaic (H, image.dim[0], image.dim[1], H.size (0), H.size (1), H.size (2)));
+          io_handler.reset (new MR::ImageIO::Mosaic (H, frame.dim[0], frame.dim[1], H.size (0), H.size (1), H.size (2)));
         }
         else 
           io_handler.reset (new MR::ImageIO::Default (H));

--- a/core/file/dicom/mapper.cpp
+++ b/core/file/dicom/mapper.cpp
@@ -71,7 +71,8 @@ namespace MR {
             if (image_it->frames.size()) {
               std::sort (image_it->frames.begin(), image_it->frames.end(), compare_ptr_contents());
               for (auto frame_it : image_it->frames) 
-                frames.push_back (frame_it.get());
+                if (frame_it->image_type == series_it->image_type)
+                  frames.push_back (frame_it.get());
             }
             // otherwise add image frame:
             else 
@@ -99,7 +100,7 @@ namespace MR {
         default_type slice_separation = Frame::get_slice_separation (frames, dim[1]);
 
         if (series[0]->study->name.size()) 
-          add_line (H.keyval()["comments"], std::string ("study: " + series[0]->study->name));
+          add_line (H.keyval()["comments"], std::string ("study: " + series[0]->study->name + " [ " + series[0]->image_type + " ]"));
 
         if (patient->DOB.size()) 
           add_line (H.keyval()["comments"], std::string ("DOB: " + format_date (patient->DOB)));

--- a/core/file/dicom/quick_scan.cpp
+++ b/core/file/dicom/quick_scan.cpp
@@ -16,6 +16,7 @@
 #include "file/dicom/definitions.h"
 #include "file/dicom/element.h"
 #include "file/dicom/csa_entry.h"
+#include "debug.h"
 
 namespace MR {
   namespace File {
@@ -33,6 +34,7 @@ namespace MR {
         study_ID.clear();
         study_time.clear();
         series.clear();
+        image_type.clear();
         series_date.clear();
         series_time.clear();
         sequence.clear();
@@ -42,9 +44,12 @@ namespace MR {
         Element item;
         try {
           item.set (filename, force_read); 
+          std::string current_image_type; 
+          bool in_frames = false;
 
           while (item.read()) {
-            if      (item.is (0x0008U, 0x0020U)) study_date = item.get_string()[0];
+            if      (item.is (0x0008U, 0x0008U)) current_image_type = join (item.get_string(), " ");
+            else if (item.is (0x0008U, 0x0020U)) study_date = item.get_string()[0];
             else if (item.is (0x0008U, 0x0021U)) series_date = item.get_string()[0];
             else if (item.is (0x0008U, 0x0030U)) study_time = item.get_string()[0];
             else if (item.is (0x0008U, 0x0031U)) series_time = item.get_string()[0];
@@ -61,13 +66,12 @@ namespace MR {
             else if (item.is (0x0028U, 0x0011U)) dim[0] = item.get_uint()[0];
             else if (item.is (0x0028U, 0x0100U)) bits_alloc = item.get_uint()[0];
             else if (item.is (0x7FE0U, 0x0010U)) data = item.offset (item.data);
-            else if (item.is (0x0008U, 0x0008U)) {
-              // exclude Siemens MPR info image:
-              // TODO: could handle this by splitting on basis on this entry
-              vector<std::string> V (item.get_string());
-              for (size_t n = 0; n < V.size(); n++) {
-                if (uppercase (V[n]) == "CSAPARALLEL") 
-                  return true;
+            else if (item.is (0xFFFEU, 0xE000U)) {
+              if (item.parents.size() &&
+                  item.parents.back().group ==  0x5200U &&
+                  item.parents.back().element == 0x9230U) { // multi-frame item
+                if (in_frames) ++image_type[current_image_type];
+                else in_frames = true;
               }
             }
 
@@ -82,6 +86,8 @@ namespace MR {
               }
             }
           }
+
+          ++image_type[current_image_type];
 
           transfer_syntax_supported = item.transfer_syntax_supported;
 
@@ -114,8 +120,10 @@ namespace MR {
           << file.series_number << "] " 
           << ( file.series.size() ? file.series : "[unspecified]" ) << " - " 
           << format_date (file.series_date) << " " 
-          << format_time (file.series_time) << "\n    sequence: " 
-          << ( file.sequence.size() ? file.sequence : "[unspecified]" ) << "\n";
+          << format_time (file.series_time) << "\n";
+        for (const auto& type : file.image_type) 
+          stream << "      image type: " << type.first << " [ " << type.second << " frames ]\n";
+        stream << "    sequence: " << ( file.sequence.size() ? file.sequence : "[unspecified]" ) << "\n";
 
         return stream;
       }

--- a/core/file/dicom/quick_scan.h
+++ b/core/file/dicom/quick_scan.h
@@ -15,6 +15,7 @@
 #ifndef __file_dicom_quick_scan_h__
 #define __file_dicom_quick_scan_h__
 
+#include <map>
 #include "mrtrix.h"
 
 namespace MR {
@@ -30,6 +31,7 @@ namespace MR {
           std::string patient, patient_ID, patient_DOB;
           std::string study, study_ID, study_date, study_time;
           std::string series, series_date, series_time, sequence;
+          std::map<std::string, size_t> image_type;
           size_t series_number, bits_alloc, dim[2], data;
           bool transfer_syntax_supported;
       };

--- a/core/file/dicom/select_cmdline.cpp
+++ b/core/file/dicom/select_cmdline.cpp
@@ -115,14 +115,14 @@ namespace MR {
           while (series.size() == 0) {
             fprintf (stderr, "Select series ('q' to abort):\n");
             for (size_t i = 0; i < study.size(); i++) {
-              fprintf (stderr, "  %2zu - %4zu %s images %8s %s (%s) [%zu]\n", 
+              fprintf (stderr, "  %2zu - %4zu %s images %8s %s (%s) [%zu] %s\n", 
                   i,
                   study[i]->size(), 
                   ( study[i]->modality.size() ? study[i]->modality.c_str() : "" ), 
                   format_time (study[i]->time).c_str(), 
                   ( study[i]->name.size() ? study[i]->name.c_str() : "unnamed" ),
                   ( (*study[i])[0]->sequence_name.size() ? (*study[i])[0]->sequence_name.c_str() : "?" ),
-                  study[i]->number);
+                  study[i]->number, study[i]->image_type.c_str());
             }
             std::cerr << "? ";
             std::cin >> buf;

--- a/core/file/dicom/series.cpp
+++ b/core/file/dicom/series.cpp
@@ -80,13 +80,14 @@ namespace MR {
 
       std::ostream& operator<< (std::ostream& stream, const Series& item)
       {
-        stream << MR::printf ("      %4u - %4u %4s images %10s %8s %s\n", 
+        stream << MR::printf ("      %4u - %4u %4s images %10s %8s %s [ %s ]\n", 
               item.number, 
               item.size(), 
               ( item.modality.size() ? item.modality.c_str() : "(?)" ),
               format_date(item.date).c_str(),
               format_time(item.time).c_str(),
-              item.name.c_str() );
+              item.name.c_str(),
+              item.image_type.c_str() );
 
         for (size_t n = 0; n < item.size(); n++) 
           stream << *item[n];

--- a/core/file/dicom/series.h
+++ b/core/file/dicom/series.h
@@ -28,15 +28,15 @@ namespace MR {
 
       class Series : public vector<std::shared_ptr<Image>> { NOMEMALIGN
         public:
-          Series (Study* parent, const std::string& series_name, size_t series_number,
+          Series (Study* parent, const std::string& series_name, size_t series_number, const std::string& image_type,
               const std::string& series_modality = "", const std::string& series_date = "", const std::string& series_time = "") :
-            study (parent), name (series_name), modality (series_modality),
+            study (parent), name (series_name), image_type (image_type), modality (series_modality),
             date (series_date), time (series_time) { 
               number = series_number; 
             }
 
           Study* study;
-          std::string name;
+          std::string name, image_type;
           size_t number;
           std::string modality;
           std::string date;

--- a/core/file/dicom/study.cpp
+++ b/core/file/dicom/study.cpp
@@ -24,13 +24,15 @@ namespace MR {
         bool series_time_mismatch_warning_issued = false;
       }
 
-      std::shared_ptr<Series> Study::find (const std::string& series_name, size_t series_number,
+      std::shared_ptr<Series> Study::find (const std::string& series_name, size_t series_number, const std::string& image_type,
           const std::string& series_modality, const std::string& series_date, const std::string& series_time)
       {
         for (size_t n = 0; n < size(); n++) {
           bool match = true;
           if (series_name == (*this)[n]->name) {
             if (series_number == (*this)[n]->number) {
+              if (image_type != (*this)[n]->image_type)
+                match = false;
               if (series_modality.size() && (*this)[n]->modality.size()) 
                 if (series_modality != (*this)[n]->modality) 
                   match = false;
@@ -59,7 +61,7 @@ namespace MR {
           }
         }
 
-        push_back (std::shared_ptr<Series> (new Series (this, series_name, series_number, series_modality, series_date, series_time)));
+        push_back (std::shared_ptr<Series> (new Series (this, series_name, series_number, image_type, series_modality, series_date, series_time)));
         return back();
       }
 

--- a/core/file/dicom/study.h
+++ b/core/file/dicom/study.h
@@ -35,7 +35,7 @@ namespace MR {
           Patient* patient;
           std::string name, ID, date, time;
 
-          std::shared_ptr<Series> find (const std::string& series_name, size_t series_number,
+          std::shared_ptr<Series> find (const std::string& series_name, size_t series_number, const std::string& image_type,
               const std::string& series_modality = "", const std::string& series_date = "", const std::string& series_time = "");
       };
 

--- a/core/file/dicom/tree.cpp
+++ b/core/file/dicom/tree.cpp
@@ -96,14 +96,17 @@ namespace MR {
 
         std::shared_ptr<Patient> patient = find (reader.patient, reader.patient_ID, reader.patient_DOB);
         std::shared_ptr<Study> study = patient->find (reader.study, reader.study_ID, reader.study_date, reader.study_time);
-        std::shared_ptr<Series> series = study->find (reader.series, reader.series_number, reader.modality, reader.series_date, reader.series_time);
+        for (const auto& image_type : reader.image_type) {
+          std::shared_ptr<Series> series = study->find (reader.series, reader.series_number, image_type.first, reader.modality, reader.series_date, reader.series_time);
 
-        std::shared_ptr<Image> image (new Image);
-        image->filename = filename;
-        image->series = series.get();
-        image->sequence_name = reader.sequence;
-        image->transfer_syntax_supported = reader.transfer_syntax_supported;
-        series->push_back (image);
+          std::shared_ptr<Image> image (new Image);
+          image->filename = filename;
+          image->series = series.get();
+          image->sequence_name = reader.sequence;
+          image->image_type = image_type.first;
+          image->transfer_syntax_supported = reader.transfer_syntax_supported;
+          series->push_back (image);
+        }
       }
 
 

--- a/src/gui/dialog/dicom.cpp
+++ b/src/gui/dialog/dicom.cpp
@@ -45,7 +45,7 @@ namespace MR
               itemData = (str (p->size()) + " " + (p->modality.size() ? p->modality : std::string()) + " images " +
                           format_time (p->time) + " " + (p->name.size() ? p->name : std::string ("unnamed")) + " (" +
                           ( (*p) [0]->sequence_name.size() ? (*p) [0]->sequence_name : std::string ("?")) +
-                          ") [" + str (p->number) + "]").c_str();
+                          ") [" + str (p->number) + "] " + p->image_type).c_str();
             }
             ~Item() {
               qDeleteAll (childItems);


### PR DESCRIPTION
This adds improved support for some DICOM files, by splitting series by ImageType. This means series that for example contain magnitude and phase data can be imported correctly (although separately), when before they were likely to fail due to the different data scaling parameters. It also avoids issues with some series that contain the image and the reformatting information (on Siemens scanners), and when derived images were included in the same series as the original (e.g. a mean DWI image at the end of the DW data on Philips scanners). Don't know why it's taken me so long to get around to dealing with, there was a comment in there with a [long-standing TODO item](https://github.com/MRtrix3/mrtrix3/blob/master/core/file/dicom/quick_scan.cpp#L66) to do just this... 

This is probably the smallest set of changes to handle this I could get away with, and it seems to work on my test data. I've yet to verify all this, but my little script that checks DICOM conversions falls over in cases where the data that would previously have been imported as a single series is now split into two due to containing different types of data... I'll just need to go through and verify that the conversion behaves as expected in these cases, and update the tests to match. Shouldn't take too long... 