### PR TITLE
allow quiet operation from environment variable MRTRIX_QUIET

### DIFF
--- a/core/app.cpp
+++ b/core/app.cpp
@@ -1087,6 +1087,10 @@ namespace MR
 #endif
 
       srand (time (nullptr));
+      
+
+      if (getenv ("MRTRIX_QUIET"))
+        log_level = 0;
     }
 
 


### PR DESCRIPTION
As [requested on the forum](http://community.mrtrix.org/t/mrtrix-redirect-output-and-error-to-a-file/314/7?u=jdtournier)...