### PR TITLE
Fine-tuning docs for RC3

### DIFF
--- a/docs/constrained_spherical_deconvolution/multi_shell_multi_tissue_csd.rst
+++ b/docs/constrained_spherical_deconvolution/multi_shell_multi_tissue_csd.rst
@@ -69,7 +69,7 @@ where
 
 Note that the order of the tissue responses output by this algorithm is always: WM, GM, CSF.
 
-See the <response_function_estimation>`__ page for more information on available methods.
+See the `response function estimation <response_function_estimation>`__ page for more information on available methods.
 
 References
 ----------

--- a/docs/constrained_spherical_deconvolution/multi_shell_multi_tissue_csd.rst
+++ b/docs/constrained_spherical_deconvolution/multi_shell_multi_tissue_csd.rst
@@ -54,9 +54,8 @@ The resulting WM FODs can be displayed together with the tissue signal contribut
 Per tissue response function estimation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Input response functions for single-fibre WM, GM and CSF can be estimated directly from the data.
-The most convenient way of doing so, is via the ``dwi2response dhollander`` algorithm
-(`Dhollander et al. (2016) <#references>`__):
+Input response functions for single-fibre WM, GM and CSF can be estimated directly from the data
+via the ``dwi2response dhollander`` algorithm (`Dhollander et al. (2016) <#references>`__):
 
 ::
 
@@ -68,13 +67,9 @@ where
 
 - ``<tissue>_response.txt`` is the tissue-specific response function as used above (output)
 
-Note that the order of the tissue responses output for this algorithm is always: WM, GM, CSF.
+Note that the order of the tissue responses output by this algorithm is always: WM, GM, CSF.
 
-Other methods exist, notably ``dwi2response msmt_5tt``, but this requires a co-registered T1 volume
-and very accurate correction of EPI geometric distortions (both up to sub-voxel accuracy), as well as
-accurate segmentation of the T1 volume.
-Even then, still, ``dwi2response msmt_5tt`` may be less accurate than ``dwi2response dhollander``
-in a range of scenarios (`Dhollander et al. (2016) <#references>`__).
+See the <response_function_estimation>`__ page for more information on available methods.
 
 References
 ----------

--- a/docs/constrained_spherical_deconvolution/response_function_estimation.rst
+++ b/docs/constrained_spherical_deconvolution/response_function_estimation.rst
@@ -105,7 +105,7 @@ The following sections provide more details on each algorithm specifically.
 'dhollander' algorithm
 ^^^^^^^^^^^^^^^^^^^^^^
 
-This algorithm is the original implementation of the strategy proposed in
+This algorithm currently is the original implementation of the strategy proposed in
 `Dhollander et al. (2016) <https://www.researchgate.net/publication/307863133_Unsupervised_3-tissue_response_function_estimation_from_single-shell_or_multi-shell_diffusion_MR_data_without_a_co-registered_T1_image>`__
 to estimate multi b-value (single-shell + b=0, or multi-shell) response
 functions of single-fibre white matter (*anisotropic*), grey matter
@@ -118,12 +118,17 @@ to select the best voxels to estimate the response functions from.
 
 The algorithm has been succesfully tested in a wide range of conditions
 (overall data quality, pathology, developmental state of the subjects,
-animal data and ex-vivo data).  In almost all cases, it runs and performs
-well out of the box.  In exceptional cases where the anisotropy in the
-data is particularly low (*very* early development, ex-vivo data with low
-b-value, ...), it may be advisable to set the ``-fa`` parameter lower
-than its default value (of 0.2).  As always, check the ``-voxels`` option
-output in unusually (challenging) cases.
+animal data and ex-vivo data). Additional insights into a few specific
+aspects of its performance can be found in
+`Dhollander et al. (2018a) <https://www.researchgate.net/publication/324770874_Accuracy_of_response_function_estimation_algorithms_for_3-tissue_spherical_deconvolution_of_diverse_quality_diffusion_MRI_data>`__ .
+In almost all cases, it runs and performs well out of the box.
+In exceptional cases where the anisotropy in the data is particularly low
+(*very* early development, ex-vivo data with low b-value, ...), it may be
+advisable to set the ``-fa`` parameter lower than its default value (of 0.2).
+See `Dhollander et al. (2018b) <https://www.researchgate.net/publication/324770875_Feasibility_and_benefits_of_3-tissue_constrained_spherical_deconvolution_for_studying_the_brains_of_babies>`__
+for an example of a dataset where changing this parameter was required
+to obtain the best results.
+As always, check the ``-voxels`` option output in unusually (challenging) cases.
 
 
 For more information, refer to the
