### PR TITLE
5ttgen: Fix printing output of 5ttcheck

### DIFF
--- a/bin/5ttgen
+++ b/bin/5ttgen
@@ -49,7 +49,7 @@ alg.execute()
 stderr = run.command('5ttcheck result.mif')[1]
 if stderr:
   app.warn('Generated image does not perfectly conform to 5TT format:')
-  for line in stderr:
+  for line in stderr.splitlines():
     app.warn(line)
 
 run.command('mrconvert result.mif ' + path.fromUser(app.args.output, True) + (' -force' if app.forceOverwrite else ''))


### PR DESCRIPTION
If the text output from `5ttcheck` was a single-line warning, then "`for line in stderr:`" would print a warning line *per word* :-/