### PR TITLE
Dwipreproc: Handle inappropriate slspec input

### DIFF
--- a/bin/dwipreproc
+++ b/bin/dwipreproc
@@ -213,12 +213,26 @@ if eddy_mporder:
     if os.path.isfile(slspec_file_path):
       # Since there's a chance that we may need to pad this info, we can't just copy this file
       #   to the temporary directory...
-      with open(slspec_file_path, 'r') as f:
-        for line in f:
-          line = line.strip()
-          if line:
-            slice_groups.append([int(value) for value in line.split()])
-      app.var(slice_groups)
+      try:
+        with open(slspec_file_path, 'r') as f:
+          for line in f:
+            line = line.strip()
+            if line:
+              slice_groups.append([int(value) for value in line.split()])
+        app.var(slice_groups)
+      except ValueError:
+        try:
+          with open(slspec_file_path, 'r') as f:
+            for line in f:
+              line = line.strip()
+              if line:
+                slice_timing.append(float(line))
+          app.warning('\"slspec\" file provided to FSL eddy should contain slice indices for slice groups, not slice timing; nevertheless, slice timing has been imported from file \"' + slspec_file_path + '\"')
+          app.var(slice_timing)
+          if len(slice_timing) != dwi_num_slices:
+            app.error('Cannot use slice timing information from file \"' + slspec_file_path + '\" for slice-to-volume correction: Number of entries (' + len(slice_timing) + ') does not match number of slices (' + dwi_header.size()[2] + ')')
+        except ValueError:
+          app.error('Error parsing \"slspec\" file (this should contain integer values indicating slice groups, not slice timing; please see FSL eddy help page)')
       # Remove this entry from eddy_manual_options; it'll be inserted later, with the
       #   path to the new slspec file
       eddy_manual_options = [ s for s in eddy_manual_options if not s.startswith('--slspec') ]

--- a/bin/dwipreproc
+++ b/bin/dwipreproc
@@ -227,7 +227,7 @@ if eddy_mporder:
               line = line.strip()
               if line:
                 slice_timing.append(float(line))
-          app.warning('\"slspec\" file provided to FSL eddy should contain slice indices for slice groups, not slice timing; nevertheless, slice timing has been imported from file \"' + slspec_file_path + '\"')
+          app.warn('\"slspec\" file provided to FSL eddy should contain slice indices for slice groups, not slice timing; nevertheless, slice timing has been imported from file \"' + slspec_file_path + '\"')
           app.var(slice_timing)
           if len(slice_timing) != dwi_num_slices:
             app.error('Cannot use slice timing information from file \"' + slspec_file_path + '\" for slice-to-volume correction: Number of entries (' + len(slice_timing) + ') does not match number of slices (' + dwi_header.size()[2] + ')')


### PR DESCRIPTION
Some users may not appreciate the difference between slice timing data, and the "slspec" data required by `eddy` for slice-to-volume correction. This change catches the case where the user erroneously provides the former, performing the appropriate conversion whilst also warning the user that their input was in fact inappropriate.