### PR TITLE
Build tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
     # (Note: Run this one first, since it'll be the longest job)        #
     #####################################################################
     - os: linux
-      env: CFLAGS="-Werror -Wno-inconsistent-missing-override" TRAVIS_CXX=clang++-6.0 py=python3 test=run
+      env: CFLAGS="-Werror -Wno-inconsistent-missing-override -Wno-deprecated-register" TRAVIS_CXX=clang++-6.0 py=python3 test=run
     #######################################################################
     # Build binaries (without optimisation): GCC, Python2                 #
     # (Also ensures both Python 2 and 3 are tested for configure & build) #

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
     # (Note: Run this one first, since it'll be the longest job)        #
     #####################################################################
     - os: linux
-      env: CFLAGS="-Werror" TRAVIS_CXX=clang++-6.0 py=python3 test=run
+      env: CFLAGS="-Werror -Wno-inconsistent-missing-override" TRAVIS_CXX=clang++-6.0 py=python3 test=run
     #######################################################################
     # Build binaries (without optimisation): GCC, Python2                 #
     # (Also ensures both Python 2 and 3 are tested for configure & build) #

--- a/build
+++ b/build
@@ -180,7 +180,7 @@ def pipe_errors_to_less_handler():
       [ fid, name ] = tempfile.mkstemp()
       try:
         fid = os.fdopen (fid, 'wb')
-        fid.write ([ x.encode (errors='ignore') for x in colorize(error_stream) ])
+        fid.write (''.join (colorize(error_stream)).encode (errors='ignore'))
         fid.close()
         os.system ("less -RX " + name)
       except Exception as e: # pylint: disable=broad-except

