### PR TITLE
mtnormalise bug fix

### DIFF
--- a/cmd/mtnormalise.cpp
+++ b/cmd/mtnormalise.cpp
@@ -331,8 +331,8 @@ void run_primitive () {
   auto outlier_rejection = [&](float outlier_range) {
 
     auto summed_log = ImageType::scratch (header_3D, "Log of summed tissue volumes");
-    for (size_t j = 0; j < n_tissue_types; ++j) {
-      for (auto i = Loop (0, 3) (summed_log, combined_tissue, norm_field_image); i; ++i) {
+    for (auto i = Loop (0, 3) (summed_log, combined_tissue, norm_field_image); i; ++i) {
+      for (size_t j = 0; j < n_tissue_types; ++j) {
         combined_tissue.index(3) = j;
         summed_log.value() += balance_factors(j) * combined_tissue.value() / norm_field_image.value();
       }


### PR DESCRIPTION
In a very unlikely course of events, I happened to spot this one while staring at this bit of code for other reasons.  @rtabbara : looks like our masterpiece still had a little imperfection. :wink: 

For the RC3 release notes; can keep it short: "mtnormalise: bugfix related to outlier rejection"

For future reference: the bug made it a bit less likely for negative outliers to be detected (as they should've), and a bit more likely for positive outliers to be detected (as they shouldn't have).  Even though we intended for this step to be in the log domain, due to a small mistake in the looping, the log was essentially not applied (apart from one voxel, where is was wrong in another way).