### PR TITLE
tckgen: Permit -downsample 1

### DIFF
--- a/src/dwi/tractography/tracking/tractography.cpp
+++ b/src/dwi/tractography/tracking/tractography.cpp
@@ -83,7 +83,7 @@ namespace MR
 
       + Option ("downsample", "downsample the generated streamlines to reduce output file size "
                               "(default is (samples-1) for iFOD2, no downsampling for all other algorithms)")
-          + Argument ("factor").type_integer (2);
+          + Argument ("factor").type_integer (1);
 
 
 


### PR DESCRIPTION
As noted in my response on [this forum thread](http://community.mrtrix.org/t/tckedit-after-targeted-tracking/1835). This change is necessary to be able to fully disable downsampling of track outputs for iFOD2.