### PR TITLE
mrmesh: Rename to voxel2mesh

### DIFF
--- a/cmd/voxel2mesh.cpp
+++ b/cmd/voxel2mesh.cpp
@@ -42,7 +42,7 @@ void usage ()
     "the intensity value of the isocontour(s) can instead be set manually using the -threhsold "
     "option."
 
-    "If the -blocky option is used, then the Marching Cubes algorithm will not be used. "
+  + "If the -blocky option is used, then the Marching Cubes algorithm will not be used. "
     "Instead, the input image will be interpreted as a binary mask image, and polygonal "
     "surfaces will be generated at the outer faces of the voxel clusters within the mask.";
 

--- a/cmd/voxel2mesh.cpp
+++ b/cmd/voxel2mesh.cpp
@@ -33,7 +33,18 @@ void usage ()
 {
   AUTHOR = "Robert E. Smith (robert.smith@florey.edu.au)";
 
-  SYNOPSIS = "Generate a mesh file from an image";
+  SYNOPSIS = "Generate a surface mesh representation from a voxel image";
+
+  DESCRIPTION +
+    "This command utilises the Marching Cubes algorithm to generate a polygonal surface "
+    "that represents the isocontour(s) of the input image at a particular intensity. By default, "
+    "an appropriate threshold will be determined automatically from the input image, however "
+    "the intensity value of the isocontour(s) can instead be set manually using the -threhsold "
+    "option."
+
+    "If the -blocky option is used, then the Marching Cubes algorithm will not be used. "
+    "Instead, the input image will be interpreted as a binary mask image, and polygonal "
+    "surfaces will be generated at the outer faces of the voxel clusters within the mask.";
 
   ARGUMENTS
   + Argument ("input",  "the input image.").type_image_in ()
@@ -42,8 +53,7 @@ void usage ()
   OPTIONS
   + Option ("blocky", "generate a \'blocky\' mesh that precisely represents the voxel edges")
 
-  + Option ("threshold", "manually set the intensity threshold at which the mesh will be generated "
-                         "(if omitted, a threshold will be determined automatically)")
+  + Option ("threshold", "manually set the intensity threshold for the Marching Cubes algorithm")
     + Argument ("value").type_float();
 }
 
@@ -59,14 +69,8 @@ void run ()
     Surface::Algo::image2mesh_blocky (input, mesh);
 
   } else {
-    default_type threshold = 0.0;
     auto input = Image<float>::open (argument[0]);
-    auto opt = get_options("threshold");
-    if ( opt.size() ) {
-      threshold = (default_type) opt[0][0];
-    } else {
-      threshold = Filter::estimate_optimal_threshold (input);
-    }
+    const default_type threshold = get_option_value ("threshold", Filter::estimate_optimal_threshold (input));
     Surface::Algo::image2mesh_mc (input, mesh, threshold);
 
   }

--- a/docs/reference/commands/voxel2mesh.rst
+++ b/docs/reference/commands/voxel2mesh.rst
@@ -1,29 +1,34 @@
-.. _mrmesh:
+.. _voxel2mesh:
 
-mrmesh
+voxel2mesh
 ===================
 
 Synopsis
 --------
 
-Generate a mesh file from an image
+Generate a surface mesh representation from a voxel image
 
 Usage
 --------
 
 ::
 
-    mrmesh [ options ]  input output
+    voxel2mesh [ options ]  input output
 
 -  *input*: the input image.
 -  *output*: the output mesh file.
+
+Description
+-----------
+
+This command utilises the Marching Cubes algorithm to generate a polygonal surface that represents the isocontour(s) of the input image at a particular intensity. By default, an appropriate threshold will be determined automatically from the input image, however the intensity value of the isocontour(s) can instead be set manually using the -threhsold option.If the -blocky option is used, then the Marching Cubes algorithm will not be used. Instead, the input image will be interpreted as a binary mask image, and polygonal surfaces will be generated at the outer faces of the voxel clusters within the mask.
 
 Options
 -------
 
 -  **-blocky** generate a 'blocky' mesh that precisely represents the voxel edges
 
