### PR TITLE
average_response: Bug fix

### DIFF
--- a/bin/average_response
+++ b/bin/average_response
@@ -32,7 +32,8 @@ for i in range(1, num_subjects + 1):
 
 sys.stdout.write("Number of b-values: " + str(num_bvals) + '\n')
 
-average_response = [[0] * num_coeff] * num_bvals
+# Can't use multiplication operator in outer loop since it duplicates by reference rather than value
+average_response = [[0] * num_coeff for _ in range(num_bvals)]
 for i in range(1, num_subjects + 1):
   with open(sys.argv[i], 'r') as f:
     lines = f.readlines()

--- a/bin/average_response
+++ b/bin/average_response
@@ -33,7 +33,7 @@ for i in range(1, num_subjects + 1):
 sys.stdout.write("Number of b-values: " + str(num_bvals) + '\n')
 
 # Can't use multiplication operator in outer loop since it duplicates by reference rather than value
-average_response = [[0] * num_coeff for _ in range(num_bvals)]
+average_response = [[0] * num_coeff for _ in range(num_bvals)] #pylint: disable=unused-variable
 for i in range(1, num_subjects + 1):
   with open(sys.argv[i], 'r') as f:
     lines = f.readlines()


### PR DESCRIPTION
Issue introduced in #1098.
Duplication of list rows using the '*' operator generates duplicate references to the first line, not duplicates of the first line contents; hence any modification to a value would be reflected synchronously across _all_ lines.
Closes #1216.