### PR TITLE
include build information in -version output

### DIFF
--- a/configure
+++ b/configure
@@ -215,15 +215,23 @@ def error (message):
   sys.exit (1)
 
 
+if profile: build_type = 'profiling version'
+elif debug: build_type = 'debug version'
+else: build_type = 'release version'
+
+build_options = []
+if asserts: build_options.append ('asserts')
+if nooptim: build_options.append ('nooptim')
+if nogui: build_options.append ('nogui')
+if noshared: build_options.application ('noshared')
+if static: build_options.append ('static')
+if openmp: build_options.append ('openmp')
+
+if len(build_options):
+  build_type += ' with ' + ', '.join (build_options)
+
 report ("""
-MRtrix build type requested: """)
-if profile: report ('profiling')
-elif debug: report ('debug')
-else: report ('release')
-if asserts: report (' with asserts')
-if nooptim: report (' without optimisation')
-if nogui: report (' [command-line only]')
-report ('\n\n')
+MRtrix build type requested: """ + build_type + '\n\n')
 
 
 # remove any mention of anaconda from PATH:
@@ -249,7 +257,7 @@ global cpp, cpp_cmd, ld, ld_args, ld_cmd
 
 cxx = [ 'clang++', 'g++' ]
 cxx_args = '-c CFLAGS SRC -o OBJECT'.split()
-cpp_flags = [ '-std=c++11' ]
+cpp_flags = [ '-std=c++11', '-DMRTRIX_BUILD_TYPE="'+build_type+'"' ]
 
 ld_args = 'OBJECTS LDFLAGS -o EXECUTABLE'.split()
 ld_flags = []

--- a/core/app.cpp
+++ b/core/app.cpp
@@ -552,13 +552,7 @@ namespace MR
     {
       std::string version =
         "== " + App::NAME + " " + ( project_version ? project_version : mrtrix_version ) + " ==\n" +
-        str(8*sizeof (size_t)) + " bit "
-#ifdef NDEBUG
-        "release"
-#else
-        "debug"
-#endif
-        " version, built " __DATE__
+        str(8*sizeof (size_t)) + " bit " + MRTRIX_BUILD_TYPE + ", built " __DATE__
         + ( project_version ? std::string(" against MRtrix ") + mrtrix_version : std::string("") )
         + ", using Eigen " + str(EIGEN_WORLD_VERSION) + "." + str(EIGEN_MAJOR_VERSION) + "." + str(EIGEN_MINOR_VERSION) + "\n"
         "Author(s): " + AUTHOR + "\n" +

--- a/core/app.cpp
+++ b/core/app.cpp
@@ -547,6 +547,9 @@ namespace MR
 
 
 
+#ifndef MRTRIX_BUILD_TYPE
+#error "MRtrix build type is not defined; you need to re-run configure script"
+#endif
 
     std::string version_string ()
     {


### PR DESCRIPTION
I've been meaning to do this for a while, and [this recent post](http://community.mrtrix.org/t/tckgen-on-hcp-dataset-takes-excessively-long/1471/5?u=jdtournier) finally prompted some action... 