### PR TITLE
Stats: Fix segfault when using -nonstationary

### DIFF
--- a/cmd/connectomestats.cpp
+++ b/cmd/connectomestats.cpp
@@ -266,6 +266,7 @@ void run()
   // If performing non-stationarity adjustment we need to pre-compute the empirical statistic
   vector_type empirical_statistic;
   if (do_nonstationary_adjustment) {
+    empirical_statistic = vector_type::Zero (num_edges);
     if (permutations_nonstationary.size()) {
       Stats::PermTest::PermutationStack perm_stack (permutations_nonstationary, "precomputing empirical statistic for non-stationarity adjustment...");
       Stats::PermTest::precompute_empirical_stat (glm_ttest, enhancer, perm_stack, empirical_statistic);

--- a/cmd/fixelcfestats.cpp
+++ b/cmd/fixelcfestats.cpp
@@ -462,7 +462,7 @@ void run() {
 
   // If performing non-stationarity adjustment we need to pre-compute the empirical CFE statistic
   if (do_nonstationary_adjustment) {
-
+    empirical_cfe_statistic = vector_type::Zero (mask_fixels);
     if (permutations_nonstationary.size()) {
       Stats::PermTest::PermutationStack permutations (permutations_nonstationary, "precomputing empirical statistic for non-stationarity adjustment");
       Stats::PermTest::precompute_empirical_stat (glm_ttest, cfe_integrator, permutations, empirical_cfe_statistic);

--- a/cmd/mrclusterstats.cpp
+++ b/cmd/mrclusterstats.cpp
@@ -223,6 +223,7 @@ void run() {
   if (do_nonstationary_adjustment) {
     if (!use_tfce)
       throw Exception ("nonstationary adjustment is not currently implemented for threshold-based cluster analysis");
+    empirical_enhanced_statistic = vector_type::Zero (num_vox);
     if (permutations_nonstationary.size()) {
       Stats::PermTest::PermutationStack permutations (permutations_nonstationary, "precomputing empirical statistic for non-stationarity adjustment...");
       Stats::PermTest::precompute_empirical_stat (glm, enhancer, permutations, empirical_enhanced_statistic);


### PR DESCRIPTION
Memory for storing empirical statistics was not being allocated either before or during `Stats::PermTest::precompute_empirical_stat()` function.