### PR TITLE
Prevent erroneous command-line usage warning

### DIFF
--- a/core/app.h
+++ b/core/app.h
@@ -243,7 +243,9 @@ namespace MR
             opt (option), args (arguments)
         {
           for (size_t i = 0; i != option->size(); ++i) {
-            if (arguments[i][0] == '-' && !((*option)[i].type == Integer || (*option)[i].type == Float || (*option)[i].type == IntSeq || (*option)[i].type == FloatSeq || (*option)[i].type == Various)) {
+            if (arguments[i][0] == '-' &&
+                !(((*option)[i].type == ImageIn || (*option)[i].type == ImageOut) && !strcmp(arguments[i], std::string("-").c_str())) &&
+                !((*option)[i].type == Integer || (*option)[i].type == Float || (*option)[i].type == IntSeq || (*option)[i].type == FloatSeq || (*option)[i].type == Various)) {
               WARN (std::string("Value \"") + arguments[i] + "\" is being used as " +
                     ((option->size() == 1) ? "the expected argument" : ("one of the " + str(option->size()) + " expected arguments")) +
                     " for option \"-" + option->id + "\"; is this what you intended?");


### PR DESCRIPTION
In #1282, a terminal warning was introduced in an attempt to catch cases where users failed to provide enough input arguments to command-line options.
This was refined in #1293 to prevent erroneous warnings from being displayed when having an input argument begin with a dash character is entirely reasonable.
This change further refines the logic dictating when a terminal warning should be issued, by identifying the use of piped images with command-line option inputs and not issuing the warning in that circumstance.