### PR TITLE
dwigradcheck: Fix dwi2maskcall

### DIFF
--- a/bin/dwigradcheck
+++ b/bin/dwigradcheck
@@ -89,16 +89,18 @@ if not len(grad_mrtrix) == num_volumes:
 if not len(grad_fsl) == 3 or not len(grad_fsl[0]) == num_volumes:
   app.error('Internal error (inconsistent gradient table storage)')
 
-  
+
 # Generate a brain mask if we weren't provided with one
+# Note that gradient table must be explicitly loaded, since there may not
+#   be one in the image header (user may be relying on -grad or -fslgrad input options)
 if not os.path.exists('mask.mif'):
-  run.command('dwi2mask data.mif mask.mif')
+  run.command('dwi2mask data.mif mask.mif -grad grad.b')
 
 # How many tracks are we going to generate?
 number_option = ' -select ' + str(app.args.number)
 
 
-# 
+#
 # TODO What variations of gradient errors can we conceive?
 
 # Done:


### PR DESCRIPTION
In use case where input image header does not contain a gradient table, and user instead relies on the -grad or -fslgrad option, dwi2mask would fail due to the absence of a gradient table.
Instead have dwi2mask explicitly import from grad.b, which is guaranteed to exist regardless of how the baseline gradient table was provided.
No need to import the gradient table into the image header for the rest of the script, since tckgen is always run with an explicit -grad or -fslgrad option based on a permuted gradient table.
Supersedes #1151.