### PR TITLE
Docs: Update advanced debugging page for 3.0_RC1

### DIFF
--- a/docs/troubleshooting/advanced_debugging.rst
+++ b/docs/troubleshooting/advanced_debugging.rst
@@ -21,24 +21,26 @@ resulting information. The instructions for doing so are below.
 3. Configure and compile *MRtrix3* in debug mode:
 
    ::
-   
-       ./configure -debug -assert debug; ./build debug
-       
-   Note that this compilation will reside *alongside* your existing *MRtrix3*
-   installation, but will not interfere with it in any way. Commands
-   that are compiled in debug mode will reside in the ``debug/bin``
-   directory.
+
+       ./build select debug
+       ./configure -debug -assert
+       ./build bin/command
+
+   Note that this process will move your existing *MRtrix3*
+   compilation into a temporary directory. This means that your
+   compiled binaries will no longer be in your PATH; but it also
+   means that later we can restore them quickly without re-compiling
+   all of *MRtrix3*. In addition, we only compile the command that we
+   need to test (replace "``command``" with the name of the command
+   you are testing).
 
 4. Execute the problematic command within ``gdb``:
 
    ::
    
-       gdb --args debug/bin/command (arguments) (-options) -debug
-       
-   Note that the version of the command that is compiled in debug mode
-   resides in the ``debug/bin`` directory; you must provide this full
-   path *explicitly* to ensure that this is the version of the command that
-   is executed. The preceding ``gdb --args`` at the beginning of the
+       gdb --args bin/command (arguments) (-options) -debug
+
+   The preceding ``gdb --args`` at the beginning of the
    line is simply the easiest way to execute the command within ``gdb``.
    Include all of the file paths, options etc. that you used previously
    when the problem occurred. It is also recommended to use the *MRtrix3*
@@ -47,9 +49,9 @@ resulting information. The instructions for doing so are below.
 
 5. If running on Windows, once ``gdb`` has loaded, type the following into
    the terminal:
-   
+
    ::
-   
+
        b abort
        b exit
 
@@ -78,8 +80,21 @@ resulting information. The instructions for doing so are below.
    run exceptionally slowly):
    
    ::
-   
-       valgrind debug/bin/command (arguments) (-options)
+
+       valgrind bin/command (arguments) (-options)
+      
+10. When you have finished debugging, restore your default *MRtrix3*
+    compilation:
+
+    ::
+    
+       ./build select default
+
+    Binaries compiled in debug mode run considerably slower than those
+    compiled using the default settings (even if not running within ``gdb``),
+    due to the inclusion of various symbols that assist in debugging and the
+    removal of various optimisations. Therefore it's best to restore the
+    default configuration for your ongoing use.
 
 We greatly appreciate any contribution that the community can make
 toward making *MRtrix3* as robust as possible, so please don't hesitate to

--- a/docs/troubleshooting/advanced_debugging.rst
+++ b/docs/troubleshooting/advanced_debugging.rst
@@ -13,7 +13,8 @@ resulting information. The instructions for doing so are below.
 1. If required, install ``gdb``; the
    `GNU Debugging Tool <https://www.gnu.org/software/gdb/>`_
    (specific instructions for this installation will depend on your
-   operating system)
+   operating system). If using macOS, the equivalent debugging tool
+   is ``lldb``, which comes with the installation of Xcode.
 
 2. *Make sure* you are using the most up-to-date *MRtrix3* code!
    (``git pull``)
@@ -39,9 +40,14 @@ resulting information. The instructions for doing so are below.
    ::
    
        gdb --args bin/command (arguments) (-options) -debug
+   
+   or ``lldb`` on macOS:
+   ::
+   
+       lldb -- bin/command (arguments) (-options) -debug
 
-   The preceding ``gdb --args`` at the beginning of the
-   line is simply the easiest way to execute the command within ``gdb``.
+   The preceding ``gdb --args`` or ``lldb --`` at the beginning of the
+   line is simply the easiest way to execute the command within ``gdb`` or ``lldb``.
    Include all of the file paths, options etc. that you used previously
    when the problem occurred. It is also recommended to use the *MRtrix3*
    ``-debug`` option so that *MRtrix3* produces more verbose information
@@ -59,10 +65,10 @@ resulting information. The instructions for doing so are below.
    from being terminated completely on an error, which would otherwise
    preclude debugging once an error is actually encountered.
 
-6. At the ``gdb`` terminal, type ``r`` and hit ENTER to run the command.
+6. At the ``gdb`` or ``lldb`` terminal, type ``r`` and hit ENTER to run the command.
 
-7. If an error is encountered, ``gdb`` will print an error, and then provide
-   a terminal with ``(gdb)`` shown on the left hand side. Type ``bt``
+7. If an error is encountered, ``gdb`` or ``lldb`` will print an error, and then provide
+   a terminal with ``(gdb)`` or ``(lldb)`` shown on the left hand side. Type ``bt``
    and hit ENTER: This stands for 'backtrace', and will print details on
    the internal code that was running when the problem occurred.
 
@@ -72,7 +78,7 @@ resulting information. The instructions for doing so are below.
    issue in the `Issues <https://github.com/MRtrix3/mrtrix3/issues>`__
    tracker for the GitHub repository.
 
-9. If ``gdb`` does not report any error, it is possible that a memory error
+9. If ``gdb`` or ``lldb`` does not report any error, it is possible that a memory error
    is occurring, but even the debug version of the software is not performing
    the necessary checks to detect it. If this is the case, you can also try
    using `Valgrind <http://valgrind.org/>`_, which will perform a more
@@ -91,7 +97,7 @@ resulting information. The instructions for doing so are below.
        ./build select default
 
     Binaries compiled in debug mode run considerably slower than those
-    compiled using the default settings (even if not running within ``gdb``),
+    compiled using the default settings (even if not running within ``gdb`` or ``lldb``),
     due to the inclusion of various symbols that assist in debugging and the
     removal of various optimisations. Therefore it's best to restore the
     default configuration for your ongoing use.


### PR DESCRIPTION
Triggered by [this post](http://community.mrtrix.org/t/error-segmentation-fault-invalid-memory-access/1071).

Is nice to have an up-to-date documentation page on debugging so that a link can be provided rather than having to repeat the details each time. However "Advanced debugging" documentation page was not updated to reflect changes to binary location and multi-build-configuration with `3.0_RC1`. 