### PR TITLE
mrview Connectome tool: Fix edge visibility

### DIFF
--- a/src/gui/mrview/tool/connectome/connectome.cpp
+++ b/src/gui/mrview/tool/connectome/connectome.cpp
@@ -442,10 +442,9 @@ namespace MR
           edge_visibility_combobox->setToolTip (tr ("Set which edges are visible"));
           edge_visibility_combobox->addItem ("All");
           edge_visibility_combobox->addItem ("None");
-          edge_visibility_combobox->addItem ("By nodes");
           edge_visibility_combobox->addItem ("Connectome");
           edge_visibility_combobox->addItem ("Matrix file");
-          edge_visibility_combobox->setCurrentIndex (3);
+          edge_visibility_combobox->setCurrentIndex (2);
           connect (edge_visibility_combobox, SIGNAL (activated(int)), this, SLOT (edge_visibility_selection_slot (int)));
           gridlayout->addWidget (edge_visibility_combobox, 0, 2);
           edge_visibility_warning_icon = new QLabel();


### PR DESCRIPTION
In f0ef4d6f, controlling of connectome edge visibility was altered due to an observed inadequacy when attempting to suppress the display of edges based on the visibility of the nodes to which they are connected. However, removal of the relevant group box entry for some reason was not included in the commit, leading to the behaviour of each entry in the group box being inconsistent with its description. This change rectifies the mismatch.