### PR TITLE
dcminfo: fix -tags output

### DIFF
--- a/cmd/dcminfo.cpp
+++ b/cmd/dcminfo.cpp
@@ -76,11 +76,8 @@ void run ()
     while (item.read()) {
       for (size_t n = 0; n < opt.size(); ++n)
         if (item.is (tags[n].group, tags[n].element))
-          tags[n].value = join (item.get_string(), " ");
+          std::cout << MR::printf ("[%04X,%04X] ", tags[n].group, tags[n].element) <<  item.as_string() << "\n";
     }
-
-    for (size_t n = 0; n < opt.size(); ++n)
-      std::cout << tags[n].value << "\n";
 
     return;
   }

--- a/core/file/dicom/element.cpp
+++ b/core/file/dicom/element.cpp
@@ -392,6 +392,50 @@ namespace MR {
 
 
 
+
+      std::string Element::as_string () const
+      {
+        std::ostringstream out;
+        switch (type()) {
+          case Element::INT:
+            for (const auto& x : get_int())
+              out << x << " ";
+            return out.str();
+          case Element::UINT:
+            for (const auto& x : get_uint())
+              out << x << " ";
+            return out.str();
+          case Element::FLOAT:
+            for (const auto& x : get_float())
+              out << x << " ";
+            return out.str();
+          case Element::DATE:
+            return str(get_date());
+          case Element::TIME:
+            return str(get_time());
+          case Element::STRING:
+            if (group == GROUP_DATA && element == ELEMENT_DATA) {
+              return "(data)";
+            }
+            else {
+              for (const auto& x : get_string())
+                out << x << " ";
+              return out.str();
+            }
+          case Element::SEQ:
+            return "";
+          default:
+            if (group != GROUP_SEQUENCE || element != ELEMENT_SEQUENCE_ITEM)
+              return "unknown data type";
+        }
+        return "";
+      }
+
+
+
+
+
+
       namespace {
         template <class T>
           inline void print_vec (const vector<T>& V)
@@ -448,38 +492,7 @@ namespace MR {
           tmp += "  ";
         tmp += ( name.size() ? name.substr(2) : "unknown" );
         tmp.resize (40, ' ');
-        stream << tmp + ' ';
-
-        switch (item.type()) {
-          case Element::INT:
-            stream << item.get_int();
-            break;
-          case Element::UINT:
-            stream << item.get_uint();
-            break;
-          case Element::FLOAT:
-            stream << item.get_float();
-            break;
-          case Element::DATE:
-            stream << "[ " << item.get_date() << " ]";
-            break;
-          case Element::TIME:
-            stream << "[ " << item.get_time() << " ]";
-            break;
-          case Element::STRING:
-            if (item.group == GROUP_DATA && item.element == ELEMENT_DATA)
-              stream << "(data)";
-            else
-              stream << item.get_string();
-            break;
-          case Element::SEQ:
-            break;
-          default:
-            if (item.group != GROUP_SEQUENCE || item.element != ELEMENT_SEQUENCE_ITEM)
-              stream << "unknown data type";
-        }
-
-        stream << "\n";
+        stream << tmp << " " << item.as_string() << "\n";
 
         return stream;
       }

--- a/core/file/dicom/element.h
+++ b/core/file/dicom/element.h
@@ -150,6 +150,8 @@ namespace MR {
           double      get_float (size_t idx, double default_value = 0.0)                 const { auto v (get_float());  return check_get (idx, v.size()) ? v[idx] : default_value; }
           std::string get_string (size_t idx, std::string default_value = std::string()) const { auto v (get_string()); return check_get (idx, v.size()) ? v[idx] : default_value; }
 
+          std::string   as_string () const;
+
           size_t level () const { return parents.size(); }
 
           friend std::ostream& operator<< (std::ostream& stream, const Element& item);
@@ -159,8 +161,8 @@ namespace MR {
           }
 
 
-          template <typename VectorType> 
-            FORCE_INLINE void check_size (const VectorType v, size_t min_size = 1) { 
+          template <typename VectorType>
+            FORCE_INLINE void check_size (const VectorType v, size_t min_size = 1) {
               if (v.size() < min_size)
                 error_in_check_size (min_size, v.size());
             }
@@ -190,8 +192,8 @@ namespace MR {
           static void init_dict();
 
           bool check_get (size_t idx, size_t size) const { if (idx >= size) { error_in_get (idx); return false; } return true; }
-          void error_in_get (size_t idx) const; 
-          void error_in_check_size (size_t min_size, size_t actual_size) const; 
+          void error_in_get (size_t idx) const;
+          void error_in_check_size (size_t min_size, size_t actual_size) const;
           void report_unknown_tag_with_implicit_syntax () const;
       };
 


### PR DESCRIPTION
As discussed on [this forum thread](http://community.mrtrix.org/t/dcminfo-tag-broken/1986).

Suggest committing to `master` since this is a (admittedly minor) bug fix, but also unlikely to affect anything else. Happy to commit it to `dev` if this is deemed more appropriate.

In case you're wondering: this passes all testing on my DICOM store.