### PR TITLE
delay signal handling initialisation

### DIFF
--- a/core/app.cpp
+++ b/core/app.cpp
@@ -20,6 +20,7 @@
 #include "progressbar.h"
 #include "file/path.h"
 #include "file/config.h"
+#include "signal_handler.h"
 
 #define MRTRIX_HELP_COMMAND "less -X"
 
@@ -79,8 +80,6 @@ namespace MR
 
     const char* project_version = nullptr;
     const char* build_date = __DATE__;
-
-    SignalHandler signal_handler;
 
     int argc = 0;
     const char* const* argv = nullptr;
@@ -1062,6 +1061,7 @@ namespace MR
         }
       }
 
+      SignalHandler::init();
     }
 
 

--- a/core/app.h
+++ b/core/app.h
@@ -24,7 +24,6 @@
 #endif
 
 #include "cmdline_option.h"
-#include "signal_handler.h"
 #include "types.h"
 #include "file/path.h"
 
@@ -51,8 +50,6 @@ namespace MR
 
     extern const char* project_version;
     extern const char* build_date;
-
-    extern SignalHandler signal_handler;
 
 
     const char* argtype_description (ArgType type);

--- a/core/formats/pipe.cpp
+++ b/core/formats/pipe.cpp
@@ -12,7 +12,7 @@
  */
 
 
-#include "app.h"
+#include "signal_handler.h"
 #include "file/utils.h"
 #include "file/path.h"
 #include "header.h"
@@ -39,7 +39,7 @@ namespace MR
       if (H.name().empty())
         throw Exception ("no filename supplied to standard input (broken pipe?)");
 
-      App::signal_handler += H.name();
+      SignalHandler::mark_file_for_deletion (H.name());
 
       if (!Path::has_suffix (H.name(), ".mif"))
         throw Exception ("MRtrix only supports the .mif format for command-line piping");
@@ -60,7 +60,7 @@ namespace MR
 
       H.name() = File::create_tempfile (0, "mif");
 
-      App::signal_handler += H.name();
+      SignalHandler::mark_file_for_deletion (H.name());
 
       return mrtrix_handler.check (H, num_axes);
     }

--- a/core/image_io/pipe.cpp
+++ b/core/image_io/pipe.cpp
@@ -15,7 +15,7 @@
 #include <limits>
 #include <unistd.h>
 
-#include "app.h"
+#include "signal_handler.h"
 #include "header.h"
 #include "image_io/pipe.h"
 
@@ -54,7 +54,7 @@ namespace MR
       if (!is_new && files.size() == 1) {
         DEBUG ("deleting piped image file \"" + files[0].name + "\"...");
         unlink (files[0].name.c_str());
-        App::signal_handler -= files[0].name;
+        SignalHandler::unmark_file_for_deletion (files[0].name);
       }
 
     }

--- a/core/signal_handler.cpp
+++ b/core/signal_handler.cpp
@@ -17,6 +17,8 @@
 #include <cstdlib>
 #include <iostream>
 #include <signal.h>
+#include <atomic>
+#include <vector>
 
 #include "exception.h"
 #include "file/path.h"
