### PR TITLE
run.command(): Fix app cleanup with exitOnError=False

### DIFF
--- a/lib/mrtrix3/run.py
+++ b/lib/mrtrix3/run.py
@@ -203,8 +203,8 @@ def command(cmd, exitOnError=True): #pylint: disable=unused-variable
   _processes = [ ]
 
   if error:
-    app.cleanup = False
     if exitOnError:
+      app.cleanup = False
       caller = inspect.getframeinfo(inspect.stack()[1][0])
       script_name = os.path.basename(sys.argv[0])
       app.console('')


### PR DESCRIPTION
In rare instances, `run.command()` may be run with the argument `exitOnError=False`, allowing the underlying command to fail without aborting the script. When this occurs, only a warning-level message is issued. However, due to misplacement of code, such a circumstance would lead to the temporary directory not being erased on script completion, even if the script goes on to completion. This fix ensures that forcing the temporary directory to be retained only occurs if the underlying command both fails and is not permitted to fail.