### PR TITLE
mrhistmatch: Use LU rather than normal equation

### DIFF
--- a/cmd/mrhistmatch.cpp
+++ b/cmd/mrhistmatch.cpp
@@ -121,7 +121,7 @@ void match_linear (Image<float>& input,
   if (estimate_intercept)
     input_matrix.col(1).fill (1.0f);
 
-  auto parameters = (input_matrix.transpose() * input_matrix).ldlt().solve(input_matrix.transpose() * output_vector).eval();
+  auto parameters = input_matrix.fullPivLu().solve (output_vector).eval();
 
   Header H (input);
   H.datatype() = DataType::Float32;

--- a/testing/tests/mrhistmatch
+++ b/testing/tests/mrhistmatch
@@ -1,5 +1,5 @@
 # Test "scale" mode
-M=$(bc <<< "scale=9; $RANDOM/16384") && echo $M > tmp1.txt && mrcalc b0.nii.gz $M -mult tmp1.mif -force && mrhistmatch scale b0.nii.gz tmp1.mif tmp2.mif -force && mrinfo tmp2.mif -property mrhistmatch_scale > tmp2.txt && testing_diff_matrix tmp1.txt tmp2.txt -frac 1e-3
+M=$(bc <<< "scale=9; $RANDOM/16384") && echo $M > tmp1.txt && mrcalc b0.nii.gz $M -mult tmp1.mif -force && mrhistmatch scale b0.nii.gz tmp1.mif tmp2.mif -force && mrinfo tmp2.mif -property mrhistmatch_scale > tmp2.txt && testing_diff_matrix tmp1.txt tmp2.txt -frac 1e-5
 # Test "linear" mode
 # Note: Use fractional tolerance for scale parameter, absolute tolerance for offset parameter
-M=$(bc <<< "scale=9; $RANDOM/16384") && C=$(bc <<< "$RANDOM-16384") && echo $M > tmp1.txt && echo $C > tmp2.txt && mrcalc b0.nii.gz $M -mult $C -add tmp1.mif -force && mrhistmatch linear b0.nii.gz tmp1.mif tmp2.mif -force && mrinfo tmp2.mif -property mrhistmatch_scale > tmp3.txt && mrinfo tmp2.mif -property mrhistmatch_offset > tmp4.txt && testing_diff_matrix tmp1.txt tmp3.txt -frac 1e-2 && testing_diff_matrix tmp2.txt tmp4.txt -abs 10.0
+M=$(bc <<< "scale=9; $RANDOM/16384") && C=$(bc <<< "$RANDOM-16384") && echo $M > tmp1.txt && echo $C > tmp2.txt && mrcalc b0.nii.gz $M -mult $C -add tmp1.mif -force && mrhistmatch linear b0.nii.gz tmp1.mif tmp2.mif -force && mrinfo tmp2.mif -property mrhistmatch_scale > tmp3.txt && mrinfo tmp2.mif -property mrhistmatch_offset > tmp4.txt && testing_diff_matrix tmp1.txt tmp3.txt -frac 1e-5 && testing_diff_matrix tmp2.txt tmp4.txt -abs 0.5


### PR DESCRIPTION
This provides greater precision with respect to ground truth when run on test data; tolerances on automated testing updated accordingly.

Should resolve CI testing issues encountered in #1327 and #1332.