### PR TITLE
DICOM: Fix slice timing import for mosaic data

### DIFF
--- a/core/file/dicom/csa_entry.h
+++ b/core/file/dicom/csa_entry.h
@@ -88,7 +88,8 @@ namespace MR {
 
             const char* key () const { return name; }
 
-            uint32_t size () const { return num; }
+            uint32_t num_items() const { return nitems; }
+            uint32_t size() const { return num; }
 
             int get_int () const {
               const uint8_t* p = start + 84;
@@ -122,7 +123,7 @@ namespace MR {
                   v[m] = length ? to<default_type> (std::string (reinterpret_cast<const char*> (p)+16, 4*((length+3)/4))) : NaN;
                   p += 16 + 4*((length+3)/4);
                 }
-                for (uint32_t m = nitems; m < v.size(); ++m) 
+                for (uint32_t m = nitems; m < v.size(); ++m)
                   v[m] = NaN;
               }
 

--- a/core/file/dicom/image.cpp
+++ b/core/file/dicom/image.cpp
@@ -352,7 +352,7 @@ namespace MR {
           else if (strcmp ("BandwidthPerPixelPhaseEncode", entry.key()) == 0)
             bandwidth_per_pixel_phase_encode = entry.get_float();
           else if (strcmp ("MosaicRefAcqTimes", entry.key()) == 0) {
-            mosaic_slices_timing.resize (entry.size(), NaN);
+            mosaic_slices_timing.resize (entry.num_items());
             entry.get_float (mosaic_slices_timing);
           }
           else if (strcmp ("TimeAfterStart", entry.key()) == 0)


### PR DESCRIPTION
The wrong member function of class `File::DICOM::CSAEntry` was being used to pre-allocate the memory required to store slice timing, resulting in a mismatch in length between this data vector and the number of slices in the image.

For the sake of web searches, the issue that this fix corrects looks something like:
```
[WARNING] Number of entries in mosaic slice timing (82) does not match number of images in mosaic (60); omitting
```

Closes #1252.

Should probably wait for @jdtournier to run against private DICOM test suite.