### PR TITLE
Scripts: Tweak message on command failure

### DIFF
--- a/lib/mrtrix3/app.py
+++ b/lib/mrtrix3/app.py
@@ -270,7 +270,8 @@ def complete(): #pylint: disable=unused-variable
     # This needs to be printed even if the -quiet option is used
     if os.path.isfile(os.path.join(tempDir, 'error.txt')):
       with open(os.path.join(tempDir, 'error.txt'), 'r') as errortext:
-        sys.stderr.write(os.path.basename(sys.argv[0]) + ': ' + colourWarn + 'Script failed while executing the command: ' + errortext.readline().rstrip() + colourClear + '\n')
+        sys.stderr.write(os.path.basename(sys.argv[0]) + ': ' + colourWarn + 'Following command failed during execution of the script:' + colourClear + '\n')
+        sys.stderr.write(os.path.basename(sys.argv[0]) + ': ' + colourWarn + errortext.readline().rstrip() + colourClear + '\n')
       sys.stderr.write(os.path.basename(sys.argv[0]) + ': ' + colourWarn + 'For debugging, inspect contents of temporary directory: ' + tempDir + colourClear + '\n')
     else:
       sys.stderr.write(os.path.basename(sys.argv[0]) + ': ' + colourConsole + 'Contents of temporary directory kept, location: ' + tempDir + colourClear + '\n')


### PR DESCRIPTION
Users seem to continue reporting failure of commands executed within a wrapping script as though they are failures of the script itself. Maybe a minor rewording of how the error message is presented will reinforce the fact that in many circumstances, such commands are responsible for their own failure, rather than the script providing the command with bad data resulting in a failure.