### PR TITLE
Typo fix in warping_images_with_warps_from_other_packages

### DIFF
--- a/docs/spatial_normalisation/warping_images_with_warps_from_other_packages.rst
+++ b/docs/spatial_normalisation/warping_images_with_warps_from_other_packages.rst
@@ -13,7 +13,7 @@ However, you can also use :code:`mrtransform` to apply warps generated from othe
 
     for i in {0..2}; 
     do;
-      WarpImageMultiTransform 3 identity_warp${i}.nii mrtrix_warp{i}.nii -R template.nii ants_warp.nii ants_affine.txt;
+      WarpImageMultiTransform 3 identity_warp${i}.nii mrtrix_warp${i}.nii -R template.nii ants_warp.nii ants_affine.txt;
     done;
 
 


### PR DESCRIPTION
Fixes typo in command line reported [here](http://community.mrtrix.org/t/cross-correlation-metric-as-in-raffelt-et-al-2011/1263/3).