### PR TITLE
dwiextract: Fix extraction based on total readout time

### DIFF
--- a/cmd/dwiextract.cpp
+++ b/cmd/dwiextract.cpp
@@ -106,10 +106,8 @@ void run()
         }
       }
       if (filter.size() == 4) {
-        if (abs (pe_scheme(i, 3) - filter[3]) > 5e-3) {
+        if (abs (pe_scheme(i, 3) - filter[3]) > 5e-3)
           keep = false;
-          break;
-        }
       }
       if (keep)
         new_volumes.push_back (i);


### PR DESCRIPTION
Fix to selection of DWI volumes where there are volumes with the same phase encoding direction but different readout times.

Thanks to @treanus for report, solution & test.