### PR TITLE
fixelcfestats: Remove erroneous warning

### DIFF
--- a/cmd/fixelcfestats.cpp
+++ b/cmd/fixelcfestats.cpp
@@ -188,8 +188,9 @@ void run() {
     data_header.size(0) = num_fixels;
     data_header.size(1) = 1;
     data_header.size(2) = 1;
-    data_header.spacing(0) = data_header.spacing(1) = data_header.spacing(2) = NaN;
+    data_header.spacing(0) = data_header.spacing(1) = data_header.spacing(2) = 1.0;
     data_header.stride(0) = 1; data_header.stride(1) = 2; data_header.stride(2) = 3;
+    data_header.transform().setIdentity();
     mask = Image<bool>::scratch (data_header, "scratch fixel mask");
     for (index_type f = 0; f != num_fixels; ++f) {
       mask.index(0) = f;


### PR DESCRIPTION
When constructing a scratch fixel mask due to non-use of the `-mask` option, give sensible values to the voxel sizes and transform matrix so as to suppress terminal warnings.

Eventually I would prefer to modify the fixel format handling more deeply so that header information such as spacing and transforms are ignored entirely for ndim < 3 (e.g. for fixel data files). But the change in this PR should at least reduce user feedback about irrelevant warnings.

Closes #1102.