### PR TITLE
run_tests: handle comments in test files

### DIFF
--- a/run_tests
+++ b/run_tests
@@ -72,7 +72,7 @@ EOD
   rm -rf testing/data/tmp*
   ((ntests=0))
   ((success=0))
-  while IFS='' read -r cmd; do
+  while IFS='' read -r cmd || [[ -n "$cmd" ]]; do
     cmd="${cmd%\#*}"
     [[ -n "$cmd" ]] || continue
     echo -n '# command: '$cmd >> $LOGFILE 

--- a/run_tests
+++ b/run_tests
@@ -72,7 +72,9 @@ EOD
   rm -rf testing/data/tmp*
   ((ntests=0))
   ((success=0))
-  while IFS='' read -r cmd || [[ -n "$cmd" ]]; do
+  while IFS='' read -r cmd; do
+    cmd="${cmd%\#*}"
+    [[ -n "$cmd" ]] || continue
     echo -n '# command: '$cmd >> $LOGFILE 
     (
       export PATH="$(pwd)/testing/bin:$(pwd)/bin:$PATH"; 


### PR DESCRIPTION
Simple change. As requested in #1268. 
Allows comments in test files. Anything that after a `#` will be stripped out and ignored during testing. 