### PR TITLE
Ensure the MSY2 version of python is invoked on Windows

### DIFF
--- a/build
+++ b/build
@@ -80,7 +80,7 @@ OPTIONS
 import platform, sys, os, time, threading, subprocess, copy, codecs, glob, atexit, tempfile, shutil
 
 # on Windows, need to use MSYS2 version of python - not MinGW version:
-if sys.executable.lower().startswith('c:/'):
+if sys.executable[0].isalpha() and sys.executable[1] == ':':
   python_cmd = subprocess.check_output ([ 'cygpath.exe', '-w', '/usr/bin/python' ]).splitlines()[0].strip()
   sys.exit (subprocess.call ([ python_cmd ] + sys.argv))
 

--- a/build
+++ b/build
@@ -79,6 +79,11 @@ OPTIONS
 
 import platform, sys, os, time, threading, subprocess, copy, codecs, glob, atexit, tempfile, shutil
 
+# on Windows, need to use MSYS2 version of python - not MinGW version:
+if sys.executable.lower().startswith('c:/'):
+  python_cmd = subprocess.check_output ([ 'cygpath.exe', '-w', '/usr/bin/python' ]).splitlines()[0].strip()
+  sys.exit (subprocess.call ([ python_cmd ] + sys.argv))
+
 global todo, headers, object_deps, file_flags, lock, print_lock, stop, main_cindex
 global include_paths
 

--- a/configure
+++ b/configure
@@ -145,6 +145,11 @@ ENVIRONMENT VARIABLES
 
 import subprocess, sys, os, platform, tempfile, shutil, shlex, re, copy
 
+# on Windows, need to use MSYS2 version of python - not MinGW version:
+if sys.executable.lower().startswith('c:/'):
+  python_cmd = subprocess.check_output ([ 'cygpath.exe', '-w', '/usr/bin/python' ]).splitlines()[0].strip()
+  sys.exit (subprocess.call ([ python_cmd ] + sys.argv))
+
 
 debug = False
 asserts = False

--- a/configure
+++ b/configure
@@ -146,7 +146,7 @@ ENVIRONMENT VARIABLES
 import subprocess, sys, os, platform, tempfile, shutil, shlex, re, copy
 
 # on Windows, need to use MSYS2 version of python - not MinGW version:
-if sys.executable.lower().startswith('c:/'):
+if sys.executable[0].isalpha() and sys.executable[1] == ':':
   python_cmd = subprocess.check_output ([ 'cygpath.exe', '-w', '/usr/bin/python' ]).splitlines()[0].strip()
   sys.exit (subprocess.call ([ python_cmd ] + sys.argv))
 

--- a/set_path
+++ b/set_path
@@ -20,7 +20,7 @@
 import sys, os, platform, subprocess
 
 # on Windows, need to use MSYS2 version of python - not MinGW version:
-if sys.executable.lower().startswith('c:/'):
+if sys.executable[0].isalpha() and sys.executable[1] == ':':
   python_cmd = subprocess.check_output ([ 'cygpath.exe', '-w', '/usr/bin/python' ]).splitlines()[0].strip()
   sys.exit (subprocess.call ([ python_cmd ] + sys.argv))
 

--- a/set_path
+++ b/set_path
@@ -17,25 +17,18 @@
 # particular). This will not work for the C shell and derivatives. 
 
 
-import sys, os, platform, codecs
+import sys, os, platform, subprocess
+
+# on Windows, need to use MSYS2 version of python - not MinGW version:
+if sys.executable.lower().startswith('c:/'):
+  python_cmd = subprocess.check_output ([ 'cygpath.exe', '-w', '/usr/bin/python' ]).splitlines()[0].strip()
+  sys.exit (subprocess.call ([ python_cmd ] + sys.argv))
 
 # check whether we are in the right location:
-config_file = 'config'
-
-try:
-  # load config file:
-  exec (codecs.open (config_file, mode='r', encoding='utf-8').read())
-except IOError:
-  sys.stderr.write ('''no configuration file found!
-please run "./configure"  and "./build" prior to invoking this script
-
-''')
-  sys.exit (1)
-
 basedir = os.getcwd()
-if not os.path.isfile (os.path.join(basedir, 'bin', 'mrinfo'+exe_suffix)):
+if not os.path.isfile (os.path.join(basedir, 'bin', 'mrinfo')):
   basedir = os.path.dirname (os.path.abspath(__file__))
-  if not os.path.isfile (os.path.join(basedir, 'bin', 'mrinfo'+exe_suffix)):
+  if not os.path.isfile (os.path.join(basedir, 'bin', 'mrinfo')):
     print ('''
 ERROR: MRtrix3 executables not found in expected location.
 


### PR DESCRIPTION
OK, the fix I'd added in #1172 to allow `set_path` to run without error on Windows turns out to have been a dud - it runs, but it adds to the PATH using Windows paths and separator (i.e. `c:\blah` separated by `;`). Makes all but useless. Yet it runs correctly when invoked using the MSYS2-provided python executable - as do `configure` and `build`. 

So my thinking here is that we need to somehow force these scripts (and potentially all the others too) to use the MSYS2 python interpreter. One option is to modify the PATH to make sure `/usr/bin` is listed first, but given that this is set in the MSYS2-provided default `/etc/profile`, there's a good chance this might have unintended side effects - like using the wrong compiler if the user happened to have installed the MSYS2 version of GCC alongside the MinGW version. So I don't think that's an option. We could ask users to prefix all scripts with the appropriate interpreter, but somehow I don't think that forcing users to type e.g. `/usr/bin/python dwipreproc ...` is going to reduce the amount of traffic on the forum. Another potential option is to add our own wrapper script, which would ensure the correct version of python is invoked (very much like these changes), and then replace the shebang line in all scripts to use that - i.e. change from `#!/usr/bin/env python` to `#!/usr/bin/env mrtrix3_python_wrapper`. That's a potential solution, but it sounds a bit heavy for the non-Windows platforms. 

So what these changes do is detect when we are running within a MinGW python interpreter (the `sys.executable` string then starts with a Windows-style path), and if so, work out the correct location of the MSYS2 `/usr/bin/python` executable and invoke that with the original arguments. Seems to work fine on my system, and obsoletes both #1172 and #1160. 

So I think this is the simplest solution. It's not perfect by any stretch, of course:

- what if users don't have `/usr/bin/python`? Well, this being MSYS2, I think we can expect users to have installed the `python` package as directed in the instructions, which should ensure that it exists. And I don't expect many users to have particularly exotic setups - this is much more likely on macOS or Unix systems. 

- what if users have installed MSYS2 in a different location than `c:/`? Currently, we explicitly match for that, but I guess it would be trivial to match for `?:/` instead, with equivalent specificity. I might do that just for good measure.

- should we implement the equivalent changes to all the other scripts too? I have no evidence either way as to how well the other scripts will perform under a MinGW interpreter... Needs testing I suppose. 