@@ -171,7 +176,7 @@ For more information, refer to the
 This algorithm is a reimplementation of the strategy proposed in
 `Jeurissen et al. (2014) <http://www.sciencedirect.com/science/article/pii/S1053811914006442>`__
 to estimate multi b-value response functions of single-fibre
-white matter (*anisotropic*), grey matter and CSF( both *isotropic*),
+white matter (*anisotropic*), grey matter and CSF (both *isotropic*),
 which can subsequently be used for multi-tissue (constrained) spherical
 deconvolution. The algorithm is primarily driven by a prior ('5TT')
 tissue segmentation, typically obtained from a spatially aligned anatomical
@@ -186,14 +191,16 @@ segmentation: this implementation calls upon the ``tournier`` algorithm
 to do so, while the paper uses a simple (lower) 0.7 FA threshold.
 
 Due to the challenge of accurately aligning an anatomical image (e.g.
-T1-weighted image) with the diffusion data, including correction for distortions
-up to an accuracy on the order of magnitude of the spatial resolution of
-the anatomical image, as well as accurate spatial segmentation, this
-algorithm has more prerequisites than the ``dhollander`` algorithm.
-Furthermore, this algorithm was found to be *less* accurate than the
-``dhollander`` algorithm.
-See `Dhollander et al. (2016) <https://www.researchgate.net/publication/307863133_Unsupervised_3-tissue_response_function_estimation_from_single-shell_or_multi-shell_diffusion_MR_data_without_a_co-registered_T1_image>`__
-for more information on this topic.
+T1-weighted image) with the diffusion MR data, including correction
+for motion and (EPI and other) distortions present in the diffusion MR data,
+as well as accurate spatial segmentation of the anatomical image,
+this algorithm has more prerequisites than the ``dhollander`` algorithm.
+Furthermore, in our experience, this algorithm often results in a *less*
+accurate selection of voxels for tissue response function calibration,
+compared to the ``dhollander`` algorithm.
+See `Dhollander et al. (2018a) <https://www.researchgate.net/publication/324770874_Accuracy_of_response_function_estimation_algorithms_for_3-tissue_spherical_deconvolution_of_diverse_quality_diffusion_MRI_data>`__
+for further insights into the nature of potential accuracy differences
+between the ``dhollander`` and ``msmt_5tt`` algorithms.
 
 For more information, refer to the
 :ref:`msmt_5tt algorithm documentation <dwi2response_msmt_5tt>`.

--- a/docs/quantitative_structural_connectivity/global_tractography.rst
+++ b/docs/quantitative_structural_connectivity/global_tractography.rst
@@ -25,7 +25,7 @@ For multi-shell DWI data, the most common use will be:
 
 ::
 
-    tckglobal dwi.mif wmr.txt -riso csfr.txt -riso gmr.txt -mask mask.mif -niter 1e9 -fod fod.mif -fiso fiso.mif tracks.tck
+    tckglobal dwi.mif wm_response.txt -riso csf_response.txt -riso gm_response.txt -mask mask.mif -niter 1e9 -fod fod.mif -fiso fiso.mif tracks.tck
 
 In this example, ``dwi.mif`` is the input dataset, including the
 gradient table, and ``tracks.tck`` is the output tractogram. ``wm_response.txt``, 
@@ -39,26 +39,33 @@ Per tissue response function estimation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Input response functions for single-fibre WM, GM and CSF can be estimated directly from the data.
-The most convenient way of doing so, is via the ``dwi2response dhollander`` algorithm
-(`Dhollander et al. (2016) <#references>`__):
+An up to date overview of our methods for responce function estimation can be found on the
+`response function estimation <response_function_estimation>`__ page.
+
+In the original global tractography paper (`Christiaens et al. (2015) <#references>`__), 
+response functions were estimated using a prior tissue segmentation obtained from a 
+coregistered structural T1 scan. For the WM response, a further FA threshold was used.
+This pipeline can be most closely replicated using the 
+``5ttgen`` and ``dwi2response msmt_5tt`` commands in this fashion: 
 
 ::
 
