### PR TITLE
Change FSL autodetect behaviour

### DIFF
--- a/lib/mrtrix3/fsl.py
+++ b/lib/mrtrix3/fsl.py
@@ -71,10 +71,10 @@ def eddyBinary(cuda): #pylint: disable=unused-variable
 def exeName(name, required=True): #pylint: disable=unused-variable
   from mrtrix3 import app
   from distutils.spawn import find_executable
-  if find_executable('fsl5.0-' + name):
-    output = 'fsl5.0-' + name
-  elif find_executable(name):
+  if find_executable(name):
     output = name
+  elif find_executable('fsl5.0-' + name):
+    output = 'fsl5.0-' + name
   elif required:
     app.error('Could not find FSL program \"' + name + '\"; please verify FSL install')
   app.debug(output)


### PR DESCRIPTION
In environments where multiple FSL versions can be loaded (HPC),
preferring the fsl5.0-X defaults leads to undesirable behaviour.

Users may explicitly activate some custom FSL either with environment
modules or manually with the default FSL setup procedure. If there is
a fsl package installed which prefixes their scripts with "fsl5.0-"
(i.e. neurodebian) mrtrix should not prefer that one over the explicit
user choice. This PR defensively changes the preference, but actually I would argue to completely drop the fsl5.0 convenience detection. If this is just to work with neurodebian then this assumption is missing the fact that neurodebian still requires users to run `source /etc/fsl/5.0/fsl.sh` to actually load and activate everything. Afterwards all binaries are in PATH and can and should be found with `find_executable(name)`.