### PR TITLE
system-wide config file location can now be overridden by MRTRIX_CONFIGFILE environment variable

### DIFF
--- a/core/file/config.cpp
+++ b/core/file/config.cpp
@@ -32,17 +32,21 @@ namespace MR
 
     void Config::init ()
     {
-      if (Path::is_file (MRTRIX_SYS_CONFIG_FILE)) {
-        INFO ("reading config file \"" MRTRIX_SYS_CONFIG_FILE "\"...");
+      const char* sysconf_location = getenv ("MRTRIX_CONFIGFILE");
+      if (!sysconf_location) 
+        sysconf_location = MRTRIX_SYS_CONFIG_FILE;
+
+      if (Path::is_file (sysconf_location)) {
+        INFO (std::string("reading config file \"") + sysconf_location + "\"...");
         try {
-          KeyValue kv (MRTRIX_SYS_CONFIG_FILE);
+          KeyValue kv (sysconf_location);
           while (kv.next()) {
             config[kv.key()] = kv.value();
           }
         }
         catch (...) { }
       } else {
-        DEBUG ("No config file found at \"" MRTRIX_SYS_CONFIG_FILE "\"");
+        DEBUG (std::string ("No config file found at \"") + sysconf_location + "\"");
       }
 
       std::string path = Path::join (Path::home(), MRTRIX_USER_CONFIG_FILE);

--- a/core/file/config.cpp
+++ b/core/file/config.cpp
@@ -56,7 +56,7 @@ namespace MR
         }
         catch (...) { }
       } else {
-        DEBUG ("No config file found at \"" MRTRIX_USER_CONFIG_FILE "\"");
+        DEBUG ("No config file found at \"" + path + "\"");
       }
     }
 

--- a/lib/mrtrix3/app.py
+++ b/lib/mrtrix3/app.py
@@ -82,7 +82,7 @@ def init(author, synopsis):
   _workingDir = os.getcwd()
   # Load the MRtrix configuration files here, and create a dictionary
   # Load system config first, user second: Allows user settings to override
-  for path in [ os.path.join(os.path.sep, 'etc', 'mrtrix.conf'),
+  for path in [ os.environ.get ('MRTRIX_CONFIGFILE', os.path.join(os.path.sep, 'etc', 'mrtrix.conf')),
                 os.path.join(os.path.expanduser('~'), '.mrtrix.conf') ]:
     try:
       f = open (path, 'r')


### PR DESCRIPTION
This is prompted by a HPC sysadmin who prefers to keep all files related to a given package in a single location (likely to be a very common scenario). This is fine for everything apart from the config file, which is hard-coded to `/etc/mrtrix.conf`. It's difficult to see how the binaries could be modified to auto-detect the location of their config file, so it looks like an environment variable might be the only way to allow this. It's a trivial change, seems to work on my system.

Still need to fix up the scripts to match though...