### PR TITLE
App: New argument types for input/output directories

### DIFF
--- a/cmd/fixelcfestats.cpp
+++ b/cmd/fixelcfestats.cpp
@@ -74,7 +74,7 @@ void usage ()
     "NeuroImage, 2011, 54(3), 2006-19\n" ;
 
   ARGUMENTS
-  + Argument ("in_fixel_directory", "the fixel directory containing the data files for each subject (after obtaining fixel correspondence").type_file_in ()
+  + Argument ("in_fixel_directory", "the fixel directory containing the data files for each subject (after obtaining fixel correspondence").type_directory_in()
 
   + Argument ("subjects", "a text file listing the subject identifiers (one per line). This should correspond with the filenames "
                           "in the fixel directory (including the file extension), and be listed in the same order as the rows of the design matrix.").type_image_in ()

--- a/cmd/fixelcorrespondence.cpp
+++ b/cmd/fixelcorrespondence.cpp
@@ -37,8 +37,8 @@ void usage ()
 
   ARGUMENTS
   + Argument ("subject_data", "the input subject fixel data file. This should be a file inside the fixel directory").type_image_in ()
-  + Argument ("template_directory", "the input template fixel directory.").type_image_in ()
-  + Argument ("output_directory", "the output fixel directory.").type_text()
+  + Argument ("template_directory", "the input template fixel directory.").type_directory_in()
+  + Argument ("output_directory", "the fixel directory where the output file will be written.").type_text()
   + Argument ("output_data", "the name of the output fixel data file. This will be placed in the output fixel directory").type_image_out ();
 
   OPTIONS

--- a/cmd/fixelcrop.cpp
+++ b/cmd/fixelcrop.cpp
@@ -37,10 +37,10 @@ void usage ()
 
   ARGUMENTS
   + Argument ("input_fixel_directory", "input fixel directory, all data files and directions "
-                                       "file will be cropped and saved in the output fixel directory").type_text ()
+                                       "file will be cropped and saved in the output fixel directory").type_directory_in()
   + Argument ("input_fixel_mask", "the input fixel data file defining which fixels to crop. "
                                   "Fixels with zero values will be removed").type_image_in ()
-  + Argument ("output_fixel_directory", "the output directory to store the cropped directions and data files").type_text ();
+  + Argument ("output_fixel_directory", "the output directory to store the cropped directions and data files").type_directory_out();
 }
 
 

--- a/cmd/fixelreorient.cpp
+++ b/cmd/fixelreorient.cpp
@@ -38,13 +38,13 @@ void usage ()
     "then re-normalising the vector.";
 
   ARGUMENTS
-  + Argument ("fixel_in", "the fixel directory").type_text ()
+  + Argument ("fixel_in", "the input fixel directory").type_directory_in()
   + Argument ("warp", "a 4D deformation field used to perform reorientation. "
                       "Reorientation is performed by applying the Jacobian affine transform in each voxel in the warp, "
                       "then re-normalising the vector representing the fixel direction").type_image_in ()
-  + Argument ("fixel_out", "the output fixel directory. If the the input and output directorys are the same, the existing directions file will "
-                           "be replaced (providing the --force option is supplied). If a new directory is supplied then the fixel directions and all "
-                           "other fixel data will be copied to the new directory.").type_text ();
+  + Argument ("fixel_out", "the output fixel directory. If the the input and output directories are the same, the existing directions file will "
+                           "be replaced (providing the -force option is supplied). If a new directory is supplied then the fixel directions and all "
+                           "other fixel data will be copied to the new directory.").type_text();
 }
 
 

--- a/cmd/fod2fixel.cpp
+++ b/cmd/fod2fixel.cpp
@@ -77,7 +77,7 @@ void usage ()
 
   ARGUMENTS
   + Argument ("fod", "the input fod image.").type_image_in ()
-  + Argument ("fixel_directory", "the output fixel directory").type_text();
+  + Argument ("fixel_directory", "the output fixel directory").type_directory_out();
 
 
   OPTIONS

--- a/cmd/tck2fixel.cpp
+++ b/cmd/tck2fixel.cpp
@@ -96,8 +96,8 @@ void usage ()
 
   ARGUMENTS
   + Argument ("tracks",  "the input tracks.").type_tracks_in()
-  + Argument ("fixel_folder_in", "the input fixel folder. Used to define the fixels and their directions").type_text()
-  + Argument ("fixel_folder_out", "the output fixel folder. This can be the same as the input folder if desired").type_text()
+  + Argument ("fixel_folder_in", "the input fixel folder. Used to define the fixels and their directions").type_directory_in()
+  + Argument ("fixel_folder_out", "the fixel folder to which the output will be written. This can be the same as the input folder if desired").type_text()
   + Argument ("fixel_data_out", "the name of the fixel data image.").type_image_out();
 
   OPTIONS

