### PR TITLE
path.toTemp(): Deal with spaces in working directory

### DIFF
--- a/lib/mrtrix3/path.py
+++ b/lib/mrtrix3/path.py
@@ -120,7 +120,7 @@ def toTemp(filename, is_command): #pylint: disable=unused-variable
   import os
   from mrtrix3 import app
   wrapper=''
-  if is_command and filename.count(' '):
+  if is_command and (filename.count(' ') or app.tempDir.count(' ')):
     wrapper='\"'
   path = wrapper + os.path.abspath(os.path.join(app.tempDir, filename)) + wrapper
   app.debug(filename + ' -> ' + path)


### PR DESCRIPTION
Fixes issue reported [here](http://community.mrtrix.org/t/5ttgen-fsl-error-mrconvert/1622/1).