### PR TITLE
tckresample: Fix -line, -arc options

### DIFF
--- a/src/dwi/tractography/resampling/arc.cpp
+++ b/src/dwi/tractography/resampling/arc.cpp
@@ -34,28 +34,27 @@ namespace MR {
 
           // Determine which points on the streamline correspond to the endpoints of the arc
           idx_start = idx_end = 0;
-          size_t a (0), b (0);
+          size_t a (in.size()), b (in.size());
 
-          int prev_s = -1;
+          state_t prev_s = state_t::BEFORE_START;
           for (size_t i = 0; i < in.size(); ++i) {
-            int s = state (in[i]);
+            const state_t s = state (in[i]);
             if (i) {
-              if (prev_s == -1 && s == 0) a = i-1;
-              if (prev_s == 0 && s == -1) a = i;
-              if (prev_s == 1 && s == 2)  b = i;
-              if (prev_s == 2 && s == 1)  b = i-1;
+              if (prev_s == state_t::BEFORE_START && s == state_t::AFTER_START)  a = i-1;
+              if (prev_s == state_t::AFTER_START  && s == state_t::BEFORE_START) a = i;
+              if (prev_s == state_t::BEFORE_END   && s == state_t::AFTER_END)    b = i;
+              if (prev_s == state_t::AFTER_END    && s == state_t::BEFORE_END)   b = i-1;
 
-              if (a && b) {
+              if (a != in.size() && b != in.size()) {
                 if (b - a > idx_end - idx_start) {
                   idx_start = a;
                   idx_end = b;
                 }
-                a = b = 0;
+                a = b = in.size();
               }
             }
             prev_s = s;
           }
-          ++idx_end;
 
           if (!(idx_start && idx_end))
             return false;
@@ -64,16 +63,19 @@ namespace MR {
           size_t i = idx_start;
 
           for (size_t n = 0; n < nsamples; n++) {
-            while (i != idx_end) {
+            do {
               const value_type d = planes[n].dist (in[i]);
               if (d > 0.0) {
                 const value_type f = d / (d - planes[n].dist (in[reverse ? i+1 : i-1]));
-                out.push_back (f*in[i-1] + (1.0f-f)*in[i]);
+                assert (f >= 0.0 && f <= 1.0);
+                out.push_back (f*in[reverse ? i+1 : i-1] + (1.0f-f)*in[i]);
                 break;
               }
               reverse ? --i : ++i;
-            }
+            } while ((!reverse && i <= idx_end) || (reverse && i >= idx_end));
           }
+
+          assert (out.size() == nsamples);
           return true;
         }
 
@@ -91,7 +93,7 @@ namespace MR {
 
 
 
-        void Arc::init_arc (const point_type& waypoint)
+        void Arc::init_arc()
         {
           mid_dir = (end - start).normalized();
 
@@ -141,15 +143,15 @@ namespace MR {
 
 
 
-        int Arc::state (const point_type& p) const
+        Arc::state_t Arc::state (const point_type& p) const
         {
-          const bool after_start = start_dir.dot (p - start) >= 0;
+          const bool after_start = start_dir.dot (p - start) >= 0.0;
           const bool after_mid = mid_dir.dot (p - mid) > 0.0;
           const bool after_end = end_dir.dot (p - end) >= 0.0;
-          if (!after_start && !after_mid) return -1; // before start
-          if (after_start && !after_mid) return 0; // after start
-          if (after_mid && !after_end) return 1; // before end
-          return 2; // after end
+          if (!after_start && !after_mid) return state_t::BEFORE_START;
+          if (after_start && !after_mid) return state_t::AFTER_START;
+          if (after_mid && !after_end) return state_t::BEFORE_END;
+          return state_t::AFTER_END;
         }
 
 

--- a/src/dwi/tractography/resampling/arc.h
+++ b/src/dwi/tractography/resampling/arc.h
@@ -32,6 +32,8 @@ namespace MR {
             using value_type = float;
             using point_type = Eigen::Vector3f;
 
+            enum class state_t { BEFORE_START, AFTER_START, BEFORE_END, AFTER_END };
+
           private:
             class Plane { MEMALIGN(Plane)
               public:
@@ -64,12 +66,12 @@ namespace MR {
             Arc (const size_t n, const point_type& s, const point_type& w, const point_type& e) :
                 nsamples (n),
                 start (s),
-                mid (0.5*(s+e)),
+                mid (w),
                 end (e),
                 idx_start (0),
                 idx_end (0)
             {
-              init_arc (w);
+              init_arc();
             }
 
             bool operator() (const Streamline<>&, Streamline<>&) const override;
@@ -83,10 +85,10 @@ namespace MR {
             mutable point_type start_dir, mid_dir, end_dir;
 
             void init_line();
-            void init_arc (const point_type&);
+            void init_arc();
 
 
-            int state (const point_type&) const;
+            state_t state (const point_type&) const;
 
         };
 


### PR DESCRIPTION
Fixing issues reported on forum [here](http://community.mrtrix.org/t/tckresample-and-tcksample-for-along-the-tract-statistics/1368).

Example data:

![screenshot0000](https://user-images.githubusercontent.com/5637955/35784959-bb7222a0-0a70-11e8-8e31-37af422a9f21.png)

Current `master` code, using `-line` option:

![screenshot0001](https://user-images.githubusercontent.com/5637955/35784963-c9839950-0a70-11e8-8adc-a8c0625007f3.png)

Current `master` code, using `-arc` option:

![screenshot0002](https://user-images.githubusercontent.com/5637955/35784965-d190cb54-0a70-11e8-9d1c-567fe231291b.png)

PR code, using `-line` option:

![screenshot0003](https://user-images.githubusercontent.com/5637955/35784969-d966f4fc-0a70-11e8-8cc6-c3b98b06015d.png)

PR code, using `-arc` option:

![screenshot0004](https://user-images.githubusercontent.com/5637955/35784974-e0b90e16-0a70-11e8-83b3-bdda36018c16.png)