--- a/cmd/voxel2fixel.cpp
+++ b/cmd/voxel2fixel.cpp
@@ -36,9 +36,9 @@ void usage ()
   + "This command is designed to enable CFE-based statistical analysis to be performed on voxel-wise measures.";
 
   ARGUMENTS
-  + Argument ("image_in",  "the input image.").type_image_in()
-  + Argument ("fixel_directory_in",  "the input fixel directory. Used to define the fixels and their directions").type_text()
-  + Argument ("fixel_directory_out", "the output fixel directory. This can be the same as the input directory if desired").type_text()
+  + Argument ("image_in", "the input image.").type_image_in()
+  + Argument ("fixel_directory_in",  "the input fixel directory. Used to define the fixels and their directions").type_directory_in()
+  + Argument ("fixel_directory_out", "the fixel directory where the output will be written. This can be the same as the input directory if desired").type_text()
   + Argument ("fixel_data_out", "the name of the fixel data image.").type_image_out();
 }
 

--- a/core/app.cpp
+++ b/core/app.cpp
@@ -1076,11 +1076,6 @@ namespace MR
           throw Exception ("input file \"" + text + "\" is not a valid track file");
         if (i.arg->type == TracksOut && !Path::has_suffix (text, ".tck"))
           throw Exception ("output track file \"" + text + "\" must use the .tck suffix");
-        if (i.arg->type == ArgDirectoryOut) {
-          const std::string base_name = Path::basename (text);
-          if (base_name.find (".") != std::string::npos)
-            throw Exception ("output path \"" + text + "\" is not a valid directory path (contains a \'.\')");
-        }
       }
       for (const auto& i : option) {
         for (size_t j = 0; j != i.opt->size(); ++j) {
@@ -1109,11 +1104,6 @@ namespace MR
             throw Exception ("input file \"" + text + "\" for option \"-" + std::string(i.opt->id) + "\" is not a valid track file");
           if (arg.type == TracksOut && !Path::has_suffix (text, ".tck"))
             throw Exception ("output track file \"" + text + "\" for option \"-" + std::string(i.opt->id) + "\" must use the .tck suffix");
-          if (arg.type == ArgDirectoryOut) {
-            const std::string base_name = Path::basename (text);
-            if (base_name.find (".") != std::string::npos)
-              throw Exception ("output path \"" + text + "\" for option \"-" + std::string(i.opt->id) + "\" is not a valid directory path (contains a \'.\')");
-          }
         }
       }
 

--- a/core/app.cpp
+++ b/core/app.cpp
@@ -183,6 +183,10 @@ namespace MR
           return ("file in");
         case ArgFileOut:
           return ("file out");
+        case ArgDirectoryIn:
+          return ("directory in");
+        case ArgDirectoryOut:
+          return ("directory out");
         case ImageIn:
           return ("image in");
         case ImageOut:
@@ -429,6 +433,12 @@ namespace MR
           break;
         case ArgFileOut:
           stream << "FILEOUT";
+          break;
+        case ArgDirectoryIn:
+          stream << "DIRIN";
+          break;
+        case ArgDirectoryOut:
+          stream << "DIROUT";
           break;
         case Choice:
           stream << "CHOICE";
