### PR TITLE
tckgen: Fix -backtrack memory error

### DIFF
--- a/src/dwi/tractography/tracking/method.cpp
+++ b/src/dwi/tractography/tracking/method.cpp
@@ -36,6 +36,8 @@ namespace MR
             dir = { NaN, NaN, NaN };
             return;
           }
+          if (tck.size() + revert_step == length_to_revert_from)
+            return;
           const size_t new_size = length_to_revert_from - revert_step;
           if (tck.size() == 2 || new_size == 1)
             dir = (tck[1] - tck[0]).normalized();


### PR DESCRIPTION
In some instances, when the `-backtrack` option was used with an algorithm other than iFOD2, attempting to revise the streamline direction upon truncation would result in accessing data outside of allocated memory.

Popped up in a failed CI test for #1313.