### PR TITLE
connectomestats: Alter output file names

### DIFF
--- a/cmd/connectomestats.cpp
+++ b/cmd/connectomestats.cpp
@@ -239,12 +239,12 @@ void run()
 
     const matrix_type betas = Math::Stats::GLM::solve_betas (data, design);
     for (size_t i = 0; i < size_t(contrast.cols()); ++i) {
-      save_matrix (mat2vec.V2M (betas.col(i)), output_prefix + "_beta_" + str(i) + ".csv");
+      save_matrix (mat2vec.V2M (betas.col(i)), output_prefix + "beta_" + str(i) + ".csv");
       ++progress;
     }
 
     const matrix_type abs_effects = Math::Stats::GLM::abs_effect_size (data, design, contrast);
-    save_matrix (mat2vec.V2M (abs_effects.col(0)), output_prefix + "_abs_effect.csv");
+    save_matrix (mat2vec.V2M (abs_effects.col(0)), output_prefix + "abs_effect.csv");
     ++progress;
 
     const matrix_type std_effects = Math::Stats::GLM::std_effect_size (data, design, contrast);
@@ -255,11 +255,11 @@ void run()
           first_std_effect (i, j) = 0.0;
       }
     }
-    save_matrix (first_std_effect, output_prefix + "_std_effect.csv");
+    save_matrix (first_std_effect, output_prefix + "std_effect.csv");
     ++progress;
 
     const matrix_type stdev = Math::Stats::GLM::stdev (data, design);
-    save_matrix (mat2vec.V2M(stdev.row(0)), output_prefix + "_std_dev.csv");
+    save_matrix (mat2vec.V2M(stdev.row(0)), output_prefix + "std_dev.csv");
   }
 
   Math::Stats::GLMTTest glm_ttest (data, design, contrast);
@@ -275,7 +275,7 @@ void run()
       Stats::PermTest::PermutationStack perm_stack (nperms_nonstationary, design.rows(), "precomputing empirical statistic for non-stationarity adjustment...", true);
       Stats::PermTest::precompute_empirical_stat (glm_ttest, enhancer, perm_stack, empirical_statistic);
     }
-    save_matrix (mat2vec.V2M (empirical_statistic), output_prefix + "_empirical.csv");
+    save_matrix (mat2vec.V2M (empirical_statistic), output_prefix + "empirical.csv");
   }
 
   // Precompute default statistic and enhanced statistic
@@ -284,8 +284,8 @@ void run()
 
   Stats::PermTest::precompute_default_permutation (glm_ttest, enhancer, empirical_statistic, enhanced_output, std::shared_ptr<vector_type>(), tvalue_output);
 
-  save_matrix (mat2vec.V2M (tvalue_output),   output_prefix + "_tvalue.csv");
-  save_matrix (mat2vec.V2M (enhanced_output), output_prefix + "_enhanced.csv");
+  save_matrix (mat2vec.V2M (tvalue_output),   output_prefix + "tvalue.csv");
+  save_matrix (mat2vec.V2M (enhanced_output), output_prefix + "enhanced.csv");
 
   // Perform permutation testing
   if (!get_options ("notest").size()) {
@@ -307,11 +307,11 @@ void run()
                                          uncorrected_pvalues, std::shared_ptr<vector_type>());
     }
 
-    save_vector (null_distribution, output_prefix + "_null_dist.txt");
+    save_vector (null_distribution, output_prefix + "null_dist.txt");
     vector_type pvalue_output (num_edges);
     Math::Stats::Permutation::statistic2pvalue (null_distribution, enhanced_output, pvalue_output);
-    save_matrix (mat2vec.V2M (pvalue_output),       output_prefix + "_fwe_pvalue.csv");
-    save_matrix (mat2vec.V2M (uncorrected_pvalues), output_prefix + "_uncorrected_pvalue.csv");
+    save_matrix (mat2vec.V2M (pvalue_output),       output_prefix + "fwe_pvalue.csv");
+    save_matrix (mat2vec.V2M (uncorrected_pvalues), output_prefix + "uncorrected_pvalue.csv");
 
   }
 


### PR DESCRIPTION
Remove underscore between output prefix and fixed output file suffixes, in order to make output file names more consistent with other MRtrix3 statistical inference commands.