### PR TITLE
fixel2voxel: Fix dimensionality of output image

### DIFF
--- a/cmd/fixel2voxel.cpp
+++ b/cmd/fixel2voxel.cpp
@@ -524,6 +524,7 @@ void run ()
   H_out.datatype().set_byte_order_native();
   H_out.keyval().erase (Fixel::n_fixels_key);
   if (op == 7) { // count
+    H_out.ndim() = 3;
     H_out.datatype() = DataType::UInt8;
   } else if (op == 10 || op == 11) { // dec
     H_out.ndim() = 4;
@@ -542,6 +543,8 @@ void run ()
       // 3 volumes per fixel if performing split_dir
       H_out.size(3) = (op == 13) ? (3 * max_count) : max_count;
     }
+  } else {
+    H_out.ndim() = 3;
   }
 
   if (op == 10 || op == 11 || op == 13)  // dec or split_dir


### PR DESCRIPTION
When the operator chosen to map fixel data to a voxel grid results in a single scalar value per voxel, the output image should logically be a 3D image. However, due to use of the fixel format index image as the template, many such images come out as 4D. This change explicitly sets the output image dimensionality for each choice of operator.

The test data need to be updated also; but I'm posting here first to see people's opinions on base branch for the merge before I do so. I personally consider this a "bug", since when writing a script wrapping this functionality I had to explicitly pipe the result to `mrconvert -coord 3 - -axes 0,1,2` in order to get what would intuitively seem the "correct" result. But conversely, the command is not fundamentally "broken" in terms of crashing or producing outright erroneous results, and this change does "alter behaviour", which would justify instead going to `dev`... Thoughts?