### PR TITLE
Doxyfile: update input folders to list 'core' rather than 'lib'

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -161,7 +161,7 @@ STRIP_FROM_PATH        =
 # specify the list of include paths that are normally passed to the compiler
 # using the -I flag.
 
-STRIP_FROM_INC_PATH    = lib \
+STRIP_FROM_INC_PATH    = core \
                          src \
                          cmd
 
@@ -755,7 +755,7 @@ WARN_LOGFILE           =
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = lib \
+INPUT                  = core \
                          src
 
 # This tag can be used to specify the character encoding of the source files
@@ -792,8 +792,9 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = lib/file/nifti1.h \
-                         lib/file/mgh.h \
+EXCLUDE                = core/file/nifti1.h \
+                         core/file/mgh.h \
+                         core/file/json.h \
                          src/gui/opengl/gl_core_3_3.h
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or


### PR DESCRIPTION
The [developer documentation](http://www.mrtrix.org/developer-documentation/) is currently missing heaps of stuff since `lib/` has been moved to `core/`... 