### PR TITLE
5tt2gmwmi: Fix -mask option

### DIFF
--- a/cmd/5tt2gmwmi.cpp
+++ b/cmd/5tt2gmwmi.cpp
@@ -124,7 +124,7 @@ void run ()
   Image<bool> mask;
   auto opt = get_options ("mask_in");
   if (opt.size()) {
-    mask.open (opt[0][0]);
+    mask = Image<bool>::open (opt[0][0]);
     if (!dimensions_match (input, mask, 0, 3))
       throw Exception ("Mask image provided using the -mask option must match the input 5TT image");
   }


### PR DESCRIPTION
Error was made in porting to new syntax as part of 0.3.14, within commit ec49edcaf.

(Pretty sure this would have been one of the very first commands I ported...)