### PR TITLE
Tractography::File::Writer: Fix weights output

### DIFF
--- a/cmd/connectome2tck.cpp
+++ b/cmd/connectome2tck.cpp
@@ -294,7 +294,7 @@ void run ()
               writer.add (one, two, prefix + str(one) + "-" + str(two) + ".tck", weights_prefix.size() ? (weights_prefix + str(one) + "-" + str(two) + ".csv") : "");
             }
           } else {
-            // Allow duplication of edges; want to have a set of files for each node
+            // Allow duplication of edges; want to have an exhaustive set of files for each node
             for (node_t two = first_node; two <= max_node_index; ++two)
               writer.add (one, two, prefix + str(one) + "-" + str(two) + ".tck", weights_prefix.size() ? (weights_prefix + str(one) + "-" + str(two) + ".csv") : "");
           }

--- a/src/dwi/tractography/connectome/extract.cpp
+++ b/src/dwi/tractography/connectome/extract.cpp
@@ -208,21 +208,13 @@ WriterExtraction::WriterExtraction (const Tractography::Properties& p, const vec
     exclusive (exclusive),
     keep_self (keep_self) { }
 
-WriterExtraction::~WriterExtraction()
-{
-  for (size_t i = 0; i != writers.size(); ++i) {
-    delete writers[i];
-    writers[i] = nullptr;
-  }
-}
-
 
 
 
 void WriterExtraction::add (const node_t node, const std::string& path, const std::string weights_path = "")
 {
-  selectors.push_back (Selector (node, keep_self));
-  writers.push_back (new Tractography::WriterUnbuffered<float> (path, properties));
+  selectors.emplace_back (Selector (node, keep_self));
+  writers.emplace_back (new Tractography::WriterUnbuffered<float> (path, properties));
   if (weights_path.size())
     writers.back()->set_weights_path (weights_path);
 }
@@ -230,8 +222,8 @@ void WriterExtraction::add (const node_t node, const std::string& path, const st
 void WriterExtraction::add (const node_t node_one, const node_t node_two, const std::string& path, const std::string weights_path = "")
 {
   if (keep_self || (node_one != node_two)) {
-    selectors.push_back (Selector (node_one, node_two));
-    writers.push_back (new Tractography::WriterUnbuffered<float> (path, properties));
+    selectors.emplace_back (Selector (node_one, node_two));
+    writers.emplace_back (new Tractography::WriterUnbuffered<float> (path, properties));
     if (weights_path.size())
       writers.back()->set_weights_path (weights_path);
   }
@@ -239,8 +231,8 @@ void WriterExtraction::add (const node_t node_one, const node_t node_two, const 
 
 void WriterExtraction::add (const vector<node_t>& list, const std::string& path, const std::string weights_path = "")
 {
-  selectors.push_back (Selector (list, exclusive, keep_self));
-  writers.push_back (new Tractography::WriterUnbuffered<float> (path, properties));
+  selectors.emplace_back (Selector (list, exclusive, keep_self));
+  writers.emplace_back (new Tractography::WriterUnbuffered<float> (path, properties));
   if (weights_path.size())
     writers.back()->set_weights_path (weights_path);
 }
@@ -250,10 +242,6 @@ void WriterExtraction::add (const vector<node_t>& list, const std::string& path,
 void WriterExtraction::clear()
 {
   selectors.clear();
-  for (size_t i = 0; i != writers.size(); ++i) {
-    delete writers[i];
-    writers[i] = NULL;
-  }
   writers.clear();
 }
 

--- a/src/dwi/tractography/connectome/extract.h
+++ b/src/dwi/tractography/connectome/extract.h
@@ -68,7 +68,7 @@ class Selector
 
 
 
-class WriterExemplars 
+class WriterExemplars
 { MEMALIGN(WriterExemplars)
   public:
     WriterExemplars (const Tractography::Properties&, const vector<node_t>&, const bool, const node_t, const vector<Eigen::Vector3f>&);
@@ -102,7 +102,6 @@ class WriterExtraction
 
   public:
     WriterExtraction (const Tractography::Properties&, const vector<node_t>&, const bool, const bool);
-    ~WriterExtraction();
 
     void add (const node_t, const std::string&, const std::string);
     void add (const node_t, const node_t, const std::string&, const std::string);
@@ -122,7 +121,7 @@ class WriterExtraction
     const bool exclusive;
     const bool keep_self;
     vector< Selector > selectors;
-    vector< Tractography::WriterUnbuffered<float>* > writers;
+    vector< std::unique_ptr< Tractography::WriterUnbuffered<float> > > writers;
     Tractography::Streamline<> empty_tck;
 
 };

--- a/src/dwi/tractography/file.h
+++ b/src/dwi/tractography/file.h
@@ -50,8 +50,8 @@ namespace MR
           virtual bool operator() (Streamline<ValueType>&) = 0;
           virtual ~ReaderInterface() { }
       };
-      
-      
+
+
       template <class ValueType>
       class WriterInterface
       { NOMEMALIGN
@@ -140,10 +140,10 @@ namespace MR
           //! takes care of byte ordering issues
 
             Eigen::Matrix<ValueType,3,1> get_next_point ()
-            { 
+            {
               using namespace ByteOrder;
               switch (dtype()) {
-                case DataType::Float32LE: 
+                case DataType::Float32LE:
                   {
                     float p[3];
                     in.read ((char*) p, sizeof (p));
@@ -265,7 +265,7 @@ namespace MR
 
               commit (buffer, tck.size()+1);
 
-              if (weights_name.size()) 
+              if (weights_name.size())
                 write_weights (str(tck.weight) + "\n");
 
               ++count;
@@ -280,7 +280,7 @@ namespace MR
             if (weights_name.size())
               throw Exception ("Cannot change output streamline weights file path");
             weights_name = path;
-            App::check_overwrite (name);
+            App::check_overwrite (weights_name);
             File::OFStream out (weights_name, std::ios::out | std::ios::binary | std::ios::trunc);
           }
 
@@ -296,7 +296,7 @@ namespace MR
           //! perform per-point byte-swapping if required
           void format_point (const vector_type& src, vector_type& dest) {
             using namespace ByteOrder;
-            if (dtype.is_little_endian()) 
+            if (dtype.is_little_endian())
               dest = { LE(src[0]), LE(src[1]), LE(src[2]) };
             else
               dest = { BE(src[0]), BE(src[1]), BE(src[2]) };
@@ -352,7 +352,7 @@ namespace MR
        * It also helps reduce file fragmentation when multiple processes write
        * to file concurrently. The size of the write-back buffer defaults to
        * 16MB, and can be set in the config file using the
-       * TrackWriterBufferSize field (in bytes). 
+       * TrackWriterBufferSize field (in bytes).
        * */
       template <typename ValueType = float>
         class Writer : public WriterUnbuffered<ValueType>
@@ -376,9 +376,9 @@ namespace MR
           //CONF The size of the write-back buffer (in bytes) to use when
           //CONF writing track files. MRtrix will store the output tracks in a
           //CONF relatively large buffer to limit the number of write() calls,
-          //CONF avoid associated issues such as file fragmentation. 
+          //CONF avoid associated issues such as file fragmentation.
           Writer (const std::string& file, const Properties& properties, size_t default_buffer_capacity = 16777216) :
-            WriterUnbuffered<ValueType> (file, properties), 
+            WriterUnbuffered<ValueType> (file, properties),
             buffer_capacity (File::Config::get_int ("TrackWriterBufferSize", default_buffer_capacity) / sizeof (vector_type)),
             buffer (new vector_type [buffer_capacity]),
             buffer_size (0) { }
@@ -416,7 +416,7 @@ namespace MR
           size_t buffer_size;
           std::string weights_buffer;
 
-          //! add point to buffer and increment buffer_size accordingly 
+          //! add point to buffer and increment buffer_size accordingly
           void add_point (const vector_type& p) {
             format_point (p, buffer[buffer_size++]);
           }


### PR DESCRIPTION
When creating an output weights file, the `App::check_overwrite()` function was erroneously being called using the path to the track file rather than the weights file (`src/dwi/tractography/file.h:283`). This would persistently fail, since the header of the track file would be created before the path to the output weights file was specified.

Also cleaned up some `connectome2tck` code to use smart pointers rather than C-style pointers.