### PR TITLE
Tractography::Properties::get_step_size() function

### DIFF
--- a/cmd/tckresample.cpp
+++ b/cmd/tckresample.cpp
@@ -113,18 +113,9 @@ void run ()
 
   const std::unique_ptr<Resampling::Base> resampler (Resampling::get_resampler());
 
-  float old_step_size = NaN;
-  try {
-    Properties::const_iterator i = properties.find ("output_step_size");
-    if (i == properties.end()) {
-      i = properties.find ("step_size");
-      if (i != properties.end())
-        old_step_size = to<float> (i->second);
-    } else {
-      old_step_size = to<float> (i->second);
-    }
-  } catch (...) {
-    DEBUG ("Unable to read input track file step size");
+  const float old_step_size = get_step_size (properties);
+  if (!std::isfinite (old_step_size)) {
+    INFO ("Do not have step size information from input track file");
   }
 
   float new_step_size = NaN;

--- a/cmd/tckstats.cpp
+++ b/cmd/tckstats.cpp
@@ -119,14 +119,13 @@ void run ()
     if (properties.find ("count") != properties.end())
       header_count = to<size_t> (properties["count"]);
 
-    if (properties.find ("output_step_size") != properties.end())
-      step_size = to<float> (properties["output_step_size"]);
-    else
-      step_size = to<float> (properties["step_size"]);
+    step_size = get_step_size (properties);
+
     if (!std::isfinite (step_size) || !step_size) {
-      WARN ("Streamline step size undefined in header");
-      if (get_options ("histogram").size())
-        WARN ("Histogram will be henerated using a 1mm interval");
+      INFO ("Streamline step size undefined in header; lengths will be calculated manually");
+      if (get_options ("histogram").size()) {
+        WARN ("Do not have streamline step size with which to construct histogram; histogram will be generated using 1mm bin widths");
+      }
     }
 
     std::unique_ptr<File::OFStream> dump;

--- a/src/dwi/tractography/connectome/extract.cpp
+++ b/src/dwi/tractography/connectome/extract.cpp
@@ -73,21 +73,13 @@ bool Selector::operator() (const vector<node_t>& nodes) const
 
 
 WriterExemplars::WriterExemplars (const Tractography::Properties& properties, const vector<node_t>& nodes, const bool exclusive, const node_t first_node, const vector<Eigen::Vector3f>& COMs) :
-    step_size (NAN)
+    step_size (get_step_size (properties))
 {
+  if (!std::isfinite (step_size))
+    step_size = 1.0f;
+
   // Determine how many points to use in the initial representation of each exemplar
   size_t length = 0;
-  auto output_step_size_it = properties.find ("output_step_size");
-  if (output_step_size_it == properties.end()) {
-    auto step_size_it = properties.find ("step_size");
-    if (step_size_it == properties.end())
-      step_size = 1.0f;
-    else
-      step_size = to<float>(step_size_it->second);
-  } else {
-    step_size = to<float>(output_step_size_it->second);
-  }
-
   auto max_dist_it = properties.find ("max_dist");
   if (max_dist_it == properties.end())
     length = 201;

--- a/src/dwi/tractography/editing/worker.cpp
+++ b/src/dwi/tractography/editing/worker.cpp
@@ -133,15 +133,8 @@ namespace MR {
           min_length (0.0f),
           max_weight (std::numeric_limits<float>::infinity()),
           min_weight (0.0f),
-          step_size (NaN)
+          step_size (get_step_size (properties))
         {
-
-          std::string step_size_string;
-          if (properties.find ("output_step_size") == properties.end())
-            step_size_string = ((properties.find ("step_size") == properties.end()) ? "0.0" : properties["step_size"]);
-          else
-            step_size_string = properties["output_step_size"];
-
           if (properties.find ("max_dist") != properties.end()) {
             try {
               max_length = to<float>(properties["max_dist"]);
@@ -153,8 +146,7 @@ namespace MR {
             } catch (...) { }
           }
 
-          try {
-            step_size = to<float>(step_size_string);
+          if (std::isfinite (step_size)) {
             // User may set these values to a precise value, which may then fail due to floating-point
             //   calculation of streamline length
             // Therefore throw a bit of error margin in here
@@ -163,14 +155,13 @@ namespace MR {
               error_margin = 0.5 / to<float>(properties["downsample_factor"]);
             max_length += error_margin * step_size;
             min_length -= error_margin * step_size;
-          } catch (...) { }
+          }
 
           if (properties.find ("max_weight") != properties.end())
             max_weight = to<float>(properties["max_weight"]);
 
           if (properties.find ("min_weight") != properties.end())
             min_weight = to<float>(properties["min_weight"]);
-
         }
 
 

--- a/src/dwi/tractography/mapping/mapping.cpp
+++ b/src/dwi/tractography/mapping/mapping.cpp
@@ -43,16 +43,7 @@ namespace MR {
         {
           if (header.ndim() < 3)
             throw Exception ("Cannot perform streamline mapping on image with less than three dimensions");
-
-          Properties::const_iterator i = properties.find ("output_step_size");
-          if (i == properties.end()) {
-            i = properties.find ("step_size");
-            if (i == properties.end())
-              throw Exception ("Cannot perform streamline mapping: no step size information in track file header");
-          }
-          const float step_size = to<float> (i->second);
-
-          return determine_upsample_ratio (header, step_size, ratio);
+          return determine_upsample_ratio (header, get_step_size (properties), ratio);
         }
 
 

--- a/src/dwi/tractography/properties.h
+++ b/src/dwi/tractography/properties.h
@@ -106,6 +106,23 @@ namespace MR
 
 
 
+      inline float get_step_size (const Properties& p)
+      {
+        for (size_t index = 0; index != 2; ++index) {
+          const std::string key (index ? "step_size" : "output_step_size");
+          auto it = p.find (key);
+          if (it != p.end()) {
+            try {
+              return to<float> (it->second);
+            } catch (...) { }
+          }
+        }
+        return NaN;
+      }
+
+
+
+
 
       inline std::ostream& operator<< (std::ostream& stream, const Properties& P)
       {


### PR DESCRIPTION
As raised [here](http://community.mrtrix.org/t/tckstats-on-global-tractography/1049).

Have identified this duplication of code many times, but never gotten around to functionalising it.