### PR TITLE
Script updates to reflect 5ttcheck changes

### DIFF
--- a/bin/5ttgen
+++ b/bin/5ttgen
@@ -46,9 +46,11 @@ app.gotoTempDir()
 
 alg.execute()
 
-stderr = run.command('5ttcheck result.mif', False)[1]
-if stderr and 'ERROR' in stderr:
-  app.warn('Generated image does not perfectly conform to 5TT format')
+stderr = run.command('5ttcheck result.mif')[1]
+if stderr:
+  app.warn('Generated image does not perfectly conform to 5TT format:')
+  for line in stderr:
+    app.warn(line)
 
 run.command('mrconvert result.mif ' + path.fromUser(app.args.output, True) + (' -force' if app.forceOverwrite else ''))
 app.complete()

--- a/lib/mrtrix3/dwi2response/msmt_5tt.py
+++ b/lib/mrtrix3/dwi2response/msmt_5tt.py
@@ -43,7 +43,12 @@ def execute(): #pylint: disable=unused-variable
   # May need to commit 5ttregrid...
 
   # Verify input 5tt image
-  run.command('5ttcheck 5tt.mif', False)
+  stderr_5ttcheck = run.command('5ttcheck 5tt.mif')[1]
+  if stderr_5ttcheck:
+    app.warn('Command 5ttcheck indicates minor problems with provided input 5TT image \'' + app.args.in_5tt + '\':')
+    for line in stderr_5ttcheck.splitlines():
+      app.warn(line)
+    app.warn('These should however not significantly interfere with the dwi2response msmt_5tt script')
 
   # Get shell information
   shells = [ int(round(float(x))) for x in image.mrinfo('dwi.mif', 'shell_bvalues').split() ]

--- a/lib/mrtrix3/dwi2response/msmt_5tt.py
+++ b/lib/mrtrix3/dwi2response/msmt_5tt.py
@@ -48,7 +48,7 @@ def execute(): #pylint: disable=unused-variable
     app.warn('Command 5ttcheck indicates minor problems with provided input 5TT image \'' + app.args.in_5tt + '\':')
     for line in stderr_5ttcheck.splitlines():
       app.warn(line)
-    app.warn('These should however not significantly interfere with the dwi2response msmt_5tt script')
+    app.warn('These may or may not interfere with the dwi2response msmt_5tt script')
 
   # Get shell information
   shells = [ int(round(float(x))) for x in image.mrinfo('dwi.mif', 'shell_bvalues').split() ]


### PR DESCRIPTION
Follows from dca25c9c.

- In `dwi2response msmt_5tt`, if `5ttcheck` throws an exception, abort the script. However, if a warning is issued by `5ttcheck` rather than an exception, echo that warning to the user.

- In `5ttgen`, don't permit `5ttcheck` to throw an exception, but echo any warning issued.

Inspired by [this forum thread](http://community.mrtrix.org/t/dwi2response-msmt-5tt-error-axis-3-provided-with-coord-option-is-out-of-range-of-input-image/1417).