### PR TITLE
Use tmp prefix in testing for population template

### DIFF
--- a/bin/population_template
+++ b/bin/population_template
@@ -59,7 +59,7 @@ except ImportError:
       fmt = [fmt, ] * ncol
       format = delimiter.join(fmt)
       for row in X:
-        fh.write((format % tuple(row) + '\n'))
+        fh.write((format % tuple(row) + '\n').encode (errors='ignore'))
     finally:
         fh.close()
 

--- a/testing/tests/population_template
+++ b/testing/tests/population_template
@@ -1,2 +1,2 @@
 population_template population_template/in tmp-population_template-out.mif.gz -type rigid_nonlinear -rigid_scale 0.2,0.3 -rigid_niter 20,20 -nl_scale 0.2,0.3 -nl_niter 1,1 -tempdir tmp-population_template -force 
-population_template population_template/in tmp-population_template-out.mif.gz -type nonlinear -nl_scale 0.2,0.3 -nl_niter 1,1 -tempdir tmp-population_template -force 
+population_template population_template/in tmp-population_template-out.mif.gz -type nonlinear -nl_scale 0.2,0.3 -nl_niter 1,1 -tempdir tmp-population_template2 -force 

--- a/testing/tests/population_template
+++ b/testing/tests/population_template
@@ -1,2 +1,2 @@
-population_template population_template/in population_template/out.mif.gz -type rigid_nonlinear -rigid_scale 0.2,0.3 -rigid_niter 20,20 -nl_scale 0.2,0.3 -nl_niter 1,1 -force && rm population_template/out.mif.gz  
-population_template population_template/in population_template/out.mif.gz -type nonlinear -nl_scale 0.2,0.3 -nl_niter 1,1 -force && rm population_template/out.mif.gz  
+population_template population_template/in tmp-population_template-out.mif.gz -type rigid_nonlinear -rigid_scale 0.2,0.3 -rigid_niter 20,20 -nl_scale 0.2,0.3 -nl_niter 1,1 -tempdir tmp-population_template -force 
+population_template population_template/in tmp-population_template-out.mif.gz -type nonlinear -nl_scale 0.2,0.3 -nl_niter 1,1 -tempdir tmp-population_template -force 


### PR DESCRIPTION
This had been bugging me for a while now, so I finally did something about it...

Issue was that `population_template` would invariably fail a test on my system. The issue was an incompatibility with Python3, due to writing a `str` to a binary file, without converting to `bytes` via `encode()` (fix in this pull request). What this did was to cause `population_template` to leave its temporary folder behind, and since that folder was not being deleted by `run_tests` either, this left untracked content in the testing repo, which would show up in the `git status` of the main repo. So I'd be doing `./run_tests` on a clean repo, and a subsequent `./build` would change the version string to add `-dirty` to it, simply because `population_template` had failed a test...

These changes rely on the fact that `run_tests` will clean up any files or folders that start with `tmp` - a feature that most tests rely on. Also, any files prefixed with `tmp` are ignored (or at least they should have been - just [fixed that too on the testing repo](https://github.com/MRtrix3/test_data/commit/5e0f3ccb63ef2bdea941092ccd017b4af94dcc5d)). So the output file and the (now explicitly named) temporary folder both now start with `tmp`, and there is no need to manually delete the output any more.