-  dwi2response dhollander dwi.mif wm_response.txt gm_response.txt csf_response.txt
-	
+  5ttgen fsl T1.mif 5tt.mif
+  dwi2response msmt_5tt dwi.mif 5tt.mif wm_response.txt gm_response.txt csf_response.txt -wm_algo fa
+
 where
+
+- ``T1.mif`` is a coregistered T1 data set from the same subject (input)
+
+- ``5tt.mif`` is the resulting tissue type segmentation, used subsequently used in the response function estimation (output/input)
 
 - ``dwi.mif`` is the same dwi data set as used above (input)
 
 - ``<tissue>_response.txt`` is the tissue-specific response function as used above (output)
 
-Note that the order of the tissue responses output for this algorithm is always: WM, GM, CSF.
+The difference between these instructions and the method described in `Christiaens et al. (2015) <#references>`__ is that instead of selecting WM single-fibre voxels using an absolute FA threshold of 0.75, the 300 voxels with the highest FA value inside the WM segmentation are used.
 
-Other methods exist, notably ``dwi2response msmt_5tt``, but this requires a co-registered T1 volume
-and very accurate correction of EPI geometric distortions (both up to sub-voxel accuracy), as well as
-accurate segmentation of the T1 volume.
-Even then, still, ``dwi2response msmt_5tt`` may be less accurate than ``dwi2response dhollander``
-in a range of scenarios (`Dhollander et al. (2016) <#references>`__).
+Note that this process is dependent on accurate correction of EPI geometric distortions, and rigid-body registration between the DWI and T1 modalities, such that the T1 image can be reliably used to select pure-tissue voxels in the DWI volumes. Failure to achieve these may result in inappropriate voxels being used for response function estimation, with concomitant errors in tissue estimates.
 
 Parameters
 ~~~~~~~~~~
@@ -136,9 +143,4 @@ References
    Orientation Distribution (TOD) based tractography.* NeuroImage, 94
    (2014), pp. 312–336 [`SD
    link <http://www.sciencedirect.com/science/article/pii/S1053811913012676>`__\ ]
-
-5. T. Dhollander, D. Raffelt, and A. Connelly. *Unsupervised 3-tissue response
-   function estimation from single-shell or multi-shell diffusion MR data without
-   a co-registered T1 image.* ISMRM Workshop on Breaking the Barriers of Diffusion MRI (2016), pp. 5 [`full text
-   link <https://www.researchgate.net/publication/307863133_Unsupervised_3-tissue_response_function_estimation_from_single-shell_or_multi-shell_diffusion_MR_data_without_a_co-registered_T1_image>`__\ ]
 


### PR DESCRIPTION
There you go, all fine-tuned properly.

- MSMT-CSD page keeps it shorter, but is still a manual that allows people access to the technique in the most convenient fashion, using our most up to date techniques that have proven themselves in our lab and collaborations very well.  No more discussion on algos on this page, for the details, the reader is referred to the response function algo page.
- No more mention of sub-voxel whatever, because let's not discuss this until the middle of the night.. no-one will really care; I'm happy to just let it go.  Furthermore, many more references, so users can go read and figure out the most up to date results on their own, and appreciate those for what they are.  Also, clarify that the accuracy is (for the time being) "in our experience".  True to reality; no blatant lies to accuse people of.
- It's clear that this pickle only truly became hot because the global tractography page was touched, so I take the intentions of rather replicating the original paper there on board, and have done exactly that.  In my personal opinion, I don't think this is really relevant as a manual (to replicate the paper, the paper is documented in.. the paper, because that's what the *paper* is for).  Enabling users to access the technique, and set it up for a good result make more sense, in my personal opinion.  But I take note of some kind of sensitivity around this, so I'm letting this one go as well.

@bjeurissen : are you fully happy with the response function section in the MSMT-CSD page?  This would be it: https://github.com/MRtrix3/mrtrix3/blob/rc3docs_finetuning/docs/constrained_spherical_deconvolution/multi_shell_multi_tissue_csd.rst .  Providing this to users, I've been able to make many (many) more enthusiast that having a go at MSMT-CSD doesn't have to be difficult, and works very well out of the box.  I think it's definitely in our best interest of having people adopt MSMT-CSD.  What do you reckon?