### PR TITLE
dwipreproc: Compatibility with FSL6.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ install:
   - |
     if [[ "${test}" == "build" || "${test}" == "run" ]]; then
         export EIGEN_CFLAGS=-I`pwd`/../eigen;
-        (cd ..; hg clone https://bitbucket.org/eigen/eigen/; cd eigen; hg update 3.3);
+        ( cd ..; git clone https://github.com/eigenteam/eigen-git-mirror.git eigen; cd eigen; git checkout branches/3.3 )
     fi
 before_script:
   #######################################################################################################################

--- a/bin/dwipreproc
+++ b/bin/dwipreproc
@@ -964,10 +964,20 @@ else:
   #   (even if this doesn't cause an issue with the subsequent mrcalc command, it may in the future, it's better for
   #   visualising the script temporary files, and it gives the user a warning about an out-of-date FSL)
   field_map_image = fsl.findImage('field_map')
-  if not image.match('topup_in.nii', field_map_image):
+  field_map_header = image.Header(field_map_image)
+  if not image.match('topup_in.nii', field_map_header, 3):
     app.warn('topup output field image has erroneous header; recommend updating FSL to version 5.0.8 or later')
     new_field_map_image = 'field_map_fix.mif'
     run.command('mrtransform ' + field_map_image + ' -replace topup_in.nii ' + new_field_map_image)
+    file.delTemporary(field_map_image)
+    field_map_image = new_field_map_image
+  # In FSL 6.0.0, field map image is erroneously constructed with the same number of volumes as the input image,
+  #   with all but the first volume containing intensity-scaled duplicates of the uncorrected input images
+  # The first volume is however the expected field offset image
+  elif len(field_map_header.size()) == 4:
+    app.console('Correcting erroneous FSL 6.0.0 field map image output')
+    new_field_map_image = 'field_map_fix.mif'
+    run.command('mrconvert ' + field_map_image + ' -coord 3 0 -axes 0,1,2 ' + new_field_map_image)
     file.delTemporary(field_map_image)
     field_map_image = new_field_map_image
   file.delTemporary('topup_in.nii')


### PR DESCRIPTION
My guess is that somewhere in the `topup` code, when provided with the `--fout` option to output the estimated field, it generates a deep copy of the input *b*=0 series, and then overwrites the contents of the first volume with the estimated field. However because they erroneously don't reduce the template image to 3 axes when generating said copy, the output "field map" image contains copies of all but the first input *b*=0 volume.

Would expect to be fixed reasonably quickly at their end, but need to catch and handle here nonetheless.

Closes #1493.