### PR TITLE
fix broken links in documentation

### DIFF
--- a/docs/constrained_spherical_deconvolution/response_function_estimation.rst
+++ b/docs/constrained_spherical_deconvolution/response_function_estimation.rst
@@ -118,8 +118,6 @@ manual definition of both the single-fibre voxel mask (or just a voxel
 mask for isotropic tissues); the fibre directions can also be provided
 manually if necessary (otherwise a tensor fit will be used).
 
-.. _msmt_5tt_response_function_estimation:
-
 ``msmt_5tt``
 ^^^^^^^^^^^^
 

--- a/docs/constrained_spherical_deconvolution/response_function_estimation.rst
+++ b/docs/constrained_spherical_deconvolution/response_function_estimation.rst
@@ -118,6 +118,8 @@ manual definition of both the single-fibre voxel mask (or just a voxel
 mask for isotropic tissues); the fibre directions can also be provided
 manually if necessary (otherwise a tensor fit will be used).
 
+.. _msmt_5tt_response_function_estimation:
+
 ``msmt_5tt``
 ^^^^^^^^^^^^
 

--- a/docs/quantitative_structural_connectivity/act.rst
+++ b/docs/quantitative_structural_connectivity/act.rst
@@ -33,6 +33,8 @@ DWI pre-processing
 
 Because the anatomical image is used to limit the spatial extent of streamlines propagation rather than a binary mask derived from the diffusion image series, I highly recommend dilating the DWI brain mask prior to computing FODs; this is to make sure that any errors in derivation of the DWI mask do not leave gaps in the FOD data within the brain white matter, and therefore result in erroneous streamlines termination.
 
+.. _act_tissue_segmentation:
+
 Tissue segmentation
 ^^^^^^^^^^^^^^^^^^^
 

--- a/docs/quantitative_structural_connectivity/act.rst
+++ b/docs/quantitative_structural_connectivity/act.rst
@@ -15,6 +15,8 @@ For full details on ACT, please refer to the following journal article:
 If you use ACT in your research, please cite the article above in your manuscripts.
 
 
+.. _act_preprocessing:
+
 Pre-processing steps
 --------------------
 
@@ -32,8 +34,6 @@ DWI pre-processing
 ^^^^^^^^^^^^^^^^^^
 
 Because the anatomical image is used to limit the spatial extent of streamlines propagation rather than a binary mask derived from the diffusion image series, I highly recommend dilating the DWI brain mask prior to computing FODs; this is to make sure that any errors in derivation of the DWI mask do not leave gaps in the FOD data within the brain white matter, and therefore result in erroneous streamlines termination.
-
-.. _act_tissue_segmentation:
 
 Tissue segmentation
 ^^^^^^^^^^^^^^^^^^^

--- a/docs/quantitative_structural_connectivity/global_tractography.rst
+++ b/docs/quantitative_structural_connectivity/global_tractography.rst
@@ -53,8 +53,7 @@ a tissue segmentation in the appropriate format, for example:
     5ttgen fsl T1.mif 5tt.mif
 
 Note that the T1 image must be aligned with (e.g. registered to) the DWI data. 
-See `this page <http://mrtrix.readthedocs.org/en/latest/workflows/act.html#tissue-segmentation>`__ 
-for more information.
+See :ref:`this page <act_tissue_segmentation>` for more information.
 
 Response functions for single-fibre WM, GM, and CSF, can then be 
 estimated using:
@@ -64,7 +63,7 @@ estimated using:
     dwi2response msmt_5tt dwi.mif 5tt.mif wm.txt gm.txt csf.txt
 
 For a detailed explanation of different strategies for response function 
-estimation, have a look at `this page <http://mrtrix.readthedocs.org/en/latest/concepts/response_function_estimation.html#msmt-5tt>`__.
+estimation, have a look at :ref:`this page <msmt_5tt_response_function_estimation>`.
 
 Parameters
 ~~~~~~~~~~

--- a/docs/quantitative_structural_connectivity/global_tractography.rst
+++ b/docs/quantitative_structural_connectivity/global_tractography.rst
@@ -53,7 +53,7 @@ a tissue segmentation in the appropriate format, for example:
     5ttgen fsl T1.mif 5tt.mif
 
 Note that the T1 image must be aligned with (e.g. registered to) the DWI data. 
-See the first two steps in :ref:`ACT preprocessing pipeline <act_preprocessing>` 
+See the :ref:`ACT preprocessing pipeline <act_preprocessing>` 
 for more information.
 
 Response functions for single-fibre WM, GM, and CSF, can then be 

--- a/docs/quantitative_structural_connectivity/global_tractography.rst
+++ b/docs/quantitative_structural_connectivity/global_tractography.rst
@@ -53,7 +53,8 @@ a tissue segmentation in the appropriate format, for example:
     5ttgen fsl T1.mif 5tt.mif
 
 Note that the T1 image must be aligned with (e.g. registered to) the DWI data. 
-See :ref:`this page <act_tissue_segmentation>` for more information.
+See the first two steps in :ref:`ACT preprocessing pipeline <act_preprocessing>` 
+for more information.
 
 Response functions for single-fibre WM, GM, and CSF, can then be 
 estimated using:
@@ -63,7 +64,7 @@ estimated using:
     dwi2response msmt_5tt dwi.mif 5tt.mif wm.txt gm.txt csf.txt
 
 For a detailed explanation of different strategies for response function 
-estimation, have a look at :ref:`this page <msmt_5tt_response_function_estimation>`.
+estimation, have a look at :ref:`this page <response_fn_estimation>`.
 
 Parameters
 ~~~~~~~~~~


### PR DESCRIPTION
raised in #1306 

I'm guessing this was already addressed in #1244, but given how huge that PR is, it'll most likely be merged to `dev` first before landing on `master`. This is a quick fix to make sure the docs are relatively self-consistent for the current version - I assume everyone is happy with this?