### PR TITLE
Ensure stat is 64-bit on Windows

### DIFF
--- a/configure
+++ b/configure
@@ -509,7 +509,7 @@ if system == 'linux':
   runpath = '-Wl,-rpath,$ORIGIN/'
 elif system == 'windows':
   cxx = [ 'g++', 'clang++' ]
-  cpp_flags += [ '-pthread', '-DMRTRIX_WINDOWS', '-mms-bitfields', '-Wa,-mbig-obj' ]
+  cpp_flags += [ '-pthread', '-DMRTRIX_WINDOWS', '-mms-bitfields', '-Wa,-mbig-obj', '-D_FILE_OFFSET_BITS=64' ]
   exe_suffix = '.exe'
   lib_prefix = ''
   lib_suffix = '.dll'


### PR DESCRIPTION
Without this define stat was 32-bit, causing problems with large files (see https://gnunet.org/sorting-out-stat-thing).

Should address issue #1058 