### PR TITLE
run.command(): Support native Windows Python

### DIFF
--- a/lib/mrtrix3/run.py
+++ b/lib/mrtrix3/run.py
@@ -25,7 +25,10 @@ def command(cmd, exitOnError=True):
   global _processes
 
   # Vectorise the command string, preserving anything encased within quotation marks
-  cmdsplit = shlex.split(cmd)
+  if os.sep is '/': # Cheap POSIX compliance check
+    cmdsplit = shlex.split(cmd)
+  else: # Native Windows Python
+    cmdsplit = [ entry.strip('\"') for entry in shlex.split(cmd, posix=False) ]
 
   if app._lastFile:
     # Check to see if the last file produced in the previous script execution is


### PR DESCRIPTION
Unlike the Python versions provided by either MSYS or MinGW, the native Windows versions of Python are not POSIX compliant. As a result, `shlex.split()` does not appropriately handle the file system separator symbol. This change performs the necessary alterations to the `shlex.split()` call under such an environment.