### PR TITLE
configure: handle path translation when importing settings from pkg-config

### DIFF
--- a/configure
+++ b/configure
@@ -485,6 +485,16 @@ def compare_version (needed, observed):
 
 
 
+
+
+
+def MSYS2_translate_path (path):
+  try:
+    return execute ([ 'cygpath.exe', '-w', path ], RuntimeError)[1]
+  except:
+    return path
+
+
 def get_flags (default=None, env=None, pkg_config_flags=None):
   """Return a list of the flags required for a given packagei
   
@@ -501,7 +511,7 @@ def get_flags (default=None, env=None, pkg_config_flags=None):
       flags = []
       for entry in shlex.split (execute ([ 'pkg-config' ] + pkg_config_flags.split(), RuntimeError)[1]):
         if entry.startswith ('-I'):
-          flags += [ '-isystem', entry[2:] ]
+          flags += [ '-isystem', MSYS2_translate_path (entry[2:]) ]
         else:
           flags += [ entry ]
       return flags
@@ -602,7 +612,7 @@ exe_suffix = ''
 lib_prefix = 'lib'
 
 system = platform.system().lower()
-if system.startswith('mingw') or system.startswith('msys'):
+if system.startswith('mingw') or system.startswith('msys') or system.startswith('windows'):
   system = 'windows'
 report ('Detecting OS: ' + system + '\n')
 if system == 'linux':


### PR DESCRIPTION
Proposed solution to the issue raised [here](http://community.mrtrix.org/t/configure-and-build-fails-on-windows-install/323/4?u=jdtournier) and [here](https://github.com/MRtrix3/mrtrix3/pull/1090#issuecomment-334740664). Turns out there's a `cygpath` executable provided with MSYS2 (actually part of cygwin) to translate paths, so all this does is try to use that to translate include paths... Seems to allow _MRtrix3_ to build properly using the MinGW version of python. 

Note this only translates header paths (i.e. starting with `-I`), not library search paths (which start with `-L`). Still, it builds fine with the default packages, so I've not done anything about it at this point. Worth bearing in mind for the future though...