### PR TITLE
Diagnostic changes

### DIFF
--- a/cmd/5ttcheck.cpp
+++ b/cmd/5ttcheck.cpp
@@ -139,6 +139,8 @@ void run ()
     } else {
       WARN ("Input image does not perfectly conform to 5TT format, but may still be applicable" + vox_option_suggestion);
     }
+  } else {
+    CONSOLE(std::string(argument.size() > 1 ? "All images" : "Input image") + " checked OK");
   }
 }
 

--- a/lib/mrtrix3/run.py
+++ b/lib/mrtrix3/run.py
@@ -215,11 +215,14 @@ def command(cmd, exitOnError=True): #pylint: disable=unused-variable
         filename = caller[1]
         lineno = caller[2]
       sys.stderr.write(script_name + ': ' + app.colourError + '[ERROR] Command failed: ' + cmd + app.colourClear + app.colourDebug + ' (' + os.path.basename(filename) + ':' + str(lineno) + ')' + app.colourClear + '\n')
-      sys.stderr.write(script_name + ': ' + app.colourConsole + 'Output of failed command:' + app.colourClear + '\n')
-      for line in error_text.splitlines():
-        sys.stderr.write(' ' * (len(script_name)+2) + line + '\n')
-      app.console('')
+      if error_text:
+        sys.stderr.write(script_name + ': ' + app.colourConsole + 'Output of failed command:' + app.colourClear + '\n')
+        for line in error_text.splitlines():
+          sys.stderr.write(' ' * (len(script_name)+2) + line + '\n')
+      else:
+        sys.stderr.write(script_name + ': ' + app.colourConsole + 'Failed command did not provide any diagnostic information' + app.colourClear + '\n')
       sys.stderr.flush()
+      app.console('')
       if app.tempDir:
         with open(os.path.join(app.tempDir, 'error.txt'), 'w') as outfile:
           outfile.write(cmd + '\n\n' + error_text + '\n')


### PR DESCRIPTION
Just a couple of tweaks to diagnostic messages:

- `5ttcheck` when all is good.

- `run.command()` when a command fails but `stdout` / `stderr` are empty.