### PR TITLE
mrview: fix -norealign option

### DIFF
--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -718,6 +718,9 @@ namespace MR
 
       void Window::parse_arguments ()
       {
+        if (MR::App::get_options ("norealign").size())
+          Header::do_not_realign_transform = true;
+
         if (MR::App::argument.size()) {
           if (MR::App::option.size())  {
             // check that first non-standard option appears after last argument:


### PR DESCRIPTION
Processing of this option was removed in merge commit 42573be60, presumably due to a mistake during conflict resolution.

Suggest merging to `master` directly since this is a clear bug fix, and the fix is totally benign.

[EDIT]
See [original report on the forum](http://community.mrtrix.org/t/mrview-norealign/1988).