### PR TITLE
Disable signal handlers with env var

### DIFF
--- a/core/app.cpp
+++ b/core/app.cpp
@@ -77,6 +77,9 @@ namespace MR
     std::string NAME;
     vector<ParsedArgument> argument;
     vector<ParsedOption> option;
+    //ENVVAR name: MRTRIX_QUIET
+    //ENVVAR Do not display information messages or progress status. This has
+    //ENVVAR the same effect as the ``-quiet`` command-line option.
     int log_level = getenv("MRTRIX_QUIET") ? 0 : 1;
     int exit_error_code = 0;
     bool fail_on_warn = false;

--- a/core/file/config.cpp
+++ b/core/file/config.cpp
@@ -31,10 +31,17 @@ namespace MR
 
     std::map<std::string, std::string> Config::config;
 
+    //ENVVAR name: MRTRIX_CONFIGFILE
+    //ENVVAR This can be used to set the location of the system-wide
+    //ENVVAR configuration file. By default, this is ``/etc/mrtrix.conf``.
+    //ENVVAR This can be useful for deployments where access to the system's
+    //ENVVAR ``/etc`` folder is problematic, or to allow different versions of
+    //ENVVAR the software to have different configurations, etc.
+
     void Config::init ()
     {
       const char* sysconf_location = getenv ("MRTRIX_CONFIGFILE");
-      if (!sysconf_location) 
+      if (!sysconf_location)
         sysconf_location = MRTRIX_SYS_CONFIG_FILE;
 
       if (Path::is_file (sysconf_location)) {
@@ -70,7 +77,7 @@ namespace MR
     bool Config::get_bool (const std::string& key, bool default_value)
     {
       std::string value = get (key);
-      if (value.empty()) 
+      if (value.empty())
         return default_value;
       try {
         return to<bool> (value);
@@ -85,7 +92,7 @@ namespace MR
     int Config::get_int (const std::string& key, int default_value)
     {
       std::string value = get (key);
-      if (value.empty()) 
+      if (value.empty())
         return default_value;
       try {
         return to<int> (value);
@@ -100,7 +107,7 @@ namespace MR
     float Config::get_float (const std::string& key, float default_value)
     {
       std::string value = get (key);
-      if (value.empty()) 
+      if (value.empty())
         return default_value;
       try {
         return to<float> (value);
@@ -119,7 +126,7 @@ namespace MR
       if (value.size()) {
         try {
           vector<default_type> V (parse_floats (value));
-          if (V.size() < 3) 
+          if (V.size() < 3)
             throw Exception ("malformed RGB entry \"" + value + "\" for key \"" + key + "\" in configuration file - ignored");
           ret[0] = V[0];
           ret[1] = V[1];

--- a/core/file/nifti1_utils.cpp
+++ b/core/file/nifti1_utils.cpp
@@ -298,7 +298,12 @@ namespace MR
 
         const auto hit = H.keyval().find("comments");
         auto comments = split_lines (hit == H.keyval().end() ? std::string() : hit->second);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wunknown-warning-option"
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
         strncpy ( (char*) &NH.db_name, comments.size() ? comments[0].c_str() : "untitled\0\0\0\0\0\0\0\0\0\0\0", 18);
+#pragma GCC diagnostic pop
         Raw::store<int32_t> (16384, &NH.extents, is_BE);
         NH.regular = 'r';
         NH.dim_info = 0;

--- a/core/file/utils.h
+++ b/core/file/utils.h
@@ -53,12 +53,20 @@ namespace MR
       //CONF /tmp/, which is typically a RAM file system and should therefore
       //CONF be fast; but may cause issues on machines with little RAM
       //CONF capacity or where write-access to this location is not permitted.
+      //CONF
       //CONF Note that this location can also be manipulated using the
-      //CONF `MRTRIX_TMPFILE_DIR` environment variable, without editing the
+      //CONF :envvar:`MRTRIX_TMPFILE_DIR` environment variable, without editing the
       //CONF config file. Note also that this setting does not influence the
       //CONF location in which Python scripts construct their temporary
       //CONF directories; that is determined based on config file option
       //CONF ScriptTmpDir.
+
+      //ENVVAR name: MRTRIX_TMPFILE_DIR
+      //ENVVAR This has the same effect as the :option:`TmpFileDir`
+      //ENVVAR configuration file entry, and can be used to set the location of
+      //ENVVAR temporary files (as used in Unix pipes) for a single session,
+      //ENVVAR within a single script, or for a single command without
+      //ENVVAR modifying the configuration  file.
       const std::string __get_tmpfile_dir () {
         const char* from_env_mrtrix = getenv ("MRTRIX_TMPFILE_DIR");
         if (from_env_mrtrix)
@@ -92,6 +100,13 @@ namespace MR
       //CONF suffix (depending on file type). Note that this prefix can also be
       //CONF manipulated using the `MRTRIX_TMPFILE_PREFIX` environment
       //CONF variable, without editing the config file.
+
+      //ENVVAR name: MRTRIX_TMPFILE_PREFIX
+      //ENVVAR This has the same effect as the :option:`TmpFilePrefix`
+      //ENVVAR configuration file entry, and can be used to set the prefix for
+      //ENVVAR the name  of temporary files (as used in Unix pipes) for a
+      //ENVVAR single session, within a single script, or for a single command
+      //ENVVAR without modifying the configuration file.
       const std::string __get_tmpfile_prefix () {
         const char* from_env = getenv ("MRTRIX_TMPFILE_PREFIX");
         if (from_env) return from_env;

--- a/core/math/rng.h
+++ b/core/math/rng.h
@@ -71,7 +71,7 @@ namespace MR
           //ENVVAR Note that to obtain the same results
           //ENVVAR from a multi-threaded command, you should also disable
           //ENVVAR multi-threading (using the option ``-nthread 0`` or by
-          //ENVVAR setting the MRTRIX_NTHREADS environment variable to zero).
+          //ENVVAR setting the :envvar:`MRTRIX_NTHREADS` environment variable to zero).
           //ENVVAR Multi-threading introduces randomness in the order of execution, which
           //ENVVAR will generally also affect the reproducibility of results.
           const char* from_env = getenv ("MRTRIX_RNG_SEED");

--- a/core/math/rng.h
+++ b/core/math/rng.h
@@ -46,8 +46,8 @@ namespace MR
         RNG () : std::mt19937 (get_seed()) { }
         RNG (std::mt19937::result_type seed) : std::mt19937 (seed) { }
         RNG (const RNG&) : std::mt19937 (get_seed()) { }
-        template <typename ValueType> class Uniform; 
-        template <typename ValueType> class Normal; 
+        template <typename ValueType> class Uniform;
+        template <typename ValueType> class Normal;
         template <typename ValueType> class Integer;
 
         static std::mt19937::result_type get_seed () {
@@ -59,15 +59,30 @@ namespace MR
 
       private:
         static std::mt19937::result_type get_seed_private () {
+          //ENVVAR name: MRTRIX_RNG_SEED
+          //ENVVAR Set the seed used for the random number generator.
+          //ENVVAR Ordinarily, MRtrix applications will use random seeds to ensure
+          //ENVVAR repeat runs of stochastic processes are never the same.
+          //ENVVAR However, when experimenting or debugging, it may be useful to
+          //ENVVAR explicitly set the RNG seed to ensure reproducible results across
+          //ENVVAR runs. To do this, set this variable to a fixed number prior to
+          //ENVVAR running the command(s).
+          //ENVVAR
+          //ENVVAR Note that to obtain the same results
+          //ENVVAR from a multi-threaded command, you should also disable
+          //ENVVAR multi-threading (using the option ``-nthread 0`` or by
+          //ENVVAR setting the MRTRIX_NTHREADS environment variable to zero).
+          //ENVVAR Multi-threading introduces randomness in the order of execution, which
+          //ENVVAR will generally also affect the reproducibility of results.
           const char* from_env = getenv ("MRTRIX_RNG_SEED");
-          if (from_env) 
+          if (from_env)
             return to<std::mt19937::result_type> (from_env);
 
 #ifdef MRTRIX_WINDOWS
           struct timeval tv;
           gettimeofday (&tv, nullptr);
           return tv.tv_sec ^ tv.tv_usec;
-#else 
+#else
           // TODO check whether this does in fact work on Windows...
           std::random_device rd;
           return rd();

--- a/core/signal_handler.cpp
+++ b/core/signal_handler.cpp
@@ -89,6 +89,12 @@ namespace MR
 
     void init()
     {
+      //ENVVAR name: MRTRIX_NOSIGNALS
+      //ENVVAR If this variable is set to any value, disable MRtrix3's custom
+      //ENVVAR signal handlers. This may sometimes be useful when debugging.
+      //ENVVAR Note however that this prevents the
+      //ENVVAR deletion of temporary files when the command terminates
+      //ENVVAR abnormally.
       if (getenv ("MRTRIX_NOSIGNALS"))
         return;
 

--- a/core/signal_handler.cpp
+++ b/core/signal_handler.cpp
@@ -89,6 +89,9 @@ namespace MR
 
     void init()
     {
+      if (getenv ("MRTRIX_NOSIGNALS"))
+        return;
+
 #ifdef MRTRIX_WINDOWS
       // Use signal() rather than sigaction() for Windows, as the latter is not supported
 # define __SIGNAL(SIG,MSG) signal (SIG, handler)

--- a/core/thread.cpp
+++ b/core/thread.cpp
@@ -49,6 +49,11 @@ namespace MR
         return __number_of_threads;
       }
 
+      //ENVVAR name: MRTRIX_NTHREADS
+      //ENVVAR set the number of threads that MRtrix3 applications should use.
+      //ENVVAR This overrides the automatically determined number, or the
+      //ENVVAR :option:`NumberOfThreads` setting in the configuration file, but
+      //ENVVAR will be overridden by the ENVVAR ``-nthreads`` command-line option.
       const char* from_env = getenv ("MRTRIX_NTHREADS");
       if (from_env) {
         __number_of_threads = to<size_t> (from_env);

--- a/docs/format_config_options
+++ b/docs/format_config_options
@@ -5,14 +5,11 @@ import sys
 optionlist =  [ ]
 
 for line in sys.stdin:
-  line = line.strip()
   if line.startswith ('option:'):
-    optionlist += [ [ line[8:], '', '' ] ]
+    optionlist += [ [ line[8:].strip(), '', '' ] ]
   elif line.startswith ('default:'):
-    optionlist[-1][1] = line
+    optionlist[-1][1] = line.strip()
   else:
-    if optionlist[-1][2]:
-      optionlist[-1][2] += ' '
     optionlist[-1][2] += line
 
 optionlist.sort()
@@ -26,6 +23,8 @@ string += '##########################################\n\n'
 for entry in optionlist:
   string += '*  **' + entry[0] + '**\n'
   string += '    *' + entry[1] + '*\n\n'
-  string += '     ' + entry[2] + '\n\n'
+  for line in entry[2].splitlines():
+    string += '     ' + line + '\n'
+  string += '\n'
 
 sys.stdout.write(string)

--- a/docs/format_config_options
+++ b/docs/format_config_options
@@ -5,12 +5,13 @@ import sys
 optionlist =  [ ]
 
 for line in sys.stdin:
+  line = line.split ('//CONF')[1][1:]
   if line.startswith ('option:'):
     optionlist += [ [ line[8:].strip(), '', '' ] ]
   elif line.startswith ('default:'):
     optionlist[-1][1] = line.strip()
   else:
-    optionlist[-1][2] += line
+    optionlist[-1][2] += line.rstrip() + '\n'
 
 optionlist.sort()
 

--- a/docs/format_environment_variables
+++ b/docs/format_environment_variables
@@ -5,10 +5,11 @@ import sys
 varlist =  [ ]
 
 for line in sys.stdin:
+  line = line.split ('//ENVVAR')[1][1:]
   if line.startswith ('name:'):
     varlist += [ [ line[6:].strip(), '', '' ] ]
   else:
-    varlist[-1][1] += line
+    varlist[-1][1] += line.rstrip() + '\n'
 
 varlist.sort()
 
@@ -19,8 +20,8 @@ string += 'List of MRtrix3 environment variables\n'
 string += '##########################################\n\n'
 
 for entry in varlist:
-  string += '*  **' + entry[0] + '**\n'
-  for line in entry[2].splitlines():
+  string += '.. envvar:: ' + entry[0] + '\n\n'
+  for line in entry[1].splitlines():
     string += '     ' + line + '\n'
   string += '\n'
 

--- a/docs/format_environment_variables
+++ b/docs/format_environment_variables
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+import sys
+
+varlist =  [ ]
+
+for line in sys.stdin:
+  if line.startswith ('name:'):
+    varlist += [ [ line[6:].strip(), '', '' ] ]
+  else:
+    varlist[-1][1] += line
+
+varlist.sort()
+
+string = '.. _environment_variables:\n'
+string += '\n'
+string += '##########################################\n'
+string += 'List of MRtrix3 environment variables\n'
+string += '##########################################\n\n'
+
+for entry in varlist:
+  string += '*  **' + entry[0] + '**\n'
+  for line in entry[2].splitlines():
+    string += '     ' + line + '\n'
+  string += '\n'
+
+sys.stdout.write(string)

--- a/docs/generate_user_docs.sh
+++ b/docs/generate_user_docs.sh
@@ -96,7 +96,18 @@ List of MRtrix3 scripts
   cat $toctree_file $table_file >> ${mrtrix_root}/docs/reference/scripts_list.rst
   rm -f $toctree_file $temp_file
 
+
+
+
 # Generating list of configuration file options
 
   grep -rn --include=\*.h --include=\*.cpp '^\s*//CONF\b ' "${mrtrix_root}" | sed -ne 's/^.*CONF \(.*\)/\1/p' | "${mrtrix_root}"/docs/format_config_options > ${mrtrix_root}/docs/reference/config_file_options.rst
+
+
+
+
+
+# Generating list of environment variables
+
+  grep -rn --include=\*.h --include=\*.cpp '^\s*//ENVVAR\b ' "${mrtrix_root}" | sed -ne 's/^.*ENVVAR \(.*\)/\1/p' | "${mrtrix_root}"/docs/format_environment_variables > ${mrtrix_root}/docs/reference/environment_variables.rst
 

--- a/docs/generate_user_docs.sh
+++ b/docs/generate_user_docs.sh
@@ -14,7 +14,7 @@
 mrtrix_root=$( cd "$(dirname "${BASH_SOURCE}")"/../ ; pwd -P )
 export PATH=$mrtrix_root/bin:"$PATH"
 
-  echo "
+echo "
 .. _list-of-mrtrix3-commands:
 
 ########################
@@ -23,42 +23,42 @@ List of MRtrix3 commands
 
 " > ${mrtrix_root}/docs/reference/commands_list.rst
 
-  rm -rf   ${mrtrix_root}/docs/reference/commands
-  mkdir -p ${mrtrix_root}/docs/reference/commands
-  toctree_file=$(mktemp)
-  table_file=$(mktemp)
+rm -rf   ${mrtrix_root}/docs/reference/commands
+mkdir -p ${mrtrix_root}/docs/reference/commands
+toctree_file=$(mktemp)
+table_file=$(mktemp)
 
-  echo "
+echo "
 
 .. toctree::
     :hidden:
 " > $toctree_file
 
-  echo "
+echo "
 
 .. csv-table::
     :header: \"Command\", \"Synopsis\"
 " > $table_file
 
-  for n in `find "${mrtrix_root}"/cmd/ -name "*.cpp" | sort`; do
-    dirpath=${mrtrix_root}'/docs/reference/commands'
-    cppname=`basename $n`
-    cmdname=${cppname%".cpp"}
-    cmdpath=$cmdname
-    if [ "$OSTYPE" == "cygwin" ] || [ "$OSTYPE" == "msys" ] || [ "$OSTYPE" == "win32" ]; then
-      cmdpath=${cmdpath}'.exe'
-    fi
-    $cmdpath __print_usage_rst__ > $dirpath/$cmdname.rst
-    sed -ie "1i.. _$cmdname:\n\n$cmdname\n===================\n" $dirpath/$cmdname.rst
-    echo '    commands/'"$cmdname" >> $toctree_file
-    echo '    :ref:`'"$cmdname"'`, "'`$cmdpath __print_synopsis__`'"' >> $table_file
-  done
-  cat $toctree_file $table_file >> ${mrtrix_root}/docs/reference/commands_list.rst
-  rm -f $toctree_file $temp_file
+for n in `find "${mrtrix_root}"/cmd/ -name "*.cpp" | sort`; do
+  dirpath=${mrtrix_root}'/docs/reference/commands'
+  cppname=`basename $n`
+  cmdname=${cppname%".cpp"}
+  cmdpath=$cmdname
+  if [ "$OSTYPE" == "cygwin" ] || [ "$OSTYPE" == "msys" ] || [ "$OSTYPE" == "win32" ]; then
+    cmdpath=${cmdpath}'.exe'
+  fi
+  $cmdpath __print_usage_rst__ > $dirpath/$cmdname.rst
+  sed -ie "1i.. _$cmdname:\n\n$cmdname\n===================\n" $dirpath/$cmdname.rst
+  echo '    commands/'"$cmdname" >> $toctree_file
+  echo '    :ref:`'"$cmdname"'`, "'`$cmdpath __print_synopsis__`'"' >> $table_file
+done
+cat $toctree_file $table_file >> ${mrtrix_root}/docs/reference/commands_list.rst
+rm -f $toctree_file $temp_file
 
 # Generating documentation for all scripts
 
-  echo "
+echo "
 .. _list-of-mrtrix3-scripts:
 
 #######################
@@ -67,41 +67,42 @@ List of MRtrix3 scripts
 
 " > ${mrtrix_root}/docs/reference/scripts_list.rst
 
-  rm -rf   ${mrtrix_root}/docs/reference/scripts
-  mkdir -p ${mrtrix_root}/docs/reference/scripts
-  toctree_file=$(mktemp)
-  table_file=$(mktemp)
+rm -rf   ${mrtrix_root}/docs/reference/scripts
+mkdir -p ${mrtrix_root}/docs/reference/scripts
+toctree_file=$(mktemp)
+table_file=$(mktemp)
 
-  echo "
+echo "
 
 .. toctree::
     :hidden:
 " > $toctree_file
 
-  echo "
+echo "
 
 .. csv-table::
     :header: \"Command\", \"Synopsis\"
 " > $table_file
 
-  for n in `find "${mrtrix_root}"/bin/ -type f -print0 | xargs -0 grep -l "app.parse" | sort`; do
-    filepath=${mrtrix_root}'/docs/reference/scripts'
-    filename=`basename $n`
-    $n __print_usage_rst__ > $filepath/$filename.rst
-    #sed -ie "1i$filename\n===========\n" $filepath/$filename.rst
+for n in `find "${mrtrix_root}"/bin/ -type f -print0 | xargs -0 grep -l "app.parse" | sort`; do
+  filepath=${mrtrix_root}'/docs/reference/scripts'
+  filename=`basename $n`
+  $n __print_usage_rst__ > $filepath/$filename.rst
+  #sed -ie "1i$filename\n===========\n" $filepath/$filename.rst
 
-    echo '    scripts/'"$filename" >> $toctree_file
-    echo '    :ref:`'"$filename"'`, "'`$filename __print_synopsis__`'"' >> $table_file
-  done
-  cat $toctree_file $table_file >> ${mrtrix_root}/docs/reference/scripts_list.rst
-  rm -f $toctree_file $temp_file
+  echo '    scripts/'"$filename" >> $toctree_file
+  echo '    :ref:`'"$filename"'`, "'`$filename __print_synopsis__`'"' >> $table_file
+done
+cat $toctree_file $table_file >> ${mrtrix_root}/docs/reference/scripts_list.rst
+rm -f $toctree_file $temp_file
 
 
 
 
 # Generating list of configuration file options
 
-  grep -rn --include=\*.h --include=\*.cpp '^\s*//CONF\b ' "${mrtrix_root}" | sed -ne 's/^.*CONF \(.*\)/\1/p' | "${mrtrix_root}"/docs/format_config_options > ${mrtrix_root}/docs/reference/config_file_options.rst
+grep -rn --include=\*.h --include=\*.cpp '^\s*//CONF\b' "${mrtrix_root}" |\
+  "${mrtrix_root}"/docs/format_config_options > ${mrtrix_root}/docs/reference/config_file_options.rst
 
 
 
@@ -109,5 +110,6 @@ List of MRtrix3 scripts
 
 # Generating list of environment variables
 
-  grep -rn --include=\*.h --include=\*.cpp '^\s*//ENVVAR\b ' "${mrtrix_root}" | sed -ne 's/^.*ENVVAR \(.*\)/\1/p' | "${mrtrix_root}"/docs/format_environment_variables > ${mrtrix_root}/docs/reference/environment_variables.rst
+grep -rn --include=\*.h --include=\*.cpp '^\s*//ENVVAR\b' "${mrtrix_root}" |\
+  "${mrtrix_root}"/docs/format_environment_variables > ${mrtrix_root}/docs/reference/environment_variables.rst
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -113,6 +113,7 @@ These applications have been written from scratch in C++, using the functionalit
    reference/commands_list
    reference/scripts_list
    reference/config_file_options
+   reference/environment_variables
    reference/mrtrix2_equivalent_commands
    reference/references
 

--- a/docs/reference/config_file_options.rst
+++ b/docs/reference/config_file_options.rst
@@ -14,25 +14,34 @@ List of MRtrix3 configuration file options
 
     *default: 0 (false)*
 
-     A boolean value to indicate whether images in Analyse format should be assumed to be in LAS orientation (default) or RAS (when this is option is turned on).
+     A boolean value to indicate whether images in Analyse format
+     should be assumed to be in LAS orientation (default) or RAS
+     (when this is option is turned on).
 
 .. option:: BValueScaling
 
     *default: 1 (true)*
 
-     Specifies whether the b-values should be scaled by the squared norm of the gradient vectors when loading a DW gradient scheme. This is commonly required to correctly interpret images acquired on scanners that nominally only allow a single b-value, as the common workaround is to scale the gradient vectors to modulate the actual b-value.
+     Specifies whether the b-values should be scaled by the squared
+     norm of the gradient vectors when loading a DW gradient scheme.
+     This is commonly required to correctly interpret images acquired
+     on scanners that nominally only allow a single b-value, as the
+     common workaround is to scale the gradient vectors to modulate
+     the actual b-value.
 
 .. option:: BZeroThreshold
 
     *default: 10.0*
 
-     Specifies the b-value threshold for determining those image volumes that correspond to b=0.
+     Specifies the b-value threshold for determining those image
+     volumes that correspond to b=0.
 
 .. option:: BackgroundColor
 
     *default: 1.0,1.0,1.0*
 
-     The default colour to use for the background in OpenGL panels, notably the SH viewer.
+     The default colour to use for the background in OpenGL panels, notably
+     the SH viewer.
 
 .. option:: ConnectomeEdgeAssociatedAlphaMultiplier
 
@@ -212,7 +221,8 @@ List of MRtrix3 configuration file options
 
     *default: 0 (false)*
 
-     A boolean value specifying whether MRtrix applications should abort as soon as any (otherwise non-fatal) warning is issued.
+     A boolean value specifying whether MRtrix applications should
+     abort as soon as any (otherwise non-fatal) warning is issued.
 
 .. option:: FontSize
 
@@ -224,7 +234,8 @@ List of MRtrix3 configuration file options
 
     *default: less*
 
-     The command to use to display each command's help page (leave empty to send directly to the terminal).
+     The command to use to display each command's help page (leave
+     empty to send directly to the terminal).
 
 .. option:: IconSize
 
@@ -242,13 +253,15 @@ List of MRtrix3 configuration file options
 
     *default: top*
 
-     The starting position of the MRView toolbar. Valid values are: top, bottom, left, right.
+     The starting position of the MRView toolbar. Valid values are:
+     top, bottom, left, right.
 
 .. option:: LightPosition
 
     *default: 1.0,1.0,3.0*
 
-     The default position vector to use for the light in OpenGL renders.
+     The default position vector to use for the light in OpenGL
+     renders.
 
 .. option:: MRViewColourBarHeight
 
@@ -260,19 +273,22 @@ List of MRtrix3 configuration file options
 
     *default: 20*
 
-     How far away from the edge of the main window to place the colourbar in MRView, in pixels.
+     How far away from the edge of the main window to place the
+     colourbar in MRView, in pixels.
 
 .. option:: MRViewColourBarPosition
 
     *default: bottomright*
 
-     The position of the colourbar within the main window in MRView. Valid values are: bottomleft, bottomright, topleft, topright.
+     The position of the colourbar within the main window in MRView.
+     Valid values are: bottomleft, bottomright, topleft, topright.
 
 .. option:: MRViewColourBarTextOffset
 
     *default: 10*
 
-     How far away from the colourbar to place the associated text, in pixels.
+     How far away from the colourbar to place the associated text,
+     in pixels.
 
 .. option:: MRViewColourBarWidth
 
@@ -290,19 +306,23 @@ List of MRtrix3 configuration file options
 
     *default: Pseudotubes*
 
-     The default geometry type used to render tractograms. Options are Pseudotubes, Lines or Points
+     The default geometry type used to render tractograms.
+     Options are Pseudotubes, Lines or Points
 
 .. option:: MRViewDockFloating
 
     *default: 0 (false)*
 
-     Whether MRView tools should start docked in the main window, or floating (detached from the main window).
+     Whether MRView tools should start docked in the main window, or
+     floating (detached from the main window).
 
 .. option:: MRViewFocusModifierKey
 
     *default: meta (cmd on MacOSX)*
 
-     Modifier key to select focus mode in MRView. Valid choices include shift, alt, ctrl, meta (on MacOSX: shift, alt, ctrl, cmd).
+     Modifier key to select focus mode in MRView. Valid
+     choices include shift, alt, ctrl, meta (on MacOSX: shift, alt,
+     ctrl, cmd).
 
 .. option:: MRViewImageBackgroundColour
 
@@ -320,13 +340,16 @@ List of MRtrix3 configuration file options
 
     *default: 3*
 
-     The maximal number of rows used to layout a collection of rendered colourbars Note, that all tool-specific colourbars will form a single collection.
+     The maximal number of rows used to layout a collection of rendered colourbars
+     Note, that all tool-specific colourbars will form a single collection.
 
 .. option:: MRViewMoveModifierKey
 
     *default: shift*
 
-     Modifier key to select move mode in MRView. Valid choices include shift, alt, ctrl, meta (on MacOSX: shift, alt, ctrl, cmd).
+     Modifier key to select move mode in MRView. Valid
+     choices include shift, alt, ctrl, meta (on MacOSX: shift, alt,
+     ctrl, cmd).
 
 .. option:: MRViewOdfScale
 
@@ -338,7 +361,9 @@ List of MRtrix3 configuration file options
 
     *default: ctrl*
 
-     Modifier key to select rotate mode in MRView. Valid choices include shift, alt, ctrl, meta (on MacOSX: shift, alt, ctrl, cmd).
+     Modifier key to select rotate mode in MRView. Valid
+     choices include shift, alt, ctrl, meta (on MacOSX: shift, alt,
+     ctrl, cmd).
 
 .. option:: MRViewShowColourbar
 
@@ -380,49 +405,70 @@ List of MRtrix3 configuration file options
 
     *default: topright*
 
-     The position of all visible tool colourbars within the main window in MRView. Valid values are: bottomleft, bottomright, topleft, topright.
+     The position of all visible tool colourbars within the main window in MRView.
+     Valid values are: bottomleft, bottomright, topleft, topright.
 
 .. option:: MSAA
 
     *default: 0 (false)*
 
-     How many samples to use for multi-sample anti-aliasing (to improve display quality).
+     How many samples to use for multi-sample anti-aliasing (to
+     improve display quality).
 
 .. option:: NIfTIAllowBitwise
 
     *default: 0 (false)*
 
-     A boolean value to indicate whether bitwise storage of binary data is permitted (most 3rd party software packages don't support bitwise data). If false (the default), data will be stored using more widely supported unsigned 8-bit integers.
+     A boolean value to indicate whether bitwise storage of binary
+     data is permitted (most 3rd party software packages don't
+     support bitwise data). If false (the default), data will be
+     stored using more widely supported unsigned 8-bit integers.
 
 .. option:: NIfTIAlwaysUseVer2
 
     *default: 0 (false)*
 
-     A boolean value to indicate whether NIfTI images should always be written in the new NIfTI-2 format. If false, images will be written in the older NIfTI-1 format by default, with the exception being files where the number of voxels along any axis exceeds the maximum permissible in that format (32767), in which case the output file will automatically switch to the NIfTI-2 format.
+     A boolean value to indicate whether NIfTI images should
+     always be written in the new NIfTI-2 format. If false,
+     images will be written in the older NIfTI-1 format by
+     default, with the exception being files where the number
+     of voxels along any axis exceeds the maximum permissible
+     in that format (32767), in which case the output file
+     will automatically switch to the NIfTI-2 format.
 
 .. option:: NIfTIAutoLoadJSON
 
     *default: 0 (false)*
 
-     A boolean value to indicate whether, when opening NIfTI images, any corresponding JSON file should be automatically loaded.
+     A boolean value to indicate whether, when opening NIfTI images,
+     any corresponding JSON file should be automatically loaded.
 
 .. option:: NIfTIAutoSaveJSON
 
     *default: 0 (false)*
 
-     A boolean value to indicate whether, when writing NIfTI images, a corresponding JSON file should be automatically created in order to save any header entries that cannot be stored in the NIfTI header.
+     A boolean value to indicate whether, when writing NIfTI images,
+     a corresponding JSON file should be automatically created in order
+     to save any header entries that cannot be stored in the NIfTI
+     header.
 
 .. option:: NIfTIUseSform
 
     *default: 0 (false)*
 
-     A boolean value to control whether, in cases where both the sform and qform transformations are defined in an input NIfTI image, but those transformations differ, the sform transformation should be used in preference to the qform matrix (the default behaviour).
+     A boolean value to control whether, in cases where both
+     the sform and qform transformations are defined in an
+     input NIfTI image, but those transformations differ, the
+     sform transformation should be used in preference to the
+     qform matrix (the default behaviour).
 
 .. option:: NeedOpenGLCoreProfile
 
     *default: 1 (true)*
 
-     Whether the creation of an OpenGL 3.3 context requires it to be a core profile (needed on newer versions of the ATI drivers on Linux, for instance).
+     Whether the creation of an OpenGL 3.3 context requires it to be
+     a core profile (needed on newer versions of the ATI drivers on
+     Linux, for instance).
 
 .. option:: NumberOfThreads
 
@@ -440,13 +486,15 @@ List of MRtrix3 configuration file options
 
     *default: 1,1,0 (yellow)*
 
-     The default colour to use for objects (i.e. SH glyphs) when not colouring by direction.
+     The default colour to use for objects (i.e. SH glyphs) when not
+     colouring by direction.
 
 .. option:: RegAnalyseDescent
 
     *default: 0 (false)*
 
-     Linear registration: write comma separated gradient descent parameters and gradients to stdout and verbose gradient descent output to stderr.
+     Linear registration: write comma separated gradient descent parameters and gradients
+     to stdout and verbose gradient descent output to stderr.
 
 .. option:: RegCoherenceLen
 
@@ -458,7 +506,8 @@ List of MRtrix3 configuration file options
 
     *default: 0.8*
 
-     Linear registration: control point trajectory smoothing value used in convergence check parameter range: [0...1].
+     Linear registration: control point trajectory smoothing value used in convergence check
+     parameter range: [0...1].
 
 .. option:: RegGdConvergenceMinIter
 
@@ -470,13 +519,15 @@ List of MRtrix3 configuration file options
 
     *default: 0.1*
 
-     Linear registration: control point trajectory slope smoothing value used in convergence check parameter range: [0...1].
+     Linear registration: control point trajectory slope smoothing value used in convergence check
+     parameter range: [0...1].
 
 .. option:: RegGdConvergenceThresh
 
     *default: 5e-3*
 
-     Linear registration: threshold for convergence check using the smoothed control point trajectories measured in fraction of a voxel.
+     Linear registration: threshold for convergence check using the smoothed control point trajectories
+     measured in fraction of a voxel.
 
 .. option:: RegGdWeightMatrix
 
@@ -500,13 +551,22 @@ List of MRtrix3 configuration file options
 
     *default: `.`*
 
-     The location in which to generate the temporary directories to be used by MRtrix Python scripts. By default they will be generated in the working directory. Note that this setting does not influence the location in which piped images and other temporary files are created by MRtrix3; that is determined based on config file option :option:`TmpFileDir`.
+     The location in which to generate the temporary directories to be
+     used by MRtrix Python scripts. By default they will be generated
+     in the working directory.
+     Note that this setting does not influence the location in which
+     piped images and other temporary files are created by MRtrix3;
+     that is determined based on config file option :option:`TmpFileDir`.
 
 .. option:: ScriptTmpPrefix
 
     *default: `<script>-tmp-`*
 
-     The prefix to use when generating a unique name for a Python script temporary directory. By default the name of the invoked script itself will be used, followed by `-tmp-` (six random characters are then appended to produce a unique name in cases where a script may be run multiple times in parallel).
+     The prefix to use when generating a unique name for a Python
+     script temporary directory. By default the name of the invoked
+     script itself will be used, followed by `-tmp-` (six random
+     characters are then appended to produce a unique name in cases
+     where a script may be run multiple times in parallel).
 
 .. option:: SparseDataInitialSize
 
@@ -530,7 +590,9 @@ List of MRtrix3 configuration file options
 
     *default: 0 (false)*
 
-     Specifies whether tckgen should be terminated prematurely in cases where it appears as though the target number of accepted streamlines is not going to be met.
+     Specifies whether tckgen should be terminated prematurely
+     in cases where it appears as though the target number of
+     accepted streamlines is not going to be met.
 
 .. option:: TerminalColor
 
@@ -542,29 +604,51 @@ List of MRtrix3 configuration file options
 
     *default: `/tmp` (on Unix), `.` (on Windows)*
 
-     The prefix for temporary files (as used in pipelines). By default, these files get written to the current folder on Windows machines, which may cause performance issues, particularly when operating over distributed file systems. On Unix machines, the default is /tmp/, which is typically a RAM file system and should therefore be fast; but may cause issues on machines with little RAM capacity or where write-access to this location is not permitted. Note that this location can also be manipulated using the `MRTRIX_TMPFILE_DIR` environment variable, without editing the config file. Note also that this setting does not influence the location in which Python scripts construct their temporary directories; that is determined based on config file option ScriptTmpDir.
+     The prefix for temporary files (as used in pipelines). By default,
+     these files get written to the current folder on Windows machines,
+     which may cause performance issues, particularly when operating
+     over distributed file systems. On Unix machines, the default is
+     /tmp/, which is typically a RAM file system and should therefore
+     be fast; but may cause issues on machines with little RAM
+     capacity or where write-access to this location is not permitted.
+     Note that this location can also be manipulated using the
+     `MRTRIX_TMPFILE_DIR` environment variable, without editing the
+     config file. Note also that this setting does not influence the
+     location in which Python scripts construct their temporary
+     directories; that is determined based on config file option
+     ScriptTmpDir.
 
 .. option:: TmpFilePrefix
 
     *default: `mrtrix-tmp-`*
 
-     The prefix to use for the basename of temporary files. This will be used to generate a unique filename for the temporary file, by adding random characters to this prefix, followed by a suitable suffix (depending on file type). Note that this prefix can also be manipulated using the `MRTRIX_TMPFILE_PREFIX` environment variable, without editing the config file.
+     The prefix to use for the basename of temporary files. This will
+     be used to generate a unique filename for the temporary file, by
+     adding random characters to this prefix, followed by a suitable
+     suffix (depending on file type). Note that this prefix can also be
+     manipulated using the `MRTRIX_TMPFILE_PREFIX` environment
+     variable, without editing the config file.
 
 .. option:: ToolbarStyle
 
     *default: 2*
 
-     The style of the main toolbar buttons in MRView. See Qt's documentation for Qt::ToolButtonStyle.
+     The style of the main toolbar buttons in MRView. See Qt's
+     documentation for Qt::ToolButtonStyle.
 
 .. option:: TrackWriterBufferSize
 
     *default: 16777216*
 
-     The size of the write-back buffer (in bytes) to use when writing track files. MRtrix will store the output tracks in a relatively large buffer to limit the number of write() calls, avoid associated issues such as file fragmentation.
+     The size of the write-back buffer (in bytes) to use when
+     writing track files. MRtrix will store the output tracks in a
+     relatively large buffer to limit the number of write() calls,
+     avoid associated issues such as file fragmentation.
 
 .. option:: VSync
 
     *default: 0 (false)*
 
-     Whether the screen update should synchronise with the monitor's vertical refresh (to avoid tearing artefacts).
+     Whether the screen update should synchronise with the monitor's
+     vertical refresh (to avoid tearing artefacts).
 

--- a/docs/reference/config_file_options.rst
+++ b/docs/reference/config_file_options.rst
@@ -611,8 +611,9 @@ List of MRtrix3 configuration file options
      /tmp/, which is typically a RAM file system and should therefore
      be fast; but may cause issues on machines with little RAM
      capacity or where write-access to this location is not permitted.
+     
      Note that this location can also be manipulated using the
-     `MRTRIX_TMPFILE_DIR` environment variable, without editing the
+     :envvar:`MRTRIX_TMPFILE_DIR` environment variable, without editing the
      config file. Note also that this setting does not influence the
      location in which Python scripts construct their temporary
      directories; that is determined based on config file option

--- a/docs/reference/environment_variables.rst
+++ b/docs/reference/environment_variables.rst
@@ -1,0 +1,67 @@
+.. _environment_variables:
+
+##########################################
+List of MRtrix3 environment variables
+##########################################
+
+.. envvar:: MRTRIX_CONFIGFILE
+
+     This can be used to set the location of the system-wide
+     configuration file. By default, this is ``/etc/mrtrix.conf``.
+     This can be useful for deployments where access to the system's
+     ``/etc`` folder is problematic, or to allow different versions of
+     the software to have different configurations, etc.
+
+.. envvar:: MRTRIX_NOSIGNALS
+
+     If this variable is set to any value, disable MRtrix3's custom
+     signal handlers. This may sometimes be useful when debugging.
+     Note however that this prevents the
+     deletion of temporary files when the command terminates
+     abnormally.
+
+.. envvar:: MRTRIX_NTHREADS
+
+     set the number of threads that MRtrix3 applications should use.
+     This overrides the automatically determined number, or the
+     :option:`NumberOfThreads` setting in the configuration file, but
+     will be overridden by the ENVVAR ``-nthreads`` command-line option.
+
+.. envvar:: MRTRIX_QUIET
+
+     Do not display information messages or progress status. This has
+     the same effect as the ``-quiet`` command-line option.
+
+.. envvar:: MRTRIX_RNG_SEED
+
+     Set the seed used for the random number generator.
+     Ordinarily, MRtrix applications will use random seeds to ensure
+     repeat runs of stochastic processes are never the same.
+     However, when experimenting or debugging, it may be useful to
+     explicitly set the RNG seed to ensure reproducible results across
+     runs. To do this, set this variable to a fixed number prior to
+     running the command(s).
+     
+     Note that to obtain the same results
+     from a multi-threaded command, you should also disable
+     multi-threading (using the option ``-nthread 0`` or by
+     setting the :envvar:`MRTRIX_NTHREADS` environment variable to zero).
+     Multi-threading introduces randomness in the order of execution, which
+     will generally also affect the reproducibility of results.
+
+.. envvar:: MRTRIX_TMPFILE_DIR
+
+     This has the same effect as the :option:`TmpFileDir`
+     configuration file entry, and can be used to set the location of
+     temporary files (as used in Unix pipes) for a single session,
+     within a single script, or for a single command without
+     modifying the configuration  file.
+
+.. envvar:: MRTRIX_TMPFILE_PREFIX
+
+     This has the same effect as the :option:`TmpFilePrefix`
+     configuration file entry, and can be used to set the prefix for
+     the name  of temporary files (as used in Unix pipes) for a
+     single session, within a single script, or for a single command
+     without modifying the configuration file.
+

--- a/src/gui/opengl/gl_core_3_3.cpp
+++ b/src/gui/opengl/gl_core_3_3.cpp
@@ -67,9 +67,9 @@ static int TestPointer(const PROC pTest)
 	ptrdiff_t iTest;
 	if(!pTest) return 0;
 	iTest = (ptrdiff_t)pTest;
-	
+
 	if(iTest == 1 || iTest == 2 || iTest == 3 || iTest == -1) return 0;
-	
+
 	return 1;
 }
 
@@ -84,7 +84,12 @@ static PROC WinGetProcAddress(const char *name)
 	glMod = GetModuleHandleA("OpenGL32.dll");
 	return (PROC)GetProcAddress(glMod, (LPCSTR)name);
 }
-	
+
+
+
+
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+
 #define IntGetProcAddress(name) WinGetProcAddress(name)
 #else
 	#if defined(__APPLE__)
@@ -105,7 +110,7 @@ namespace gl
 	namespace exts
 	{
 	}
-	
+
 	// Extension: 1.0
     using PFNBLENDFUNCPROC = void (CODEGEN_FUNCPTR *)(GLenum, GLenum);
     using PFNCLEARPROC = void (CODEGEN_FUNCPTR *)(GLbitfield);
@@ -155,7 +160,7 @@ namespace gl
 	using PFNTEXPARAMETERIPROC = void (CODEGEN_FUNCPTR *)(GLenum, GLenum, GLint);
 	using PFNTEXPARAMETERIVPROC = void (CODEGEN_FUNCPTR *)(GLenum, GLenum, const GLint *);
 	using PFNVIEWPORTPROC = void (CODEGEN_FUNCPTR *)(GLint, GLint, GLsizei, GLsizei);
-	
+
 	// Extension: 1.1
 	using PFNBINDTEXTUREPROC = void (CODEGEN_FUNCPTR *)(GLenum, GLuint);
 	using PFNCOPYTEXIMAGE1DPROC = void (CODEGEN_FUNCPTR *)(GLenum, GLint, GLenum, GLint, GLint, GLsizei, GLint);
@@ -170,7 +175,7 @@ namespace gl
 	using PFNPOLYGONOFFSETPROC = void (CODEGEN_FUNCPTR *)(GLfloat, GLfloat);
 	using PFNTEXSUBIMAGE1DPROC = void (CODEGEN_FUNCPTR *)(GLenum, GLint, GLint, GLsizei, GLenum, GLenum, const GLvoid *);
 	using PFNTEXSUBIMAGE2DPROC = void (CODEGEN_FUNCPTR *)(GLenum, GLint, GLint, GLint, GLsizei, GLsizei, GLenum, GLenum, const GLvoid *);
-	
+
 	// Extension: 1.2
 	using PFNBLENDCOLORPROC = void (CODEGEN_FUNCPTR *)(GLfloat, GLfloat, GLfloat, GLfloat);
 	using PFNBLENDEQUATIONPROC = void (CODEGEN_FUNCPTR *)(GLenum);
@@ -178,7 +183,7 @@ namespace gl
 	using PFNDRAWRANGEELEMENTSPROC = void (CODEGEN_FUNCPTR *)(GLenum, GLuint, GLuint, GLsizei, GLenum, const GLvoid *);
 	using PFNTEXIMAGE3DPROC = void (CODEGEN_FUNCPTR *)(GLenum, GLint, GLint, GLsizei, GLsizei, GLsizei, GLint, GLenum, GLenum, const GLvoid *);
 	using PFNTEXSUBIMAGE3DPROC = void (CODEGEN_FUNCPTR *)(GLenum, GLint, GLint, GLint, GLint, GLsizei, GLsizei, GLsizei, GLenum, GLenum, const GLvoid *);
-	
+
 	// Extension: 1.3
 	using PFNACTIVETEXTUREPROC = void (CODEGEN_FUNCPTR *)(GLenum);
 	using PFNCOMPRESSEDTEXIMAGE1DPROC = void (CODEGEN_FUNCPTR *)(GLenum, GLint, GLenum, GLsizei, GLint, GLsizei, const GLvoid *);
@@ -189,7 +194,7 @@ namespace gl
 	using PFNCOMPRESSEDTEXSUBIMAGE3DPROC = void (CODEGEN_FUNCPTR *)(GLenum, GLint, GLint, GLint, GLint, GLsizei, GLsizei, GLsizei, GLenum, GLsizei, const GLvoid *);
 	using PFNGETCOMPRESSEDTEXIMAGEPROC = void (CODEGEN_FUNCPTR *)(GLenum, GLint, GLvoid *);
 	using PFNSAMPLECOVERAGEPROC = void (CODEGEN_FUNCPTR *)(GLfloat, GLboolean);
-	
+
 	// Extension: 1.4
 	using PFNBLENDFUNCSEPARATEPROC = void (CODEGEN_FUNCPTR *)(GLenum, GLenum, GLenum, GLenum);
 	using PFNMULTIDRAWARRAYSPROC = void (CODEGEN_FUNCPTR *)(GLenum, const GLint *, const GLsizei *, GLsizei);
@@ -198,7 +203,7 @@ namespace gl
 	using PFNPOINTPARAMETERFVPROC = void (CODEGEN_FUNCPTR *)(GLenum, const GLfloat *);
 	using PFNPOINTPARAMETERIPROC = void (CODEGEN_FUNCPTR *)(GLenum, GLint);
 	using PFNPOINTPARAMETERIVPROC = void (CODEGEN_FUNCPTR *)(GLenum, const GLint *);
-	
+
 	// Extension: 1.5
 	using PFNBEGINQUERYPROC = void (CODEGEN_FUNCPTR *)(GLenum, GLuint);
 	using PFNBINDBUFFERPROC = void (CODEGEN_FUNCPTR *)(GLenum, GLuint);
@@ -219,7 +224,7 @@ namespace gl
 	using PFNISQUERYPROC = GLboolean (CODEGEN_FUNCPTR *)(GLuint);
 	using PFNMAPBUFFERPROC = void * (CODEGEN_FUNCPTR *)(GLenum, GLenum);
 	using PFNUNMAPBUFFERPROC = GLboolean (CODEGEN_FUNCPTR *)(GLenum);
-	
+
 	// Extension: 2.0
 	using PFNATTACHSHADERPROC = void (CODEGEN_FUNCPTR *)(GLuint, GLuint);
 	using PFNBINDATTRIBLOCATIONPROC = void (CODEGEN_FUNCPTR *)(GLuint, GLuint, const GLchar *);
@@ -314,7 +319,7 @@ namespace gl
 	using PFNVERTEXATTRIB4UIVPROC = void (CODEGEN_FUNCPTR *)(GLuint, const GLuint *);
 	using PFNVERTEXATTRIB4USVPROC = void (CODEGEN_FUNCPTR *)(GLuint, const GLushort *);
 	using PFNVERTEXATTRIBPOINTERPROC = void (CODEGEN_FUNCPTR *)(GLuint, GLint, GLenum, GLboolean, GLsizei, const GLvoid *);
-	
+
 	// Extension: 2.1
 	using PFNUNIFORMMATRIX2X3FVPROC = void (CODEGEN_FUNCPTR *)(GLint, GLsizei, GLboolean, const GLfloat *);
 	using PFNUNIFORMMATRIX2X4FVPROC = void (CODEGEN_FUNCPTR *)(GLint, GLsizei, GLboolean, const GLfloat *);
@@ -322,7 +327,7 @@ namespace gl
 	using PFNUNIFORMMATRIX3X4FVPROC = void (CODEGEN_FUNCPTR *)(GLint, GLsizei, GLboolean, const GLfloat *);
 	using PFNUNIFORMMATRIX4X2FVPROC = void (CODEGEN_FUNCPTR *)(GLint, GLsizei, GLboolean, const GLfloat *);
 	using PFNUNIFORMMATRIX4X3FVPROC = void (CODEGEN_FUNCPTR *)(GLint, GLsizei, GLboolean, const GLfloat *);
-	
+
 	// Extension: 3.0
 	using PFNBEGINCONDITIONALRENDERPROC = void (CODEGEN_FUNCPTR *)(GLuint, GLenum);
 	using PFNBEGINTRANSFORMFEEDBACKPROC = void (CODEGEN_FUNCPTR *)(GLenum);
@@ -408,7 +413,7 @@ namespace gl
 	using PFNVERTEXATTRIBI4UIVPROC = void (CODEGEN_FUNCPTR *)(GLuint, const GLuint *);
 	using PFNVERTEXATTRIBI4USVPROC = void (CODEGEN_FUNCPTR *)(GLuint, const GLushort *);
 	using PFNVERTEXATTRIBIPOINTERPROC = void (CODEGEN_FUNCPTR *)(GLuint, GLint, GLenum, GLsizei, const GLvoid *);
-	
+
 	// Extension: 3.1
 	using PFNCOPYBUFFERSUBDATAPROC = void (CODEGEN_FUNCPTR *)(GLenum, GLenum, GLintptr, GLintptr, GLsizeiptr);
 	using PFNDRAWARRAYSINSTANCEDPROC = void (CODEGEN_FUNCPTR *)(GLenum, GLint, GLsizei, GLsizei);
@@ -422,7 +427,7 @@ namespace gl
 	using PFNPRIMITIVERESTARTINDEXPROC = void (CODEGEN_FUNCPTR *)(GLuint);
 	using PFNTEXBUFFERPROC = void (CODEGEN_FUNCPTR *)(GLenum, GLenum, GLuint);
 	using PFNUNIFORMBLOCKBINDINGPROC = void (CODEGEN_FUNCPTR *)(GLuint, GLuint, GLuint);
-	
+
 	// Extension: 3.2
 	using PFNCLIENTWAITSYNCPROC = GLenum (CODEGEN_FUNCPTR *)(GLsync, GLbitfield, GLuint64);
 	using PFNDELETESYNCPROC = void (CODEGEN_FUNCPTR *)(GLsync);
@@ -443,7 +448,7 @@ namespace gl
 	using PFNTEXIMAGE2DMULTISAMPLEPROC = void (CODEGEN_FUNCPTR *)(GLenum, GLsizei, GLint, GLsizei, GLsizei, GLboolean);
 	using PFNTEXIMAGE3DMULTISAMPLEPROC = void (CODEGEN_FUNCPTR *)(GLenum, GLsizei, GLint, GLsizei, GLsizei, GLsizei, GLboolean);
 	using PFNWAITSYNCPROC = void (CODEGEN_FUNCPTR *)(GLsync, GLbitfield, GLuint64);
-	
+
 	// Extension: 3.3
 	using PFNBINDFRAGDATALOCATIONINDEXEDPROC = void (CODEGEN_FUNCPTR *)(GLuint, GLuint, GLuint, const GLchar *);
 	using PFNBINDSAMPLERPROC = void (CODEGEN_FUNCPTR *)(GLuint, GLuint);
@@ -473,8 +478,8 @@ namespace gl
 	using PFNVERTEXATTRIBP3UIVPROC = void (CODEGEN_FUNCPTR *)(GLuint, GLenum, GLboolean, const GLuint *);
 	using PFNVERTEXATTRIBP4UIPROC = void (CODEGEN_FUNCPTR *)(GLuint, GLenum, GLboolean, GLuint);
 	using PFNVERTEXATTRIBP4UIVPROC = void (CODEGEN_FUNCPTR *)(GLuint, GLenum, GLboolean, const GLuint *);
-	
-	
+
+
 	// Extension: 1.0
 	PFNBLENDFUNCPROC BlendFunc;
 	PFNCLEARPROC Clear;
@@ -524,7 +529,7 @@ namespace gl
 	PFNTEXPARAMETERIPROC TexParameteri;
 	PFNTEXPARAMETERIVPROC TexParameteriv;
 	PFNVIEWPORTPROC Viewport;
-	
+
 	// Extension: 1.1
 	PFNBINDTEXTUREPROC BindTexture;
 	PFNCOPYTEXIMAGE1DPROC CopyTexImage1D;
@@ -539,7 +544,7 @@ namespace gl
 	PFNPOLYGONOFFSETPROC PolygonOffset;
 	PFNTEXSUBIMAGE1DPROC TexSubImage1D;
 	PFNTEXSUBIMAGE2DPROC TexSubImage2D;
-	
+
 	// Extension: 1.2
 	PFNBLENDCOLORPROC BlendColor;
 	PFNBLENDEQUATIONPROC BlendEquation;
@@ -547,7 +552,7 @@ namespace gl
 	PFNDRAWRANGEELEMENTSPROC DrawRangeElements;
 	PFNTEXIMAGE3DPROC TexImage3D;
 	PFNTEXSUBIMAGE3DPROC TexSubImage3D;
-	
+
 	// Extension: 1.3
 	PFNACTIVETEXTUREPROC ActiveTexture;
 	PFNCOMPRESSEDTEXIMAGE1DPROC CompressedTexImage1D;
@@ -558,7 +563,7 @@ namespace gl
 	PFNCOMPRESSEDTEXSUBIMAGE3DPROC CompressedTexSubImage3D;
 	PFNGETCOMPRESSEDTEXIMAGEPROC GetCompressedTexImage;
 	PFNSAMPLECOVERAGEPROC SampleCoverage;
-	
+
 	// Extension: 1.4
 	PFNBLENDFUNCSEPARATEPROC BlendFuncSeparate;
 	PFNMULTIDRAWARRAYSPROC MultiDrawArrays;
@@ -567,7 +572,7 @@ namespace gl
 	PFNPOINTPARAMETERFVPROC PointParameterfv;
 	PFNPOINTPARAMETERIPROC PointParameteri;
 	PFNPOINTPARAMETERIVPROC PointParameteriv;
-	
+
 	// Extension: 1.5
 	PFNBEGINQUERYPROC BeginQuery;
 	PFNBINDBUFFERPROC BindBuffer;
@@ -588,7 +593,7 @@ namespace gl
 	PFNISQUERYPROC IsQuery;
 	PFNMAPBUFFERPROC MapBuffer;
 	PFNUNMAPBUFFERPROC UnmapBuffer;
-	
+
 	// Extension: 2.0
 	PFNATTACHSHADERPROC AttachShader;
 	PFNBINDATTRIBLOCATIONPROC BindAttribLocation;
@@ -683,7 +688,7 @@ namespace gl
 	PFNVERTEXATTRIB4UIVPROC VertexAttrib4uiv;
 	PFNVERTEXATTRIB4USVPROC VertexAttrib4usv;
 	PFNVERTEXATTRIBPOINTERPROC VertexAttribPointer;
-	
+
 	// Extension: 2.1
 	PFNUNIFORMMATRIX2X3FVPROC UniformMatrix2x3fv;
 	PFNUNIFORMMATRIX2X4FVPROC UniformMatrix2x4fv;
@@ -691,7 +696,7 @@ namespace gl
 	PFNUNIFORMMATRIX3X4FVPROC UniformMatrix3x4fv;
 	PFNUNIFORMMATRIX4X2FVPROC UniformMatrix4x2fv;
 	PFNUNIFORMMATRIX4X3FVPROC UniformMatrix4x3fv;
-	
+
 	// Extension: 3.0
 	PFNBEGINCONDITIONALRENDERPROC BeginConditionalRender;
 	PFNBEGINTRANSFORMFEEDBACKPROC BeginTransformFeedback;
@@ -777,7 +782,7 @@ namespace gl
 	PFNVERTEXATTRIBI4UIVPROC VertexAttribI4uiv;
 	PFNVERTEXATTRIBI4USVPROC VertexAttribI4usv;
 	PFNVERTEXATTRIBIPOINTERPROC VertexAttribIPointer;
-	
+
 	// Extension: 3.1
 	PFNCOPYBUFFERSUBDATAPROC CopyBufferSubData;
 	PFNDRAWARRAYSINSTANCEDPROC DrawArraysInstanced;
@@ -791,7 +796,7 @@ namespace gl
 	PFNPRIMITIVERESTARTINDEXPROC PrimitiveRestartIndex;
 	PFNTEXBUFFERPROC TexBuffer;
 	PFNUNIFORMBLOCKBINDINGPROC UniformBlockBinding;
-	
+
 	// Extension: 3.2
 	PFNCLIENTWAITSYNCPROC ClientWaitSync;
 	PFNDELETESYNCPROC DeleteSync;
@@ -812,7 +817,7 @@ namespace gl
 	PFNTEXIMAGE2DMULTISAMPLEPROC TexImage2DMultisample;
 	PFNTEXIMAGE3DMULTISAMPLEPROC TexImage3DMultisample;
 	PFNWAITSYNCPROC WaitSync;
-	
+
 	// Extension: 3.3
 	PFNBINDFRAGDATALOCATIONINDEXEDPROC BindFragDataLocationIndexed;
 	PFNBINDSAMPLERPROC BindSampler;
@@ -842,8 +847,8 @@ namespace gl
 	PFNVERTEXATTRIBP3UIVPROC VertexAttribP3uiv;
 	PFNVERTEXATTRIBP4UIPROC VertexAttribP4ui;
 	PFNVERTEXATTRIBP4UIVPROC VertexAttribP4uiv;
-	
-	
+
+
 	// Extension: 1.0
 	static void CODEGEN_FUNCPTR Switch_BlendFunc(GLenum sfactor, GLenum dfactor)
 	{
@@ -1133,7 +1138,7 @@ namespace gl
 		Viewport(x, y, width, height);
 	}
 
-	
+
 	// Extension: 1.1
 	static void CODEGEN_FUNCPTR Switch_BindTexture(GLenum target, GLuint texture)
 	{
@@ -1213,7 +1218,7 @@ namespace gl
 		TexSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixels);
 	}
 
-	
+
 	// Extension: 1.2
 	static void CODEGEN_FUNCPTR Switch_BlendColor(GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha)
 	{
@@ -1251,7 +1256,7 @@ namespace gl
 		TexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
 	}
 
-	
+
 	// Extension: 1.3
 	static void CODEGEN_FUNCPTR Switch_ActiveTexture(GLenum texture)
 	{
@@ -1307,7 +1312,7 @@ namespace gl
 		SampleCoverage(value, invert);
 	}
 
-	
+
 	// Extension: 1.4
 	static void CODEGEN_FUNCPTR Switch_BlendFuncSeparate(GLenum sfactorRGB, GLenum dfactorRGB, GLenum sfactorAlpha, GLenum dfactorAlpha)
 	{
@@ -1351,7 +1356,7 @@ namespace gl
 		PointParameteriv(pname, params);
 	}
 
-	
+
 	// Extension: 1.5
 	static void CODEGEN_FUNCPTR Switch_BeginQuery(GLenum target, GLuint id)
 	{
@@ -1467,7 +1472,7 @@ namespace gl
 		return UnmapBuffer(target);
 	}
 
-	
+
 	// Extension: 2.0
 	static void CODEGEN_FUNCPTR Switch_AttachShader(GLuint program, GLuint shader)
 	{
@@ -2027,7 +2032,7 @@ namespace gl
 		VertexAttribPointer(index, size, type, normalized, stride, pointer);
 	}
 
-	
+
 	// Extension: 2.1
 	static void CODEGEN_FUNCPTR Switch_UniformMatrix2x3fv(GLint location, GLsizei count, GLboolean transpose, const GLfloat * value)
 	{
@@ -2065,7 +2070,7 @@ namespace gl
 		UniformMatrix4x3fv(location, count, transpose, value);
 	}
 
-	
+
 	// Extension: 3.0
 	static void CODEGEN_FUNCPTR Switch_BeginConditionalRender(GLuint id, GLenum mode)
 	{
@@ -2571,7 +2576,7 @@ namespace gl
 		VertexAttribIPointer(index, size, type, stride, pointer);
 	}
 
-	
+
 	// Extension: 3.1
 	static void CODEGEN_FUNCPTR Switch_CopyBufferSubData(GLenum readTarget, GLenum writeTarget, GLintptr readOffset, GLintptr writeOffset, GLsizeiptr size)
 	{
@@ -2645,7 +2650,7 @@ namespace gl
 		UniformBlockBinding(program, uniformBlockIndex, uniformBlockBinding);
 	}
 
-	
+
 	// Extension: 3.2
 	static GLenum CODEGEN_FUNCPTR Switch_ClientWaitSync(GLsync sync, GLbitfield flags, GLuint64 timeout)
 	{
@@ -2761,7 +2766,7 @@ namespace gl
 		WaitSync(sync, flags, timeout);
 	}
 
-	
+
 	// Extension: 3.3
 	static void CODEGEN_FUNCPTR Switch_BindFragDataLocationIndexed(GLuint program, GLuint colorNumber, GLuint index, const GLchar * name)
 	{
@@ -2931,9 +2936,9 @@ namespace gl
 		VertexAttribP4uiv(index, type, normalized, value);
 	}
 
-	
-	
-	namespace 
+
+
+	namespace
 	{
 		struct InitializeVariables
 		{ NOMEMALIGN
@@ -2988,7 +2993,7 @@ namespace gl
 				TexParameteri = Switch_TexParameteri;
 				TexParameteriv = Switch_TexParameteriv;
 				Viewport = Switch_Viewport;
-				
+
 				// Extension: 1.1
 				BindTexture = Switch_BindTexture;
 				CopyTexImage1D = Switch_CopyTexImage1D;
@@ -3003,7 +3008,7 @@ namespace gl
 				PolygonOffset = Switch_PolygonOffset;
 				TexSubImage1D = Switch_TexSubImage1D;
 				TexSubImage2D = Switch_TexSubImage2D;
-				
+
 				// Extension: 1.2
 				BlendColor = Switch_BlendColor;
 				BlendEquation = Switch_BlendEquation;
@@ -3011,7 +3016,7 @@ namespace gl
 				DrawRangeElements = Switch_DrawRangeElements;
 				TexImage3D = Switch_TexImage3D;
 				TexSubImage3D = Switch_TexSubImage3D;
-				
+
 				// Extension: 1.3
 				ActiveTexture = Switch_ActiveTexture;
 				CompressedTexImage1D = Switch_CompressedTexImage1D;
@@ -3022,7 +3027,7 @@ namespace gl
 				CompressedTexSubImage3D = Switch_CompressedTexSubImage3D;
 				GetCompressedTexImage = Switch_GetCompressedTexImage;
 				SampleCoverage = Switch_SampleCoverage;
-				
+
 				// Extension: 1.4
 				BlendFuncSeparate = Switch_BlendFuncSeparate;
 				MultiDrawArrays = Switch_MultiDrawArrays;
@@ -3031,7 +3036,7 @@ namespace gl
 				PointParameterfv = Switch_PointParameterfv;
 				PointParameteri = Switch_PointParameteri;
 				PointParameteriv = Switch_PointParameteriv;
-				
+
 				// Extension: 1.5
 				BeginQuery = Switch_BeginQuery;
 				BindBuffer = Switch_BindBuffer;
@@ -3052,7 +3057,7 @@ namespace gl
 				IsQuery = Switch_IsQuery;
 				MapBuffer = Switch_MapBuffer;
 				UnmapBuffer = Switch_UnmapBuffer;
-				
+
 				// Extension: 2.0
 				AttachShader = Switch_AttachShader;
 				BindAttribLocation = Switch_BindAttribLocation;
@@ -3147,7 +3152,7 @@ namespace gl
 				VertexAttrib4uiv = Switch_VertexAttrib4uiv;
 				VertexAttrib4usv = Switch_VertexAttrib4usv;
 				VertexAttribPointer = Switch_VertexAttribPointer;
-				
+
 				// Extension: 2.1
 				UniformMatrix2x3fv = Switch_UniformMatrix2x3fv;
 				UniformMatrix2x4fv = Switch_UniformMatrix2x4fv;
@@ -3155,7 +3160,7 @@ namespace gl
 				UniformMatrix3x4fv = Switch_UniformMatrix3x4fv;
 				UniformMatrix4x2fv = Switch_UniformMatrix4x2fv;
 				UniformMatrix4x3fv = Switch_UniformMatrix4x3fv;
-				
+
 				// Extension: 3.0
 				BeginConditionalRender = Switch_BeginConditionalRender;
 				BeginTransformFeedback = Switch_BeginTransformFeedback;
@@ -3241,7 +3246,7 @@ namespace gl
 				VertexAttribI4uiv = Switch_VertexAttribI4uiv;
 				VertexAttribI4usv = Switch_VertexAttribI4usv;
 				VertexAttribIPointer = Switch_VertexAttribIPointer;
-				
+
 				// Extension: 3.1
 				CopyBufferSubData = Switch_CopyBufferSubData;
 				DrawArraysInstanced = Switch_DrawArraysInstanced;
@@ -3255,7 +3260,7 @@ namespace gl
 				PrimitiveRestartIndex = Switch_PrimitiveRestartIndex;
 				TexBuffer = Switch_TexBuffer;
 				UniformBlockBinding = Switch_UniformBlockBinding;
-				
+
 				// Extension: 3.2
 				ClientWaitSync = Switch_ClientWaitSync;
 				DeleteSync = Switch_DeleteSync;
@@ -3276,7 +3281,7 @@ namespace gl
 				TexImage2DMultisample = Switch_TexImage2DMultisample;
 				TexImage3DMultisample = Switch_TexImage3DMultisample;
 				WaitSync = Switch_WaitSync;
-				
+
 				// Extension: 3.3
 				BindFragDataLocationIndexed = Switch_BindFragDataLocationIndexed;
 				BindSampler = Switch_BindSampler;
@@ -3306,56 +3311,56 @@ namespace gl
 				VertexAttribP3uiv = Switch_VertexAttribP3uiv;
 				VertexAttribP4ui = Switch_VertexAttribP4ui;
 				VertexAttribP4uiv = Switch_VertexAttribP4uiv;
-				
+
 			}
 		};
 
 		InitializeVariables g_initVariables;
 	}
-	
+
 	namespace sys
 	{
-		namespace 
+		namespace
 		{
 			void ClearExtensionVariables()
 			{
 			}
-			
+
 			struct MapEntry
 			{ NOMEMALIGN
 				const char *extName;
 				bool *extVariable;
 			};
-			
+
 			struct MapCompare
 			{ NOMEMALIGN
 				MapCompare(const char *test_) : test(test_) {}
 				bool operator()(const MapEntry &other) { return strcmp(test, other.extName) == 0; }
 				const char *test;
 			};
-			
+
 			struct ClearEntry
 			{ NOMEMALIGN
 			  void operator()(MapEntry &entry) { *(entry.extVariable) = false;}
 			};
-			
-			MapEntry g_mappingTable[1]; //This is intensionally left uninitialized. 
-			
+
+			MapEntry g_mappingTable[1]; //This is intensionally left uninitialized.
+
 			void LoadExtByName(const char *extensionName)
 			{
 				MapEntry *tableEnd = &g_mappingTable[0];
 				MapEntry *entry = std::find_if(&g_mappingTable[0], tableEnd, MapCompare(extensionName));
-				
+
 				if(entry != tableEnd)
 					*(entry->extVariable) = true;
 			}
-			
+
 			void ProcExtsFromExtList()
 			{
 				GLint iLoop;
 				GLint iNumExtensions = 0;
 				GetIntegerv(NUM_EXTENSIONS, &iNumExtensions);
-			
+
 				for(iLoop = 0; iLoop < iNumExtensions; iLoop++)
 				{
 					const char *strExtensionName = (const char *)GetStringi(EXTENSIONS, iLoop);
@@ -3367,9 +3372,9 @@ namespace gl
 		{
 			ClearExtensionVariables();
 			std::for_each(&g_mappingTable[0], &g_mappingTable[0], ClearEntry());
-			
+
 			ProcExtsFromExtList();
 		}
-		
+
 	}
 }

--- a/src/surface/mesh.cpp
+++ b/src/surface/mesh.cpp
@@ -656,7 +656,7 @@ namespace MR
 
         File::OFStream out (path, std::ios_base::binary | std::ios_base::out);
         const std::string string = std::string ("mrtrix_version: ") + App::mrtrix_version;
-        char header[80];
+        char header[81];
         strncpy (header, string.c_str(), 80);
         out.write (header, 80);
         const uint32_t count = triangles.size();


### PR DESCRIPTION
This allows signal handlers to be disabled with an environment variable. However, as noted in #1391, this may not necessarily be all that useful. 

A more useful feature on this pull request is that environment variables can now be documented in the same way as config file options, and will be updated with a call to `generate_user_docs`. 

This pull request also includes a few changes to quieten warnings with GCC 8.2.0 on MSYS2.