### PR TITLE
Alternative handling for abs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,11 +46,11 @@ matrix:
       env: py=python2 test=sphinx
     - os: linux
       env: py=python3 test=sphinx
-    #############################################################
-    # Run the check_memalign script; only needs to be done once #
-    #############################################################
+    ###########################################################
+    # Run the check_syntax script; only needs to be done once #
+    ###########################################################
     - os: linux
-      env: test=memalign
+      env: test=syntax
     ##############################################
     # Run PyLint tests; both Python2 and Python3 #
     ##############################################
@@ -114,8 +114,8 @@ after_failure:
       "sphinx")
         cat sphinx.log
         ;;
-      "memalign")
-        cat memalign.log
+      "syntax")
+        cat syntax.log
         ;;
       "pylint")
         cat pylint.log

--- a/check_syntax
+++ b/check_syntax
@@ -102,13 +102,13 @@ if [[ $retval == 0 ]]; then
   echo "OK"
   echo "no issues detected" >> $LOG
 else
-  echo "FAIL"
+  echo "FAIL (see syntax.log for details)"
 
   echo "" >> $LOG
-  echo "Please add MEMALIGN() or NOMEMALIGN macro to the class declarations identified above,
-replace all occurrences of std::vector<> with MR::vector<> (or just vector<>),
-avoid use of std::make_shared(),
-and replace all instances of std::abs() with MR::abs() (or just abs())" >> $LOG
+  echo "Please add MEMALIGN() or NOMEMALIGN macro to the class declarations
+  identified above, replace all occurrences of std::vector<> with MR::vector<>
+  (or just vector<>), avoid use of std::make_shared(), and replace all
+  instances of std::abs() with MR::abs() (or just abs())" >> $LOG
   exit 1
 fi
 

--- a/check_syntax
+++ b/check_syntax
@@ -1,28 +1,28 @@
 #!/bin/bash
 
-LOG=memalign.log
-echo -n "Checking memory alignment for Eigen 3.3 compatibility... "
-echo "Checking memory alignment for Eigen 3.3 compatibility..." > $LOG
+LOG=syntax.log
+echo -n "Checking syntax and memory alignment for Eigen 3.3 compatibility... "
+echo "Checking syntax and memory alignment for Eigen 3.3 compatibility..." > $LOG
 echo "" >> $LOG
 
 retval=0
 
-for f in $(find cmd core src -type f -name '*.h' -o -name '*.cpp' | grep -v '_moc.cpp'); do 
+for f in $(find cmd core src -type f -name '*.h' -o -name '*.cpp' | grep -v '_moc.cpp'); do
 
 # files to ignore:
