### PR TITLE
Tracking code: Proper use of polymorphism

### DIFF
--- a/src/dwi/tractography/algorithms/fact.h
+++ b/src/dwi/tractography/algorithms/fact.h
@@ -90,20 +90,20 @@ namespace MR
 
 
 
-      bool init()
+      bool init() override
       {
         if (!get_data (source)) return false;
         if (!S.init_dir.allFinite()) {
           if (!dir.allFinite())
             dir = random_direction();
-        } 
-        else 
+        }
+        else
           dir = S.init_dir;
-        
+
         return do_next (dir) >= S.threshold;
       }
 
-      term_t next ()
+      term_t next () override
       {
         if (!get_data (source))
           return EXIT_IMAGE;
@@ -118,7 +118,7 @@ namespace MR
       }
 
 
-      float get_metric()
+      float get_metric() override
       {
         Eigen::Vector3f d (dir);
         return do_next (d);
@@ -138,7 +138,7 @@ namespace MR
         for (size_t n = 0; n < S.num_vec; ++n) {
           Eigen::Vector3f v (values[3*n], values[3*n+1], values[3*n+2]);
           float norm = v.norm();
-          float dot = v.dot(d) / norm; 
+          float dot = v.dot(d) / norm;
           float abs_dot = std::abs (dot);
           if (abs_dot < S.dot_threshold) continue;
           if (max_abs_dot < abs_dot) {
@@ -153,7 +153,7 @@ namespace MR
 
         d = { values[3*idx], values[3*idx+1], values[3*idx+2] };
         d.normalize();
-        if (max_dot < 0.0) 
+        if (max_dot < 0.0)
           d = -d;
 
         return max_norm;

--- a/src/dwi/tractography/algorithms/iFOD1.h
+++ b/src/dwi/tractography/algorithms/iFOD1.h
@@ -132,7 +132,7 @@ namespace MR
 
 
 
-      bool init()
+      bool init() override
       {
         if (!get_data (source))
           return (false);
@@ -149,7 +149,7 @@ namespace MR
                 return true;
           }
 
-        } 
+        }
         else {
           dir = S.init_dir;
           float val = FOD (dir);
@@ -164,7 +164,7 @@ namespace MR
 
 
 
-      term_t next ()
+      term_t next () override
       {
         if (!get_data (source))
           return EXIT_IMAGE;
@@ -213,7 +213,7 @@ namespace MR
       }
 
 
-      float get_metric()
+      float get_metric() override
       {
         return FOD (dir);
       }

--- a/src/dwi/tractography/algorithms/iFOD2.h
+++ b/src/dwi/tractography/algorithms/iFOD2.h
@@ -195,7 +195,7 @@ namespace MR
 
 
 
-            bool init()
+            bool init() override
             {
               if (!get_data (source))
                 return false;
@@ -230,7 +230,7 @@ end_init:
 
 
 
-            term_t next ()
+            term_t next () override
             {
 
               if (++sample_idx < S.num_samples) {
@@ -282,7 +282,7 @@ end_init:
             }
 
 
-            FORCE_INLINE float get_metric()
+            float get_metric() override
             {
               return FOD (dir);
             }
@@ -297,7 +297,7 @@ end_init:
             }
 
 
-            void truncate_track (GeneratedTrack& tck, const size_t length_to_revert_from, const size_t revert_step)
+            void truncate_track (GeneratedTrack& tck, const size_t length_to_revert_from, const size_t revert_step) override
             {
               // OK, if we know length_to_revert_from, we can reconstruct what sample_idx was at that point
               size_t sample_idx_at_full_length = (length_to_revert_from - tck.get_seed_index()) % S.num_samples;
@@ -328,7 +328,8 @@ end_init:
               sample_idx = S.num_samples;
 
               // Need to update sgm_depth appropriately, remembering that it is tracked by exec
-              act().sgm_depth = (act().sgm_depth > points_to_remove) ? act().sgm_depth - points_to_remove : 0;
+              if (S.is_act())
+                act().sgm_depth = (act().sgm_depth > points_to_remove) ? act().sgm_depth - points_to_remove : 0;
             }
 
 

--- a/src/dwi/tractography/algorithms/nulldist.h
+++ b/src/dwi/tractography/algorithms/nulldist.h
@@ -55,14 +55,14 @@ namespace MR
         source (S.source) { }
 
 
-      bool init() {
+      bool init() override {
         if (!get_data (source))
           return false;
         dir = S.init_dir.allFinite() ? S.init_dir : random_direction();
         return true;
       }
 
-      term_t next () {
+      term_t next () override {
         if (!get_data (source))
           return EXIT_IMAGE;
         dir = rand_dir (dir);
@@ -71,7 +71,7 @@ namespace MR
         return CONTINUE;
       }
 
-      float get_metric() { return uniform(*rng); }
+      float get_metric() override { return uniform(*rng); }
 
 
       protected:
@@ -110,7 +110,7 @@ namespace MR
         tangents (S.num_samples),
         sample_idx (S.num_samples) { }
 
-      bool init() {
+      bool init() override {
         if (!get_data (source))
           return false;
         dir = S.init_dir.allFinite() ? S.init_dir : random_direction();
@@ -118,7 +118,7 @@ namespace MR
         return true;
       }
 
-      term_t next () {
+      term_t next () override {
 
         if (++sample_idx < S.num_samples) {
           pos = positions[sample_idx];
@@ -144,13 +144,13 @@ namespace MR
         MethodBase::reverse_track();
       }
 
-      void truncate_track (GeneratedTrack& tck, const size_t length_to_revert_from, const size_t revert_step)
+      void truncate_track (GeneratedTrack& tck, const size_t length_to_revert_from, const size_t revert_step) override
       {
         iFOD2::truncate_track (tck, length_to_revert_from, revert_step);
         sample_idx = S.num_samples;
       }
 
-      float get_metric() { return uniform(*rng); }
+      float get_metric() override { return uniform(*rng); }
 
 
       protected:

--- a/src/dwi/tractography/algorithms/sd_stream.h
+++ b/src/dwi/tractography/algorithms/sd_stream.h
@@ -95,7 +95,7 @@ class SDStream : public MethodBase { MEMALIGN(SDStream)
 
 
 
-    bool init()
+    bool init() override
     {
       if (!get_data (source))
         return (false);
@@ -103,8 +103,8 @@ class SDStream : public MethodBase { MEMALIGN(SDStream)
       if (!S.init_dir.allFinite()) {
         if (!dir.allFinite())
           dir = random_direction();
-      } 
-      else 
+      }
+      else
         dir = S.init_dir;
 
       dir.normalize();
@@ -116,7 +116,7 @@ class SDStream : public MethodBase { MEMALIGN(SDStream)
 
 
 
-    term_t next ()
+    term_t next () override
     {
       if (!get_data (source))
         return EXIT_IMAGE;
@@ -134,7 +134,7 @@ class SDStream : public MethodBase { MEMALIGN(SDStream)
     }
 
 
-    float get_metric()
+    float get_metric() override
     {
       return FOD (dir);
     }

--- a/src/dwi/tractography/algorithms/seedtest.h
+++ b/src/dwi/tractography/algorithms/seedtest.h
@@ -51,9 +51,9 @@ class Seedtest : public MethodBase { MEMALIGN(Seedtest)
     S (shared) { }
 
 
-  bool init() { return true; }
-  term_t next () { return EXIT_IMAGE; }
-  float get_metric() { return 1.0; }
+  bool init() override { return true; }
+  term_t next () override { return EXIT_IMAGE; }
+  float get_metric() override { return 1.0; }
 
 
   protected:

--- a/src/dwi/tractography/algorithms/tensor_det.h
+++ b/src/dwi/tractography/algorithms/tensor_det.h
@@ -19,7 +19,7 @@
 // These lines are to silence deprecation warnings with Eigen & GCC v5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#include <Eigen/Eigenvalues> 
+#include <Eigen/Eigenvalues>
 #pragma GCC diagnostic pop
 
 #include "math/least_squares.h"
@@ -89,12 +89,12 @@ namespace MR
         eig (3),
         M (3,3),
         dt (6) { }
-        
 
 
 
 
-      bool init()
+
+      bool init() override
       {
         if (!get_data (source))
           return false;
@@ -103,7 +103,7 @@ namespace MR
 
 
 
-      term_t next ()
+      term_t next () override
       {
         if (!get_data (source))
           return Tracking::EXIT_IMAGE;
@@ -111,7 +111,7 @@ namespace MR
       }
 
 
-      float get_metric()
+      float get_metric() override
       {
         dwi2tensor (dt, S.binv, values);
         return tensor2FA (dt);

--- a/src/dwi/tractography/algorithms/tensor_prob.h
+++ b/src/dwi/tractography/algorithms/tensor_prob.h
@@ -67,7 +67,7 @@ namespace MR
 
 
 
-            bool init() {
+            bool init() override {
               source.clear();
               if (!source.get (pos, values))
                 return false;
@@ -76,14 +76,14 @@ namespace MR
 
 
 
-            term_t next () {
+            term_t next () override {
               if (!source.get (pos, values))
                 return EXIT_IMAGE;
               return Tensor_Det::do_next();
             }
 
 
-            void truncate_track (vector<Eigen::Vector3f>& tck, const size_t length_to_revert_from, const int revert_step) {}
+            void truncate_track (GeneratedTrack& tck, const size_t length_to_revert_from, const size_t revert_step) override { assert (0); }
 
 
           protected:

--- a/src/dwi/tractography/tracking/method.cpp
+++ b/src/dwi/tractography/tracking/method.cpp
@@ -28,23 +28,6 @@ namespace MR
 
 
 
-        bool MethodBase::check_seed()
-        {
-          if (!pos.allFinite())
-            return false;
-
-          if ((S.properties.mask.size() && !S.properties.mask.contains (pos))
-              || (S.properties.exclude.contains (pos))
-              || (S.is_act() && !act().check_seed (pos))) {
-            pos = { NaN, NaN, NaN };
-            return false;
-          }
-
-          return true;
-        }
-
-
-
         void MethodBase::truncate_track (GeneratedTrack& tck, const size_t length_to_revert_from, const size_t revert_step)
         {
           if (tck.get_seed_index() + revert_step >= length_to_revert_from) {
@@ -60,8 +43,25 @@ namespace MR
             dir = (tck[new_size] - tck[new_size - 2]).normalized();
           tck.resize (length_to_revert_from - revert_step);
           pos = tck.back();
-          if (S.is_act())
+          if (act_method_additions)
             act().sgm_depth = (act().sgm_depth > revert_step) ? act().sgm_depth - revert_step : 0;
+        }
+
+
+
+        bool MethodBase::check_seed()
+        {
+          if (!pos.allFinite())
+            return false;
+
+          if ((S.properties.mask.size() && !S.properties.mask.contains (pos))
+              || (S.properties.exclude.contains (pos))
+              || (S.is_act() && !act().check_seed (pos))) {
+            pos = { NaN, NaN, NaN };
+            return false;
+          }
+
+          return true;
         }
 
 

--- a/src/dwi/tractography/tracking/method.h
+++ b/src/dwi/tractography/tracking/method.h
@@ -72,13 +72,14 @@ namespace MR
             }
 
 
+            virtual bool init() = 0;
+            virtual term_t next() = 0;
+            virtual float get_metric() = 0;
+
             virtual void reverse_track() { if (act_method_additions) act().reverse_track(); }
-            bool init() { return false; }
-            term_t next() { return term_t(); }
-            float get_metric() { return NaN; }
+            virtual void truncate_track (GeneratedTrack& tck, const size_t length_to_revert_from, const size_t revert_step);
 
             bool check_seed();
-            void truncate_track (GeneratedTrack& tck, const size_t length_to_revert_from, const size_t revert_step);
 
             ACT::ACT_Method_additions& act() const { return *act_method_additions; }
 


### PR DESCRIPTION
As requested by @LeeReidCSIRO.

Previously, some tracking code was heavily reliant on the use of templating in `cmd/tckgen.cpp`. While the code would behave as expected in this context, some aspects appeared as though they had been designed with polymorphism in mind, but would not exhibit the expected behaviour if actually used in this fashion. This change introduces the correct polymorphism concepts such that the code can be used in this way if desired. It however does not have any significant influence on execution speed of `tckgen`, since it still exploits the template parameter of the `Tracking::Exec` class and hence does not use the underlying polymorphism.

Closes #1234.

Have confirmed that there is no measurable effect on `tckgen` performance.