### PR TITLE
app.makeTempDir(): Fix syntax error

### DIFF
--- a/lib/mrtrix3/app.py
+++ b/lib/mrtrix3/app.py
@@ -223,7 +223,7 @@ def makeTempDir(): #pylint: disable=unused-variable
     dir_path = os.path.abspath(args.tempdir)
   else:
     # Defaulting to working directory since too many users have encountered storage issues
-    dir_path = dict.get('ScriptTmpDir', workingDir)
+    dir_path = config.get('ScriptTmpDir', workingDir)
   prefix = config.get('ScriptTmpPrefix', os.path.basename(sys.argv[0]) + '-tmp-')
   tempDir = dir_path
   while os.path.isdir(tempDir):


### PR DESCRIPTION
Urgent fix for `master`: Python scripts currently failing.

Mistake introduced in #1410 / 292355ae.

Drastically need CI tests for scripts... Might upload one of the datasets I use for CI testing my BIDS app, which is whole-brain DWI & T1 but both downsampled by a factor of 2. Going to increase the size of the test_data module, but it's a necessary evil.