### PR TITLE
mrtrix3.image.statistic(): Fix parameter naming

### DIFF
--- a/lib/mrtrix3/_5ttgen/gif.py
+++ b/lib/mrtrix3/_5ttgen/gif.py
@@ -18,15 +18,13 @@ def checkGIFinput(image_path):
 
 
 def getInputs(): #pylint: disable=unused-variable
-  import os, shutil #pylint: disable=unused-variable
   from mrtrix3 import app, path, run
   checkGIFinput(path.fromUser(app.args.input, True))
   run.command('mrconvert ' + path.fromUser(app.args.input, True) + ' ' + path.toTemp('input.mif', True))
 
 
 def execute(): #pylint: disable=unused-variable
-  import os, sys #pylint: disable=unused-variable
-  from mrtrix3 import app, path, run #pylint: disable=unused-variable
+  from mrtrix3 import app, run #pylint: disable=unused-variable
 
   # Generate the images related to each tissue
   run.command('mrconvert input.mif -coord 3 1 CSF.mif')

--- a/lib/mrtrix3/_5ttgen/gif.py
+++ b/lib/mrtrix3/_5ttgen/gif.py
@@ -24,7 +24,7 @@ def getInputs(): #pylint: disable=unused-variable
 
 
 def execute(): #pylint: disable=unused-variable
-  from mrtrix3 import app, run #pylint: disable=unused-variable
+  from mrtrix3 import app, run
 
   # Generate the images related to each tissue
   run.command('mrconvert input.mif -coord 3 1 CSF.mif')

--- a/lib/mrtrix3/image.py
+++ b/lib/mrtrix3/image.py
@@ -197,5 +197,5 @@ def statistic(image_path, stat, options=''): #pylint: disable=unused-variable
   if app.verbosity > 1:
     app.console('Result: ' + result)
   if proc.returncode:
-    app.error('Error trying to calculate statistic \'' + statistic + '\' from image \'' + image_path + '\'')
+    app.error('Error trying to calculate statistic \'' + stat + '\' from image \'' + image_path + '\'')
   return result

--- a/run_pylint
+++ b/run_pylint
@@ -5,10 +5,21 @@ echo logging to \""$LOGFILE"\"
 
 cat > $LOGFILE <<EOD
 -------------------------------------------
+  Version information
+-------------------------------------------
+
+EOD
+
+eval ${forcepyversion} pylint --version >> $LOGFILE
+
+cat >> $LOGFILE <<EOD
+
+-------------------------------------------
   Testing MRtrix3 Python scripts
 -------------------------------------------
 
 EOD
+
 
 # generate list of tests to run:
 if [ $# == 0 ]; then

--- a/run_pylint
+++ b/run_pylint
@@ -3,24 +3,6 @@
 LOGFILE=pylint.log
 echo logging to \""$LOGFILE"\"
 
-cat > $LOGFILE <<EOD
--------------------------------------------
-  Version information
--------------------------------------------
-
-EOD
-
-eval ${forcepyversion} pylint --version >> $LOGFILE
-
-cat >> $LOGFILE <<EOD
-
--------------------------------------------
-  Testing MRtrix3 Python scripts
--------------------------------------------
-
-EOD
-
-
 # generate list of tests to run:
 if [ $# == 0 ]; then
   for lib_path in lib/mrtrix3/*; do
@@ -50,6 +32,26 @@ else
   echo "Using pylint for "${PYTHON}" (from PYTHON environment variable)"
   forcepyversion="$PYTHON -m "
 fi
+
+
+
+cat > $LOGFILE <<EOD
+-------------------------------------------
+  Version information
+-------------------------------------------
+
+EOD
+
+eval ${forcepyversion} pylint --version >> $LOGFILE
+
+cat >> $LOGFILE <<EOD
+
+-------------------------------------------
+  Testing MRtrix3 Python scripts
+-------------------------------------------
+
+EOD
+
 
 export PYTHONPATH="$(pwd)/lib:$PYTHONPATH"
 for file in $tests; do


### PR DESCRIPTION
`app.error()` call contained a reference to the function being invoked, rather than the parameter that was passed to the function.

Not hugely consequential given the script is throwing an error at that point anyway; but nevertheless preferable for a more appropriate error message than "`TypeError: must be str, not function`".

Observed on [forum](http://community.mrtrix.org/t/dwi2response-dhollander-script-meet-error/2054).