### PR TITLE
Documentation fixes / updates after 3.0_RC3 merge

### DIFF
--- a/core/file/utils.h
+++ b/core/file/utils.h
@@ -53,6 +53,9 @@ namespace MR
       //CONF /tmp/, which is typically a RAM file system and should therefore
       //CONF be fast; but may cause issues on machines with little RAM
       //CONF capacity or where write-access to this location is not permitted.
+      //CONF Note that this setting does not influence the location in which
+      //CONF Python scripts construct their temporary directories; that is
+      //CONF determined based on config file option ScriptTmpDir.
       const std::string& tmpfile_dir () {
         static const std::string __tmpfile_dir = File::Config::get ("TmpFileDir",
 #ifdef MRTRIX_WINDOWS
@@ -94,6 +97,9 @@ namespace MR
       //CONF The location in which to generate the temporary directories to be
       //CONF used by MRtrix Python scripts. By default they will be generated
       //CONF in the working directory.
+      //CONF Note that this setting does not influence the location in which
+      //CONF piped images and other temporary files are created by MRtrix3;
+      //CONF that is determined based on config file option TmpFileDir.
 
       //CONF option: ScriptTmpPrefix
       //CONF default: `<script>-tmp-`

--- a/docs/getting_started/image_data.rst
+++ b/docs/getting_started/image_data.rst
@@ -506,7 +506,18 @@ in order to preserve important information as image data are passed
 between commands. A prominent example is ``dw_scheme``, which is used
 to embed the diffusion gradient table within the :ref:`embedded_dw_scheme`.
 
+.. NOTE::
 
+   Any header key-value pairs that involve storage of either numerical
+   data, or multiple entries within a single key-value pair, must be
+   stored using the following convention:
+
+   -  The "``.``" period character as the numerical decimal separator.
+   -  The "``,``" comma character as the delimiter between entries.
+
+   Creation or manipulation of header data such that it does not
+   conform to these requirements may lead to unpredictable software
+   behaviour.
 
 
 
@@ -659,7 +670,7 @@ Fixel image (directory) format
 ------------------------------
 
 Images for representing discrete multi-fibre models are sparse in nature (i.e. different voxels may have different numbers of
-fibre populations - a.k.a *`fixels <fixels_dixels>`__*), and different models have different parameter requirements per fixel (e.g. orientation,
+fibre populations - a.k.a "*fixels*", as described in the :ref:`fixels_dixels` page), and different models have different parameter requirements per fixel (e.g. orientation,
 volume fraction, fanning, tensors etc). This fixel image format overcomes several issues in storing
 such data in either traditional 4D images or a custom format (such as the legacy :ref:`legacy_mrtrix_sparse_format`).
 

--- a/docs/reference/config_file_options.rst
+++ b/docs/reference/config_file_options.rst
@@ -422,7 +422,7 @@ List of MRtrix3 configuration file options
 *  **ScriptTmpDir**
     *default: `.`*
 
-     The location in which to generate the temporary directories to be used by MRtrix Python scripts. By default they will be generated in the working directory.
+     The location in which to generate the temporary directories to be used by MRtrix Python scripts. By default they will be generated in the working directory. Note that this setting does not influence the location in which piped images and other temporary files are created by MRtrix3; that is determined based on config file option TmpFileDir.
 
 *  **ScriptTmpPrefix**
     *default: `<script>-tmp-`*
@@ -457,7 +457,7 @@ List of MRtrix3 configuration file options
 *  **TmpFileDir**
     *default: `/tmp` (on Unix), `.` (on Windows)*
 
-     The prefix for temporary files (as used in pipelines). By default, these files get written to the current folder on Windows machines, which may cause performance issues, particularly when operating over distributed file systems. On Unix machines, the default is /tmp/, which is typically a RAM file system and should therefore be fast; but may cause issues on machines with little RAM capacity or where write-access to this location is not permitted.
+     The prefix for temporary files (as used in pipelines). By default, these files get written to the current folder on Windows machines, which may cause performance issues, particularly when operating over distributed file systems. On Unix machines, the default is /tmp/, which is typically a RAM file system and should therefore be fast; but may cause issues on machines with little RAM capacity or where write-access to this location is not permitted. Note that this setting does not influence the location in which Python scripts construct their temporary directories; that is determined based on config file option ScriptTmpDir.
 
 *  **TmpFilePrefix**
     *default: `mrtrix-tmp-`*


### PR DESCRIPTION
1. Fix erroneous link syntax in fixel directory format description.

2. Based on colleague feedback, clarify distinction between TmpFileDir and ScriptTmpDir config file entries.

3. As suggested in #1336, Clarify locale requirements for MRtrix image format header key-value fields.

Closes #1336.