@@ -1042,27 +1052,68 @@ namespace MR
       // if necessary, also check for pre-existence of any output files with known paths
       //   (if the output is e.g. given as a prefix, the argument should be flagged as type_text())
       for (const auto& i : argument) {
-        if ((i.arg->type == ArgFileIn || i.arg->type == TracksIn) && !Path::exists (std::string(i)))
-          throw Exception ("required input file \"" + str(i) + "\" not found");
-        if (i.arg->type == ArgFileOut || i.arg->type == TracksOut)
-          check_overwrite (std::string(i));
-        if (i.arg->type == TracksIn && !Path::has_suffix (str(i), ".tck"))
-          throw Exception ("input file " + str(i) + " is not a valid track file");
-        if (i.arg->type == TracksOut && !Path::has_suffix (str(i), ".tck"))
-          throw Exception ("output track file (" + str(i) + ") must use the .tck suffix");
+        const std::string text = std::string (i);
+        if (i.arg->type == ArgFileIn || i.arg->type == TracksIn) {
+          if (!Path::exists (text))
+            throw Exception ("required input file \"" + text + "\" not found");
+          if (!Path::is_file (text))
+            throw Exception ("required input \"" + text + "\" is not a file");
+        }
+        if (i.arg->type == ArgDirectoryIn) {
+          if (!Path::exists (text))
+            throw Exception ("required input directory \"" + text + "\" not found");
+          if (!Path::is_dir (text))
+            throw Exception ("required input \"" + text + "\" is not a directory");
+        }
+        if (i.arg->type == ArgFileOut || i.arg->type == TracksOut) {
+          if (text.find_last_of (PATH_SEPARATOR) == text.size() - std::string(PATH_SEPARATOR).size())
+            throw Exception ("output path \"" + std::string(i) + "\" is not a valid file path (ends with \'" PATH_SEPARATOR "\")");
+          check_overwrite (text);
+        }
+        if (i.arg->type == ArgDirectoryOut)
+          check_overwrite (text);
+        if (i.arg->type == TracksIn && !Path::has_suffix (text, ".tck"))
+          throw Exception ("input file \"" + text + "\" is not a valid track file");
+        if (i.arg->type == TracksOut && !Path::has_suffix (text, ".tck"))
+          throw Exception ("output track file \"" + text + "\" must use the .tck suffix");
+        if (i.arg->type == ArgDirectoryOut) {
+          const std::string base_name = Path::basename (text);
+          if (base_name.find (".") != std::string::npos)
+            throw Exception ("output path \"" + text + "\" is not a valid directory path (contains a \'.\')");
+        }
       }
       for (const auto& i : option) {
         for (size_t j = 0; j != i.opt->size(); ++j) {
           const Argument& arg = i.opt->operator [](j);
-          const char* const name = i.args[j];
-          if ((arg.type == ArgFileIn || arg.type == TracksIn) && !Path::exists (name))
-            throw Exception ("input file \"" + str(name) + "\" not found (required for option \"-" + std::string(i.opt->id) + "\")");
-          if (arg.type == ArgFileOut || arg.type == TracksOut)
-            check_overwrite (name);
-          if (arg.type == TracksIn && !Path::has_suffix (str(name), ".tck"))
-            throw Exception ("input file " + str(name) + " is not a valid track file");
-          if (arg.type == TracksOut && !Path::has_suffix (str(name), ".tck"))
-            throw Exception ("output track file (" + str(name) + ") must use the .tck suffix");
+          const std::string text = std::string (i.args[j]);
+          if (arg.type == ArgFileIn || arg.type == TracksIn) {
+            if (!Path::exists (text))
+              throw Exception ("input file \"" + text + "\" for option \"-" + std::string(i.opt->id) + "\" not found");
+            if (!Path::is_file (text))
+              throw Exception ("input \"" + text + "\" for option \"-" + std::string(i.opt->id) + "\" is not a file");
+          }
+          if (arg.type == ArgDirectoryIn) {
+            if (!Path::exists (text))
+              throw Exception ("input directory \"" + text + "\" for option \"-" + std::string(i.opt->id) + "\" not found");
+            if (!Path::is_dir (text))
+              throw Exception ("input \"" + text + "\" for option \"-" + std::string(i.opt->id) + "\" is not a directory");
+          }
+          if (arg.type == ArgFileOut || arg.type == TracksOut) {
+            if (text.find_last_of (PATH_SEPARATOR) == text.size() - std::string (PATH_SEPARATOR).size())
+              throw Exception ("output path \"" + text + "\" for option \"-" + std::string(i.opt->id) + "\" is not a valid file path (ends with \'" PATH_SEPARATOR "\")");
+            check_overwrite (text);
+          }
+          if (arg.type == ArgDirectoryOut)
+            check_overwrite (text);
+          if (arg.type == TracksIn && !Path::has_suffix (text, ".tck"))
+            throw Exception ("input file \"" + text + "\" for option \"-" + std::string(i.opt->id) + "\" is not a valid track file");
+          if (arg.type == TracksOut && !Path::has_suffix (text, ".tck"))
+            throw Exception ("output track file \"" + text + "\" for option \"-" + std::string(i.opt->id) + "\" must use the .tck suffix");
+          if (arg.type == ArgDirectoryOut) {
+            const std::string base_name = Path::basename (text);
+            if (base_name.find (".") != std::string::npos)
+              throw Exception ("output path \"" + text + "\" for option \"-" + std::string(i.opt->id) + "\" is not a valid directory path (contains a \'.\')");
+          }
         }
       }
 

--- a/core/cmdline_option.h
+++ b/core/cmdline_option.h
@@ -48,6 +48,8 @@ namespace MR
       Float,
       ArgFileIn,
       ArgFileOut,
+      ArgDirectoryIn,
+      ArgDirectoryOut,
       Choice,
       ImageIn,
       ImageOut,
@@ -76,7 +78,7 @@ namespace MR
      *
      * The list of arguments is provided by adding to the ARGUMENTS vector, like this:
      * \code
-     * ARGUMENTS 
+     * ARGUMENTS
      *   + Argument ("input", "the input image")
      *     .type_image_in()
      *
@@ -240,6 +242,20 @@ namespace MR
           return *this;
         }
 