--  **-threshold value** manually set the intensity threshold at which the mesh will be generated (if omitted, a threshold will be determined automatically)
+-  **-threshold value** manually set the intensity threshold for the Marching Cubes algorithm
 
 Standard options
 ^^^^^^^^^^^^^^^^

--- a/docs/reference/commands/voxel2mesh.rst
+++ b/docs/reference/commands/voxel2mesh.rst
@@ -21,7 +21,9 @@ Usage
 Description
 -----------
 
-This command utilises the Marching Cubes algorithm to generate a polygonal surface that represents the isocontour(s) of the input image at a particular intensity. By default, an appropriate threshold will be determined automatically from the input image, however the intensity value of the isocontour(s) can instead be set manually using the -threhsold option.If the -blocky option is used, then the Marching Cubes algorithm will not be used. Instead, the input image will be interpreted as a binary mask image, and polygonal surfaces will be generated at the outer faces of the voxel clusters within the mask.
+This command utilises the Marching Cubes algorithm to generate a polygonal surface that represents the isocontour(s) of the input image at a particular intensity. By default, an appropriate threshold will be determined automatically from the input image, however the intensity value of the isocontour(s) can instead be set manually using the -threhsold option.
+
+If the -blocky option is used, then the Marching Cubes algorithm will not be used. Instead, the input image will be interpreted as a binary mask image, and polygonal surfaces will be generated at the outer faces of the voxel clusters within the mask.
 
 Options
 -------

--- a/docs/reference/commands_list.rst
+++ b/docs/reference/commands_list.rst
@@ -68,7 +68,6 @@ List of MRtrix3 commands
     commands/mrhistogram
     commands/mrinfo
     commands/mrmath
-    commands/mrmesh
     commands/mrmetric
     commands/mrpad
     commands/mrregister
@@ -113,6 +112,7 @@ List of MRtrix3 commands
     commands/tsfvalidate
     commands/vectorstats
     commands/voxel2fixel
+    commands/voxel2mesh
     commands/warp2metric
     commands/warpconvert
     commands/warpcorrect
@@ -180,7 +180,6 @@ List of MRtrix3 commands
     :ref:`mrhistogram`, "Generate a histogram of image intensities"
     :ref:`mrinfo`, "Display image header information, or extract specific information from the header"
     :ref:`mrmath`, "Compute summary statistic on image intensities either across images, or along a specified axis of a single image"
-    :ref:`mrmesh`, "Generate a mesh file from an image"
     :ref:`mrmetric`, "Computes a dissimilarity metric between two images"
     :ref:`mrpad`, "Pad an image to increase the FOV"
     :ref:`mrregister`, "Register two images together using a symmetric rigid, affine or non-linear transformation model"
@@ -225,6 +224,7 @@ List of MRtrix3 commands
     :ref:`tsfvalidate`, "Validate a track scalar file against the corresponding track data"
     :ref:`vectorstats`, "Statistical testing of vector data using non-parametric permutation testing"
     :ref:`voxel2fixel`, "Map the scalar value in each voxel to all fixels within that voxel"
+    :ref:`voxel2mesh`, "Generate a surface mesh representation from a voxel image"
     :ref:`warp2metric`, "Compute fixel-wise or voxel-wise metrics from a 4D deformation field"
     :ref:`warpconvert`, "Convert between different representations of a non-linear warp"
     :ref:`warpcorrect`, "Replaces voxels in a deformation field that point to 0,0,0 with nan,nan,nan"


### PR DESCRIPTION
As discussed in #1211.

Command is not used in scripts or documentation anywhere (`label2mesh` is used in the Connectome Tool instructions); it only exists for my own nefarious purposes. I like the idea of being able to run `mesh2voxel` & `voxel2mesh` *ad infinitum* :stuck_out_tongue_closed_eyes: 