### PR TITLE
MSYS2: fix segfault due to use of %zu printf format

### DIFF
--- a/check_syntax
+++ b/check_syntax
@@ -23,7 +23,7 @@ for f in $(find cmd core src -type f -name '*.h' -o -name '*.cpp' | grep -v '_mo
 
 
 
-  # process the file to strip comments, macros, etc:
+# process the file to strip comments, macros, etc:
   cat $f | \
 # remove C preprocessor macros:
   grep -v '^#' | \
@@ -34,9 +34,9 @@ for f in $(find cmd core src -type f -name '*.h' -o -name '*.cpp' | grep -v '_mo
 # remove any duplicate spaces:
   perl -pe 's|\s+| |g' | \
 # remove C-style comments:
-  perl -pe 's|/\*.*?\*/||g' | \
+  perl -pe 's|/\*.*?\*/||g' > .check_syntax2.tmp
 # remove quoted strings:
-  perl -pe 's/(")(\\"|.)*?"//g' > .check_syntax.tmp
+  cat .check_syntax2.tmp | perl -pe 's/(")(\\"|.)*?"//g' > .check_syntax.tmp
 
 
 # detect classes not declared MEMALIGN or NOMEMALIGN:
@@ -86,6 +86,14 @@ for f in $(find cmd core src -type f -name '*.h' -o -name '*.cpp' | grep -v '_mo
     )
   fi
 
+# detect any instances of %zu in a print() call (not supported on MSYS2):
+  res="$res"$(
+    cat .check_syntax2.tmp | \
+# match for the parts we're interested in and output just the bits that match:
+    grep -Po '\w*print\w*.*?%\d?zu\b' |
+    grep -Po '\w*print(?!.*?print).*?$'
+  )
+
 
 # if anything is left after that, show it:
   if [[ ! -z $res ]]; then
@@ -105,10 +113,12 @@ else
   echo "FAIL (see syntax.log for details)"
 
   echo "" >> $LOG
-  echo "Please add MEMALIGN() or NOMEMALIGN macro to the class declarations
-  identified above, replace all occurrences of std::vector<> with MR::vector<>
-  (or just vector<>), avoid use of std::make_shared(), and replace all
-  instances of std::abs() with MR::abs() (or just abs())" >> $LOG
+  echo "Please check the following syntax requirements:
+  - Add MEMALIGN() or NOMEMALIGN macro to any class declarations identified above;
+  - Replace all occurrences of std::vector<> with MR::vector<> (or just vector<>);
+  - Avoid use of std::make_shared();
+  - Replace all instances of std::abs() with MR::abs() (or just abs());
+  - Replace all instances of %zu in print() calls with PRI_SIZET." >> $LOG
   exit 1
 fi
 

--- a/core/file/dicom/select_cmdline.cpp
+++ b/core/file/dicom/select_cmdline.cpp
@@ -27,7 +27,7 @@ namespace MR {
       {
         vector<std::shared_ptr<Series>> series;
 
-        if (tree.size() == 0) 
+        if (tree.size() == 0)
           throw Exception ("DICOM tree its empty");
 
         std::string buf;
@@ -36,26 +36,26 @@ namespace MR {
           while (patient_p == NULL) {
             fprintf(stderr, "Select patient (q to abort):\n");
             for (size_t i = 0; i < tree.size(); i++) {
-              fprintf (stderr, "  %2zu - %s %s %s\n", 
-                  i+1, 
-                  tree[i]->name.c_str(),  
+              fprintf (stderr, "  %2" PRI_SIZET " - %s %s %s\n",
+                  i+1,
+                  tree[i]->name.c_str(),
                   format_ID(tree[i]->ID).c_str(),
                   format_date (tree[i]->DOB).c_str() );
             }
             std::cerr << "? ";
             std::cin >> buf;
-            if (!isdigit (buf[0])) { 
-              series.clear(); 
-              return series; 
+            if (!isdigit (buf[0])) {
+              series.clear();
+              return series;
             }
             int n = to<int>(buf) - 1;
-            if (n > (int) tree.size()) 
+            if (n > (int) tree.size())
               fprintf (stderr, "invalid selection - try again\n");
             else
               patient_p = tree[n].get();
           }
         }
-        else 
+        else
           patient_p = tree[0].get();
 
 
@@ -63,8 +63,8 @@ namespace MR {
         const Patient& patient (*patient_p);
 
         if (tree.size() > 1) {
-          fprintf (stderr, "patient: %s %s %s\n", 
-              patient.name.c_str(), 
+          fprintf (stderr, "patient: %s %s %s\n",
+              patient.name.c_str(),
               format_ID (patient.ID).c_str(),
               format_date (patient.DOB).c_str() );
         }
@@ -75,27 +75,27 @@ namespace MR {
           while (study_p == NULL) {
             fprintf (stderr, "Select study (q to abort):\n");
             for (size_t i = 0; i < patient.size(); i++) {
-              fprintf (stderr, "  %4zu - %s %s %s %s\n", 
-                  i+1, 
+              fprintf (stderr, "  %4" PRI_SIZET " - %s %s %s %s\n",
+                  i+1,
                   ( patient[i]->name.size() ? patient[i]->name.c_str() : "unnamed" ),
-                  format_ID (patient[i]->ID).c_str(), 
-                  format_date (patient[i]->date).c_str(), 
+                  format_ID (patient[i]->ID).c_str(),
+                  format_date (patient[i]->date).c_str(),
                   format_time (patient[i]->time).c_str() );
             }
             std::cerr << "? ";
             std::cin >> buf;
             if (!isdigit (buf[0])) {
-              series.clear(); 
-              return series; 
+              series.clear();
+              return series;
             }
             int n = to<int>(buf) - 1;
-            if (n > (int) patient.size()) 
+            if (n > (int) patient.size())
               fprintf (stderr, "invalid selection - try again\n");
-            else 
+            else
               study_p = patient[n].get();
           }
         }
-        else 
+        else
           study_p = patient[0].get();
 
 
@@ -103,7 +103,7 @@ namespace MR {
         const Study& study(*study_p);
 
         if (patient.size() > 1) {
-          fprintf (stderr, "study: %s %s %s %s\n", 
+          fprintf (stderr, "study: %s %s %s %s\n",
               ( study.name.size() ? study.name.c_str() : "unnamed" ),
               format_ID (study.ID).c_str(),
               format_date (study.date).c_str(),
@@ -116,28 +116,28 @@ namespace MR {
           while (series.size() == 0) {
             fprintf (stderr, "Select series ('q' to abort):\n");
             for (size_t i = 0; i < study.size(); i++) {
-              fprintf (stderr, "  %2zu - %4zu %s images %8s %s (%s) [%zu] %s\n", 
+              fprintf (stderr, "  %2" PRI_SIZET " - %4" PRI_SIZET " %s images %8s %s (%s) [%" PRI_SIZET "] %s\n",
                   i,
-                  study[i]->size(), 
-                  ( study[i]->modality.size() ? study[i]->modality.c_str() : "" ), 
-                  format_time (study[i]->time).c_str(), 
+                  study[i]->size(),
+                  ( study[i]->modality.size() ? study[i]->modality.c_str() : "" ),
+                  format_time (study[i]->time).c_str(),
                   ( study[i]->name.size() ? study[i]->name.c_str() : "unnamed" ),
                   ( (*study[i])[0]->sequence_name.size() ? (*study[i])[0]->sequence_name.c_str() : "?" ),
                   study[i]->number, study[i]->image_type.c_str());
             }
             std::cerr << "? ";
             std::cin >> buf;
-            if (!isdigit (buf[0])) { 
-              series.clear(); 
-              return (series); 
+            if (!isdigit (buf[0])) {
+              series.clear();
+              return (series);
             }
             vector<int> seq;
             try {
               seq = parse_ints (buf);
             }
-            catch (Exception) { 
-              fprintf (stderr, "Invalid number sequence - please try again\n"); 
-              seq.clear(); 
+            catch (Exception) {
+              fprintf (stderr, "Invalid number sequence - please try again\n");
+              seq.clear();
             }
             if (seq.size()) {
               for (size_t i = 0; i < seq.size(); i++) {

--- a/core/progressbar.cpp
+++ b/core/progressbar.cpp
@@ -42,7 +42,7 @@ namespace MR
     {
       __need_newline = true;
       if (p.multiplier)
-        __print_stderr (printf ("\r%s: [%3zu%%] %s%s" CLEAR_LINE_CODE,
+        __print_stderr (printf ("\r%s: [%3" PRI_SIZET "%%] %s%s" CLEAR_LINE_CODE,
               App::NAME.c_str(), p.value, p.text.c_str(), p.ellipsis.c_str()));
       else
         __print_stderr (printf ("\r%s: [%s] %s%s" CLEAR_LINE_CODE,
@@ -78,7 +78,7 @@ namespace MR
           count = next_update_at = 0;
         if (count++ == next_update_at) {
           if (p.multiplier) {
-            __print_stderr (printf ("%s: [%3zu%%] %s%s\n",
+            __print_stderr (printf ("%s: [%3" PRI_SIZET "%%] %s%s\n",
                   App::NAME.c_str(), p.value, p.text.c_str(), p.ellipsis.c_str()));;
           }
           else {

--- a/core/types.h
+++ b/core/types.h
@@ -16,8 +16,7 @@
 #ifndef __mrtrix_types_h__
 #define __mrtrix_types_h__
 
-
-#include <stdint.h>
+#include <cinttypes>
 #include <complex>
 #include <iostream>
 #include <vector>
@@ -26,6 +25,17 @@
 #include <memory>
 
 #define NOMEMALIGN
+
+#ifdef _WIN32
+#  ifdef _WIN64
+#    define PRI_SIZET PRIu64
+#  else
+#    define PRI_SIZET PRIu32
+#  endif
+#else
+#  define PRI_SIZET "zu"
+#endif
+
 
 namespace MR {
 


### PR DESCRIPTION
Running `tckgen` on MSYS2 was consistently producing segfaults. This must have been happening for a while, very odd that no one's reported it so far... Here's that the output looked like on my system:
```
 $ tckgen ms_wm.mif -seed_sphere -17,-7,15,5 -seed_dir -1,1,0 OR_L.tck -select 1000 -seed_unidir -include -1,-68,-11,30 -nthread 0
tckgen: [zu%] (null)    5681 seeds,     2257 streamlines,        9 selected
tckgen: [SYSTEM FATAL CODE: SIGSEGV (11)] Segmentation fault: Invalid memory access
```
After a bit of digging around, the fix [suggested in this post](https://stackoverflow.com/a/44383330/3244166) seems to do the trick - although [this post](https://stackoverflow.com/a/30851225/3244166) also helped...

Suggest merging to `master` as it's clearly a bug, and shouldn't affect anything else on non-Windows systems (I hope...). No huge rush though, there are no user reports yet.