### PR TITLE
only include xmmintrin.h header if actually used

### DIFF
--- a/core/command.h
+++ b/core/command.h
@@ -17,7 +17,10 @@
 #define __command_h__
 
 
-#include <xmmintrin.h>
+#ifdef FLUSH_TO_ZERO
+# include <xmmintrin.h>
+#endif
+
 #include "app.h"
 #include "exec_version.h"
 #ifdef MRTRIX_PROJECT


### PR DESCRIPTION
This otherwise prevents compilation on non x86 platforms (see #1514)

This is a harmless change, no reason not to merge to `master`.