### PR TITLE
5ttgen fsl: Fixes

### DIFF
--- a/cmd/mesh2pve.cpp
+++ b/cmd/mesh2pve.cpp
@@ -62,6 +62,8 @@ void run ()
   check_3D_nonunity (template_header);
 
   // Create the output image
+  template_header.datatype() = DataType::Float32;
+  template_header.datatype().set_byte_order_native();
   Image<float> output = Image<float>::create (argument[2], template_header);
 
   // Perform the partial volume estimation

--- a/lib/mrtrix3/_5ttgen/fsl.py
+++ b/lib/mrtrix3/_5ttgen/fsl.py
@@ -39,7 +39,7 @@ def getInputs():
 def execute():
   import os
   from distutils.spawn import find_executable
-  from mrtrix3 import app, file, fsl, image, run
+  from mrtrix3 import app, file, fsl, image, path, run
 
   if app.isWindows():
     app.error('\'fsl\' algorithm of 5ttgen script cannot be run on Windows: FSL not available on Windows')
@@ -165,7 +165,7 @@ def execute():
   first_input_is_brain_extracted = ''
   if app.args.premasked:
     first_input_is_brain_extracted = ' -b'
-  run.command(first_cmd + ' -s ' + ','.join(sgm_structures) + ' -i T1.nii -o first' + first_input_is_brain_extracted)
+  run.command(first_cmd + ' -m none -s ' + ','.join(sgm_structures) + ' -i T1.nii -o first' + first_input_is_brain_extracted)
 
   # Test to see whether or not FIRST has succeeded
   # However if the expected image is absent, it may be due to FIRST being run
@@ -175,7 +175,7 @@ def execute():
   if not os.path.isfile(combined_image_path):
     if 'SGE_ROOT' in os.environ:
       app.console('FSL FIRST job has been submitted to SGE; awaiting completion')
-      app.console('(note however that FIRST may fail, and hence this script may hang indefinitely)')
+      app.console('(note however that FIRST may fail silently, and hence this script may hang indefinitely)')
       file.waitFor(combined_image_path)
     else:
       app.error('FSL FIRST has failed; not all structures were segmented successfully (check ' + path.toTemp('first.logs', False) + ')')


### PR DESCRIPTION
- Disable boundary correction in FSL FIRST, since it not only does not influence the estimated surface meshes and hence the output of `5ttgen fsl`, but may also erroneously alter the name of the combined output image that is used to detect success or failure of the segmentation.
- Add missing "`from mrtrix3 import path`" call.
- In `mesh2pve`, ensure that the output image is floating-point.

Closes #1068.