### PR TITLE
MR::printf(): Use va_copy()

### DIFF
--- a/core/mrtrix.h
+++ b/core/mrtrix.h
@@ -149,14 +149,15 @@ namespace MR
 
   inline std::string printf (const char* format, ...)
   {
-    va_list list;
-    va_start (list, format);
-    size_t len = vsnprintf (NULL, 0, format, list) + 1;
-    va_end (list);
+    size_t len = 0;
+    va_list list1, list2;
+    va_start (list1, format);
+    va_copy (list2, list1);
+    len = vsnprintf (nullptr, 0, format, list1) + 1;
+    va_end (list1);
     VLA(buf, char, len);
-    va_start (list, format);
-    vsnprintf (buf, len, format, list);
-    va_end (list);
+    vsnprintf (buf, len, format, list2);
+    va_end (list2);
     return buf;
   }
 


### PR DESCRIPTION
This prevents a segmentation fault observed on MSYS with GCC 7.3.0, apparently due to re-use of a `va_list` upon which `va_end()` has already been called.

While I couldn't find a definitive piece of documentation, I [came](https://www.redhat.com/archives/amd64-list/2006-December/msg00001.html) across [a](https://stackoverflow.com/questions/2288680/reuse-of-va-list) few [pages](https://stackoverflow.com/questions/9937505/va-list-misbehavior-on-linux) suggesting that it is not appropriate to be calling `va_start()` upon a `va_list` that has already been passed to `va_end()`; seemingly there is some internal state parameter in the `va_list` that is not fully reset, and therefore misbehaviour can occur if the same `va_list` is used to iterate through variadic arguments a second time. The solution is to use `va_copy()` to make a duplicate of the `va_list` after it has been initialised using `va_start()`, but before use of e.g. `va_arg()`.

Not sure why this has not come up until now, or on what systems / compilers it may be an issue. But it's very easy to test given `ProgressBar` relies on this function.