### PR TITLE
mrview Connectome tool: Fix streamtube initialisation

### DIFF
--- a/src/gui/mrview/tool/connectome/connectome.cpp
+++ b/src/gui/mrview/tool/connectome/connectome.cpp
@@ -82,6 +82,7 @@ namespace MR
             edge_size (edge_size_t::FIXED),
             edge_alpha (edge_alpha_t::FIXED),
             have_exemplars (false),
+            have_streamtubes (false),
             edge_fixed_colour { 0.5f, 0.5f, 0.5f },
             edge_colourmap_index (1),
             edge_colourmap_invert (false),


### PR DESCRIPTION
Failure to initialise member bool Connectome::have_streamtubes could lead to memory issues, as reported in #1330 ([this comment](https://github.com/MRtrix3/mrtrix3/issues/1330#issuecomment-390206796).

This appears to *not* be the sole issue contributing to the failure to display streamtubes, but might as well be fixed nonetheless to prevent potential segmentation faults, and help strike one potential cause off the list.