### PR TITLE
dwipreproc: Search PATH for 'eddy_cpu'

### DIFF
--- a/lib/mrtrix3/fsl.py
+++ b/lib/mrtrix3/fsl.py
@@ -58,9 +58,12 @@ def eddyBinary(cuda): #pylint: disable=unused-variable
       return exe_path
     app.debug('No CUDA version of eddy found')
     return ''
-  exe_path = 'eddy_openmp' if find_executable('eddy_openmp') else exeName('eddy')
-  app.debug(exe_path)
-  return exe_path
+  for candidate in [ 'eddy_openmp', 'eddy_cpu', 'eddy', 'fsl5.0-eddy' ]:
+    if find_executable(candidate):
+      app.debug(candidate)
+      return candidate
+  app.debug('No CPU version of eddy found')
+  return ''
 
 
 


### PR DESCRIPTION
In responding to [forum comment](http://community.mrtrix.org/t/dwipreproc-eddy-cuda-slspec-unable-to-open-file-multibandgroups/1573/26), discovered that on MacOSX, the non-CUDA version of `eddy` is called "`eddy_cpu`", not "`eddy_openmp`".