### PR TITLE
dwi2mask: Fix for low image intensities

### DIFF
--- a/core/filter/dwi_brain_mask.h
+++ b/core/filter/dwi_brain_mask.h
@@ -81,17 +81,19 @@ namespace MR
             // Loop over each shell, including b=0, in turn
             DWI::Shells shells (grad);
             for (size_t s = 0; s != shells.count(); ++s) {
-              const DWI::Shell shell (shells[s]);
+              const DWI::Shell& shell (shells[s]);
 
               auto shell_image = Image<value_type>::scratch (header, "mean b=" + str(size_t(std::round(shell.get_mean()))) + " image");
 
               for (auto l = Loop (0, 3) (input, shell_image); l; ++l) {
-                value_type mean = 0;
+                default_type sum = 0.0;
                 for (vector<size_t>::const_iterator v = shell.get_volumes().begin(); v != shell.get_volumes().end(); ++v) {
                   input.index(3) = *v;
-                  mean += (input.value() < 0) ? 0 : input.value();
+                  const value_type value = input.value();
+                  if (value > value_type(0))
+                    sum += value;
                 }
-                shell_image.value() = mean / value_type(shell.count());
+                shell_image.value() = value_type(sum / default_type(shell.count()));
               }
               if (progress)
                 ++(*progress);


### PR DESCRIPTION
When an input DWI contains exceptionally low values (i.e. even in the b=0 volumes there's no voxels greater than 1.0), `dwi2mask` will provide an empty mask, which can cause errors at later steps (e.g. providing an empty processing mask to `eddy` in `dwipreproc`). Somehow, changing the syntax by which the sum of image intensities within a shell is calculated resolves the issue.

Thanks to Hamed Zivariadab for reporting the issue & providing data.

It's literally [this change](https://github.com/MRtrix3/mrtrix3/pull/1083/files#diff-3494ad7b6f68362ec038ded397892fd7L92) that fixes the issue... :man_shrugging: 