--- a/build
+++ b/build
@@ -161,13 +161,13 @@ bcolors = {
 
 
 def colorize(s):
-  out = []
+  out = ''
   for l in s.splitlines():
     for st in bcolors:
       if st in l:
         l = l.replace (st, bcolors[st] + st) + '\033[0m'
         break
-    out.append(l + '\n')
+    out += l + '\n'
   return out
 
 
@@ -178,7 +178,7 @@ def pipe_errors_to_less_handler():
   if error_stream:
     [ fid, name ] = tempfile.mkstemp()
     fid = os.fdopen (fid, 'wb')
-    fid.write (''.join (colorize(error_stream)).encode (errors='ignore'))
+    fid.write (colorize(error_stream).encode (errors='ignore'))
     fid.close()
     os.system ("less -RX " + name)
     os.unlink (name)
@@ -1085,7 +1085,7 @@ def update_bash_completion ():
   script_path = os.path.join (mrtrix_dir[-1], 'generate_bash_completion.py')
   completion_path = os.path.join (mrtrix_dir[-1], 'mrtrix_bash_completion')
   if not os.path.isfile (script_path):
-    disp (colorize('WARNING: Skipping bash completion generation. Could not find script at ' + script_path + '\n')[0])
+    disp (colorize('WARNING: Skipping bash completion generation. Could not find script at ' + script_path + '\n'))
     return
 
   # Check whether both command files and completion file exist and completion file is newer than commands
@@ -1116,7 +1116,7 @@ def update_user_docs ():
 
   # Check whether generate docs script exists
   if not os.path.isfile (script_path):
-    disp (colorize('WARNING: Skipping user documentation generation. Could not find script at ' + script_path + '\n')[0])
+    disp (colorize('WARNING: Skipping user documentation generation. Could not find script at ' + script_path + '\n'))
     return
 
   # Check whether commands dir exists

--- a/build
+++ b/build
@@ -176,18 +176,12 @@ def colorize(s):
 def pipe_errors_to_less_handler():
   global error_stream
   if error_stream:
-    try:
-      [ fid, name ] = tempfile.mkstemp()
-      try:
-        fid = os.fdopen (fid, 'wb')
-        fid.write (''.join (colorize(error_stream)).encode (errors='ignore'))
-        fid.close()
-        os.system ("less -RX " + name)
-      except Exception as e: # pylint: disable=broad-except
-        sys.stderr.write (str (e))
-      os.unlink (name)
-    except Exception as e: # pylint: disable=broad-except
-      sys.stderr.write (str (e))
+    [ fid, name ] = tempfile.mkstemp()
+    fid = os.fdopen (fid, 'wb')
+    fid.write (''.join (colorize(error_stream)).encode (errors='ignore'))
+    fid.close()
+    os.system ("less -RX " + name)
+    os.unlink (name)
 
 
 
@@ -353,6 +347,9 @@ while os.path.abspath (os.path.dirname (get_real_name (build_script))) != os.pat
 #                             CONFIG HANDLING                              #
 ############################################################################
 
+class ConfigException (Exception):
+  pass
+
 def get_active_build (directory):
   active_configs = glob.glob (os.path.join (directory, 'build.*.active'))
   if len (active_configs) > 1:
@@ -361,9 +358,9 @@ def get_active_build (directory):
   if active_configs:
     name = active_configs[0]
     if not os.path.isdir (name):
-      raise Exception ('ERROR: active config (' + name + ') is not a directory')
+      raise ConfigException ('ERROR: active config (' + name + ') is not a directory')
     if os.listdir (name):
-      raise Exception ('ERROR: active config directory (' + name + ') is not empty')
+      raise ConfigException ('ERROR: active config directory (' + name + ') is not empty')
     return name[:-len('.active')]
   os.mkdir (os.path.join (directory, 'build.default.active'))
   return os.path.join (directory, 'build.default')
@@ -394,7 +391,7 @@ def restore_build (config_name, directory = '.'):
           os.rmdir (os.path.join(root, name))
   else:
     if os.path.exists (stored_path):
-      raise Exception ('ERROR config to be restored (' + stored_path + ') is not a directory')
+      raise ConfigException ('ERROR config to be restored (' + stored_path + ') is not a directory')
     sys.stderr.write('in "' + directory + '": creating empty "' + stored_path + '"...\n')
   if not os.path.isdir (active_path):
     os.mkdir (active_path)
@@ -463,28 +460,42 @@ if 'clean' in targets:
       for entry in files:
         filename = os.path.join(root, entry)
         sys.stderr.write('delete file: ' + filename + '\n')
-        os.remove (filename)
+        try:
+          os.remove (filename)
+        except OSError:
+          error ('error deleting file "' + filename + '": ' + os.strerror (e.errno))
+          pass
       for entry in dirs:
         dirname = os.path.join(root, entry)
         sys.stderr.write('delete directory: ' + dirname + '\n')
-        os.rmdir (dirname)
+        try:
+          os.rmdir (dirname)
+        except OSError:
+          error ('error deleting folder "' + dirname + '": ' + os.strerror (e.errno))
+          pass
     sys.stderr.write('delete directory: ' + f + '\n')
-    os.rmdir (f)
+    try:
+      os.rmdir (f)
+    except OSError:
+      error ('error deleting folder "' + f + '": ' + os.strerror (e.errno))
+      pass
 
-  try:
-    for filename in list_untracked_bin_files():
-      sys.stderr.write('delete file: ' + filename + '\n')
+  for filename in list_untracked_bin_files():
+    sys.stderr.write('delete file: ' + filename + '\n')
+    try:
       os.remove (filename)
-  except:
-    pass
+    except OSError:
+      error ('error deleting file "' + filename + '": ' + os.strerror (e.errno))
+      pass
 
-  try:
-    for filename in glob.glob (os.path.join ('lib', 'libmrtrix*')):
-      if os.path.isfile (filename):
-        sys.stderr.write('delete file: ' + filename + '\n')
+  for filename in glob.glob (os.path.join ('lib', 'libmrtrix*')):
+    if os.path.isfile (filename):
+      sys.stderr.write('delete file: ' + filename + '\n')
+      try:
         os.remove (filename)
-  except Exception:
-    pass
+      except OSError:
+        error ('error deleting file "' + filename + '": ' + os.strerror (e.errno))
+        pass
 
   sys.exit (0)
 
@@ -574,6 +585,9 @@ for entry in glob.glob (os.path.normpath (os.path.join (target_lib_dir, '*' + li
 #                           TO-DO LIST ENTRY                              #
 ###########################################################################
 
+class TargetException (Exception):
+  pass
+
 class Entry(object):
   def __init__ (self, name):
     global todo
@@ -602,7 +616,7 @@ class Entry(object):
     elif is_moc (self.name):
       self.set_moc()
     elif not os.path.exists (self.name):
-      raise Exception ('unknown target "' + self.name + '"')
+      raise TargetException ('unknown target "' + self.name + '"')
 
 
     [ Entry(item) for item in self.deps ] # pylint: disable=expression-not-assigned
@@ -851,9 +865,6 @@ def execute (message, cmd, working_dir=None):
   except OSError:
     error (cmd[0] + ': command not found')
     return 1
-  except Exception:
-    error ('unexpected exception: ' + str(sys.exc_info()))
-    raise
   return None
 
 
@@ -1047,9 +1058,8 @@ getting git version in folder "''' + folder + '"... ')
       git_version = git_version.decode(errors='ignore').strip()
       log (git_version + '\n')
       return git_version
-  except Exception:
+  except OSError:
     pass
-
 
   log ('not found\n')
   return 'unknown'
@@ -1062,7 +1072,7 @@ def update_git_version (folder, git_version_file, contents):
   try:
     with open (git_version_file) as fd:
       current_version_file_contents = fd.read()
-  except Exception:
+  except (IOError, OSError):
     pass
 
   if not current_version_file_contents or (version_file_contents != current_version_file_contents and git_version != 'unknown'):
@@ -1212,8 +1222,11 @@ namespace MR {
 log ('''
 compiling TODO list...
 ''')
-
-[ Entry(item) for item in targets ] # pylint: disable=expression-not-assigned
+try:
+  [ Entry(item) for item in targets ] # pylint: disable=expression-not-assigned
+except TargetException as excp:
+  sys.stderr.write ('ERROR: ' + str(excp) + '\n')
+  sys.exit (1)
 
 
 
@@ -1270,10 +1283,10 @@ log ('TODO list contains ' + str(len(todo)) + ''' items
 #  entry.display()
 try:
   num_processors = int(os.environ['NUMBER_OF_PROCESSORS'])
-except Exception:
+except (KeyError, TypeError):
   try:
     num_processors = os.sysconf('SC_NPROCESSORS_ONLN')
-  except Exception:
+  except (ValueError):
     num_processors = 1
 
 while todo:

--- a/build
+++ b/build
@@ -95,8 +95,9 @@ from timeit import default_timer as timer
 
 # on Windows, need to use MSYS2 version of python - not MinGW version:
 if sys.executable[0].isalpha() and sys.executable[1] == ':':
-  python_cmd = subprocess.check_output ([ 'cygpath.exe', '-w', '/usr/bin/python' ]).splitlines()[0].strip()
+  python_cmd = subprocess.check_output ([ 'cygpath.exe', '-w', '/usr/bin/python' ]).decode(errors='ignore').splitlines()[0].strip()
   sys.exit (subprocess.call ([ python_cmd ] + sys.argv))
+
 
 bin_dir = 'bin'
 cmd_dir = 'cmd'

--- a/build
+++ b/build
@@ -462,40 +462,35 @@ if 'clean' in targets:
         sys.stderr.write('delete file: ' + filename + '\n')
         try:
           os.remove (filename)
-        except OSError:
-          error ('error deleting file "' + filename + '": ' + os.strerror (e.errno))
-          pass
+        except OSError as excp:
+          error ('error deleting file "' + filename + '": ' + os.strerror (excp.errno))
       for entry in dirs:
         dirname = os.path.join(root, entry)
         sys.stderr.write('delete directory: ' + dirname + '\n')
         try:
           os.rmdir (dirname)
-        except OSError:
-          error ('error deleting folder "' + dirname + '": ' + os.strerror (e.errno))
-          pass
+        except OSError as excp:
+          error ('error deleting folder "' + dirname + '": ' + os.strerror (excp.errno))
     sys.stderr.write('delete directory: ' + f + '\n')
     try:
       os.rmdir (f)
-    except OSError:
-      error ('error deleting folder "' + f + '": ' + os.strerror (e.errno))
-      pass
+    except OSError as excp:
+      error ('error deleting folder "' + f + '": ' + os.strerror (excp.errno))
 
   for filename in list_untracked_bin_files():
     sys.stderr.write('delete file: ' + filename + '\n')
     try:
       os.remove (filename)
-    except OSError:
-      error ('error deleting file "' + filename + '": ' + os.strerror (e.errno))
-      pass
+    except OSError as excp:
+      error ('error deleting file "' + filename + '": ' + os.strerror (excp.errno))
 
   for filename in glob.glob (os.path.join ('lib', 'libmrtrix*')):
     if os.path.isfile (filename):
       sys.stderr.write('delete file: ' + filename + '\n')
       try:
         os.remove (filename)
-      except OSError:
-        error ('error deleting file "' + filename + '": ' + os.strerror (e.errno))
-        pass
+      except OSError as excp:
+        error ('error deleting file "' + filename + '": ' + os.strerror (excp.errno))
 
   sys.exit (0)
 
@@ -631,9 +626,9 @@ class Entry(object):
     folder = os.path.dirname (self.name)
     try:
       os.makedirs (folder)
-    except OSError as e:
+    except OSError as excp:
       if not os.path.isdir (folder):
-        error ('ERROR: can''t create target folder "' + folder + '": ' + os.strerror (e.errno))
+        error ('ERROR: can''t create target folder "' + folder + '": ' + os.strerror (excp.errno))
         exit (1)
 
     if self.action == 'RCC':
@@ -1286,7 +1281,7 @@ try:
 except (KeyError, TypeError):
   try:
     num_processors = os.sysconf('SC_NPROCESSORS_ONLN')
-  except (ValueError):
+  except ValueError:
     num_processors = 1
 
 while todo:

--- a/cmd/amp2response.cpp
+++ b/cmd/amp2response.cpp
@@ -13,8 +13,6 @@
  */
 
 
-#include <Eigen/Dense>
-
 #include "command.h"
 #include "header.h"
 #include "image.h"

--- a/cmd/dwidenoise.cpp
+++ b/cmd/dwidenoise.cpp
@@ -15,7 +15,6 @@
 
 #include "command.h"
 #include "image.h"
-#include <Eigen/Dense>
 #include <Eigen/Eigenvalues>
 
 #define DEFAULT_SIZE 5
@@ -27,7 +26,7 @@ using namespace App;
 void usage ()
 {
   SYNOPSIS = "Denoise DWI data and estimate the noise level based on the optimal threshold for PCA";
-    
+
   DESCRIPTION
     + "DWI data denoising and noise map estimation by exploiting data redundancy in the PCA domain "
     "using the prior knowledge that the eigenspectrum of random covariance matrices is described by "
@@ -35,11 +34,11 @@ void usage ()
 
     + "Important note: image denoising must be performed as the first step of the image processing pipeline. "
     "The routine will fail if interpolation or smoothing has been applied to the data prior to denoising."
-    
+
     + "Note that this function does not correct for non-Gaussian noise biases.";
-  
+
   AUTHOR = "Daan Christiaens (daan.christiaens@kcl.ac.uk) & Jelle Veraart (jelle.veraart@nyumc.org) & J-Donald Tournier (jdtournier@gmail.com)";
-  
+
   REFERENCES
     + "Veraart, J.; Novikov, D.S.; Christiaens, D.; Ades-aron, B.; Sijbers, J. & Fieremans, E. " // Internal
     "Denoising of diffusion MRI using random matrix theory. "
@@ -48,7 +47,7 @@ void usage ()
     + "Veraart, J.; Fieremans, E. & Novikov, D.S. " // Internal
     "Diffusion MRI noise mapping using random matrix theory. "
     "Magn. Res. Med., 2016, 76(5), 1582-1593, doi: 10.1002/mrm.26059";
-  
+
   ARGUMENTS
   + Argument ("dwi", "the input diffusion-weighted image.").type_image_in ()
 
@@ -81,7 +80,7 @@ void usage ()
       "licenses under any patents or patent application owned by NYU. \n \n"
       "\t 5. The Software may only be used for non-commercial research and may not be used for clinical care. \n \n"
       "\t 6. Any publication by Recipient of research involving the Software shall cite the references listed below.";
-    
+
 }
 
 
@@ -96,12 +95,12 @@ class DenoisingFunctor { MEMALIGN(DenoisingFunctor)
       m (dwi.size(3)),
       n (extent[0]*extent[1]*extent[2]),
       r ((m<n) ? m : n),
-      X (m,n), 
-      pos {{0, 0, 0}}, 
+      X (m,n),
+      pos {{0, 0, 0}},
       mask (mask),
       noise (noise)
   { }
-  
+
   void operator () (ImageType& dwi, ImageType& out)
   {
     if (mask.valid()) {
@@ -117,12 +116,12 @@ class DenoisingFunctor { MEMALIGN(DenoisingFunctor)
     Eigen::MatrixXf XtX (r,r);
     if (m <= n)
       XtX.template triangularView<Eigen::Lower>() = X * X.transpose();
-    else 
+    else
       XtX.template triangularView<Eigen::Lower>() = X.transpose() * X;
     Eigen::SelfAdjointEigenSolver<Eigen::MatrixXf> eig (XtX);
     // eigenvalues provide squared singular values:
     Eigen::VectorXf s = eig.eigenvalues();
-   
+
     // Marchenko-Pastur optimal threshold
     const double lam_r = s[0] / n;
     double clam = 0.0;
@@ -139,16 +138,16 @@ class DenoisingFunctor { MEMALIGN(DenoisingFunctor)
       if (sigsq2 < sigsq1) {
         sigma2 = sigsq1;
         cutoff_p = p+1;
-      } 
+      }
     }
 
     if (cutoff_p > 0) {
       // recombine data using only eigenvectors above threshold:
       s.head (cutoff_p).setZero();
       s.tail (r-cutoff_p).setOnes();
-      if (m <= n) 
+      if (m <= n)
         X.col (n/2) = eig.eigenvectors() * ( s.asDiagonal() * ( eig.eigenvectors().adjoint() * X.col(n/2) ));
-      else 
+      else
         X.col (n/2) = X * ( eig.eigenvectors() * ( s.asDiagonal() * eig.eigenvectors().adjoint().col(n/2) ));
     }
 
@@ -163,8 +162,8 @@ class DenoisingFunctor { MEMALIGN(DenoisingFunctor)
       noise.value() = value_type (std::sqrt(sigma2));
     }
   }
-  
-  
+
+
   void load_data (ImageType& dwi)
   {
     pos[0] = dwi.index(0); pos[1] = dwi.index(1); pos[2] = dwi.index(2);
@@ -180,7 +179,7 @@ class DenoisingFunctor { MEMALIGN(DenoisingFunctor)
     dwi.index(1) = pos[1];
     dwi.index(2) = pos[2];
   }
-  
+
 private:
   const std::array<ssize_t, 3> extent;
   const ssize_t m, n, r;
@@ -189,7 +188,7 @@ private:
   double sigma2;
   Image<bool> mask;
   ImageType noise;
-  
+
 };
 
 
@@ -198,7 +197,7 @@ void run ()
 {
   auto dwi_in = Image<value_type>::open (argument[0]).with_direct_io(3);
 
-  if (dwi_in.ndim() != 4 || dwi_in.size(3) <= 1) 
+  if (dwi_in.ndim() != 4 || dwi_in.size(3) <= 1)
     throw Exception ("input image must be 4-dimensional");
 
   Image<bool> mask;
@@ -211,7 +210,7 @@ void run ()
   auto header = Header (dwi_in);
   header.datatype() = DataType::Float32;
   auto dwi_out = Image<value_type>::create (argument[1], header);
-  
+
   opt = get_options("extent");
   vector<int> extent = { DEFAULT_SIZE, DEFAULT_SIZE, DEFAULT_SIZE };
   if (opt.size()) {
@@ -224,7 +223,7 @@ void run ()
       if (!(e & 1))
         throw Exception ("-extent must be a (list of) odd numbers");
   }
-  
+
   Image<value_type> noise;
   opt = get_options("noise");
   if (opt.size()) {

--- a/cmd/mrdegibbs.cpp
+++ b/cmd/mrdegibbs.cpp
@@ -13,14 +13,14 @@
  */
 
 
-#include <unsupported/Eigen/FFT>
-
 #include "axes.h"
 #include "command.h"
 #include "image.h"
 #include "progressbar.h"
 #include "algo/threaded_loop.h"
 #include <numeric>
+
+#include <unsupported/Eigen/FFT>
 
 using namespace MR;
 using namespace App;

--- a/cmd/transformcalc.cpp
+++ b/cmd/transformcalc.cpp
@@ -13,8 +13,6 @@
  */
 
 
-#include <Eigen/Geometry>
-#include <unsupported/Eigen/MatrixFunctions>
 #include <algorithm>
 #include "command.h"
 #include "math/math.h"
@@ -24,6 +22,7 @@
 #include "transform.h"
 #include "file/key_value.h"
 
+#include <unsupported/Eigen/MatrixFunctions>
 
 using namespace MR;
 using namespace App;

--- a/cmd/transformconvert.cpp
+++ b/cmd/transformconvert.cpp
@@ -13,7 +13,6 @@
  */
 
 
-#include <unsupported/Eigen/MatrixFunctions>
 #include <algorithm>
 #include "command.h"
 #include "math/math.h"
@@ -21,6 +20,8 @@
 #include "file/nifti_utils.h"
 #include "transform.h"
 #include "file/key_value.h"
+
+#include <unsupported/Eigen/MatrixFunctions>
 
 using namespace MR;
 using namespace App;

--- a/configure
+++ b/configure
@@ -150,7 +150,7 @@ system = platform.system().lower()
 
 # on Windows, need to use MSYS2 version of python - not MinGW version:
 if sys.executable[0].isalpha() and sys.executable[1] == ':':
-  python_cmd = subprocess.check_output ([ 'cygpath.exe', '-w', '/usr/bin/python' ]).splitlines()[0].strip()
+  python_cmd = subprocess.check_output ([ 'cygpath.exe', '-w', '/usr/bin/python' ]).decode(errors='ignore').splitlines()[0].strip()
   sys.exit (subprocess.call ([ python_cmd ] + sys.argv))
 
 
@@ -534,13 +534,7 @@ def get_flags (default=None, env=None, pkg_config_flags=None):
       return shlex.split (os.environ[env])
   if pkg_config_flags:
     try:
-      flags = []
-      for flag in shlex.split (execute ([ 'pkg-config' ] + pkg_config_flags.split(), RunError)[1]):
-        if flag.startswith ('-I'):
-          flags += [ '-isystem', flag[2:] ]
-        else:
-          flags += [ flag ]
-      return flags
+      return shlex.split (execute ([ 'pkg-config' ] + pkg_config_flags.split(), RunError)[1])
     except Exception:
       log('error running "pkg-config ' + pkg_config_flags + '"\n\n')
   return default
@@ -1211,11 +1205,7 @@ int main() { Foo f; }
       qt_cflags = []
       for entry in qt:
         if entry[0] != '$' and not entry == '-I.':
-          entry = entry.replace('\"','').replace("'",'')
-          if entry.startswith('-I'):
-            qt_cflags += [ '-isystem', entry[2:] ]
-          else:
-            qt_cflags += [ entry ]
+          qt_cflags += [ entry.replace('\"','').replace("'",'') ]
 
       qt = qt_ldflags + qt_libs
       qt_ldflags = []

--- a/core/filter/fft.h
+++ b/core/filter/fft.h
@@ -18,14 +18,15 @@
 
 #include <complex>
 
-#include <unsupported/Eigen/FFT>
-
 #include "datatype.h"
 #include "memory.h"
 #include "image.h"
 #include "algo/copy.h"
 #include "algo/threaded_copy.h"
 #include "filter/base.h"
+
+#include <unsupported/Eigen/FFT>
+
 
 namespace MR
 {

--- a/core/math/ZSH.h
+++ b/core/math/ZSH.h
@@ -16,8 +16,6 @@
 #ifndef __math_ZSH_h__
 #define __math_ZSH_h__
 
-#include <Eigen/Dense>
-
 #include "math/legendre.h"
 #include "math/least_squares.h"
 #include "math/SH.h"
@@ -49,7 +47,7 @@ namespace MR
         return (l/2);
       }
 
-      //! returns the largest \e lmax given \a N parameters 
+      //! returns the largest \e lmax given \a N parameters
       inline size_t LforN (int N)
       {
         return (2 * (N-1));

--- a/core/math/average_space.h
+++ b/core/math/average_space.h
@@ -16,13 +16,12 @@
 #ifndef __math_average_space_h__
 #define __math_average_space_h__
 
-#include <unsupported/Eigen/MatrixFunctions>
-#include <Eigen/SVD>
-#include <Eigen/Geometry>
 #include "transform.h"
 #include "image.h"
 #include "debug.h"
 
+#include <unsupported/Eigen/MatrixFunctions>
+#include <Eigen/SVD>
 
 namespace MR
 {

--- a/core/math/check_gradient.h
+++ b/core/math/check_gradient.h
@@ -16,9 +16,10 @@
 #ifndef __math_check_gradient_h__
 #define __math_check_gradient_h__
 
-#include <Eigen/SVD>
 #include "debug.h"
 #include "datatype.h"
+
+#include <Eigen/SVD>
 
 namespace MR {
   namespace Math {

--- a/core/math/constrained_least_squares.h
+++ b/core/math/constrained_least_squares.h
@@ -19,7 +19,7 @@
 #include <set>
 #include "math/math.h"
 
-#include <Eigen/Cholesky> 
+#include <Eigen/Cholesky>
 
 
 //#define DEBUG_ICLS
@@ -32,7 +32,7 @@ namespace MR
     /** @addtogroup linalg
       @{ */
 
-    /** @defgroup icls Inequality-constrained Least-squares 
+    /** @defgroup icls Inequality-constrained Least-squares
       @{ */
 
 
@@ -54,8 +54,8 @@ namespace MR
             /*! the problem is to solve norm(\e Hx - \e b) subject to \e Ax >=
              * 0. This sets up a class to be re-used and shared across threads,
              * assuming the matrices \e H & \e A don't change, but the vector
-             * \e b does. 
-             *  
+             * \e b does.
+             *
              *  - \a problem_matrix: \e H
              *  - \a constraint_matrix: \e A
              *  - \a solution_min_norm_regularisation: an additional minimum
@@ -70,14 +70,14 @@ namespace MR
              *  - \a max_iterations: the maximum number of iterations to run.
              *  If zero (default), this number is set to 10x the size of \e x.
              */
-            Problem (const matrix_type& problem_matrix, 
-                const matrix_type& constraint_matrix, 
+            Problem (const matrix_type& problem_matrix,
+                const matrix_type& constraint_matrix,
                 value_type solution_min_norm_regularisation = 0.0,
                 value_type constraint_min_norm_regularisation = 0.0,
                 size_t max_iterations = 0,
                 value_type tolerance = 0.0) :
               H (problem_matrix),
-              chol_HtH (H.cols(), H.cols()), 
+              chol_HtH (H.cols(), H.cols()),
               lambda_min_norm (constraint_min_norm_regularisation),
               tol (tolerance),
               max_niter (max_iterations ? max_iterations : 10*problem_matrix.cols()) {
@@ -106,11 +106,11 @@ namespace MR
                 // quadratic problem chol_HtH\H:
                 b2d.noalias() = chol_HtH.template triangularView<Eigen::Lower>().transpose().template solve<Eigen::OnTheRight> (H);
 
-                // project constraint onto preconditioned quadratic domain, 
+                // project constraint onto preconditioned quadratic domain,
                 // and normalise each row to help preconditioning (the norm of
                 // each row is irrelevant to the constraint itself):
                 B.noalias() = chol_HtH.template triangularView<Eigen::Lower>().transpose().template solve<Eigen::OnTheRight> (constraint_matrix);
-                for (ssize_t n = 0; n < B.rows(); ++n) 
+                for (ssize_t n = 0; n < B.rows(); ++n)
                   B.row(n).normalize();
               }
 
@@ -146,7 +146,7 @@ namespace MR
               l (lambda.size()),
               active (lambda.size(), false) { }
 
-            size_t operator() (vector_type& x, const vector_type& b) 
+            size_t operator() (vector_type& x, const vector_type& b)
             {
 #ifdef MRTRIX_ICLS_DEBUG
               std::ofstream l_stream ("l.txt");
@@ -194,9 +194,9 @@ namespace MR
                   BtB.diagonal().array() += P.lambda_min_norm;
                   BtB.template selfadjointView<Eigen::Lower>().llt().solveInPlace (l_active);
 
-                  // update lambda values in full vector 
+                  // update lambda values in full vector
                   // and identify worst offender if any lambda < 0
-                  // by projection from previous onto feasible 
+                  // by projection from previous onto feasible
                   // subset (i.e. l>=0):
                   value_type s_min = std::numeric_limits<value_type>::infinity();
                   size_t s_min_index = 0;
@@ -227,7 +227,7 @@ namespace MR
                 l_stream << lambda << "\n";
 #endif
 
-                  // remove worst offending lambda from active set, 
+                  // remove worst offending lambda from active set,
                   // and re-estimate remaining lambdas:
                   if (active[s_min_index])
                     active_set_changed = true;
@@ -246,7 +246,7 @@ namespace MR
 #endif
 
                 ++niter;
-                if (!active_set_changed || niter > P.max_niter) 
+                if (!active_set_changed || niter > P.max_niter)
                   break;
 
                 // compute constraint values at updated solution:

--- a/core/math/least_squares.h
+++ b/core/math/least_squares.h
@@ -16,9 +16,8 @@
 #ifndef __math_least_squares_h__
 #define __math_least_squares_h__
 
-#include <Eigen/Cholesky>
-
 #include "types.h"
+#include <Eigen/Cholesky>
 
 namespace MR
 {
@@ -37,9 +36,9 @@ namespace MR
     template <class MatrixType>
       inline Eigen::Matrix<typename MatrixType::Scalar,Eigen::Dynamic, Eigen::Dynamic> pinv (const MatrixType& M)
       {
-        if (M.rows() >= M.cols()) 
+        if (M.rows() >= M.cols())
          return (M.transpose()*M).ldlt().solve (M.transpose());
-        else 
+        else
           return (M*M.transpose()).ldlt().solve (M).transpose();
       }
 

--- a/core/math/sphere.h
+++ b/core/math/sphere.h
@@ -20,9 +20,8 @@
 #include <sys/types.h>
 #include <type_traits>
 
-#include <Eigen/Core>
-
 #include "math/math.h"
+
 
 namespace MR
 {

--- a/core/math/stats/typedefs.h
+++ b/core/math/stats/typedefs.h
@@ -18,8 +18,6 @@
 
 #include "types.h"
 
-#include <Eigen/Dense>
-
 namespace MR
 {
   namespace Math

--- a/core/math/versor.h
+++ b/core/math/versor.h
@@ -16,8 +16,6 @@
 #ifndef __math_versor_h__
 #define __math_versor_h__
 
-#include <Eigen/Geometry>
-
 #include "debug.h"
 #include "math/math.h"
 
@@ -27,7 +25,7 @@ namespace MR {
 
 
     template <typename ValueType>
-    class Versor : public Eigen::Quaternion<ValueType> 
+    class Versor : public Eigen::Quaternion<ValueType>
     { MEMALIGN(Versor<ValueType>)
 
         using value_type = ValueType;

--- a/core/phase_encoding.cpp
+++ b/core/phase_encoding.cpp
@@ -14,7 +14,6 @@
 
 
 #include "phase_encoding.h"
-
 #include "math/math.h"
 
 namespace MR

--- a/core/phase_encoding.h
+++ b/core/phase_encoding.h
@@ -16,9 +16,6 @@
 #ifndef __phaseencoding_h__
 #define __phaseencoding_h__
 
-
-#include <Eigen/Dense>
-
 #include "app.h"
 #include "axes.h"
 #include "header.h"

--- a/core/silence_eigen_warnings.h
+++ b/core/silence_eigen_warnings.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2008-2018 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/
+ *
+ * MRtrix3 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * For more details, see http://www.mrtrix.org/
+ */
+
+#pragma GCC diagnostic push
+
+// add any warnings here that emenate from within the Eigen headers as you
+// encounter them.
+// Make sure the warnings are indeed Eigen-specific first!
+
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wattributes"
+#pragma GCC diagnostic ignored "-Wint-in-bool-context"
+

--- a/core/silence_eigen_warnings.h
+++ b/core/silence_eigen_warnings.h
@@ -19,6 +19,7 @@
 // Make sure the warnings are indeed Eigen-specific first!
 
 #pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wunknown-warning-option"
 #pragma GCC diagnostic ignored "-Wattributes"
 #pragma GCC diagnostic ignored "-Wint-in-bool-context"
 

--- a/core/types.h
+++ b/core/types.h
@@ -72,9 +72,7 @@ namespace MR {
 #define EIGEN_MATRIX_PLUGIN "eigen_plugins/matrix.h"
 #define EIGEN_ARRAY_PLUGIN "eigen_plugins/array.h"
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wint-in-bool-context"
-#pragma GCC diagnostic ignored "-Wattributes"
+#include "silence_eigen_warnings.h"
 #include <Eigen/Geometry>
 #pragma GCC diagnostic pop
 

--- a/core/types.h
+++ b/core/types.h
@@ -72,7 +72,11 @@ namespace MR {
 #define EIGEN_MATRIX_PLUGIN "eigen_plugins/matrix.h"
 #define EIGEN_ARRAY_PLUGIN "eigen_plugins/array.h"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wint-in-bool-context"
+#pragma GCC diagnostic ignored "-Wattributes"
 #include <Eigen/Geometry>
+#pragma GCC diagnostic pop
 
 /*! \defgroup VLA Variable-length array macros
  *

--- a/src/connectome/connectome.h
+++ b/src/connectome/connectome.h
@@ -16,9 +16,6 @@
 #ifndef __connectome_connectome_h__
 #define __connectome_connectome_h__
 
-
-#include <Eigen/Dense>
-
 #include "app.h"
 #include "exception.h"
 #include "header.h"

--- a/src/dwi/gradient.h
+++ b/src/dwi/gradient.h
@@ -16,13 +16,6 @@
 #ifndef __dwi_gradient_h__
 #define __dwi_gradient_h__
 
-// These lines are to silence deprecation warnings with Eigen & GCC v5
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#include <Eigen/SVD>
-#pragma GCC diagnostic pop
-
-
 #include "app.h"
 #include "file/path.h"
 #include "file/config.h"
@@ -31,6 +24,7 @@
 #include "math/SH.h"
 #include "dwi/shells.h"
 
+#include <Eigen/SVD>
 
 namespace MR
 {

--- a/src/dwi/tractography/GT/gt.h
+++ b/src/dwi/tractography/GT/gt.h
@@ -23,8 +23,6 @@
 #include <iostream>
 #include <mutex>
 
-#include <Eigen/Dense>
-
 #include "progressbar.h"
 #include "types.h"
 
@@ -33,11 +31,11 @@ namespace MR {
   namespace DWI {
     namespace Tractography {
       namespace GT {
-        
+
         const double M_4PI = 4.0 * Math::pi;
         const double M_sqrt4PI = std::sqrt(M_4PI);
-        
-        
+
+
         struct Properties
         { MEMALIGN(Properties)
           float p_birth;
@@ -45,48 +43,48 @@ namespace MR {
           float p_shift;
           float p_optshift;
           float p_connect;
-          
+
           double density;
           double weight;
           int Lmax;
-          
+
           double lam_ext;
           double lam_int;
-          
+
           double beta;
           double ppot;
-          
+
           Eigen::MatrixXf resp_WM;
           vector< Eigen::VectorXf > resp_ISO;
-          
+
         };
-        
-        
-        
+
+
+
         class Stats
         { MEMALIGN(Stats)
         public:
-          
-          Stats(const double T0, const double T1, const uint64_t maxiter) 
-            : Text(T1), Tint(T0), EextTot(0.0), EintTot(0.0), n_iter(0), n_max(maxiter), 
+
+          Stats(const double T0, const double T1, const uint64_t maxiter)
+            : Text(T1), Tint(T0), EextTot(0.0), EintTot(0.0), n_iter(0), n_max(maxiter),
               progress("running MH sampler", n_max/ITER_BIGSTEP)
           {
             for (int k = 0; k != 5; k++)
               n_gen[k] = n_acc[k] = 0;
             alpha = std::pow(T1/T0, double(ITER_BIGSTEP)/double(n_max - n_max/FRAC_BURNIN - n_max/FRAC_PHASEOUT));
           }
-          
+
           ~Stats() {
             out.close();
           }
-          
-          
+
+
           void open_stream(const std::string& file) {
             out.close();
             out.open(file.c_str(), std::ofstream::out);
           }
-          
-          
+
+
           bool next() {
             std::lock_guard<std::mutex> lock (mutex);
             ++n_iter;
@@ -98,43 +96,43 @@ namespace MR {
             }
             return (n_iter < n_max);
           }
-          
-          
+
+
           // getters and setters ----------------------------------------------
-          
+
           double getText() const {
             return Text;
           }
-          
+
           double getTint() const {
             return Tint;
           }
-          
+
           void setTint(double temp) {
             std::lock_guard<std::mutex> lock (mutex);
             Tint = temp;
           }
-          
-          
+
+
           double getEextTotal() const {
             return EextTot;
           }
-          
+
           double getEintTotal() const {
             return EintTot;
           }
-          
+
           void incEextTotal(double d) {
             std::lock_guard<std::mutex> lock (mutex);
             EextTot += d;
           }
-          
+
           void incEintTotal(double d) {
             std::lock_guard<std::mutex> lock (mutex);
             EintTot += d;
-          }          
-          
-          
+          }
+
+
           unsigned int getN(const char p) const {
             switch (p) {
               case 'b': return n_gen[0];
@@ -145,7 +143,7 @@ namespace MR {
               default: return 0;
             }
           }
-          
+
           unsigned int getNa(const char p) const {
             switch (p) {
               case 'b': return n_acc[0];
@@ -156,7 +154,7 @@ namespace MR {
               default: return 0;
             }
           }
-          
+
           void incN(const char p, unsigned int i = 1) {
             std::lock_guard<std::mutex> lock (mutex);
             switch (p) {
@@ -168,7 +166,7 @@ namespace MR {
               default: return;
             }
           }
-          
+
           void incNa(const char p, unsigned int i = 1) {
             std::lock_guard<std::mutex> lock (mutex);
             switch (p) {
@@ -179,7 +177,7 @@ namespace MR {
               case 'c': n_acc[4] += i; break;
             }
           }
-          
+
           double getAcceptanceRate(const char p) const {
             switch (p) {
               case 'b': return double(n_acc[0]) / double(n_gen[0]);
@@ -190,10 +188,10 @@ namespace MR {
               default: return 0.0;
             }
           }
-          
-          
+
+
           friend std::ostream& operator<< (std::ostream& o, Stats const& stats);
-          
+
 
         protected:
           std::mutex mutex;
@@ -205,16 +203,16 @@ namespace MR {
           unsigned long n_acc[5];
           unsigned long n_iter;
           const uint64_t n_max;
-          
+
           ProgressBar progress;
           std::ofstream out;
-          
+
         };
-        
-        
-        
-        
-        
+
+
+
+
+
 
       }
     }

--- a/src/dwi/tractography/GT/spatiallock.h
+++ b/src/dwi/tractography/GT/spatiallock.h
@@ -16,7 +16,6 @@
 #ifndef __gt_spatiallock_h__
 #define __gt_spatiallock_h__
 
-#include <Eigen/Dense>
 #include <mutex>
 
 #include "types.h"
@@ -26,7 +25,7 @@ namespace MR {
   namespace DWI {
     namespace Tractography {
       namespace GT {
-        
+
         /**
          * @brief SpatialLock manages a mutex lock on n positions in 3D space.
          */
@@ -36,19 +35,19 @@ namespace MR {
         public:
           using value_type = T;
           using point_type = Eigen::Matrix<value_type, 3, 1>;
-          
+
           SpatialLock() : _tx(0), _ty(0), _tz(0) { }
           SpatialLock(const value_type t) : _tx(t), _ty(t), _tz(t) { }
           SpatialLock(const value_type tx, const value_type ty, const value_type tz) : _tx(tx), _ty(ty), _tz(tz) { }
-          
+
           ~SpatialLock() {
             lockcentres.clear();
           }
-          
+
           void setThreshold(const value_type t) {
             _tx = _ty = _tz = t;
           }
-          
+
           void setThreshold(const value_type tx, const value_type ty, const value_type tz) {
             _tx = tx;
             _ty = ty;
@@ -80,7 +79,7 @@ namespace MR {
 
           };
 
-          
+
         protected:
           std::mutex mutex;
           vector< std::pair<point_type, bool> > lockcentres;

--- a/src/dwi/tractography/algorithms/tensor_det.h
+++ b/src/dwi/tractography/algorithms/tensor_det.h
@@ -16,12 +16,6 @@
 #ifndef __dwi_tractography_algorithms_tensor_det_h__
 #define __dwi_tractography_algorithms_tensor_det_h__
 
-// These lines are to silence deprecation warnings with Eigen & GCC v5
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#include <Eigen/Eigenvalues>
-#pragma GCC diagnostic pop
-
 #include "math/least_squares.h"
 #include "dwi/gradient.h"
 #include "dwi/tensor.h"
@@ -29,6 +23,7 @@
 #include "dwi/tractography/tracking/shared.h"
 #include "dwi/tractography/tracking/types.h"
 
+#include <Eigen/Eigenvalues>
 
 
 namespace MR

--- a/src/dwi/tractography/tracking/early_exit.h
+++ b/src/dwi/tractography/tracking/early_exit.h
@@ -16,7 +16,7 @@
 #ifndef __dwi_tractography_tracking_early_exit_h__
 #define __dwi_tractography_tracking_early_exit_h__
 
-#include <Eigen/Core>
+#include "dwi/tractography/tracking/shared.h"
 
 #if EIGEN_VERSION_AT_LEAST(3,3,0)
 #define TCKGEN_EARLY_EXIT_USE_FULL_BINOMIAL
@@ -27,7 +27,6 @@
 #define TCKGEN_EARLY_EXIT_ZVALUE -4.753408 // For a p-value of 1e-6; should be negative
 #endif
 
-#include "dwi/tractography/tracking/shared.h"
 
 
 #define TCKGEN_EARLY_EXIT_STOP_TESTING_PERCENTAGE 0.20

--- a/src/gui/dwi/renderer.h
+++ b/src/gui/dwi/renderer.h
@@ -16,15 +16,15 @@
 #ifndef __gui_dwi_renderer_h__
 #define __gui_dwi_renderer_h__
 
-#include <QGLWidget>
-#include <Eigen/Eigenvalues>
-
 #include "gui/gui.h"
 #include "dwi/directions/set.h"
 #include "gui/shapes/halfsphere.h"
 #include "gui/opengl/gl.h"
 #include "gui/opengl/shader.h"
 #include "math/SH.h"
+
+#include <Eigen/Eigenvalues>
+#include <QGLWidget>
 
 namespace MR
 {
@@ -33,7 +33,7 @@ namespace MR
 
     class Projection;
 
-    namespace GL 
+    namespace GL
     {
       class Lighting;
     }
@@ -66,7 +66,7 @@ namespace MR
             mode = i;
           }
 
-          void start (const Projection& projection, const GL::Lighting& lighting, float scale, 
+          void start (const Projection& projection, const GL::Lighting& lighting, float scale,
               bool use_lighting, bool color_by_direction, bool hide_neg_lobes, bool orthographic = false);
 
           void draw (const Eigen::Vector3f& origin, int buffer_ID = 0) const {

--- a/src/gui/mrview/tool/connectome/file_data_vector.h
+++ b/src/gui/mrview/tool/connectome/file_data_vector.h
@@ -16,7 +16,10 @@
 #ifndef __gui_mrview_tool_connectome_filedatavector_h__
 #define __gui_mrview_tool_connectome_filedatavector_h__
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
 #include <QString>
+#pragma GCC diagnostic pop
 
 #include "mrtrix.h"
 

--- a/src/gui/mrview/tool/connectome/file_data_vector.h
+++ b/src/gui/mrview/tool/connectome/file_data_vector.h
@@ -16,8 +16,7 @@
 #ifndef __gui_mrview_tool_connectome_filedatavector_h__
 #define __gui_mrview_tool_connectome_filedatavector_h__
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wattributes"
+#include "gui/silence_qt_warnings.h"
 #include <QString>
 #pragma GCC diagnostic pop
 

--- a/src/gui/mrview/tool/connectome/matrix_list.h
+++ b/src/gui/mrview/tool/connectome/matrix_list.h
@@ -18,11 +18,13 @@
 
 #include <memory>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
 #include <QAbstractItemModel>
+#pragma GCC diagnostic pop
 
 #include "mrtrix.h"
 #include "gui/mrview/tool/connectome/file_data_vector.h"
-
 
 namespace MR
 {
@@ -58,7 +60,7 @@ namespace MR
             }
 
             QModelIndex parent (const QModelIndex&) const override {
-              return QModelIndex(); 
+              return QModelIndex();
             }
 
             int rowCount (const QModelIndex& parent = QModelIndex()) const override {

--- a/src/gui/mrview/tool/connectome/matrix_list.h
+++ b/src/gui/mrview/tool/connectome/matrix_list.h
@@ -18,8 +18,7 @@
 
 #include <memory>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wattributes"
+#include "gui/silence_qt_warnings.h"
 #include <QAbstractItemModel>
 #pragma GCC diagnostic pop
 

--- a/src/gui/mrview/tool/screen_capture.cpp
+++ b/src/gui/mrview/tool/screen_capture.cpp
@@ -12,9 +12,6 @@
  * For more details, see http://www.mrtrix.org/
  */
 
-
-#include <Eigen/Geometry>
-
 #include "mrtrix.h"
 #include "file/path.h"
 #include "gui/mrview/window.h"
@@ -421,7 +418,7 @@ namespace MR
             start_index->setValue (i + 1);
             this->window().updateGL();
             qApp->processEvents();
-          } 
+          }
 
           is_playing = false;
         }
@@ -456,8 +453,8 @@ namespace MR
 
 
 
-        void Capture::add_commandline_options (MR::App::OptionList& options) 
-        { 
+        void Capture::add_commandline_options (MR::App::OptionList& options)
+        {
           using namespace MR::App;
           options
             + OptionGroup ("Screen Capture tool options")
@@ -471,7 +468,7 @@ namespace MR
             + Option ("capture.grab", "Start the screen capture process.").allow_multiple();
         }
 
-        bool Capture::process_commandline_option (const MR::App::ParsedOption& opt) 
+        bool Capture::process_commandline_option (const MR::App::ParsedOption& opt)
         {
           if (opt.opt->is ("capture.folder")) {
             directory->setPath (std::string(opt[0]).c_str());

--- a/src/gui/opengl/gl.h
+++ b/src/gui/opengl/gl.h
@@ -19,6 +19,8 @@
 #include "mrtrix.h"
 #include "debug.h"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
 #include <QtGlobal>
 #if QT_VERSION >= 0x050000
 #include <QtWidgets>
@@ -26,6 +28,8 @@
 #include <QtGui>
 #endif
 #include <QGLWidget>
+#pragma GCC diagnostic pop
+
 #include "gui/opengl/gl_core_3_3.h"
 
 // necessary to avoid conflict with Qt4's macros:

--- a/src/gui/opengl/gl.h
+++ b/src/gui/opengl/gl.h
@@ -19,8 +19,8 @@
 #include "mrtrix.h"
 #include "debug.h"
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wattributes"
+#include "gui/silence_qt_warnings.h"
+
 #include <QtGlobal>
 #if QT_VERSION >= 0x050000
 #include <QtWidgets>
@@ -28,6 +28,7 @@
 #include <QtGui>
 #endif
 #include <QGLWidget>
+
 #pragma GCC diagnostic pop
 
 #include "gui/opengl/gl_core_3_3.h"

--- a/src/gui/silence_qt_warnings.h
+++ b/src/gui/silence_qt_warnings.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2008-2018 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/
+ *
+ * MRtrix3 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * For more details, see http://www.mrtrix.org/
+ */
+
+#pragma GCC diagnostic push
+
+// add any warnings here that emenate from within the Qt headers as you
+// encounter them.
+// Make sure the warnings are indeed Qt-specific first!
+
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wattributes"
+#pragma GCC diagnostic ignored "-Wdeprecated-register"
+#pragma GCC diagnostic ignored "-Winconsistent-missing-override"
+

--- a/src/gui/silence_qt_warnings.h
+++ b/src/gui/silence_qt_warnings.h
@@ -19,6 +19,7 @@
 // Make sure the warnings are indeed Qt-specific first!
 
 #pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wunknown-warning-option"
 #pragma GCC diagnostic ignored "-Wattributes"
 #pragma GCC diagnostic ignored "-Wdeprecated-register"
 #pragma GCC diagnostic ignored "-Winconsistent-missing-override"

--- a/src/registration/transform/base.h
+++ b/src/registration/transform/base.h
@@ -17,12 +17,12 @@
 #define __registration_transform_base_h__
 
 #include "types.h"
-#include <unsupported/Eigen/MatrixFunctions> // Eigen::MatrixBase::sqrt()
-#include <Eigen/SVD>
-#include <Eigen/Geometry> // Eigen::Translation
 #include "datatype.h" // debug
 #include "file/config.h"
 #include "registration/transform/convergence_check.h"
+
+#include <unsupported/Eigen/MatrixFunctions> // Eigen::MatrixBase::sqrt()
+#include <Eigen/SVD>
 
 namespace MR
 {

--- a/src/registration/transform/initialiser_helpers.cpp
+++ b/src/registration/transform/initialiser_helpers.cpp
@@ -13,15 +13,14 @@
  */
 
 
-#include <Eigen/Geometry>
-#include <Eigen/Dense>
-#include <Eigen/Eigenvalues>
 #include "registration/transform/initialiser_helpers.h"
 #include "registration/transform/search.h"
-
 #include "algo/loop.h"
 #include "debug.h"
 // #include "timer.h"
+
+#include <Eigen/Eigenvalues>
+
 // #define DEBUG_INIT
 
 namespace MR

--- a/src/registration/transform/initialiser_helpers.h
+++ b/src/registration/transform/initialiser_helpers.h
@@ -17,7 +17,6 @@
 #define __registration_transform_initialiser_helpers_h__
 
 #include <algorithm>
-#include <Eigen/Geometry>
 #include "image.h"
 #include "transform.h"
 #include "math/math.h"

--- a/src/registration/transform/search.h
+++ b/src/registration/transform/search.h
@@ -17,8 +17,6 @@
 #define __registration_transform_search_h__
 
 #include <iostream>
-#include <Eigen/Geometry>
-#include <Eigen/Eigen>
 
 #include "debug.h"
 #include "image.h"

--- a/testing/cmd/testing_diff_matrix.cpp
+++ b/testing/cmd/testing_diff_matrix.cpp
@@ -16,10 +16,8 @@
 #include <fstream>
 
 #include "command.h"
-
-#include <Eigen/Dense>
 #include "math/math.h"
- 
+
 using namespace MR;
 using namespace App;
 
@@ -32,11 +30,11 @@ void usage ()
   ARGUMENTS
   + Argument ("matrix1", "a matrix file.").type_file_in()
   + Argument ("matrix2", "another matrix file.").type_file_in();
-  
+
   OPTIONS
-  + Option ("abs", "specify an absolute tolerance") 
+  + Option ("abs", "specify an absolute tolerance")
     + Argument ("tolerance").type_float (0.0)
-  + Option ("frac", "specify a fractional tolerance") 
+  + Option ("frac", "specify a fractional tolerance")
     + Argument ("tolerance").type_float (0.0);
 }
 
@@ -46,7 +44,7 @@ void run ()
 
   const Eigen::MatrixXf in1 = load_matrix<float> (argument[0]);
   const Eigen::MatrixXf in2 = load_matrix<float> (argument[1]);
-  
+
   if (in1.rows() != in2.rows() || in1.cols() != in2.cols())
     throw Exception ("matrices \"" + Path::basename (argument[0]) + "\" and \"" + Path::basename (argument[1]) + "\" do not have matching sizes"
                      " (" + str(in1.rows()) + "x" + str(in1.cols()) + " vs " + str(in2.rows()) + "x" + str(in2.cols()) + ")");
@@ -55,17 +53,17 @@ void run ()
 
   auto opt = get_options ("frac");
   if (opt.size()) {
-  
+
     const double tol = opt[0][0];
-    
+
     for (size_t i = 0; i != numel; ++i) {
       if (abs ((*(in1.data()+i) - *(in2.data()+i)) / (0.5 * (*(in1.data()+i) + *(in2.data()+i)))) > tol)
         throw Exception ("matrices \"" + Path::basename (argument[0]) + "\" and \"" + Path::basename (argument[1]) + " do not match within fractional precision of " + str(tol)
                          + " (" + str(*(in1.data()+i)) + " vs " + str(*(in2.data()+i)) + ")");
     }
-  
+
   } else {
-  
+
     double tol = 0.0;
     opt = get_options ("abs");
     if (opt.size())
@@ -76,9 +74,9 @@ void run ()
         throw Exception ("matrices \"" + Path::basename (argument[0]) + "\" and \"" + Path::basename (argument[1]) + " do not match within absolute precision of " + str(tol)
                          + " (" + str(*(in1.data()+i)) + " vs " + str(*(in2.data()+i)) + ")");
     }
-        
+
   }
-  
+
   CONSOLE ("data checked OK");
 }
 


### PR DESCRIPTION
Addresses issues raised in #1390. 

This changes the `configure` script so that it does _not_ modify `-Ipath` include directives to `isystem path`. This means we get all warnings from Eigen & Qt headers. To silence these, I've added `#pragma GCC diagnostic` directives around the inclusion of problematic headers (at least those that were causing warnings on my Win10 MSYS2 install). 

I've also fixed a few issues with the `build` script itself, see individual commits for details.

The main thing to check here is whether this silences _all_ warnings on all platforms - there's a good chance a few warnings might remain here and there. Please give this branch a shot with a full `./configure && ./build`, and send me the `build.log` if it produces any warnings at the `./build stage`...