### PR TITLE
Scripts: Small fixes to reflect mrinfo change

### DIFF
--- a/bin/dwipreproc
+++ b/bin/dwipreproc
@@ -236,14 +236,14 @@ if eddy_mporder:
 # Need to know the mean b-value in each shell, and the asymmetry value of each shell
 # But don't bother testing / warning the user if they're already controlling for this
 if not app.args.eddy_options or not any(s.startswith('--slm=') for s in app.args.eddy_options.split()):
-  shell_bvalues = [ int(round(float(value))) for value in image.mrinfo('dwi.mif', 'shellvalues').split() ]
+  shell_bvalues = [ int(round(float(value))) for value in image.mrinfo('dwi.mif', 'shell_bvalues').split() ]
   shell_asymmetry = [ float(value) for value in run.command('dirstat dwi.mif -output asym')[0].splitlines() ]
   # dirstat will skip any b=0 shell by default; therefore for correspondence between
   #   shell_bvalues and shell_symmetry, need to remove any b=0 from the former
   if len(shell_bvalues) == len(shell_asymmetry) + 1:
     shell_bvalues = shell_bvalues[1:]
   elif len(shell_bvalues) != len(shell_asymmetry):
-    app.error('Number of b-values reported by mrinfo (' + len(shell_bvalues) + ') does not match number of outputs provided by dirstat (' + len(shell_asymmetry) + ')')
+    app.error('Number of b-values reported by mrinfo (' + str(len(shell_bvalues)) + ') does not match number of outputs provided by dirstat (' + str(len(shell_asymmetry)) + ')')
   for b, s in zip(shell_bvalues, shell_asymmetry):
     if s >= 0.1:
       app.warn('sampling of b=' + str(b) + ' shell is ' + ('strongly' if s >= 0.4 else 'moderately') + \

--- a/lib/mrtrix3/dwi2response/fa.py
+++ b/lib/mrtrix3/dwi2response/fa.py
@@ -30,7 +30,7 @@ def needsSingleShell(): #pylint: disable=unused-variable
 def execute(): #pylint: disable=unused-variable
   import shutil
   from mrtrix3 import app, image, path, run
-  bvalues = [ int(round(float(x))) for x in image.mrinfo('dwi.mif', 'shellvalues').split() ]
+  bvalues = [ int(round(float(x))) for x in image.mrinfo('dwi.mif', 'shell_bvalues').split() ]
   if len(bvalues) < 2:
     app.error('Need at least 2 unique b-values (including b=0).')
   lmax_option = ''


### PR DESCRIPTION
`mrinfo`'s command-line option `-shellvalues` was changed to `-shell_bvalues` in 29dbf025, merged to `dev` branch in #1211, but a couple of usages of this option in *MRtrix3* scripts were not updated.