+        //! specifies that the argument should be an input directory
+        Argument& type_directory_in () {
+          assert (type == Undefined);
+          type = ArgDirectoryIn;
+          return *this;
+        }
+
+        //! specifies that the argument should be an output directory
+        Argument& type_directory_out () {
+          assert (type == Undefined);
+          type = ArgDirectoryOut;
+          return *this;
+        }
+
         //! specifies that the argument should be a sequence of comma-separated integer values
         Argument& type_sequence_int () {
           assert (type == Undefined);
@@ -287,7 +303,7 @@ namespace MR
      * The list of options is provided using the OPTIONS macro, like this:
      * \code
      * OPTIONS
-     *   + Option ("exact", 
+     *   + Option ("exact",
      *        "do not use approximations when processing")
      *
      *   + Option ("mask",
@@ -295,11 +311,11 @@ namespace MR
      *        "the binary image specified")
      *     + Argument ("image").type_image_in()
      *
-     *   + Option ("regularisation", 
+     *   + Option ("regularisation",
      *        "set the regularisation term")
      *     + Argument ("value").type_float (0.0, 1.0, 100.0)
      *
-     *   Option ("dump", 
+     *   Option ("dump",
      *        "dump all intermediate values to file")
      *     + Argument ("file").type_file();
      * \endcode
@@ -389,18 +405,18 @@ namespace MR
      *   + Option ("option2", ...);
      * }
      * \endcode
-     */  
+     */
     class OptionGroup : public vector<Option> { NOMEMALIGN
       public:
         OptionGroup (const char* group_name = "OPTIONS") : name (group_name) { }
         const char* name;
 
-        OptionGroup& operator+ (const Option& option) { 
+        OptionGroup& operator+ (const Option& option) {
           push_back (option);
           return *this;
         }
 
-        OptionGroup& operator+ (const Argument& argument) { 
+        OptionGroup& operator+ (const Argument& argument) {
           assert (!empty());
           back() + argument;
           return *this;

--- a/docs/reference/commands/fixelcorrespondence.rst
+++ b/docs/reference/commands/fixelcorrespondence.rst
@@ -17,7 +17,7 @@ Usage
 
 -  *subject_data*: the input subject fixel data file. This should be a file inside the fixel directory
 -  *template_directory*: the input template fixel directory.
--  *output_directory*: the output fixel directory.
+-  *output_directory*: the fixel directory where the output file will be written.
 -  *output_data*: the name of the output fixel data file. This will be placed in the output fixel directory
 
 Description

--- a/docs/reference/commands/fixelreorient.rst
+++ b/docs/reference/commands/fixelreorient.rst
@@ -15,9 +15,9 @@ Usage
 
     fixelreorient [ options ]  fixel_in warp fixel_out
 
--  *fixel_in*: the fixel directory
+-  *fixel_in*: the input fixel directory
 -  *warp*: a 4D deformation field used to perform reorientation. Reorientation is performed by applying the Jacobian affine transform in each voxel in the warp, then re-normalising the vector representing the fixel direction
--  *fixel_out*: the output fixel directory. If the the input and output directorys are the same, the existing directions file will be replaced (providing the --force option is supplied). If a new directory is supplied then the fixel directions and all other fixel data will be copied to the new directory.
+-  *fixel_out*: the output fixel directory. If the the input and output directories are the same, the existing directions file will be replaced (providing the -force option is supplied). If a new directory is supplied then the fixel directions and all other fixel data will be copied to the new directory.
 
 Description
 -----------

--- a/docs/reference/commands/tck2fixel.rst
+++ b/docs/reference/commands/tck2fixel.rst
@@ -17,7 +17,7 @@ Usage
 
 -  *tracks*: the input tracks.
 -  *fixel_folder_in*: the input fixel folder. Used to define the fixels and their directions
--  *fixel_folder_out*: the output fixel folder. This can be the same as the input folder if desired
+-  *fixel_folder_out*: the fixel folder to which the output will be written. This can be the same as the input folder if desired
 -  *fixel_data_out*: the name of the fixel data image.
 
 Options

--- a/docs/reference/commands/voxel2fixel.rst
+++ b/docs/reference/commands/voxel2fixel.rst
@@ -17,7 +17,7 @@ Usage
 
 -  *image_in*: the input image.
 -  *fixel_directory_in*: the input fixel directory. Used to define the fixels and their directions
--  *fixel_directory_out*: the output fixel directory. This can be the same as the input directory if desired
+-  *fixel_directory_out*: the fixel directory where the output will be written. This can be the same as the input directory if desired
 -  *fixel_data_out*: the name of the fixel data image.
 
 Description


### PR DESCRIPTION
Was throwing together a command to serve a niche purpose involving fixel data, and the lack of this functionality was giving me the irrits.

Though the fact that many fixel commands have an output directory that may also be an input directory, and therefore can't actually use this functionality properly, reminded me of #1043...