### PR TITLE
remove naked except: statements from python scripts

### DIFF
--- a/build
+++ b/build
@@ -189,8 +189,6 @@ def pipe_errors_to_less_handler():
       os.unlink (name)
     except Exception as e:
       sys.stderr.write (str (e))
-    except:
-      raise
 
 
 
@@ -478,7 +476,7 @@ if 'clean' in targets:
     for fname in list_untracked_bin_files():
       print ('delete file:', fname)
       os.remove (fname)
-  except:
+  except Exception:
     pass
 
   try:
@@ -486,7 +484,7 @@ if 'clean' in targets:
       if os.path.isfile (fname):
         print ('delete file:', fname)
         os.remove (fname)
-  except:
+  except Exception:
     pass
 
   sys.exit (0)
@@ -835,7 +833,7 @@ def execute (message, cmd, working_dir=None):
   except OSError:
     error (cmd[0] + ': command not found')
     return 1
-  except:
+  except Exception:
     error ('unexpected exception: ' + str(sys.exc_info()))
     raise
 
@@ -993,7 +991,7 @@ def build_next (id):
       del todo[current]
       lock.release()
 
-  except:
+  except Exception:
     stop = 2
     return
 
@@ -1025,7 +1023,7 @@ getting git version in folder "''' + folder + '"... ')
       git_version = git_version.decode(errors='ignore').strip()
       log (git_version + '\n')
       return git_version
-  except:
+  except Exception:
     pass
 
 
@@ -1040,7 +1038,7 @@ def update_git_version (folder, git_version_file, contents):
   try:
     with open (git_version_file) as fd:
       current_version_file_contents = fd.read()
-  except:
+  except Exception:
     pass
 
   if not current_version_file_contents or (version_file_contents != current_version_file_contents and git_version != 'unknown'):
@@ -1244,9 +1242,10 @@ log ('TODO list contains ' + str(len(todo)) + ''' items
 
 #for entry in todo.values(): entry.display()
 try: num_processors = int(os.environ['NUMBER_OF_PROCESSORS'])
-except:
+except Exception:
   try: num_processors = os.sysconf('SC_NPROCESSORS_ONLN')
-  except: num_processors = 1
+  except Exception:
+    num_processors = 1
 
 while len(todo):
 

--- a/configure
+++ b/configure
@@ -290,8 +290,6 @@ class TempFile:
       os.unlink (self.name)
     except OSError as error:
       log ('error deleting temporary file "' + self.name + '": ' + error.strerror)
-    except:
-      raise
 
 
 
@@ -307,8 +305,6 @@ class DeleteAfter:
       os.unlink (self.name)
     except OSError as error:
       log ('error deleting temporary file "' + self.name + '": ' + error.strerror)
-    except:
-      raise
 
 
 class TempDir:
@@ -330,8 +326,6 @@ class TempDir:
 
     except OSError as error:
       log ('error deleting temporary folder "' + self.name + '": ' + error.strerror)
-    except:
-      raise
 
 
 
@@ -459,7 +453,7 @@ def execute (cmd, exception, raise_on_non_zero_exit_code = True, cwd = None):
   except OSError as error:
     log ('error invoking command "' + cmd[0] + '": ' + error.strerror + '\n>>\n\n')
     raise exception
-  except:
+  except Exception:
     print ('Unexpected error:', str(sys.exc_info()))
     raise
   else:
@@ -528,7 +522,7 @@ def get_flags (default=None, env=None, pkg_config_flags=None):
         else:
           flags += [ entry ]
       return flags
-    except:
+    except Exception:
       log('error running "pkg-config ' + pkg_config_flags + '"\n\n')
   return default
 
@@ -552,7 +546,7 @@ def compile_test (name, cflags, ldflags, code, on_success='ok', on_failure='not 
     else:
       report (on_success+'\n')
     return True
-  except:
+  except Exception:
     report (on_failure+'\n')
     return False
 
@@ -607,7 +601,7 @@ def compile_check (full_name, name, cflags, ldflags, code, cflags_env=None, cfla
     error ('''runtime error!
 
    Unable to configure ''' + name + configure_log_hint)
-  except:
+  except Exception:
     error ('unexpected exception!' + configure_log_hint)
 
 
@@ -707,7 +701,7 @@ for candidate in cxx:
     compiler_version = execute ([ cpp[0], '--version' ], CompileError)[1]
     if len(compiler_version) == 0: report ('(no version information)\n')
     else: report (compiler_version.splitlines()[0] + '\n')
-  except:
+  except Exception:
     report ('not found\n')
     continue
 
@@ -750,7 +744,7 @@ if not noshared:
       try: execute (cmd, CompileError)
       except CompileError:
         error ('compiler not found!' + configure_log_hint)
-      except:
+      except Exception:
         error ('unexpected exception!' + configure_log_hint)
       with DeleteAfter (lib_prefix + 'test' + lib_suffix) as lib:
         cmd = fillin (ld_lib, {
@@ -762,7 +756,7 @@ if not noshared:
           error ('''linker not found!
 
   MRtrix3 was unable to employ the linker program for shared library generation.''' + compiler_hint ('shared library linker', 'LDLIB_FLAGS', '"-L/usr/local/lib"', 'LDLIB_ARGS', '"-shared LDLIB_FLAGS OBJECTS -o LIB"'))
-        except:
+        except Exception:
           error ('unexpected exception!' + configure_log_hint)
 
         report ('ok\n')
@@ -789,7 +783,7 @@ int main() {
   if pointer_size == 8: cpp_flags += [ '-DMRTRIX_WORD64' ]
   elif pointer_size != 4:
     error ('unexpected pointer size!')
-except:
+except Exception:
   error ('unable to determine pointer size!' + configure_log_hint)
 
 
@@ -1039,7 +1033,7 @@ if not nogui:
     error (''' Qt moc not found!
 
   MRtrix3 was unable to locate the Qt meta-object compiler 'moc'.''' + qt_path_hint)
-  except:
+  except Exception:
     error ('unexpected exception!' + configure_log_hint)
 
   report ('Checking for Qt qmake: ')
@@ -1059,7 +1053,7 @@ if not nogui:
     error (''' Qt qmake not found!
 
   MRtrix3 was unable to locate the Qt command 'qmake'.''' + qt_path_hint)
-  except:
+  except Exception:
     error ('unexpected exception!' + configure_log_hint)
 
 
@@ -1082,7 +1076,7 @@ if not nogui:
     error (''' Qt rcc not found!
 
   MRtrix3 was unable to locate the Qt command 'rcc'.''' + qt_path_hint)
-  except:
+  except Exception:
     error ('unexpected exception!' + configure_log_hint)
 
 
@@ -1154,7 +1148,7 @@ int main() { Foo f; }
         error ('''error issuing qmake command!
 
   Use the QMAKE environment variable to set the correct qmake command for use with Qt''')
-      except:
+      except Exception:
         raise
 
 
@@ -1228,7 +1222,7 @@ int main() { Foo f; }
     error ('error running Qt application!' + configure_log_hint)
   except OSError as e:
     error ('unexpected error: ' + str(e) + configure_log_hint)
-  except:
+  except Exception:
     error ('unexpected exception!' + configure_log_hint)
 
 


### PR DESCRIPTION
As discussed in #1391
    
Now using 'except: Exception' as a catch-all instead. This will not catch KeyboardInterrupt, SystemExit, or GeneratorExit exception, since by design these derive from BaseException directly - precisely to ensure they don't get caught by an `except: Exception` statement.
