### PR TITLE
run.command(): More robust text decoding

### DIFF
--- a/lib/mrtrix3/run.py
+++ b/lib/mrtrix3/run.py
@@ -148,7 +148,7 @@ def command(cmd, exitOnError=True): #pylint: disable=unused-variable
         do_indent = True
         while True:
           # Have to read one character at a time: Waiting for a newline character using e.g. readline() will prevent MRtrix progressbars from appearing
-          char = process.stderr.read(1).decode('utf-8')
+          char = process.stderr.read(1).decode('cp1252', errors='ignore')
           if not char and process.poll() is not None:
             break
           if do_indent and char in string.printable:
@@ -181,7 +181,7 @@ def command(cmd, exitOnError=True): #pylint: disable=unused-variable
     if tempfiles[index][0] is not None:
       tempfiles[index][0].flush()
       tempfiles[index][0].seek(0)
-      stdout_text = tempfiles[index][0].read().decode('utf-8')
+      stdout_text = tempfiles[index][0].read().decode('utf-8', errors='replace')
       return_stdout += stdout_text
       if _processes[index].returncode:
         error = True
@@ -189,7 +189,7 @@ def command(cmd, exitOnError=True): #pylint: disable=unused-variable
     if tempfiles[index][1] is not None:
       tempfiles[index][1].flush()
       tempfiles[index][1].seek(0)
-      stderr_text = tempfiles[index][1].read().decode('utf-8')
+      stderr_text = tempfiles[index][1].read().decode('utf-8', errors='replace')
       return_stderr += stderr_text
       if _processes[index].returncode:
         error = True

--- a/lib/mrtrix3/run.py
+++ b/lib/mrtrix3/run.py
@@ -151,7 +151,7 @@ def command(cmd, exitOnError=True): #pylint: disable=unused-variable
           char = process.stderr.read(1).decode('cp1252', errors='ignore')
           if not char and process.poll() is not None:
             break
-          if do_indent and char in string.printable:
+          if do_indent and char in string.printable and char != '\r' and char != '\n':
             sys.stderr.write('          ')
             do_indent = False
           elif char == '\r' or char == '\n':

--- a/lib/mrtrix3/run.py
+++ b/lib/mrtrix3/run.py
@@ -144,11 +144,13 @@ def command(cmd, exitOnError=True): #pylint: disable=unused-variable
   try:
     if app.verbosity > 1:
       for process in _processes:
-        stderrdata = ''
+        stderrdata = b''
         do_indent = True
         while True:
           # Have to read one character at a time: Waiting for a newline character using e.g. readline() will prevent MRtrix progressbars from appearing
-          char = process.stderr.read(1).decode('cp1252', errors='ignore')
+          byte = process.stderr.read(1)
+          stderrdata += byte
+          char = byte.decode('cp1252', errors='ignore')
           if not char and process.poll() is not None:
             break
           if do_indent and char in string.printable and char != '\r' and char != '\n':
@@ -158,7 +160,7 @@ def command(cmd, exitOnError=True): #pylint: disable=unused-variable
             do_indent = True
           sys.stderr.write(char)
           sys.stderr.flush()
-          stderrdata += char
+        stderrdata = stderrdata.decode('utf-8', errors='replace')
         return_stderr += stderrdata
         if process.returncode:
           error = True


### PR DESCRIPTION
Relates to discussion in #953.

Having thought about the situation a bit, I think this is the best solution in terms of the script library. Even if decoding of DICOM text data were improved as described in #953, there's an external tool invoked by `run.command()` generating data that's genuinely invalid if interpreted as unicode, so the function needs to be robust to that.

This solution works for what I've tested it on thus far; I've got a couple of other cases to test, but would appreciate testing on problematic DICOM data as well.