-  [[ "$f" -ef "src/gui/shview/icons.h" || 
-     "$f" -ef "src/gui/shview/icons.cpp" || 
-     "$f" -ef "src/gui/mrview/icons.h" || 
-     "$f" -ef "src/gui/mrview/icons.cpp" || 
-     "$f" -ef "core/file/mgh.h" || 
-     "$f" -ef "core/file/json.h" || 
-     "$f" -ef "core/file/nifti2.h" || 
+  [[ "$f" -ef "src/gui/shview/icons.h" ||
+     "$f" -ef "src/gui/shview/icons.cpp" ||
+     "$f" -ef "src/gui/mrview/icons.h" ||
+     "$f" -ef "src/gui/mrview/icons.cpp" ||
+     "$f" -ef "core/file/mgh.h" ||
+     "$f" -ef "core/file/json.h" ||
+     "$f" -ef "core/file/nifti2.h" ||
      "$f" -ef "core/signal_handler.h" ||
      "$f" -ef "core/signal_handler.cpp" ]] && continue
 
 
 
-  
+
   # process the file to strip comments, macros, etc:
   cat $f | \
 # remove C preprocessor macros:
@@ -36,13 +36,12 @@ for f in $(find cmd core src -type f -name '*.h' -o -name '*.cpp' | grep -v '_mo
 # remove C-style comments:
   perl -pe 's|/\*.*?\*/||g' | \
 # remove quoted strings:
-  perl -pe 's/(")(\\"|.)*?"//g' > .check_memalign.tmp
+  perl -pe 's/(")(\\"|.)*?"//g' > .check_syntax.tmp
 
 
 # detect classes not declared MEMALIGN or NOMEMALIGN:
-
-  res=$( 
-    cat .check_memalign.tmp | \
+  res=$(
+    cat .check_syntax.tmp | \
 # remove any text within a template declaration (i.e. within <>):
     perl -pe 's|<[^{};<]*?>||g' | \
 # and do it multiple times to handle nested declarations:
@@ -54,52 +53,62 @@ for f in $(find cmd core src -type f -name '*.h' -o -name '*.cpp' | grep -v '_mo
 # remove matches that correspond to an enum class declaration:
     grep -Ev '\benum\s*class\b' | \
 # remove matches that are properly specified:
-    grep -Ev '\b(class|struct)\b[^;{]*?{(\s*(MEMALIGN\s*\([^\)]*\)|NOMEMALIGN))' 
+    grep -Ev '\b(class|struct)\b[^;{]*?{(\s*(MEMALIGN\s*\([^\)]*\)|NOMEMALIGN))'
   )
 
-
 # detect any instances of std::vector:
-  res="$res"$( 
-    cat .check_memalign.tmp | \
+  res="$res"$(
+    cat .check_syntax.tmp | \
 # match for the parts we're interested in and output just the bits that match:
-    grep -Po '(?<!::)std::vector\b' 
+    grep -Po '(?<!::)std::vector\b'
   )
 
 # detect any instances of std::make_shared:
-  res="$res"$( 
-    cat .check_memalign.tmp | \
+  res="$res"$(
+    cat .check_syntax.tmp | \
 # match for the parts we're interested in and output just the bits that match:
-    grep -Po '(?<!::)std::make_shared\b' 
+    grep -Po '(?<!::)std::make_shared\b'
   )
 
 # detect any instances of "using namespace std;":
-  res="$res"$( 
-    cat .check_memalign.tmp | \
+  res="$res"$(
+    cat .check_syntax.tmp | \
 # match for the parts we're interested in and output just the bits that match:
-    grep -Po '\busing\s+namespace\s+std\s*;' 
+    grep -Po '\busing\s+namespace\s+std\s*;'
   )
 
+# detect any instances of std::abs (outside of the SFINAE call in core/types.h):
+  if [[ ! "$f" -ef "core/types.h" ]]; then
+    res="$res"$(
+      cat .check_syntax.tmp | \
+# match for the parts we're interested in and output just the bits that match:
+      grep -Po '(?<!::)std::abs\b'
+    )
+  fi
+
+
 # if anything is left after that, show it:
-  if [[ ! -z $res ]]; then 
+  if [[ ! -z $res ]]; then
     echo "################################### $f" >> $LOG
     echo "$res" >> $LOG
     retval=1
-  fi 
+  fi
 
 done
 
 
 # set exit code:
 if [[ $retval == 0 ]]; then
-  echo "OK" 
+  echo "OK"
   echo "no issues detected" >> $LOG
 else
   echo "FAIL"
-  
+
   echo "" >> $LOG
-  echo "Please add MEMALIGN() macro to the class declarations identified above,
-replace all occurrences of std::vector with MR::vector,
-and avoid use of std::make_shared" >> $LOG
+  echo "Please add MEMALIGN() or NOMEMALIGN macro to the class declarations identified above,
+replace all occurrences of std::vector<> with MR::vector<> (or just vector<>),
+avoid use of std::make_shared(),
+and replace all instances of std::abs() with MR::abs() (or just abs())" >> $LOG
   exit 1
 fi
 

--- a/cmd/5tt2gmwmi.cpp
+++ b/cmd/5tt2gmwmi.cpp
@@ -95,7 +95,7 @@ class Processor
             input.index(axis) = output.index(axis) + 1;
           }
           const DWI::Tractography::ACT::Tissues pos (input);
-          gradient += Math::pow2 (multiplier * std::min (std::abs (pos.get_gm() - neg.get_gm()), std::abs (pos.get_wm() - neg.get_wm())));
+          gradient += Math::pow2 (multiplier * std::min (abs (pos.get_gm() - neg.get_gm()), abs (pos.get_wm() - neg.get_wm())));
         }
         output.value() = std::max (0.0, std::sqrt (gradient));
         assign_pos_of (output, 0, 3).to (input);

--- a/cmd/5ttcheck.cpp
+++ b/cmd/5ttcheck.cpp
@@ -83,7 +83,7 @@ void run ()
         for (auto inner = Loop(3) (in); inner; ++inner)
           sum += in.value();
         if (!sum) continue;
-        if (std::abs (sum-1.0) > MAX_ERROR) {
+        if (abs (sum-1.0) > MAX_ERROR) {
           ++voxel_error_sum;
           if (voxels.valid()) {
             assign_pos_of (in, 0, 3).to (voxels);

--- a/cmd/dirstat.cpp
+++ b/cmd/dirstat.cpp
@@ -166,7 +166,7 @@ vector<default_type> summarise_E (const vector<double>& E)
 
 
 
-class Metrics 
+class Metrics
 { MEMALIGN (Metrics)
   public:
     vector<default_type> BN, UN, BE, UE, SH;

--- a/cmd/dirstat.cpp
+++ b/cmd/dirstat.cpp
@@ -196,7 +196,7 @@ Metrics compute (Eigen::MatrixXd& directions)
       double cos_angle = directions.row(i).head(3).normalized().dot (directions.row(j).head(3).normalized());
       NN_unipolar[i] = std::max (NN_unipolar[i], cos_angle);
       NN_unipolar[j] = std::max (NN_unipolar[j], cos_angle);
-      cos_angle = std::abs (cos_angle);
+      cos_angle = abs (cos_angle);
       NN_bipolar[i] = std::max (NN_bipolar[i], cos_angle);
       NN_bipolar[j] = std::max (NN_bipolar[j], cos_angle);
 

--- a/cmd/dwiextract.cpp
+++ b/cmd/dwiextract.cpp
@@ -106,7 +106,7 @@ void run()
         }
       }
       if (filter.size() == 4) {
-        if (std::abs (pe_scheme(i, 3) - filter[3]) > 5e-3) {
+        if (abs (pe_scheme(i, 3) - filter[3]) > 5e-3) {
           keep = false;
           break;
         }

--- a/cmd/fixel2tsf.cpp
+++ b/cmd/fixel2tsf.cpp
@@ -117,7 +117,7 @@ void run ()
 
           for (size_t fixel = 0; fixel < num_fixels_in_voxel; ++fixel) {
             in_directions_image.index(0) = offset + fixel;
-            const float dp = std::abs (dir.dot (Eigen::Vector3f (in_directions_image.row(1))));
+            const float dp = abs (dir.dot (Eigen::Vector3f (in_directions_image.row(1))));
             if (dp > largest_dp) {
               largest_dp = dp;
               closest_fixel_index = fixel;

--- a/cmd/fixel2voxel.cpp
+++ b/cmd/fixel2voxel.cpp
@@ -304,8 +304,8 @@ class AbsMax : protected Base
     {
       default_type absmax = -std::numeric_limits<default_type>::infinity();
       for (auto f = Base::Loop (index) (data); f; ++f) {
-        if (!f.padding() && std::abs (data.value()) > absmax)
-          absmax = std::abs (data.value());
+        if (!f.padding() && abs (data.value()) > absmax)
+          absmax = abs (data.value());
       }
       out.value() = std::isfinite (absmax) ? absmax : 0.0;
     }
@@ -322,7 +322,7 @@ class MagMax : protected Base
     {
       default_type magmax = 0.0;
       for (auto f = Base::Loop (index) (data); f; ++f) {
-        if (!f.padding() && std::abs (data.value()) > std::abs (magmax))
+        if (!f.padding() && abs (data.value()) > abs (magmax))
           magmax = data.value();
       }
       out.value() = std::isfinite (magmax) ? magmax : 0.0;
@@ -392,12 +392,12 @@ class DEC_unit : protected Base
       if (vol.valid()) {
         for (auto f = Base::Loop (index) (data, vol, dir); f; ++f) {
           if (!f.padding())
-            sum_dec += Eigen::Vector3 (std::abs (dir.row(1)[0]), std::abs (dir.row(1)[1]), std::abs (dir.row(1)[2])) * data.value() * vol.value();
+            sum_dec += Eigen::Vector3 (abs (dir.row(1)[0]), abs (dir.row(1)[1]), abs (dir.row(1)[2])) * data.value() * vol.value();
         }
       } else {
         for (auto f = Base::Loop (index) (data, dir); f; ++f) {
           if (!f.padding())
-            sum_dec += Eigen::Vector3 (std::abs (dir.row(1)[0]), std::abs (dir.row(1)[1]), std::abs (dir.row(1)[2])) * data.value();
+            sum_dec += Eigen::Vector3 (abs (dir.row(1)[0]), abs (dir.row(1)[1]), abs (dir.row(1)[2])) * data.value();
         }
       }
       if ((sum_dec.array() != 0.0).any())
@@ -426,7 +426,7 @@ class DEC_scaled : protected Base
         default_type sum_volume = 0.0;
         for (auto f = Base::Loop (index) (data, vol, dir); f; ++f) {
           if (!f.padding()) {
-            sum_dec += Eigen::Vector3 (std::abs (dir.row(1)[0]), std::abs (dir.row(1)[1]), std::abs (dir.row(1)[2])) * data.value() * vol.value();
+            sum_dec += Eigen::Vector3 (abs (dir.row(1)[0]), abs (dir.row(1)[1]), abs (dir.row(1)[2])) * data.value() * vol.value();
             sum_volume += vol.value();
             sum_value += vol.value() * data.value();
           }
@@ -437,7 +437,7 @@ class DEC_scaled : protected Base
       } else {
         for (auto f = Base::Loop (index) (data, dir); f; ++f) {
           if (!f.padding()) {
-            sum_dec += Eigen::Vector3 (std::abs (dir.row(1)[0]), std::abs (dir.row(1)[1]), std::abs (dir.row(1)[2])) * data.value();
+            sum_dec += Eigen::Vector3 (abs (dir.row(1)[0]), abs (dir.row(1)[1]), abs (dir.row(1)[2])) * data.value();
             sum_value += data.value();
           }
         }

--- a/cmd/fixelcorrespondence.cpp
+++ b/cmd/fixelcorrespondence.cpp
@@ -100,7 +100,7 @@ void run ()
         templatedir.normalize();
         Eigen::Vector3f subjectdir = subject_directions.row(1);
         subjectdir.normalize();
-        float dp = std::abs (templatedir.dot (subjectdir));
+        float dp = abs (templatedir.dot (subjectdir));
         if (dp > largest_dp) {
           largest_dp = dp;
           index_of_closest_fixel = s;

--- a/cmd/mrcalc.cpp
+++ b/cmd/mrcalc.cpp
@@ -788,8 +788,8 @@ class OpTernary : public OpBase { NOMEMALIGN
 class OpAbs : public OpUnary { NOMEMALIGN
   public:
     OpAbs () : OpUnary ("|%1|", true) { }
-    complex_type R (real_type v) const { return std::abs (v); }
-    complex_type Z (complex_type v) const { return std::abs (v); }
+    complex_type R (real_type v) const { return abs (v); }
+    complex_type Z (complex_type v) const { return abs (v); }
 };
 
 class OpNeg : public OpUnary { NOMEMALIGN

--- a/cmd/mrdegibbs.cpp
+++ b/cmd/mrdegibbs.cpp
@@ -239,10 +239,10 @@ class ComputeSlice
             TV1arr[j] = 0.0;
             TV2arr[j] = 0.0;
             for (int t = minW; t <= maxW; t++) {
-              TV1arr[j] += std::abs (shifted((n-t)%n,j).real() - shifted((n-t-1)%n,j).real());
-              TV1arr[j] += std::abs (shifted((n-t)%n,j).imag() - shifted((n-t-1)%n,j).imag());
-              TV2arr[j] += std::abs (shifted((n+t)%n,j).real() - shifted((n+t+1)%n,j).real());
-              TV2arr[j] += std::abs (shifted((n+t)%n,j).imag() - shifted((n+t+1)%n,j).imag());
+              TV1arr[j] += abs (shifted((n-t)%n,j).real() - shifted((n-t-1)%n,j).real());
+              TV1arr[j] += abs (shifted((n-t)%n,j).imag() - shifted((n-t-1)%n,j).imag());
+              TV2arr[j] += abs (shifted((n+t)%n,j).real() - shifted((n+t+1)%n,j).real());
+              TV2arr[j] += abs (shifted((n+t)%n,j).imag() - shifted((n+t+1)%n,j).imag());
             }
           }
 
@@ -260,15 +260,15 @@ class ComputeSlice
                 minidx = j;
               }
 
-              TV1arr[j] += std::abs (shifted((l-minW+1+n)%n,j).real() - shifted((l-(minW  )+n)%n,j).real());
-              TV1arr[j] -= std::abs (shifted((l-maxW  +n)%n,j).real() - shifted((l-(maxW+1)+n)%n,j).real());
-              TV2arr[j] += std::abs (shifted((l+maxW+1+n)%n,j).real() - shifted((l+(maxW+2)+n)%n,j).real());
-              TV2arr[j] -= std::abs (shifted((l+minW  +n)%n,j).real() - shifted((l+(minW+1)+n)%n,j).real());
+              TV1arr[j] += abs (shifted((l-minW+1+n)%n,j).real() - shifted((l-(minW  )+n)%n,j).real());
+              TV1arr[j] -= abs (shifted((l-maxW  +n)%n,j).real() - shifted((l-(maxW+1)+n)%n,j).real());
+              TV2arr[j] += abs (shifted((l+maxW+1+n)%n,j).real() - shifted((l+(maxW+2)+n)%n,j).real());
+              TV2arr[j] -= abs (shifted((l+minW  +n)%n,j).real() - shifted((l+(minW+1)+n)%n,j).real());
 
-              TV1arr[j] += std::abs (shifted((l-minW+1+n)%n,j).imag() - shifted((l-(minW  )+n)%n,j).imag());
-              TV1arr[j] -= std::abs (shifted((l-maxW  +n)%n,j).imag() - shifted((l-(maxW+1)+n)%n,j).imag());
-              TV2arr[j] += std::abs (shifted((l+maxW+1+n)%n,j).imag() - shifted((l+(maxW+2)+n)%n,j).imag());
-              TV2arr[j] -= std::abs (shifted((l+minW  +n)%n,j).imag() - shifted((l+(minW+1)+n)%n,j).imag());
+              TV1arr[j] += abs (shifted((l-minW+1+n)%n,j).imag() - shifted((l-(minW  )+n)%n,j).imag());
+              TV1arr[j] -= abs (shifted((l-maxW  +n)%n,j).imag() - shifted((l-(maxW+1)+n)%n,j).imag());
+              TV2arr[j] += abs (shifted((l+maxW+1+n)%n,j).imag() - shifted((l+(maxW+2)+n)%n,j).imag());
+              TV2arr[j] -= abs (shifted((l+minW  +n)%n,j).imag() - shifted((l+(minW+1)+n)%n,j).imag());
             }
 
             double a0r = shifted((l-1+n)%n,minidx).real();

--- a/cmd/mrfilter.cpp
+++ b/cmd/mrfilter.cpp
@@ -155,7 +155,7 @@ void run () {
         filter.datatype() = DataType::Float32;
         auto output = Image<float>::create (argument[2], filter);
         for (auto l = Loop (output) (temp, output); l; ++l)
-          output.value() = std::abs (cdouble(temp.value()));
+          output.value() = abs (cdouble(temp.value()));
       } else {
         auto output = Image<cdouble>::create (argument[2], filter);
         filter (input, output);

--- a/cmd/mrmath.cpp
+++ b/cmd/mrmath.cpp
@@ -230,8 +230,8 @@ class AbsMax { NOMEMALIGN
   public:
     AbsMax () : max (-std::numeric_limits<value_type>::infinity()) { }
     void operator() (value_type val) {
-      if (std::isfinite (val) && std::abs(val) > max)
-        max = std::abs(val);
+      if (std::isfinite (val) && abs(val) > max)
+        max = abs(val);
     }
     value_type result () const { return std::isfinite (max) ? max : NAN; }
     value_type max;
@@ -242,7 +242,7 @@ class MagMax { NOMEMALIGN
     MagMax () : max (-std::numeric_limits<value_type>::infinity()) { }
     MagMax (const int i) : max (-std::numeric_limits<value_type>::infinity()) { }
     void operator() (value_type val) {
-      if (std::isfinite (val) && (!std::isfinite (max) || std::abs(val) > std::abs (max)))
+      if (std::isfinite (val) && (!std::isfinite (max) || abs(val) > abs (max)))
         max = val;
     }
     value_type result () const { return std::isfinite (max) ? max : NAN; }

--- a/cmd/sh2peaks.cpp
+++ b/cmd/sh2peaks.cpp
@@ -182,7 +182,7 @@ class Processor { MEMALIGN(Processor)
         p.a = Math::SH::get_peak (item.data, lmax, p.v);
         if (std::isfinite (p.a)) {
           for (size_t j = 0; j < all_peaks.size(); j++) {
-            if (std::abs (p.v.dot (all_peaks[j].v)) > DOT_THRESHOLD) {
+            if (abs (p.v.dot (all_peaks[j].v)) > DOT_THRESHOLD) {
               p.a = NAN;
               break;
             }
@@ -208,7 +208,7 @@ class Processor { MEMALIGN(Processor)
 
           value_type mdot = 0.0;
           for (size_t n = 0; n < all_peaks.size(); n++) {
-            value_type f = std::abs (p.dot (all_peaks[n].v));
+            value_type f = abs (p.dot (all_peaks[n].v));
             if (f > mdot) {
               mdot = f;
               peaks_out[i] = all_peaks[n];
@@ -220,7 +220,7 @@ class Processor { MEMALIGN(Processor)
         for (int i = 0; i < npeaks; i++) {
           value_type mdot = 0.0;
           for (size_t n = 0; n < all_peaks.size(); n++) {
-            value_type f = std::abs (all_peaks[n].v.dot (true_peaks[i].v));
+            value_type f = abs (all_peaks[n].v.dot (true_peaks[i].v));
             if (f > mdot) {
               mdot = f;
               peaks_out[i] = all_peaks[n];

--- a/cmd/shbasis.cpp
+++ b/cmd/shbasis.cpp
@@ -266,7 +266,7 @@ void check_and_update (Header& H, const conv_t conversion)
   // Decide whether the user needs to be warned about a poor diffusion encoding scheme
   if (regression.second)
     DEBUG ("Gradient of regression is " + str(regression.second) + "; threshold is " + str(grad_threshold));
-  if (std::abs(regression.second) > grad_threshold) {
+  if (abs(regression.second) > grad_threshold) {
     WARN ("Image \"" + H.name() + "\" may have been derived from poor directional encoding, or have some other underlying data problem");
     WARN ("(m!=0 to m==0 power ratio changing by " + str(2.0*regression.second) + " per even order)");
   }

--- a/cmd/tck2fixel.cpp
+++ b/cmd/tck2fixel.cpp
@@ -64,7 +64,7 @@ class TrackProcessor { MEMALIGN (TrackProcessor)
          float largest_dp = 0.0;
          const Eigen::Vector3 dir (i->get_dir().normalized());
          for (uint32_t j = first_index; j < last_index; ++j) {
-           const float dp = std::abs (dir.dot (fixel_directions[j]));
+           const float dp = abs (dir.dot (fixel_directions[j]));
            if (dp > largest_dp) {
              largest_dp = dp;
              closest_fixel_index = j;

--- a/cmd/tckdfc.cpp
+++ b/cmd/tckdfc.cpp
@@ -265,7 +265,7 @@ void run ()
 
       case 1: // triangle
         for (ssize_t i = 0; i != window_width; ++i)
-          window[i] = 1.0 - (std::abs (i - centre) / default_type(halfwidth));
+          window[i] = 1.0 - (abs (i - centre) / default_type(halfwidth));
         break;
 
       case 2: // cosine
@@ -285,7 +285,7 @@ void run ()
 
       case 5: // lanczos
         for (ssize_t i = 0; i != window_width; ++i) {
-          const default_type v = 2.0 * Math::pi * std::abs (i - centre) / default_type(window_width - 1);
+          const default_type v = 2.0 * Math::pi * abs (i - centre) / default_type(window_width - 1);
           window[i] = v ? std::max (0.0, (std::sin (v) / v)) : 1.0;
         }
         break;

--- a/cmd/tensor2metric.cpp
+++ b/cmd/tensor2metric.cpp
@@ -183,7 +183,7 @@ class Processor { MEMALIGN(Processor)
         eigval = es.eigenvalues();
         ith_eig[0] = 0; ith_eig[1] = 1; ith_eig[2] = 2;
         std::sort (std::begin (ith_eig), std::end (ith_eig), 
-            [&eigval](size_t a, size_t b) { return std::abs(eigval[a]) > std::abs(eigval[b]); });
+            [&eigval](size_t a, size_t b) { return abs(eigval[a]) > abs(eigval[b]); });
       }
         
       /* output value */

--- a/core/algo/histogram.cpp
+++ b/core/algo/histogram.cpp
@@ -55,7 +55,7 @@ namespace MR
           min = V[0] - (0.5 * bin_width);
           max = V[num_bins-1] + (0.5 * bin_width);
           for (size_t i = 0; i != num_bins; ++i) {
-            if (std::abs (get_bin_centre(i) - V[i]) > 1e-5)
+            if (abs (get_bin_centre(i) - V[i]) > 1e-5)
               throw Exception ("Non-equal spacing in histogram bin centres");
           }
         } catch (Exception& e) {

--- a/core/file/dicom/image.cpp
+++ b/core/file/dicom/image.cpp
@@ -488,7 +488,7 @@ namespace MR {
 
         for (size_t n = 0; n < nslices-1; ++n) {
           const default_type separation = frames[n+1]->distance - frames[n]->distance;
-          const default_type gap = std::abs (separation - frames[n]->slice_thickness);
+          const default_type gap = abs (separation - frames[n]->slice_thickness);
           max_gap = std::max (gap, max_gap);
           min_separation = std::min (min_separation, separation);
           max_separation = std::max (max_separation, separation);

--- a/core/file/nifti1_utils.cpp
+++ b/core/file/nifti1_utils.cpp
@@ -64,7 +64,7 @@ namespace MR
           H.size(i) = Raw::fetch_<int16_t> (&NH.dim[i+1], is_BE);
           if (H.size (i) < 0) {
             INFO ("dimension along axis " + str (i) + " specified as negative in NIfTI-1.1 image \"" + H.name() + "\" - taking absolute value");
-            H.size(i) = std::abs (H.size (i));
+            H.size(i) = abs (H.size (i));
           }
           if (!H.size (i))
             H.size(i) = 1;
@@ -134,7 +134,7 @@ namespace MR
           H.spacing(i) = Raw::fetch_<float32> (&NH.pixdim[i+1], is_BE);
           if (H.spacing (i) < 0.0) {
             INFO ("voxel size along axis " + str (i) + " specified as negative in NIfTI-1.1 image \"" + H.name() + "\" - taking absolute value");
-            H.spacing(i) = std::abs (H.spacing (i));
+            H.spacing(i) = abs (H.spacing (i));
           }
         }
 
@@ -184,7 +184,7 @@ namespace MR
             // check voxel sizes:
             for (size_t axis = 0; axis != 3; ++axis) {
               if (size_t(ndim) > axis)
-                if (std::abs(H.spacing(axis) - std::sqrt (Math::pow2 (M(0,axis)) + Math::pow2 (M(1,axis)) + Math::pow2 (M(2,axis)))) > 1e-4) {
+                if (abs(H.spacing(axis) - std::sqrt (Math::pow2 (M(0,axis)) + Math::pow2 (M(1,axis)) + Math::pow2 (M(2,axis)))) > 1e-4) {
                     WARN ("voxel spacings inconsistent between NIFTI s-form and header field pixdim");
                     break;
                 }

--- a/core/file/nifti2_utils.cpp
+++ b/core/file/nifti2_utils.cpp
@@ -114,7 +114,7 @@ namespace MR
           H.size(i) = Raw::fetch_<int64_t> (&NH.dim[i+1], is_BE);
           if (H.size (i) < 0) {
             INFO ("dimension along axis " + str (i) + " specified as negative in NIfTI-2 image \"" + H.name() + "\" - taking absolute value");
-            H.size(i) = std::abs (H.size (i));
+            H.size(i) = abs (H.size (i));
           }
           if (!H.size (i))
             H.size(i) = 1;
@@ -126,7 +126,7 @@ namespace MR
           H.spacing(i) = Raw::fetch_<float64> (&NH.pixdim[i+1], is_BE);
           if (H.spacing (i) < 0.0) {
             INFO ("voxel size along axis " + str (i) + " specified as negative in NIfTI-2 image \"" + H.name() + "\" - taking absolute value");
-            H.spacing(i) = std::abs (H.spacing (i));
+            H.spacing(i) = abs (H.spacing (i));
           }
         }
 
@@ -178,7 +178,7 @@ namespace MR
           // check voxel sizes:
           for (size_t axis = 0; axis != 3; ++axis) {
             if (size_t(ndim) > axis)
-                if (std::abs(H.spacing(axis) - std::sqrt (Math::pow2 (M(0,axis)) + Math::pow2 (M(1,axis)) + Math::pow2 (M(2,axis)))) > 1e-4) {
+                if (abs(H.spacing(axis) - std::sqrt (Math::pow2 (M(0,axis)) + Math::pow2 (M(1,axis)) + Math::pow2 (M(2,axis)))) > 1e-4) {
                     WARN ("voxel spacings inconsistent between NIFTI s-form and header field pixdim");
                     break;
                 }

--- a/core/file/nifti_utils.cpp
+++ b/core/file/nifti_utils.cpp
@@ -75,8 +75,8 @@ namespace MR
         // while preserving original strides as much as possible
         ssize_t max_spatial_stride = 0;
         for (size_t n = 0; n < 3; ++n)
-          if (std::abs(H.stride(n)) > max_spatial_stride)
-            max_spatial_stride = std::abs(H.stride(n));
+          if (abs(H.stride(n)) > max_spatial_stride)
+            max_spatial_stride = abs(H.stride(n));
         for (size_t n = 3; n < H.ndim(); ++n)
           H.stride(n) += H.stride(n) > 0 ? max_spatial_stride : -max_spatial_stride;
         Stride::symbolise (H);

--- a/core/formats/mri.cpp
+++ b/core/formats/mri.cpp
@@ -301,7 +301,7 @@ namespace MR
       size_t n;
       char order[4];
       for (n = 0; n < H.ndim(); ++n)
-        order[std::abs (H.stride (n))-1] = order2char (n, H.stride (n) >0);
+        order[abs (H.stride (n))-1] = order2char (n, H.stride (n) >0);
       for (; n < 4; ++n)
         order[n] = order2char (n, true);
       out.write (order, 4);

--- a/core/formats/mrtrix_utils.cpp
+++ b/core/formats/mrtrix_utils.cpp
@@ -66,12 +66,12 @@ namespace MR
       if (parsed.size() != ndim)
         throw Exception ("incorrect number of dimensions for axes specifier");
       for (size_t n = 0; n < parsed.size(); n++) {
-        if (!parsed[n] || size_t (std::abs (parsed[n])) > ndim)
+        if (!parsed[n] || size_t (abs (parsed[n])) > ndim)
           throw Exception ("axis ordering " + str (parsed[n]) + " out of range");
 
         for (size_t i = 0; i < n; i++)
-          if (std::abs (parsed[i]) == std::abs (parsed[n]))
-            throw Exception ("duplicate axis ordering (" + str (std::abs (parsed[n])) + ")");
+          if (abs (parsed[i]) == abs (parsed[n]))
+            throw Exception ("duplicate axis ordering (" + str (abs (parsed[n])) + ")");
       }
 
       return parsed;

--- a/core/formats/mrtrix_utils.h
+++ b/core/formats/mrtrix_utils.h
@@ -158,9 +158,9 @@ namespace MR
         auto stride = Stride::get (H);
         Stride::symbolise (stride);
 
-        out << "\nlayout: " << (stride[0] >0 ? "+" : "-") << std::abs (stride[0])-1;
+        out << "\nlayout: " << (stride[0] >0 ? "+" : "-") << abs (stride[0])-1;
         for (size_t n = 1; n < H.ndim(); ++n)
-          out << "," << (stride[n] >0 ? "+" : "-") << std::abs (stride[n])-1;
+          out << "," << (stride[n] >0 ? "+" : "-") << abs (stride[n])-1;
 
         DataType dt = H.datatype();
         dt.set_byte_order_native();

--- a/core/header.cpp
+++ b/core/header.cpp
@@ -276,7 +276,7 @@ namespace MR
         for (size_t i = 0; i < H.ndim(); ++i) {
           if (H.stride(i)) {
             ++n;
-            next_stride = std::max (next_stride, std::abs (H.stride(i)));
+            next_stride = std::max (next_stride, abs (H.stride(i)));
           }
         }
 

--- a/core/image_diff.h
+++ b/core/image_diff.h
@@ -29,13 +29,13 @@ namespace MR
       check_dimensions (in1, in2);
       for (size_t i = 0; i < in1.ndim(); ++i) {
         if (std::isfinite (in1.spacing(i)))
-          if (std::abs ((in1.spacing(i) - in2.spacing(i)) / (in1.spacing(i) + in2.spacing(i))) > 1e-4)
+          if (abs ((in1.spacing(i) - in2.spacing(i)) / (in1.spacing(i) + in2.spacing(i))) > 1e-4)
             throw Exception ("images \"" + in1.name() + "\" and \"" + in2.name() + "\" do not have matching voxel spacings " +
                                            str(in1.spacing(i)) + " vs " + str(in2.spacing(i)));
       }
       for (size_t i  = 0; i < 3; ++i) {
         for (size_t j  = 0; j < 4; ++j) {
-          if (std::abs (in1.transform().matrix()(i,j) - in2.transform().matrix()(i,j)) > 0.001)
+          if (abs (in1.transform().matrix()(i,j) - in2.transform().matrix()(i,j)) > 0.001)
             throw Exception ("images \"" + in1.name() + "\" and \"" + in2.name() + "\" do not have matching header transforms "
                                + "\n" + str(in1.transform().matrix()) + "vs \n " + str(in2.transform().matrix()) + ")");
         }
@@ -50,7 +50,7 @@ namespace MR
       check_headers (in1, in2);
       ThreadedLoop (in1)
       .run ([&tol] (const ImageType1& a, const ImageType2& b) {
-          if (std::abs (cdouble (a.value()) - cdouble (b.value())) > tol)
+          if (abs (cdouble (a.value()) - cdouble (b.value())) > tol)
             throw Exception ("images \"" + a.name() + "\" and \"" + b.name() + "\" do not match within absolute precision of " + str(tol)
                  + " (" + str(cdouble (a.value())) + " vs " + str(cdouble (b.value())) + ")");
           }, in1, in2);
@@ -64,7 +64,7 @@ namespace MR
       check_headers (in1, in2);
       ThreadedLoop (in1)
       .run ([&tol] (const ImageType1& a, const ImageType2& b) {
-          if (std::abs ((cdouble (a.value()) - cdouble (b.value())) / (0.5 * (cdouble (a.value()) + cdouble (b.value())))) > tol)
+          if (abs ((cdouble (a.value()) - cdouble (b.value())) / (0.5 * (cdouble (a.value()) + cdouble (b.value())))) > tol)
           throw Exception ("images \"" + a.name() + "\" and \"" + b.name() + "\" do not match within fractional precision of " + str(tol)
                + " (" + str(cdouble (a.value())) + " vs " + str(cdouble (b.value())) + ")");
           }, in1, in2);
@@ -78,7 +78,7 @@ namespace MR
       check_headers (in1, tol);
       ThreadedLoop (in1)
       .run ([] (const ImageType1& a, const ImageType2& b, const ImageTypeTol& t) {
-          if (std::abs (cdouble (a.value()) - cdouble (b.value())) > t.value())
+          if (abs (cdouble (a.value()) - cdouble (b.value())) > t.value())
           throw Exception ("images \"" + a.name() + "\" and \"" + b.name() + "\" do not match within precision of \"" + t.name() + "\""
                + " (" + str(cdouble (a.value())) + " vs " + str(cdouble (b.value())) + ", tolerance " + str(t.value()) + ")");
           }, in1, in2, tol);
@@ -91,12 +91,12 @@ namespace MR
       auto func = [&tol] (decltype(in1)& a, decltype(in2)& b) {
         double maxa = 0.0, maxb = 0.0;
         for (auto l = Loop(3) (a, b); l; ++l) {
-          maxa = std::max (maxa, std::abs (cdouble(a.value())));
-          maxb = std::max (maxb, std::abs (cdouble(b.value())));
+          maxa = std::max (maxa, abs (cdouble(a.value())));
+          maxb = std::max (maxb, abs (cdouble(b.value())));
         }
         const double threshold = tol * 0.5 * (maxa + maxb);
         for (auto l = Loop(3) (a, b); l; ++l) {
-          if (std::abs (cdouble (a.value()) - cdouble (b.value())) > threshold)
+          if (abs (cdouble (a.value()) - cdouble (b.value())) > threshold)
             throw Exception ("images \"" + a.name() + "\" and \"" + b.name() + "\" do not match within " + str(tol) + " of maximal voxel value"
                            + " (" + str(cdouble (a.value())) + " vs " + str(cdouble (b.value())) + ")");
         }
@@ -125,7 +125,7 @@ namespace MR
      {
        headers_match (in1, in2);
        for (auto i = Loop (in1)(in1, in2); i; ++i)
-         if (std::abs (cdouble (in1.value()) - cdouble (in2.value())) > tol)
+         if (abs (cdouble (in1.value()) - cdouble (in2.value())) > tol)
            return false;
        return true;
      }

--- a/core/image_helpers.h
+++ b/core/image_helpers.h
@@ -330,7 +330,7 @@ namespace MR
     {
       if (in1.ndim() != in2.ndim()) return false;
       for (size_t n = 0; n < in1.ndim(); ++n)
-        if (std::abs(in1.spacing (n) - in2.spacing (n)) > tol * 0.5 * (in1.spacing (n) + in2.spacing (n))) return false;
+        if (abs(in1.spacing (n) - in2.spacing (n)) > tol * 0.5 * (in1.spacing (n) + in2.spacing (n))) return false;
       return true;
     }
 
@@ -340,7 +340,7 @@ namespace MR
       assert (from_axis < to_axis);
       if (to_axis > in1.ndim() || to_axis > in2.ndim()) return false;
       for (size_t n = from_axis; n < to_axis; ++n)
-        if (std::abs(in1.spacing (n) - in2.spacing (n)) > tol * 0.5 * (in1.spacing (n) + in2.spacing (n))) return false;
+        if (abs(in1.spacing (n) - in2.spacing (n)) > tol * 0.5 * (in1.spacing (n) + in2.spacing (n))) return false;
       return true;
     }
 
@@ -349,7 +349,7 @@ namespace MR
     {
       for (size_t n = 0; n < axes.size(); ++n) {
         if (in1.ndim() <= axes[n] || in2.ndim() <= axes[n]) return false;
-        if (std::abs(in1.spacing (axes[n]) - in2.spacing(axes[n])) > tol * 0.5 * (in1.spacing (axes[n]) + in2.spacing(axes[n]))) return false;
+        if (abs(in1.spacing (axes[n]) - in2.spacing(axes[n])) > tol * 0.5 * (in1.spacing (axes[n]) + in2.spacing(axes[n]))) return false;
       }
       return true;
     }

--- a/core/math/Sn_scale_estimator.h
+++ b/core/math/Sn_scale_estimator.h
@@ -37,7 +37,7 @@ namespace MR {
               med_diff.resize (vec.size());
               for (ssize_t j = 0; j < vec.size(); ++j) {
                 for (ssize_t i = 0; i < vec.size(); ++i) 
-                  diff[i] = std::abs (vec[i] - vec[j]);
+                  diff[i] = abs (vec[i] - vec[j]);
                 med_diff[j] = Math::median (diff);
               }
               return 1.1926 * Math::median (med_diff);

--- a/core/math/golden_section_search.h
+++ b/core/math/golden_section_search.h
@@ -58,7 +58,7 @@ namespace MR
         const ValueType g1 = 0.61803399, g2 = 1 - g1;
         ValueType x0 = min_bound, x1, x2, x3 = max_bound;
 
-        if (std::abs(max_bound - init_estimate) > std::abs(init_estimate - min_bound)) {
+        if (abs(max_bound - init_estimate) > abs(init_estimate - min_bound)) {
           x1 = init_estimate;
           x2 = init_estimate + g2 * (max_bound - init_estimate);
         } else {
@@ -69,7 +69,7 @@ namespace MR
         ValueType f1 = function(x1);
         ValueType f2 = function(x2);
 
-        while (tolerance * (std::abs(x1) + std::abs(x2)) < std::abs(x3 - x0)) {
+        while (tolerance * (abs(x1) + abs(x2)) < abs(x3 - x0)) {
           if (f2 < f1) {
             x0 = x1;
             x1 = x2;

--- a/core/math/median.h
+++ b/core/math/median.h
@@ -112,7 +112,7 @@ namespace MR
 
         median = s1 / denum;
         if (i > 3){
-          convergence=(std::abs(dist[i]-dist[i-2])<precision);
+          convergence=(abs(dist[i]-dist[i-2])<precision);
         }
         ++i;
       }

--- a/core/math/quadratic_line_search.h
+++ b/core/math/quadratic_line_search.h
@@ -121,7 +121,7 @@ namespace MR
             //   return successfully
             // Difficult to do this without knowledge of the cost function
             if (fm > (fl + ((fu-fl)*(m-l)/(u-l)))) {
-              if ((std::min(m-l, u-m) < value_tolerance) || (std::abs((fu-fl)/(0.5*(fu+fl))) < function_tolerance)) {
+              if ((std::min(m-l, u-m) < value_tolerance) || (abs((fu-fl)/(0.5*(fu+fl))) < function_tolerance)) {
                 status = SUCCESS;
                 return m;
               }

--- a/core/math/rician.h
+++ b/core/math/rician.h
@@ -147,7 +147,7 @@ namespace MR
         for (size_t i = 0; i < measured.size(); i++) {
           assert (measured[i] > 0.0);
 
-          T actual_pos = std::abs (actual[i]);
+          T actual_pos = abs (actual[i]);
           T nm = one_over_noise_squared * measured[i];
           T nms = nm * actual_pos;
           T F0 = Bessel::I0_scaled (nms);

--- a/core/math/sinc.h
+++ b/core/math/sinc.h
@@ -62,10 +62,10 @@ namespace MR
             const value_type sinc   = offset ? std::sin (Math::pi * offset) / (Math::pi * offset) : 1.0;
 
             //const value_type hann_cos_term = Math::pi * offset / (value_type(max_offset_from_kernel_centre) + 0.5);
-            //const value_type hann_factor   = (std::abs (hann_cos_term) < Math::pi) ? 0.5 * (1.0 + std::cos (hann_cos_term)) : 0.0;
+            //const value_type hann_factor   = (abs (hann_cos_term) < Math::pi) ? 0.5 * (1.0 + std::cos (hann_cos_term)) : 0.0;
             //const value_type this_weight   = hann_factor * sinc;
 
-            const value_type lanczos_sinc_term = std::abs (Math::pi * offset / (double(max_offset_from_kernel_centre) + 0.5));
+            const value_type lanczos_sinc_term = abs (Math::pi * offset / (double(max_offset_from_kernel_centre) + 0.5));
             value_type lanczos_factor = 0.0;
             if (lanczos_sinc_term < Math::pi) {
               if (lanczos_sinc_term)

--- a/core/phase_encoding.h
+++ b/core/phase_encoding.h
@@ -169,7 +169,7 @@ namespace MR
       for (ssize_t PE_row = 0; PE_row != PE.rows(); ++PE_row) {
         for (ssize_t config_row = 0; config_row != config.rows(); ++config_row) {
           bool dir_match = PE.template block<1,3>(PE_row, 0).isApprox (config.block<1,3>(config_row, 0));
-          bool time_match = std::abs (PE(PE_row, 3) - config(config_row, 3)) < 1e-3;
+          bool time_match = abs (PE(PE_row, 3) - config(config_row, 3)) < 1e-3;
           if (dir_match && time_match) {
             // FSL-style index file indexes from 1
             indices[PE_row] = config_row + 1;

--- a/core/stride.cpp
+++ b/core/stride.cpp
@@ -46,20 +46,20 @@ namespace MR
         if (!current[i]) continue;
         for (size_t j = i+1; j < current.size(); ++j) {
           if (!current[j]) continue;
-          if (std::abs (current[i]) == std::abs (current[j]))
+          if (abs (current[i]) == abs (current[j]))
             current[j] = 0;
         }
       }
 
       ssize_t desired_max = 0;
       for (size_t i = 0; i < desired.size(); ++i)
-        if (std::abs (desired[i]) > desired_max)
-          desired_max = std::abs (desired[i]);
+        if (abs (desired[i]) > desired_max)
+          desired_max = abs (desired[i]);
 
       ssize_t in_max = 0;
       for (size_t i = 0; i < current.size(); ++i)
-        if (std::abs (current[i]) > in_max)
-          in_max = std::abs (current[i]);
+        if (abs (current[i]) > in_max)
+          in_max = abs (current[i]);
       in_max += desired_max + 1;
 
       for (size_t i = 0; i < current.size(); ++i)
@@ -105,13 +105,13 @@ namespace MR
       strides.resize (current.size(), 0);
 
       for (const auto x : strides)
-        if (std::abs(x) > int (current.size()))
+        if (abs(x) > int (current.size()))
           throw Exception ("strides specified exceed image dimensions: got " + str(opt[0][0]) + ", but image has " + str(current.size()) + " axes");
 
       for (size_t i = 0; i < strides.size()-1; ++i) {
         if (!strides[1]) continue;
         for (size_t j = i+1; j < strides.size(); ++j)
-          if (std::abs (strides[i]) == std::abs (strides[j]))
+          if (abs (strides[i]) == abs (strides[j]))
             throw Exception ("duplicate entries provided to \"-strides\" option: " + str(opt[0][0]));
       }
 
@@ -124,12 +124,12 @@ namespace MR
       prev = get_symbolic (prev);
       ssize_t max_remaining = 0;
       for (const auto x : prev)
-        if (std::abs(x) > max_remaining)
-          max_remaining = std::abs(x);
+        if (abs(x) > max_remaining)
+          max_remaining = abs(x);
 
       struct FindStride { NOMEMALIGN
-        FindStride (List::value_type value) : x (std::abs(value)) { }
-        bool operator() (List::value_type a) { return std::abs (a) == x; }
+        FindStride (List::value_type value) : x (abs(value)) { }
+        bool operator() (List::value_type a) { return abs (a) == x; }
         const List::value_type x;
       };
 

--- a/core/stride.h
+++ b/core/stride.h
@@ -78,7 +78,7 @@ namespace MR
                 return false;
               if (S.stride(b) == 0)
                 return true;
-              return std::abs (S.stride (a)) < std::abs (S.stride (b));
+              return abs (S.stride (a)) < abs (S.stride (b));
             }
           private:
             const HeaderType& S;
@@ -195,14 +195,14 @@ namespace MR
           if (!header.stride (i)) continue;
           for (size_t j = i+1; j < header.ndim(); ++j) {
             if (!header.stride (j)) continue;
-            if (std::abs (header.stride (i)) == std::abs (header.stride (j))) header.stride (j) = 0;
+            if (abs (header.stride (i)) == abs (header.stride (j))) header.stride (j) = 0;
           }
         }
 
         size_t max = 0;
         for (size_t i = 0; i < header.ndim(); ++i)
-          if (size_t (std::abs (header.stride (i))) > max)
-            max = std::abs (header.stride (i));
+          if (size_t (abs (header.stride (i))) > max)
+            max = abs (header.stride (i));
 
         for (size_t i = 0; i < header.ndim(); ++i) {
           if (header.stride (i)) continue;
@@ -371,7 +371,7 @@ namespace MR
 
         for (size_t i = 0; i < out.size(); ++i) 
           if (out[i]) 
-            if (std::abs (out[i]) != std::abs (in[i])) 
+            if (abs (out[i]) != abs (in[i])) 
               return sanitise (in, out, dims);
 
         sanitise (in, current);

--- a/core/types.h
+++ b/core/types.h
@@ -277,9 +277,9 @@ namespace MR
   // functions, etc, since the standard labels such calls ill-formed:
   // http://en.cppreference.com/w/cpp/numeric/math/abs
   template <typename X>
-    inline constexpr typename std::enable_if<std::is_unsigned<X>::value,X>::type abs (X x) { return x; }
+    inline constexpr typename std::enable_if<std::is_arithmetic<X>::value && std::is_unsigned<X>::value,X>::type abs (X x) { return x; }
   template <typename X>
-    inline constexpr typename std::enable_if<!std::is_unsigned<X>::value,X>::type abs (X x) { return std::abs(x); }
+    inline constexpr typename std::enable_if<std::is_arithmetic<X>::value && !std::is_unsigned<X>::value,X>::type abs (X x) { return std::abs(x); }
 }
 
 namespace std

--- a/core/types.h
+++ b/core/types.h
@@ -272,19 +272,18 @@ namespace MR
       return std::unique_ptr<X> (new X (std::forward<Args> (args)...));
     }
 
+
+  // required to allow use of abs() call on unsigned integers in template
+  // functions, etc, since the standard labels such calls ill-formed:
+  // http://en.cppreference.com/w/cpp/numeric/math/abs
+  template <typename X>
+    inline constexpr typename std::enable_if<std::is_unsigned<X>::value,X>::type abs (X x) { return x; }
+  template <typename X>
+    inline constexpr typename std::enable_if<!std::is_unsigned<X>::value,X>::type abs (X x) { return std::abs(x); }
 }
 
 namespace std
 {
-  // these are not defined in the standard, but are needed
-  // for use in generic templates
-#ifdef MRTRIX_MACOSX
-  FORCE_INLINE uint8_t abs (uint8_t x) { return x; }
-  FORCE_INLINE uint16_t abs (uint16_t x) { return x; }
-  FORCE_INLINE uint32_t abs (uint32_t x) { return x; }
-  FORCE_INLINE uint64_t abs (uint64_t x) { return x; }
-#endif
-
 
   template <class T> inline ostream& operator<< (ostream& stream, const vector<T>& V)
   {

--- a/src/dwi/directions/file.cpp
+++ b/src/dwi/directions/file.cpp
@@ -31,7 +31,7 @@ namespace MR {
             throw Exception ("unexpected number of columns for directions file \"" + filename + "\"");
           for (ssize_t n  = 0; n < directions.rows(); ++n) {
             auto norm = directions.row(n).norm();
-            if (std::abs(default_type(1.0) - norm) > 1.0e-4)
+            if (abs(default_type(1.0) - norm) > 1.0e-4)
               WARN ("directions file \"" + filename + "\" contains non-unit direction vectors");
             directions.row(n).array() *= norm ? default_type(1.0)/norm : default_type(0.0);
           }

--- a/src/dwi/directions/set.cpp
+++ b/src/dwi/directions/set.cpp
@@ -332,10 +332,10 @@ namespace MR {
         const size_t grid_index = dir2gridindex (p);
 
         index_type best_dir = grid_lookup[grid_index].front();
-        default_type max_dp = std::abs (p.dot (get_dir (best_dir)));
+        default_type max_dp = abs (p.dot (get_dir (best_dir)));
         for (size_t i = 1; i != grid_lookup[grid_index].size(); ++i) {
           const index_type this_dir = (grid_lookup[grid_index])[i];
-          const default_type this_dp = std::abs (p.dot (get_dir (this_dir)));
+          const default_type this_dp = abs (p.dot (get_dir (this_dir)));
           if (this_dp > max_dp) {
             max_dp = this_dp;
             best_dir = this_dir;
@@ -352,9 +352,9 @@ namespace MR {
       {
 
         index_type dir = 0;
-        default_type max_dot_product = std::abs (p.dot (unit_vectors[0]));
+        default_type max_dot_product = abs (p.dot (unit_vectors[0]));
         for (size_t i = 1; i != size(); ++i) {
-          const default_type this_dot_product = std::abs (p.dot (unit_vectors[i]));
+          const default_type this_dot_product = abs (p.dot (unit_vectors[i]));
           if (this_dot_product > max_dot_product) {
             max_dot_product = this_dot_product;
             dir = i;
@@ -375,7 +375,7 @@ namespace MR {
         for (size_t i = 0; i != size(); ++i) {
           for (vector<index_type>::const_iterator j = adj_dirs[i].begin(); j != adj_dirs[i].end(); ++j) {
             if (*j > i) {
-              adj_dot_product_sum += std::abs (unit_vectors[i].dot (unit_vectors[*j]));
+              adj_dot_product_sum += abs (unit_vectors[i].dot (unit_vectors[*j]));
               ++adj_dot_product_count;
             }
           }

--- a/src/dwi/fmls.cpp
+++ b/src/dwi/fmls.cpp
@@ -159,7 +159,7 @@ namespace MR {
 
       class Max_abs { NOMEMALIGN
         public:
-          bool operator() (const default_type& a, const default_type& b) const { return (std::abs (a) > std::abs (b)); }
+          bool operator() (const default_type& a, const default_type& b) const { return (abs (a) > abs (b)); }
       };
 
       bool Segmenter::operator() (const SH_coefs& in, FOD_lobes& out) const {
@@ -212,7 +212,7 @@ namespace MR {
             // Changed handling of lobe merges
             // Merge lobes as they appear to be merged, but update the
             //   contents of retrospective_assignments accordingly
-            if (std::abs (i.first) / out[adj_lobes.back()].get_max_peak_value() > ratio_of_peak_value_to_merge) {
+            if (abs (i.first) / out[adj_lobes.back()].get_max_peak_value() > ratio_of_peak_value_to_merge) {
 
               std::sort (adj_lobes.begin(), adj_lobes.end());
               for (size_t j = 1; j != adj_lobes.size(); ++j)
@@ -393,7 +393,7 @@ namespace MR {
                 p = -p;
               p[2] = 0.0; // Force projection onto the tangent plane
 
-              const float dp = std::abs (mean_dir.dot (dir));
+              const float dp = abs (mean_dir.dot (dir));
               const float theta = (dp < 1.0) ? std::acos (dp) : 0.0;
               const float log_transform = theta ? (theta / std::sin (theta)) : 1.0;
               p *= log_transform;

--- a/src/dwi/fmls.h
+++ b/src/dwi/fmls.h
@@ -66,10 +66,10 @@ namespace MR
           FOD_lobe (const DWI::Directions::Set& dirs, const index_type seed, const default_type value, const default_type weight) :
               mask (dirs),
               values (Eigen::Array<default_type, Eigen::Dynamic, 1>::Zero (dirs.size())),
-              max_peak_value (std::abs (value)),
+              max_peak_value (abs (value)),
               peak_dirs (1, dirs.get_dir (seed)),
-              mean_dir (peak_dirs.front() * std::abs(value) * weight),
-              integral (std::abs (value * weight)),
+              mean_dir (peak_dirs.front() * abs(value) * weight),
+              integral (abs (value * weight)),
               neg (value <= 0.0)
           {
             mask[seed] = true;
@@ -93,8 +93,8 @@ namespace MR
             values[bin] = value;
             const Eigen::Vector3& dir = mask.get_dirs()[bin];
             const default_type multiplier = (mean_dir.dot (dir)) > 0.0 ? 1.0 : -1.0;
-            mean_dir += dir * multiplier * std::abs(value) * weight;
-            integral += std::abs (value * weight);
+            mean_dir += dir * multiplier * abs(value) * weight;
+            integral += abs (value * weight);
           }
 
           void revise_peak (const size_t index, const Eigen::Vector3& real_peak, const default_type value)

--- a/src/dwi/shells.cpp
+++ b/src/dwi/shells.cpp
@@ -156,7 +156,7 @@ namespace MR
               size_t best_shell = 0;
               bool ambiguous = false;
               for (size_t s = 0; s != count(); ++s) {
-                if (std::abs (*b - shells[s].get_mean()) <= 1.0) {
+                if (abs (*b - shells[s].get_mean()) <= 1.0) {
                   if (shell_selected) {
                     ambiguous = true;
                   } else {
@@ -190,7 +190,7 @@ namespace MR
                 bool ambiguous = false;
                 for (size_t s = 0; s != count(); ++s) {
                   const default_type stdev = (shells[s].is_bzero() ? 0.5 * bzero_threshold() : (zero_stdev ? std::sqrt (shells[s].get_mean()) : shells[s].get_stdev()));
-                  const default_type num_stdev = std::abs ((*b - shells[s].get_mean()) / stdev);
+                  const default_type num_stdev = abs ((*b - shells[s].get_mean()) / stdev);
                   if (num_stdev < best_num_stdevs) {
                     ambiguous = (num_stdev >= 0.1 * best_num_stdevs);
                     best_shell = s;
@@ -383,7 +383,7 @@ namespace MR
     void Shells::regionQuery (const BValueList& bvals, const default_type b, vector<size_t>& idx) const
     {
       for (ssize_t i = 0; i < bvals.size(); i++) {
-        if (std::abs (b - bvals[i]) < DWI_SHELLS_EPSILON)
+        if (abs (b - bvals[i]) < DWI_SHELLS_EPSILON)
           idx.push_back (i);
       }
     }

--- a/src/dwi/tractography/ACT/gmwmi.cpp
+++ b/src/dwi/tractography/ACT/gmwmi.cpp
@@ -92,13 +92,13 @@ namespace MR
             p += step;
             tissues = get_tissues (p, interp);
           } while (tissues.valid() && step.squaredNorm() && 
-              (std::abs (tissues.get_gm() - tissues.get_wm()) > GMWMI_ACCURACY) && 
+              (abs (tissues.get_gm() - tissues.get_wm()) > GMWMI_ACCURACY) && 
               (++gradient_iters < GMWMI_MAX_ITERS_TO_FIND_BOUNDARY));
 
           // Make sure an appropriate cost function minimum has been found, and that
           //   this would be an acceptable termination point if it were processed by the tracking algorithm
           if (!tissues.valid() || tissues.is_csf() || tissues.is_path() || !tissues.get_wm()
-              || (std::abs (tissues.get_gm() - tissues.get_wm()) > GMWMI_ACCURACY)) {
+              || (abs (tissues.get_gm() - tissues.get_wm()) > GMWMI_ACCURACY)) {
 
             p = { NaN, NaN, NaN };
             return false;

--- a/src/dwi/tractography/SIFT/output.h
+++ b/src/dwi/tractography/SIFT/output.h
@@ -224,7 +224,7 @@ namespace MR
             default_type max_abs_diff = 0.0, diff = 0.0, cost = 0.0;
             for (typename Fixel_map<Fixel>::ConstIterator i = begin (v); i; ++i) {
               const default_type this_diff = i().get_diff (current_mu);
-              max_abs_diff = std::max (max_abs_diff, std::abs (this_diff));
+              max_abs_diff = std::max (max_abs_diff, abs (this_diff));
               diff += this_diff;
               cost += i().get_cost (current_mu) * i().get_weight();
             }

--- a/src/dwi/tractography/SIFT2/coeff_optimiser.cpp
+++ b/src/dwi/tractography/SIFT2/coeff_optimiser.cpp
@@ -365,7 +365,7 @@ namespace MR {
             dFs += change;
           }
 
-        } while ((++iter < 100) && (std::abs (change) > 0.001));
+        } while ((++iter < 100) && (abs (change) > 0.001));
 
 #ifdef SIFT2_COEFF_OPTIMISER_DEBUG
         iter_count += iter;

--- a/src/dwi/tractography/SIFT2/streamline_stats.cpp
+++ b/src/dwi/tractography/SIFT2/streamline_stats.cpp
@@ -51,7 +51,7 @@ namespace MR {
         min = std::min (min, i);
         max = std::max (max, i);
         mean += i;
-        mean_abs += std::abs (i);
+        mean_abs += abs (i);
         var += Math::pow2 (i);
         ++count;
         if (i)

--- a/src/dwi/tractography/algorithms/fact.h
+++ b/src/dwi/tractography/algorithms/fact.h
@@ -139,7 +139,7 @@ namespace MR
           Eigen::Vector3f v (values[3*n], values[3*n+1], values[3*n+2]);
           float norm = v.norm();
           float dot = v.dot(d) / norm;
-          float abs_dot = std::abs (dot);
+          float abs_dot = abs (dot);
           if (abs_dot < S.dot_threshold) continue;
           if (max_abs_dot < abs_dot) {
             max_abs_dot = abs_dot;

--- a/src/dwi/tractography/algorithms/tensor_det.h
+++ b/src/dwi/tractography/algorithms/tensor_det.h
@@ -165,7 +165,7 @@ namespace MR
         get_EV();
 
         float dot = prev_dir.dot (dir);
-        if (std::abs (dot) < S.cos_max_angle)
+        if (abs (dot) < S.cos_max_angle)
           return HIGH_CURVATURE;
 
         if (dot < 0.0)

--- a/src/dwi/tractography/mapping/buffer_scratch_dump.h
+++ b/src/dwi/tractography/mapping/buffer_scratch_dump.h
@@ -89,9 +89,9 @@ namespace MR {
             Image::Stride::List stride = Image::Stride::get (H);
             Image::Stride::symbolise (stride);
 
-            out_header << "\nlayout: " << (stride[0] >0 ? "+" : "-") << std::abs (stride[0])-1;
+            out_header << "\nlayout: " << (stride[0] >0 ? "+" : "-") << abs (stride[0])-1;
             for (size_t n = 1; n < H.ndim(); ++n)
-              out_header << "," << (stride[n] >0 ? "+" : "-") << std::abs (stride[n])-1;
+              out_header << "," << (stride[n] >0 ? "+" : "-") << abs (stride[n])-1;
 
             out_header << "\ndatatype: " << H.datatype().specifier();
 

--- a/src/dwi/tractography/mapping/mapper.cpp
+++ b/src/dwi/tractography/mapping/mapper.cpp
@@ -119,7 +119,7 @@ void TrackMapperTWI::set_factor (const Streamline<>& tck, SetVoxelExtras& out) c
 
         case ENDS_MIN:
           assert (factors.size() == 2);
-          out.factor = (std::abs(factors[0]) < std::abs(factors[1])) ? factors[0] : factors[1];
+          out.factor = (abs(factors[0]) < abs(factors[1])) ? factors[0] : factors[1];
           break;
 
         case ENDS_MEAN:
@@ -129,7 +129,7 @@ void TrackMapperTWI::set_factor (const Streamline<>& tck, SetVoxelExtras& out) c
 
         case ENDS_MAX:
           assert (factors.size() == 2);
-          out.factor = (std::abs(factors[0]) > std::abs(factors[1])) ? factors[0] : factors[1];
+          out.factor = (abs(factors[0]) > abs(factors[1])) ? factors[0] : factors[1];
           break;
 
         case ENDS_PROD:

--- a/src/dwi/tractography/mapping/voxel.h
+++ b/src/dwi/tractography/mapping/voxel.h
@@ -48,7 +48,7 @@ namespace MR {
 
         inline Eigen::Vector3 vec2DEC (const Eigen::Vector3& d)
         {
-          return { std::abs(d[0]), std::abs(d[1]), std::abs(d[2]) };
+          return { abs(d[0]), abs(d[1]), abs(d[2]) };
         }
 
 

--- a/src/gui/mrview/adjust_button.cpp
+++ b/src/gui/mrview/adjust_button.cpp
@@ -77,7 +77,7 @@ namespace MR
           else if (event->type() == QEvent::MouseMove) {
             QMouseEvent* mevent = static_cast<QMouseEvent*> (event);
             if (mevent->buttons() != Qt::NoButton) {
-              if (std::abs (mevent->y() - deadzone_y) < ADJUST_BUTTON_DEADZONE_SIZE) {
+              if (abs (mevent->y() - deadzone_y) < ADJUST_BUTTON_DEADZONE_SIZE) {
                 if (value() != deadzone_value) {
                   setValue (deadzone_value);
                   emit valueChanged();

--- a/src/gui/mrview/colourmap.cpp
+++ b/src/gui/mrview/colourmap.cpp
@@ -57,17 +57,17 @@ namespace MR
 
           Entry ("Jet", 
               "color.rgb = 1.5 - 4.0 * abs (1.0 - amplitude - vec3(0.25, 0.5, 0.75));\n",
-              [] (float amplitude) { return Eigen::Array3f (clamp (1.5f - 4.0f * std::abs (1.0f - amplitude - 0.25f)),
-                                                            clamp (1.5f - 4.0f * std::abs (1.0f - amplitude - 0.5f)),
-                                                            clamp (1.5f - 4.0f * std::abs (1.0f - amplitude - 0.75f))); }),
+              [] (float amplitude) { return Eigen::Array3f (clamp (1.5f - 4.0f * abs (1.0f - amplitude - 0.25f)),
+                                                            clamp (1.5f - 4.0f * abs (1.0f - amplitude - 0.5f)),
+                                                            clamp (1.5f - 4.0f * abs (1.0f - amplitude - 0.75f))); }),
 
           Entry ("PET",
               "color.r = 2.0*amplitude - 0.5;\n"
               "color.g = clamp (2.0 * (0.25 - abs (amplitude - 0.25)), 0.0, 1.0) + clamp (2.0*amplitude - 1.0, 0.0, 1.0);\n"
               "color.b = 1.0 - (clamp (1.0 - 2.0 * amplitude, 0.0, 1.0) + clamp (1.0 - 4.0 * abs (amplitude - 0.75), 0.0, 1.0));\n",
               [] (float amplitude) { return Eigen::Array3f (clamp (2.0f * amplitude - 0.5f),
-                                                            clamp (0.25f - std::abs (amplitude - 0.25f)) + clamp (2.0f * (amplitude - 0.5)),
-                                                            clamp (1.0f - 2.0f * amplitude) + clamp (1.0 - 4.0 * std::abs (amplitude - 0.75))); }),
+                                                            clamp (0.25f - abs (amplitude - 0.25f)) + clamp (2.0f * (amplitude - 0.5)),
+                                                            clamp (1.0f - 2.0f * amplitude) + clamp (1.0 - 4.0 * abs (amplitude - 0.75))); }),
 
           Entry ("Colour", 
               "color.rgb = amplitude * colourmap_colour;\n",

--- a/src/gui/mrview/gui_image.cpp
+++ b/src/gui/mrview/gui_image.cpp
@@ -203,7 +203,7 @@ namespace MR
               for (image.index (y) = 0; image.index (y) < ysize; ++image.index (y)) {
                 for (image.index (x) = 0; image.index (x) < xsize; ++image.index (x)) {
                   cfloat val = image.value();
-                  float mag = std::abs (val.real());
+                  float mag = abs (val.real());
                   data[3*(image.index(x)+image.index(y)*xsize) + n] = mag;
                   if (std::isfinite (mag)) {
                     slice_min[plane] = std::min (slice_min[plane], mag);
@@ -246,7 +246,7 @@ namespace MR
                 size_t idx = 2*(image.index(x)+image.index(y)*xsize);
                 data[idx] = val.real();
                 data[idx+1] = val.imag();
-                float mag = std::abs (val);
+                float mag = abs (val);
                 if (std::isfinite (mag))
                   slice_max[plane] = std::max (slice_max[plane], mag);
               }
@@ -448,10 +448,10 @@ namespace MR
       }
 
 
-      // required to shut up clang's compiler warnings about std::abs() when
+      // required to shut up clang's compiler warnings about abs() when
       // instantiating Image::copy_texture_3D() with unsigned types:
       template <typename ValueType>
-        inline ValueType abs_if_signed (ValueType x, typename std::enable_if<!std::is_unsigned<ValueType>::value>::type* = nullptr) { return std::abs(x); }
+        inline ValueType abs_if_signed (ValueType x, typename std::enable_if<!std::is_unsigned<ValueType>::value>::type* = nullptr) { return abs(x); }
 
       template <typename ValueType>
         inline ValueType abs_if_signed (ValueType x, typename std::enable_if<std::is_unsigned<ValueType>::value>::type* = nullptr) { return x; }
@@ -565,7 +565,7 @@ namespace MR
               cfloat val = image.value();
               *(p++) = val.real();
               *(p++) = val.imag();
-              float mag = std::abs (val);
+              float mag = abs (val);
               if (std::isfinite (mag)) {
                 value_min = std::min (value_min, mag);
                 value_max = std::max (value_max, mag);

--- a/src/gui/mrview/mode/base.cpp
+++ b/src/gui/mrview/mode/base.cpp
@@ -84,7 +84,7 @@ namespace MR
               cfloat value = image()->interpolate() ?
                 image()->trilinear_value (window().focus()) :
                 image()->nearest_neighbour_value (window().focus());
-              if (std::isfinite (std::abs (value)))
+              if (std::isfinite (abs (value)))
                 value_str += str(value);
               else
                 value_str += "?";

--- a/src/gui/mrview/mode/volume.cpp
+++ b/src/gui/mrview/mode/volume.cpp
@@ -277,7 +277,7 @@ namespace MR
             GL::vec4 normal = T2S * GL::vec4 (plane[0], plane[1], plane[2], 0.0);
             GL::vec4 on_plane = S2T * GL::vec4 (plane[3]*plane[0], plane[3]*plane[1], plane[3]*plane[2], 1.0);
             normal[3] = on_plane[0]*normal[0] + on_plane[1]*normal[1] + on_plane[2]*normal[2];
-            float off_axis_thickness = std::abs (ray[0]*plane[0] + ray[1]*plane[1] + ray[2]*plane[2]);
+            float off_axis_thickness = abs (ray[0]*plane[0] + ray[1]*plane[1] + ray[2]*plane[2]);
             normal[0] /= off_axis_thickness;
             normal[1] /= off_axis_thickness;
             normal[2] /= off_axis_thickness;

--- a/src/gui/mrview/tool/connectome/connectome.cpp
+++ b/src/gui/mrview/tool/connectome/connectome.cpp
@@ -3363,7 +3363,7 @@ namespace MR
           } else if (edge_colour == edge_colour_t::DIRECTION) {
 
             for (auto i = edges.begin(); i != edges.end(); ++i)
-              i->set_colour (Eigen::Array3f { std::abs (i->get_dir()[0]), std::abs (i->get_dir()[1]), std::abs (i->get_dir()[2]) } );
+              i->set_colour (Eigen::Array3f { abs (i->get_dir()[0]), abs (i->get_dir()[1]), abs (i->get_dir()[2]) } );
 
           } else if (edge_colour == edge_colour_t::CONNECTOME) {
 

--- a/src/gui/mrview/tool/overlay.cpp
+++ b/src/gui/mrview/tool/overlay.cpp
@@ -346,7 +346,7 @@ namespace MR
               cfloat value = image->interpolate() ?
                 image->trilinear_value(window().focus()) :
                 image->nearest_neighbour_value(window().focus());
-              if(std::isnan(std::abs(value)))
+              if(std::isnan(abs(value)))
                 value_str += "?";
               else value_str += str(value);
               transform.render_text (value_str, position, start_line_num + num_of_new_lines);

--- a/src/gui/mrview/tool/roi_editor/roi.cpp
+++ b/src/gui/mrview/tool/roi_editor/roi.cpp
@@ -368,9 +368,9 @@ namespace MR
 
         int ROI::normal2axis (const Eigen::Vector3f& normal, const MR::Transform& transform) const
         {
-          float x_dot_n = std::abs ((transform.image2scanner.rotation().cast<float>() * Eigen::Vector3f { 1.0f, 0.0f, 0.0f }).dot (normal));
-          float y_dot_n = std::abs ((transform.image2scanner.rotation().cast<float>() * Eigen::Vector3f { 0.0f, 1.0f, 0.0f }).dot (normal));
-          float z_dot_n = std::abs ((transform.image2scanner.rotation().cast<float>() * Eigen::Vector3f { 0.0f, 0.0f, 1.0f }).dot (normal));
+          float x_dot_n = abs ((transform.image2scanner.rotation().cast<float>() * Eigen::Vector3f { 1.0f, 0.0f, 0.0f }).dot (normal));
+          float y_dot_n = abs ((transform.image2scanner.rotation().cast<float>() * Eigen::Vector3f { 0.0f, 1.0f, 0.0f }).dot (normal));
+          float z_dot_n = abs ((transform.image2scanner.rotation().cast<float>() * Eigen::Vector3f { 0.0f, 0.0f, 1.0f }).dot (normal));
           if (x_dot_n > y_dot_n)
             return x_dot_n > z_dot_n ? 0 : 2;
           else

--- a/src/gui/mrview/tool/tractography/tractogram.cpp
+++ b/src/gui/mrview/tool/tractography/tractogram.cpp
@@ -672,7 +672,7 @@ namespace MR
             for (size_t buffer_tck_counter = 0; buffer_tck_counter != num_tracks; ++buffer_tck_counter) {
 
               const Eigen::Vector3f& tangent (endpoint_tangents[total_tck_counter++]);
-              const Eigen::Vector3f colour (std::abs (tangent[0]), std::abs (tangent[1]), std::abs (tangent[2]));
+              const Eigen::Vector3f colour (abs (tangent[0]), abs (tangent[1]), abs (tangent[2]));
               const size_t tck_length = original_track_sizes[buffer_index][buffer_tck_counter];
 
               // Includes pre- and post-padding to coincide with tracks buffer

--- a/src/gui/projection.cpp
+++ b/src/gui/projection.cpp
@@ -111,7 +111,7 @@ namespace MR
       std::sort (labels.begin(), labels.end());
       for (size_t i = 2; i < labels.size(); ++i) {
         float pos[] = { labels[i].dir[0], labels[i].dir[1] };
-        float dist = std::min (width()/std::abs (pos[0]), height()/std::abs (pos[1])) / 2.0;
+        float dist = std::min (width()/abs (pos[0]), height()/abs (pos[1])) / 2.0;
         int x = std::round (width() /2.0 + pos[0]*dist);
         int y = std::round (height() /2.0 + pos[1]*dist);
         render_text_inset (x, y, std::string (labels[i].label));

--- a/src/registration/metric/demons.h
+++ b/src/registration/metric/demons.h
@@ -102,7 +102,7 @@ namespace MR
 
 
             default_type speed = im2_image.value() - im1_image.value();
-            if (std::abs (speed) < robustness_parameter)
+            if (abs (speed) < robustness_parameter)
               speed = 0.0;
 
             default_type speed_squared = speed * speed;
@@ -113,7 +113,7 @@ namespace MR
 
             Eigen::Matrix<typename Im1ImageType::value_type, 3, 1> grad = (im2_gradient.value() + im1_gradient.value()).array() / 2.0;
             default_type denominator = speed_squared / normaliser + grad.squaredNorm();
-            if (std::abs (speed) < intensity_difference_threshold || denominator < denominator_threshold) {
+            if (abs (speed) < intensity_difference_threshold || denominator < denominator_threshold) {
               im1_update.row(3) = 0.0;
               im2_update.row(3) = 0.0;
             } else {

--- a/src/registration/metric/demons4D.h
+++ b/src/registration/metric/demons4D.h
@@ -108,7 +108,7 @@ namespace MR
               im2_image.index(3) = vol;
               im1_image.index(3) = vol;
               default_type speed = im2_image.value() - im1_image.value();
-              if (std::abs (speed) < robustness_parameter)
+              if (abs (speed) < robustness_parameter)
                 speed = 0.0;
 
               default_type speed_squared = speed * speed;
@@ -119,7 +119,7 @@ namespace MR
 
               Eigen::Matrix<typename Im1ImageType::value_type, 3, 1> grad = (im2_gradient.value() + im1_gradient.value()).array() / 2.0;
               default_type denominator = speed_squared / normaliser + grad.squaredNorm();
-              if (!(std::abs (speed) < intensity_difference_threshold || denominator < denominator_threshold)) {
+              if (!(abs (speed) < intensity_difference_threshold || denominator < denominator_threshold)) {
                 auto tmp = (speed * grad) / denominator;
                 total_update[0] += tmp[0];
                 total_update[1] += tmp[1];

--- a/src/registration/metric/robust_estimators.h
+++ b/src/registration/metric/robust_estimators.h
@@ -33,7 +33,7 @@ namespace MR
           void operator() (const default_type& x,
                            default_type& residual,
                            default_type& slope) {
-            residual = std::abs(x);
+            residual = abs(x);
             slope = Math::sgn(x);
           }
 
@@ -75,8 +75,8 @@ namespace MR
           void operator() (const default_type& x,
                            default_type& residual,
                            default_type& slope) {
-            residual = std::pow(std::abs(x), power);
-            slope = Math::sgn(x) * std::pow(std::abs(x), power - 1.0);
+            residual = std::pow(abs(x), power);
+            slope = Math::sgn(x) * std::pow(abs(x), power - 1.0);
           }
 
           void operator() (const Eigen::Matrix<default_type, Eigen::Dynamic, 1>& x,

--- a/src/registration/transform/initialiser_helpers.cpp
+++ b/src/registration/transform/initialiser_helpers.cpp
@@ -370,7 +370,7 @@ namespace MR
           Eigen::Matrix<default_type, Eigen::Dynamic, Eigen::Dynamic> A (3,3);
           A = dec.solve(im1_evec_transpose);
           assert((A * im1_evec).isApprox(im2_evec));
-          assert(std::abs(A.determinant() - 1.0) < 0.0001);
+          assert(abs(A.determinant() - 1.0) < 0.0001);
           A = A.transpose().eval(); // A * im2_evec = im1_evec
 
           // MAT(A);

--- a/src/stats/cfe.cpp
+++ b/src/stats/cfe.cpp
@@ -57,7 +57,7 @@ namespace MR
             value_type largest_dp = 0.0;
             const direction_type dir (i->get_dir().normalized());
             for (index_type j = first_index; j < last_index; ++j) {
-              const value_type dp = std::abs (dir.dot (fixel_directions[j]));
+              const value_type dp = abs (dir.dot (fixel_directions[j]));
               if (dp > largest_dp) {
                 largest_dp = dp;
                 fixel_mask.index(0) = j;

--- a/src/surface/mesh.cpp
+++ b/src/surface/mesh.cpp
@@ -291,7 +291,7 @@ namespace MR
           const Eigen::Vector3 computed_normal = Surface::normal (*this, triangles.back());
           if (computed_normal.dot (normal.cast<default_type>()) < 0.0)
             warn_right_hand_rule = true;
-          if (std::abs (computed_normal.dot (normal.cast<default_type>())) < 0.99)
+          if (abs (computed_normal.dot (normal.cast<default_type>())) < 0.99)
             warn_nonstandard_normals = true;
         }
         if (triangles.size() != count)
@@ -355,7 +355,7 @@ namespace MR
             const Eigen::Vector3 computed_normal = Surface::normal (*this, triangles.back());
             if (computed_normal.dot (normal) < 0.0)
               warn_right_hand_rule = true;
-            if (std::abs (computed_normal.dot (normal)) < 0.99)
+            if (abs (computed_normal.dot (normal)) < 0.99)
               warn_nonstandard_normals = true;
           } else if (line.substr(0, 8) == "endsolid") {
             if (inside_facet)

--- a/testing/cmd/testing_diff_dir.cpp
+++ b/testing/cmd/testing_diff_dir.cpp
@@ -48,7 +48,7 @@ void run ()
 
   for (ssize_t i = 0; i < dir1.cols(); ++i) {
     for (ssize_t j = 0; j < dir1.rows(); ++j) {
-      if (std::abs (dir1(i,j) - dir2(i,j)) > tol)
+      if (abs (dir1(i,j) - dir2(i,j)) > tol)
         throw Exception ("direction files \"" + str(argument[0]) + "\" and \"" + str(argument[1]) + "\" do not match within specified precision of " + str(tol)
             + " (" + str(dir1(i,j)) + " vs " + str(dir2(i,j)) + ")");
     }

--- a/testing/cmd/testing_diff_fixel_old.cpp
+++ b/testing/cmd/testing_diff_fixel_old.cpp
@@ -54,7 +54,7 @@ void run ()
   }
   for (size_t i  = 0; i < 3; ++i) {
     for (size_t j  = 0; j < 4; ++j) {
-      if (std::abs (buffer1.transform()(i,j) - buffer2.transform()(i,j)) > 0.001)
+      if (abs (buffer1.transform()(i,j) - buffer2.transform()(i,j)) > 0.001)
         throw Exception ("images \"" + buffer1.name() + "\" and \"" + buffer2.name() + "\" do not have matching header transforms "
                          + "\n" + str(buffer1.transform().matrix()) + "vs \n " + str(buffer2.transform().matrix()) + ")");
     }
@@ -69,16 +69,16 @@ void run ()
        // For each fixel
        for (size_t fixel = 0; fixel != a.value().size(); ++fixel) {
          // Check value
-         if (std::abs (a.value()[fixel].value - b.value()[fixel].value) > tol)
+         if (abs (a.value()[fixel].value - b.value()[fixel].value) > tol)
            throw Exception ("images \"" + a.name() + "\" and \"" + b.name() + "\" do not match fixel value within specified precision of " + str(tol)
                + " (" + str(a.value()[fixel].value) + " vs " + str(b.value()[fixel].value) + ")");
          // Check size
-         if (std::abs (a.value()[fixel].size - b.value()[fixel].size) > tol)
+         if (abs (a.value()[fixel].size - b.value()[fixel].size) > tol)
            throw Exception ("images \"" + a.name() + "\" and \"" + b.name() + "\" do not match fixel size within specified precision of " + str(tol)
                + " (" + str(a.value()[fixel].size) + " vs " + str(b.value()[fixel].size) + ")");
          // Check Direction
          for (size_t dim = 0; dim < 3; ++dim) {
-           if (std::abs (a.value()[fixel].dir[dim] - b.value()[fixel].dir[dim]) > tol)
+           if (abs (a.value()[fixel].dir[dim] - b.value()[fixel].dir[dim]) > tol)
              throw Exception ("images \"" + a.name() + "\" and \"" + b.name() + "\" do not match fixel direction within specified precision of " + str(tol)
                  + " (" + str(a.value()[fixel].dir[dim]) + " vs " + str(b.value()[fixel].dir[dim]) + ")");
          }

--- a/testing/cmd/testing_diff_matrix.cpp
+++ b/testing/cmd/testing_diff_matrix.cpp
@@ -59,7 +59,7 @@ void run ()
     const double tol = opt[0][0];
     
     for (size_t i = 0; i != numel; ++i) {
-      if (std::abs ((*(in1.data()+i) - *(in2.data()+i)) / (0.5 * (*(in1.data()+i) + *(in2.data()+i)))) > tol)
+      if (abs ((*(in1.data()+i) - *(in2.data()+i)) / (0.5 * (*(in1.data()+i) + *(in2.data()+i)))) > tol)
         throw Exception ("matrices \"" + Path::basename (argument[0]) + "\" and \"" + Path::basename (argument[1]) + " do not match within fractional precision of " + str(tol)
                          + " (" + str(*(in1.data()+i)) + " vs " + str(*(in2.data()+i)) + ")");
     }
@@ -72,7 +72,7 @@ void run ()
       tol = opt[0][0];
 
     for (size_t i = 0; i != numel; ++i) {
-      if (std::abs (*(in1.data()+i) - *(in2.data()+i)) > tol)
+      if (abs (*(in1.data()+i) - *(in2.data()+i)) > tol)
         throw Exception ("matrices \"" + Path::basename (argument[0]) + "\" and \"" + Path::basename (argument[1]) + " do not match within absolute precision of " + str(tol)
                          + " (" + str(*(in1.data()+i)) + " vs " + str(*(in2.data()+i)) + ")");
     }

--- a/testing/cmd/testing_diff_peaks.cpp
+++ b/testing/cmd/testing_diff_peaks.cpp
@@ -54,7 +54,7 @@ void run ()
   }
   for (size_t i  = 0; i < 3; ++i) {
     for (size_t j  = 0; j < 4; ++j) {
-      if (std::abs (in1.transform().matrix()(i,j) - in2.transform().matrix()(i,j)) > 0.0001)
+      if (abs (in1.transform().matrix()(i,j) - in2.transform().matrix()(i,j)) > 0.0001)
         throw Exception ("images \"" + in1.name() + "\" and \"" + in2.name() + "\" do not have matching header transforms "
                            + "\n" + str(in1.transform().matrix()) + "vs \n " + str(in2.transform().matrix()) + ")");
     }
@@ -75,8 +75,8 @@ void run ()
       }
       const double norma = veca.norm(), normb = vecb.norm();
       veca.normalize(); vecb.normalize();
-      const double dp = std::abs (veca.dot (vecb));
-      if (1.0 - dp > tol || std::abs (norma - normb) > tol)
+      const double dp = abs (veca.dot (vecb));
+      if (1.0 - dp > tol || abs (norma - normb) > tol)
         throw Exception ("images \"" + a.name() + "\" and \"" + b.name() + "\" do not match within specified precision of " + str(tol) + " ( [" + str(veca.transpose().cast<float>()) + "] vs [" + str(vecb.transpose().cast<float>()) + "], norms [" + str(norma) + " " + str(normb) + "], dot product = " + str(dp) + ")");
     }
   }, in1, in2);

--- a/testing/cmd/testing_diff_tsf.cpp
+++ b/testing/cmd/testing_diff_tsf.cpp
@@ -63,7 +63,7 @@ void run ()
         throw Exception ("track scalar length mismatch - test FAILED");
 
       for (size_t i = 0; i < tck_scalar1.size(); ++i) {
-        if (std::abs ((tck_scalar1[i] - tck_scalar2[i]) / (0.5 * (tck_scalar1[i] + tck_scalar2[i]))) > tol)
+        if (abs ((tck_scalar1[i] - tck_scalar2[i]) / (0.5 * (tck_scalar1[i] + tck_scalar2[i]))) > tol)
           throw Exception ("track scalar files \"" + str(argument[0]) + "\" and \"" + str(argument[1]) + "\" do not match within fractional precision of " + str(tol)
                            + " (" + str(cdouble (tck_scalar1[i])) + " vs " + str(cdouble (tck_scalar2[i])) + ")");
       }
@@ -83,7 +83,7 @@ void run ()
         throw Exception ("track scalar length mismatch - test FAILED");
 
       for (size_t i = 0; i < tck_scalar1.size(); ++i) {
-        if (std::abs (tck_scalar1[i] - tck_scalar2[i]) > tol)
+        if (abs (tck_scalar1[i] - tck_scalar2[i]) > tol)
           throw Exception ("track scalar files \"" + str(argument[0]) + "\" and \"" + str(argument[1]) + "\" do not match within absolute precision of " + str(tol)
                            + " (" + str(cdouble (tck_scalar1[i])) + " vs " + str(cdouble (tck_scalar2[i])) + ")");
       }

--- a/travis.sh
+++ b/travis.sh
@@ -8,8 +8,8 @@ case  $test in
   "sphinx")
     $py -m sphinx -n -N -W -w sphinx.log docs/ tmp/
     ;;
-  "memalign")
-    ./check_memalign
+  "syntax")
+    ./check_syntax
     ;;
   "pylint")
     # Normally rely on build script to create this file


### PR DESCRIPTION
This is an alternative solution to #1247, which was already addressed in #1299. My concern is that relying on the built-in `std::abs()` calls means casting from unsigned to signed versions of each variant. This is probably fine for most operations, but it is [technically ill-defined](http://en.cppreference.com/w/cpp/numeric/math/abs) if the integer can't be promoted to something that can't handle the precision of the original. This solution means we have our own `MR::abs()` call, and rely on SFINAE to call the built-in `std::abs()` call unless the type is unsigned. This seems to work on Linux, currently building on Windows (no errors so far... :crossed_fingers:)