### PR TITLE
tckresample: Fix command exit on resampling error

### DIFF
--- a/cmd/tckresample.cpp
+++ b/cmd/tckresample.cpp
@@ -75,7 +75,8 @@ class Worker
         resampler (that.resampler->clone()) { }
 
     bool operator() (const Streamline<value_type>& in, Streamline<value_type>& out) const {
-      return (*resampler) (in, out);
+      (*resampler) (in, out);
+      return true;
     }
 
   private:


### PR DESCRIPTION
This command should, in all instances, be capable of proceeding regardless of the proportion of streamlines that can or can not be resampled based on user request.

As raised [here](http://community.mrtrix.org/t/coordinates-for-tckresample-for-along-tract-analysis/1179).