### PR TITLE
tck2connectome empty output on 4-D parcellation image 

### DIFF
--- a/cmd/tck2connectome.cpp
+++ b/cmd/tck2connectome.cpp
@@ -146,6 +146,8 @@ void execute (Image<node_t>& node_image, const node_t max_node_index, const std:
 void run ()
 {
   auto node_image = Image<node_t>::open (argument[1]);
+  if (node_image.ndim() != 3)
+    throw Exception("Node image must be a 3-D volume of node labels.");
 
   // First, find out how many segmented nodes there are, so the matrix can be pre-allocated
   // Also check for node volume for all nodes

--- a/cmd/tck2connectome.cpp
+++ b/cmd/tck2connectome.cpp
@@ -145,15 +145,15 @@ void execute (Image<node_t>& node_image, const node_t max_node_index, const std:
 
 void run ()
 {
-  auto node_image = Image<node_t>::open (argument[1]);
-  if (node_image.ndim() != 3)
-    throw Exception("Node image must be a 3-D volume of node labels.");
+  auto node_header = Header::open (argument[1]);
+  MR::Connectome::check (node_header);
+  auto node_image = node_header.get_image<node_t>();
 
   // First, find out how many segmented nodes there are, so the matrix can be pre-allocated
   // Also check for node volume for all nodes
   vector<uint32_t> node_volumes (1, 0);
   node_t max_node_index = 0;
-  for (auto i = Loop (node_image) (node_image); i; ++i) {
+  for (auto i = Loop (node_image, 0, 3) (node_image); i; ++i) {
     if (node_image.value() > max_node_index) {
       max_node_index = node_image.value();
       node_volumes.resize (max_node_index + 1, 0);

--- a/src/connectome/connectome.cpp
+++ b/src/connectome/connectome.cpp
@@ -34,6 +34,8 @@ namespace MR {
 
     void check (const Header& H)
     {
+      if (!(H.ndim() == 3 || (H.ndim() == 4 && H.size(3) == 1)))
+        throw Exception ("Image \"" + H.name() + "\" is not 3D, and hence is not a volume of node parcel indices");
       if (H.datatype().is_floating_point()) {
         CONSOLE ("Image \"" + H.name() + "\" stored with floating-point type; need to check for non-integer or negative values");
         // Need to open the image WITHOUT using the IO handler stored in H;


### PR DESCRIPTION
(Reported to me by Tanya Poppe)

On 4-D node images, `tck2connectome` outputs a warning for missing nodes, and produces an empty connectivity matrix. The commit in this pull request adds a trivial check for 3-D inputs, which can hopefully demystify such error cases more easily.