@@ -28,92 +30,103 @@
 
 namespace MR
 {
+  namespace SignalHandler {
 
-  std::vector<std::string> SignalHandler::data;
-  std::atomic_flag SignalHandler::flag = ATOMIC_FLAG_INIT;
+    namespace {
+      std::vector<std::string> marked_files;
+      std::atomic_flag flag = ATOMIC_FLAG_INIT;
 
-  SignalHandler::SignalHandler()
-  {
+
+
+
+      void handler (int i) noexcept
+      {
+        // Only process this once if using multi-threading:
+        if (!flag.test_and_set()) {
+
+          // Try to do a tempfile cleanup before printing the error, since the latter's not guaranteed to work...
+          // Don't use File::unlink: may throw an exception
+          for (const auto& i : marked_files) 
+            ::unlink (i.c_str());
+
+
+          const char* sig = nullptr;
+          const char* msg = nullptr;
+          switch (i) {
+
+#define __SIGNAL(SIG,MSG) case SIG: sig = #SIG; msg = MSG; break; 
+#include "signals.h"
+#undef __SIGNAL
+
+            default:
+              sig = "UNKNOWN"; 
+              msg = "Unknown fatal system signal";
+              break;
+          }
+
+          // Don't use std::cerr << here: Use basic C string-handling functions and a write() call to STDERR_FILENO
+          // Don't attempt to use any terminal colouring
+          char str[256];
+          str[255] = '\0';
+          snprintf (str, 255, "\n%s: [SYSTEM FATAL CODE: %s (%d)] %s\n", App::NAME.c_str(), sig, i, msg);
+          if (write (STDERR_FILENO, str, strnlen(str,256)) == 0)
+            std::_Exit (i);
+          else
+            std::_Exit (i);
+        }
+      }
+
+    }
+
+
+
+
+
+
+
+
+
+    void init()
+    {
 #ifdef MRTRIX_WINDOWS
-    // Use signal() rather than sigaction() for Windows, as the latter is not supported
+      // Use signal() rather than sigaction() for Windows, as the latter is not supported
 # define __SIGNAL(SIG,MSG) signal (SIG, handler)
 #else
-    // Construct the signal structure
-    struct sigaction act;
-    act.sa_handler = &handler;
-    // Since we're _Exit()-ing for any of these signals, block them all
-    sigfillset (&act.sa_mask);
-    act.sa_flags = 0;
+      // Construct the signal structure
+      struct sigaction act;
+      act.sa_handler = &handler;
+      // Since we're _Exit()-ing for any of these signals, block them all
+      sigfillset (&act.sa_mask);
+      act.sa_flags = 0;
 # define __SIGNAL(SIG,MSG) sigaction (SIG, &act, nullptr)
 #endif
 
 #include "signals.h"
-
-#undef __SIGNAL
-  }
-
-
-
-
-  void SignalHandler::operator+= (const std::string& s)
-  {
-    while (!flag.test_and_set());
-    data.push_back (s);
-    flag.clear();
-  }
-
-  void SignalHandler::operator-= (const std::string& s)
-  {
-    while (!flag.test_and_set());
-    auto i = data.begin();
-    while (i != data.end()) {
-      if (*i == s)
-        i = data.erase (i);
-      else
-        ++i;
     }
-    flag.clear();
-  }
 
 
 
 
-  void SignalHandler::handler (int i) noexcept
-  {
-    // Only process this once if using multi-threading:
-    if (!flag.test_and_set()) {
+    void mark_file_for_deletion (const std::string& s)
+    {
+      while (!flag.test_and_set());
+      marked_files.push_back (s);
+      flag.clear();
+    }
 
-      // Try to do a tempfile cleanup before printing the error, since the latter's not guaranteed to work...
-      // Don't use File::unlink: may throw an exception
-      for (const auto& i : data) 
-        ::unlink (i.c_str());
-
-
-      const char* sig = nullptr;
-      const char* msg = nullptr;
-      switch (i) {
-
-#define __SIGNAL(SIG,MSG) case SIG: sig = #SIG; msg = MSG; break; 
-#include "signals.h"
-
-        default:
-          sig = "UNKNOWN"; 
-          msg = "Unknown fatal system signal";
-          break;
+    void unmark_file_for_deletion (const std::string& s)
+    {
+      while (!flag.test_and_set());
+      auto i = marked_files.begin();
+      while (i != marked_files.end()) {
+        if (*i == s)
+          i = marked_files.erase (i);
+        else
+          ++i;
       }
-
-      // Don't use std::cerr << here: Use basic C string-handling functions and a write() call to STDERR_FILENO
-      // Don't attempt to use any terminal colouring
-      char str[256];
-      str[255] = '\0';
-      snprintf (str, 255, "\n%s: [SYSTEM FATAL CODE: %s (%d)] %s\n", App::NAME.c_str(), sig, i, msg);
-      if (write (STDERR_FILENO, str, strnlen(str,256)) == 0)
-        std::_Exit (i);
-      else
-        std::_Exit (i);
+      flag.clear();
     }
+
   }
-
-
-
 }
+

--- a/core/signal_handler.h
+++ b/core/signal_handler.h
@@ -15,35 +15,16 @@
 #ifndef __signal_handler_h__
 #define __signal_handler_h__
 
-#include <atomic>
 #include <string>
-#include <vector>
 
 namespace MR
 {
-
-
-
-  class SignalHandler
+  namespace SignalHandler
   { 
-    public:
-      SignalHandler();
-      SignalHandler (const SignalHandler&) = delete;
-
-      void operator+= (const std::string&);
-      void operator-= (const std::string&);
-
-    private:
-      static std::vector<std::string> data;
-      static std::atomic_flag flag;
-
-      static void on_exit() noexcept;
-      static void handler (int) noexcept;
-
-  };
-
-
-
+      void init(); 
+      void mark_file_for_deletion (const std::string&);
+      void unmark_file_for_deletion (const std::string&);
+  }
 }
 
 #endif


### PR DESCRIPTION
Someone just brought to my attention the fact that pressing Ctrl-C while a help page is displayed in the terminal renders the display unusable. I'm not sure why, but the terminal is left in a strange state, with typed commands not showing... You can see that the interrupt is handled by the invoking MRtrix command though, not the page display command (i.e. not `less`): our signal handling message pops up. 

So I figured the simplest fix was to delay setting our custom signal handlers until _after_ the command-line parsing has been done, particularly the handling of the help page. This seems to more or less fix it. 

The cleaner solution would be to have the invoking MRtrix command actually exit as soon as it's done piping its help page contents to the display command, but that turns out to be basically impossible using `popen()`, or even using an explicit `pipe()` & `fork()` - the process writing to the pipe needs to wait for the child process to finish. This seems to differ from explicitly invoking the pipe at the command-line: in this case, it seems the feeding process exits when it's done - or at least the interrupt does not get passed to the feeding process, but to the last one, not sure. For example:
```
mrinfo > help.txt
cat help.txt | less -X
```
and pressing Ctrl-C does not result in `less` terminating - far from it, it seems to handles the interrupt itself. So there's a difference between the `popen()` call and what the shell does to set up pipes... More trouble than it's worth though, so I think I'll stick with this simple solution... 

Thoughts welcome.