### PR TITLE
RNG: use std::random_device on all platforms

### DIFF
--- a/core/math/rng.h
+++ b/core/math/rng.h
@@ -62,15 +62,8 @@ namespace MR
           if (from_env) 
             return to<std::mt19937::result_type> (from_env);
 
-#ifdef MRTRIX_WINDOWS
-          struct timeval tv;
-          gettimeofday (&tv, nullptr);
-          return tv.tv_sec ^ tv.tv_usec;
-#else 
-          // TODO check whether this does in fact work on Windows...
           std::random_device rd;
           return rd();
-#endif
         }
 
 


### PR DESCRIPTION
as discussed here:
http://community.mrtrix.org/t/tck2connectome-edge-statistic-sift2-questions/1059/5?u=jdtournier