### PR TITLE
PBRT writer for tckconvert

### DIFF
--- a/cmd/tckconvert.cpp
+++ b/cmd/tckconvert.cpp
@@ -675,7 +675,9 @@ void run ()
         writer.reset( new PLYWriter(argument[1], increment, radius, sides) );
     }
     else if (has_suffix(argument[1], ".rib")) {
-        writer.reset( new RibWriter(argument[1]) );
+        auto radius = get_options("radius").size() ? get_options("radius")[0][0].as_float() : 0.1f;
+        writer.reset( new RibWriter(argument[1], radius) );
+    }
     }
     else if (has_suffix(argument[1], ".txt")) {
         writer.reset( new ASCIIWriter(argument[1]) );

--- a/testing/tests/tckconvert
+++ b/testing/tests/tckconvert
@@ -6,3 +6,5 @@ tckedit tracks.tck -number 10 tmp.tck -nthread 0 && tckconvert tmp.tck tmp-[].tx
 tckconvert tckconvert/out2-[2:9].txt tmp.tck -force && testing_diff_tck tmp.tck tckconvert/out3.tck 1e-4
 echo 1 2 3 > tmp.txt && tckconvert -force -quiet tmp.txt tmp.tck && tckconvert -quiet -force tmp.tck tmp.rib && [ $(wc -l < tmp.rib ) == 4 ]
 tckconvert -force -quiet tckconvert/empty.vtk tmp.tck
+# Test PBRT export
+tckconvert tracks.tck tmp.pbrt -force && [ $(wc -l < tmp.pbrt ) == 1515 ]


### PR DESCRIPTION
The PBRT rendering engine (https://www.pbrt.org/) is a [well documented](http://www.pbr-book.org/) and versatile open source rendering engine on the order of Pixar's RenderMan.

This pull request adds support to export `.tck` files as PBRT `curve` objects, essentially a series of
`C0` and `C1` continuous Bezier splines.

The exporter allows the radius of the curves to be set and honors the `-increment` flag to skip points along the streamlines, thus reducing file size and rendering time.

The pull request includes a simple smoke test to detect if the exporter writes a file of the correct number of lines.