### PR TITLE
mrview: Fix a couple of command-line options

### DIFF
--- a/src/gui/mrview/tool/overlay.cpp
+++ b/src/gui/mrview/tool/overlay.cpp
@@ -813,6 +813,7 @@ namespace MR
           if (opt.opt->is ("overlay.interpolation")) {
             interpolate_check_box->setCheckState (bool(opt[0]) ? Qt::Checked : Qt::Unchecked);
             interpolate_changed();
+            return true;
           }
 
 

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -1930,6 +1930,7 @@ namespace MR
               throw Exception ("-interpolation option expects a boolean");
             }
             image_interpolate_slot();
+            return;
           }
 
           if (opt.opt->is ("intensity_range")) {


### PR DESCRIPTION
For options `-interpolation` and `-overlay.interpolation`, failure to flag correct parsing of the command-line option via return call resulted in a failed assertion.