### PR TITLE
dirsplit: Ensure more than one output file

### DIFF
--- a/cmd/dirsplit.cpp
+++ b/cmd/dirsplit.cpp
@@ -51,7 +51,7 @@ using vector3_type = Eigen::Vector3d;
 class Shared { MEMALIGN(Shared)
   public:
     Shared (const Eigen::MatrixXd& directions, size_t num_subsets, size_t target_num_permutations) :
-      directions (directions), subset (num_subsets), 
+      directions (directions), subset (num_subsets),
       best_energy (std::numeric_limits<value_type>::max()),
       target_num_permutations (target_num_permutations),
       num_permutations (0) {
@@ -60,14 +60,14 @@ class Shared { MEMALIGN(Shared)
           subset[s++].push_back (n);
           if (s >= num_subsets) s = 0;
         }
-        INFO ("split " + str(directions.rows()) + " directions into subsets with " + 
+        INFO ("split " + str(directions.rows()) + " directions into subsets with " +
             str([&]{ vector<size_t> c; for (auto& x : subset) c.push_back (x.size()); return c; }()) + " volumes");
       }
 
 
 
 
-    bool update (value_type energy, const vector<vector<size_t>>& set) 
+    bool update (value_type energy, const vector<vector<size_t>>& set)
     {
       std::lock_guard<std::mutex> lock (mutex);
       if (!progress) progress.reset (new ProgressBar ("distributing directions", target_num_permutations));
@@ -115,7 +115,7 @@ class EnergyCalculator { MEMALIGN(EnergyCalculator)
     EnergyCalculator (Shared& shared) : shared (shared), subset (shared.get_init_subset()) { }
 
     void execute () {
-      while (eval()); 
+      while (eval());
     }
 
 
@@ -141,8 +141,8 @@ class EnergyCalculator { MEMALIGN(EnergyCalculator)
       value_type energy = 0.0;
       for (auto& s: subset) {
         value_type current_energy = 0.0;
-        for (size_t i = 0; i < s.size(); ++i) 
-          for (size_t j = i+1; j < s.size(); ++j) 
+        for (size_t i = 0; i < s.size(); ++i)
+          for (size_t j = i+1; j < s.size(); ++j)
             current_energy += shared.energy (s[i], s[j]);
         energy = std::max (energy, current_energy);
       }
@@ -162,13 +162,15 @@ class EnergyCalculator { MEMALIGN(EnergyCalculator)
 
 
 
-void run () 
+void run ()
 {
   auto directions = DWI::Directions::load_cartesian (argument[0]);
 
-  size_t num_subsets = argument.size() - 1;
+  const size_t num_subsets = argument.size() - 1;
+  if (num_subsets == 1)
+    throw Exception ("Directions must be split across two or more output files");
 
-  size_t num_permutations = get_option_value ("permutations", DEFAULT_PERMUTATIONS);
+  const size_t num_permutations = get_option_value ("permutations", DEFAULT_PERMUTATIONS);
 
   vector<vector<size_t>> best;
   {
@@ -177,12 +179,10 @@ void run ()
     best = shared.get_best_subset();
   }
 
-
-
-  bool cartesian = get_options("cartesian").size();
+  const bool cartesian = get_options("cartesian").size();
   for (size_t i = 0; i < best.size(); ++i) {
     Eigen::MatrixXd output (best[i].size(), 3);
-    for (size_t n = 0; n < best[i].size(); ++n) 
+    for (size_t n = 0; n < best[i].size(); ++n)
       output.row(n) = directions.row (best[i][n]);
     DWI::Directions::save (output, argument[i+1], cartesian);
   }


### PR DESCRIPTION
Prevents command from hanging with 100% CPU utilisation if only one output file is specified erroneously.