### PR TITLE
tcknormalise: fix extraneous NaN triplets in output

### DIFF
--- a/cmd/tcknormalise.cpp
+++ b/cmd/tcknormalise.cpp
@@ -65,9 +65,19 @@ class Warper { MEMALIGN(Warper)
       interp (warp) { }
 
     bool operator () (const TrackType& in, TrackType& out) {
-      out.resize (in.size());
-      for (size_t n = 0; n < in.size(); ++n) 
-        out[n] = pos(in[n]);
+      out.clear();
+      for (size_t n = 0; n < in.size(); ++n) {
+        auto vertex = pos(in[n]);
+        if (!vertex.allFinite()) {
+          if (out.empty())
+            continue;
+          if (!out.back().allFinite())
+            continue;
+        }
+        out.push_back (vertex);
+      }
+      if (!out.back().allFinite())
+        out.resize (out.size()-1);
       return true;
     }
 


### PR DESCRIPTION
This occurs when streamlines venture outside the deformation field, and causes additional empty streamlines to show up in output. As discussed in http://community.mrtrix.org/t/bug-in-tcknormalise-when-using-warpcorrect/1175

Not sold on merging to `master` on this one - happy to cherry-pick and create a fresh pull request to `dev` if this isn't felt sufficiently critical, it does modify behaviour slightly....