### PR TITLE
dwi2response: Accept floating-point numbers in -shells option

### DIFF
--- a/bin/dwi2response
+++ b/bin/dwi2response
@@ -59,7 +59,7 @@ if app.args.lmax:
 shells_option = ''
 if app.args.shells:
   try:
-    shells_values = [ int(x) for x in app.args.shells.split(',') ]
+    shells_values = [ int(round(float(x))) for x in app.args.shells.split(',') ]
   except:
     app.error('-shells option should provide a comma-separated list of b-values')
   if alg.needsSingleShell() and not len(shells_values) == 1:


### PR DESCRIPTION
If floating-point *b*-values are provided as input to `-shells`, the error produced is "`-shells option should provide a comma-separated list of b-values`", which isn't entirely intuitive.

This change is consistent with existing code within individual `dwi2response` algorithms for getting the list of *b*-values from an image.