### PR TITLE
DICOM: increase resilience to errors and empty fields

### DIFF
--- a/core/file/dicom/element.cpp
+++ b/core/file/dicom/element.cpp
@@ -396,37 +396,43 @@ namespace MR {
       std::string Element::as_string () const
       {
         std::ostringstream out;
-        switch (type()) {
-          case Element::INT:
-            for (const auto& x : get_int())
-              out << x << " ";
-            return out.str();
-          case Element::UINT:
-            for (const auto& x : get_uint())
-              out << x << " ";
-            return out.str();
-          case Element::FLOAT:
-            for (const auto& x : get_float())
-              out << x << " ";
-            return out.str();
-          case Element::DATE:
-            return str(get_date());
-          case Element::TIME:
-            return str(get_time());
-          case Element::STRING:
-            if (group == GROUP_DATA && element == ELEMENT_DATA) {
-              return "(data)";
-            }
-            else {
-              for (const auto& x : get_string())
+        try {
+          switch (type()) {
+            case Element::INT:
+              for (const auto& x : get_int())
                 out << x << " ";
               return out.str();
-            }
-          case Element::SEQ:
-            return "";
-          default:
-            if (group != GROUP_SEQUENCE || element != ELEMENT_SEQUENCE_ITEM)
-              return "unknown data type";
+            case Element::UINT:
+              for (const auto& x : get_uint())
+                out << x << " ";
+              return out.str();
+            case Element::FLOAT:
+              for (const auto& x : get_float())
+                out << x << " ";
+              return out.str();
+            case Element::DATE:
+              return str(get_date());
+            case Element::TIME:
+              return str(get_time());
+            case Element::STRING:
+              if (group == GROUP_DATA && element == ELEMENT_DATA) {
+                return "(data)";
+              }
+              else {
+                for (const auto& x : get_string())
+                  out << x << " ";
+                return out.str();
+              }
+            case Element::SEQ:
+              return "";
+            default:
+              if (group != GROUP_SEQUENCE || element != ELEMENT_SEQUENCE_ITEM)
+                return "unknown data type";
+          }
+        }
+        catch (Exception& e) {
+          e.display();
+          return "invalid entry";
         }
         return "";
       }

--- a/core/file/dicom/element.h
+++ b/core/file/dicom/element.h
@@ -39,10 +39,12 @@ namespace MR {
       class Date { NOMEMALIGN
         public:
           Date (const std::string& entry) :
-              year  (to<uint32_t> (entry.substr (0, 4))),
-              month (to<uint32_t> (entry.substr (4, 2))),
-              day   (to<uint32_t> (entry.substr (6, 2)))
-          {
+            year(0), month(0), day(0) {
+            if (entry.size() >= 8) {
+              year = to<uint32_t> (entry.substr (0, 4));
+              month = to<uint32_t> (entry.substr (4, 2));
+              day = to<uint32_t> (entry.substr (6, 2));
+            }
             if (year < 1000 || month > 12 || day > 31)
               throw Exception ("Error converting string \"" + entry + "\" to date");
           }

--- a/core/file/dicom/image.cpp
+++ b/core/file/dicom/image.cpp
@@ -312,8 +312,15 @@ namespace MR {
           Element item;
           item.set (filename);
 
-          while (item.read())
-            parse_item (item);
+          while (item.read()){
+            try {
+              parse_item (item);
+            }
+            catch (Exception& E) {
+              WARN (printf ("error reading tag (%04X,%04X):", item.group, item.element));
+              E.display(1);
+            }
+          }
 
           calc_distance();
 

--- a/core/file/dicom/series.cpp
+++ b/core/file/dicom/series.cpp
@@ -28,7 +28,7 @@ namespace MR {
         dim[0] = dim[1] = dim[2] = 0;
         current_dim[0] = current_dim[1] = 1;
 
-        if (size() == 0) 
+        if (size() == 0)
           return dim;
 
         const Image* first[] = { (*this)[0].get(), (*this)[0].get() };
@@ -37,10 +37,10 @@ namespace MR {
         for (size_t current_entry = 1; current_entry < size(); current_entry++) {
 
           if ((*this)[current_entry]->acq != first[1]->acq) {
-            if (dim[1] && dim[1] != current_dim[1]) 
+            if (dim[1] && dim[1] != current_dim[1])
               throw Exception ("mismatch between number of images along slice dimension");
 
-            if (dim[0] && dim[0] != current_dim[0]) 
+            if (dim[0] && dim[0] != current_dim[0])
               throw Exception ("mismatch between number of images along sequence dimension");
 
             first[0] = first[1] = (*this)[current_entry].get();
@@ -50,7 +50,7 @@ namespace MR {
             dim[2]++;
           }
           else if ((*this)[current_entry]->distance != first[0]->distance) {
-            if (dim[0] && dim[0] != current_dim[0]) 
+            if (dim[0] && dim[0] != current_dim[0])
               throw Exception ("mismatch between number of images along sequence dimension");
 
             first[0] = (*this)[current_entry].get();
@@ -61,10 +61,10 @@ namespace MR {
           else current_dim[0]++;
         }
 
-        if (dim[1] && dim[1] != current_dim[1]) 
+        if (dim[1] && dim[1] != current_dim[1])
           throw Exception ("mismatch between number of images along slice dimension");
 
-        if (dim[0] && dim[0] != current_dim[0]) 
+        if (dim[0] && dim[0] != current_dim[0])
           throw Exception ("mismatch between number of images along sequence dimension");
 
         dim[0] = current_dim[0];
@@ -81,16 +81,16 @@ namespace MR {
 
       std::ostream& operator<< (std::ostream& stream, const Series& item)
       {
-        stream << MR::printf ("      %4u - %4u %4s images %10s %8s %s [ %s ]\n", 
-              item.number, 
-              item.size(), 
+        stream << MR::printf ("      %4u - %4u %4s images %10s %8s %s [ %s ]\n",
+              item.number,
+              item.size(),
               ( item.modality.size() ? item.modality.c_str() : "(?)" ),
               format_date(item.date).c_str(),
               format_time(item.time).c_str(),
               item.name.c_str(),
               item.image_type.c_str() );
 
-        for (size_t n = 0; n < item.size(); n++) 
+        for (size_t n = 0; n < item.size(); n++)
           stream << *item[n];
 
         return stream;


### PR DESCRIPTION
A bunch of simple changes to prevent crashes when reading slightly malformed DICOM files with field present but left empty. 