### PR TITLE
Fix tckconvert vtk to tck

### DIFF
--- a/cmd/tckconvert.cpp
+++ b/cmd/tckconvert.cpp
@@ -160,8 +160,8 @@ public:
       number_of_lines = 0;
       number_of_line_indices = 0;
       while ( std::getline(input,line) ) {
-        if ( line.find ( "ASCII") == 0 ) {
-          throw Exception("VTK Reader only supports ASCII input");
+        if ( line.find ( "ASCII" ) == 0 ) {
+          throw Exception("VTK Reader only supports BINARY input");
         }
         if ( sscanf ( line.c_str(), "POINTS %d float", &number_of_points ) == 1) {
           points = new float[3*number_of_points];

--- a/cmd/tckconvert.cpp
+++ b/cmd/tckconvert.cpp
@@ -156,7 +156,9 @@ public:
       lines = NULL;
       std::ifstream input (file, std::ios::binary );
       std::string line;
-      int number_of_points;
+      int number_of_points = 0;
+      number_of_lines = 0;
+      number_of_line_indices = 0;
       while ( std::getline(input,line) ) {
         if ( line.find ( "ASCII") == 0 ) {
           throw Exception("VTK Reader only supports ASCII input");

--- a/testing/tests/tckconvert
+++ b/testing/tests/tckconvert
@@ -4,6 +4,6 @@ tckconvert tracks.tck -scanner2voxel dwi.mif tmp.vtk -force && awk '/POINTS/{s=1
 tckconvert tracks.tck -scanner2voxel dwi.mif tmp.vtk -force && awk '/LINES/,0' tmp.vtk >tmplines1.txt && awk '/LINES/,0' tckconvert/out1.vtk >tmplines2.txt && diff tmplines1.txt tmplines2.txt
 tckedit tracks.tck -number 10 tmp.tck -nthread 0 && tckconvert tmp.tck tmp-[].txt && cat tmp-*.txt > tmp-all.txt && testing_diff_matrix tmp-all.txt tckconvert/out2-all.txt -abs 1e-4
 tckconvert tckconvert/out2-[2:9].txt tmp.tck -force && testing_diff_tck tmp.tck tckconvert/out3.tck 1e-4
-echo 1 2 3 > tmp.txt && tckconvert -force -quiet tmp.txt tmp.tck && tckconvert -quiet -force tmp.tck tmp.rib && wc -l < tmp.rib > tmpcount.txt && echo 4 > tmpexpected.txt && testing_diff_matrix tmpcount.txt tmpexpected.txt
+echo 1 2 3 > tmp.txt && tckconvert -force -quiet tmp.txt tmp.tck && tckconvert -quiet -force tmp.tck tmp.rib && [ $(wc -l < tmp.rib ) == 4 ]
 printf "# vtk DataFile Version 1.0\nBINARY\nDATASET POLYDATA\nPOINTS 0 float" > tmp.vtk && tckconvert -force -quiet tmp.vtk tmp.tck
 

--- a/testing/tests/tckconvert
+++ b/testing/tests/tckconvert
@@ -4,3 +4,6 @@ tckconvert tracks.tck -scanner2voxel dwi.mif tmp.vtk -force && awk '/POINTS/{s=1
 tckconvert tracks.tck -scanner2voxel dwi.mif tmp.vtk -force && awk '/LINES/,0' tmp.vtk >tmplines1.txt && awk '/LINES/,0' tckconvert/out1.vtk >tmplines2.txt && diff tmplines1.txt tmplines2.txt
 tckedit tracks.tck -number 10 tmp.tck -nthread 0 && tckconvert tmp.tck tmp-[].txt && cat tmp-*.txt > tmp-all.txt && testing_diff_matrix tmp-all.txt tckconvert/out2-all.txt -abs 1e-4
 tckconvert tckconvert/out2-[2:9].txt tmp.tck -force && testing_diff_tck tmp.tck tckconvert/out3.tck 1e-4
+echo 1 2 3 > tmp.txt && tckconvert -force -quiet tmp.txt tmp.tck && tckconvert -quiet -force tmp.tck tmp.rib && wc -l < tmp.rib > tmpcount.txt && echo 4 > tmpexpected.txt && testing_diff_matrix tmpcount.txt tmpexpected.txt
+printf "# vtk DataFile Version 1.0\nBINARY\nDATASET POLYDATA\nPOINTS 0 float" > tmp.vtk && tckconvert -force -quiet tmp.vtk tmp.tck
+


### PR DESCRIPTION
Fixes 2 edge cases.

1. when a VTK file does not have any lines, an uninitialized variable caused segfaults on Linux (but not Mac, hmm)

2. A .tck file with 0 streamlines now produces a valid RIB file.