### PR TITLE
dwibiascorrect: Scale N4 bias field output

### DIFF
--- a/bin/dwibiascorrect
+++ b/bin/dwibiascorrect
@@ -107,8 +107,19 @@ elif app.args.ants:
   #   will have a smoothly-varying bias field correction applied, rather than multiplying by 1.0 outside the mask
   run.command('mrconvert mean_bzero.mif mean_bzero.nii -strides +1,+2,+3')
   run.command('mrconvert mask.mif mask.nii -strides +1,+2,+3')
-  bias_path = 'bias.nii'
-  run.command('N4BiasFieldCorrection -d 3 -i mean_bzero.nii -w mask.nii -o [corrected.nii,' + bias_path + '] -s 4 -b [100,3] -c [1000,0.0]')
+  init_bias_path = 'init_bias.nii'
+  corrected_path = 'corrected.nii'
+  run.command('N4BiasFieldCorrection -d 3 -i mean_bzero.nii -w mask.nii -o [' + corrected_path + ',' + init_bias_path + '] -s 4 -b [100,3] -c [1000,0.0]')
+
+  # N4 can introduce large differences between subjects via a global scaling of the bias field
+  # Estimate this scaling based on the total integral of the pre- and post-correction images within the brain mask
+  input_integral  = float(run.command('mrcalc mean_bzero.mif mask.mif -mult - | mrmath - sum - -axis 0 | mrmath - sum - -axis 1 | mrmath - sum - -axis 2 | mrdump -')[0])
+  output_integral = float(run.command('mrcalc ' + corrected_path + ' mask.mif -mult - | mrmath - sum - -axis 0 | mrmath - sum - -axis 1 | mrmath - sum - -axis 2 | mrdump -')[0])
+  app.var(input_integral, output_integral)
+  bias_path = 'bias.mif'
+  run.command('mrcalc ' + init_bias_path + ' ' + str(output_integral / input_integral) + ' -mult ' + bias_path)
+
+
 
 run.command('mrcalc in.mif ' + bias_path + ' -div result.mif')
 run.command('mrconvert result.mif ' + path.fromUser(app.args.output, True) + (' -force' if app.forceOverwrite else ''))


### PR DESCRIPTION
N4's estimated bias field can contain a substantial yet unpredictable constant component, drastically changing the overall signal intensity across all image volumes and all voxels. This change scales the contant component of the estimated bias field in order to remove this effect, by computing the total image integral within the brain mask of the images before and after bias field correction, and then scaling the bias field to be applied by the ratio of these two values.

This should reduce (likely minor) differences in CSD behaviour in FBA studies due to differential scaling of estimated FOD amplitudes, and reduce the discrepancy between reported scaling factors by `mtnormalise`.

Closes #1265.