### PR TITLE
Recipe to build Singularity images for development

### DIFF
--- a/envs/Singularity.debian-dev-unstable-amd64
+++ b/envs/Singularity.debian-dev-unstable-amd64
@@ -1,0 +1,24 @@
+BootStrap: docker
+From: debian:unstable
+
+# so if image is executed we just enter the environment
+%runscript
+    echo "Welcome to the Debian unstable mrtrix3 dev env. (Architecture: amd64)"
+    echo "Just cd to your mrtrix3 sources or"
+    echo " git clone http://github.com/MRtrix3/mrtrix3"
+    /bin/bash
+
+
+%post
+    echo "Configuring the environment"
+    sed -e  's,^deb ,deb-src ,g' /etc/apt/sources.list > /etc/apt/sources.list.d/sources.list
+    apt-get update
+    apt-get -y install eatmydata
+    # just useful little tools
+    eatmydata apt-get -y install vim wget strace time ncdu gnupg curl procps netcat
+    eatmydata apt-get -y build-dep mrtrix3
+    # some external depends might have not been needed then
+    eatmydata apt-get -y install markdown html2text rapidjson-dev libboost-python-dev git clang valgrind lintian
+    chmod a+rX -R /etc/apt/sources.list.d
+    rm -rf /var/lib/apt/lists/*
+    apt-get clean

--- a/envs/Singularity.debian-dev-unstable-i386
+++ b/envs/Singularity.debian-dev-unstable-i386
@@ -1,0 +1,24 @@
+BootStrap: docker
+From: i386/debian:unstable
+
+# so if image is executed we just enter the environment
+%runscript
+    echo "Welcome to the Debian unstable mrtrix3 dev env. (Architecture: i386)"
+    echo "Just cd to your mrtrix3 sources or"
+    echo " git clone http://github.com/MRtrix3/mrtrix3"
+    /bin/bash
+
+
+%post
+    echo "Configuring the environment"
+    sed -e  's,^deb ,deb-src ,g' /etc/apt/sources.list > /etc/apt/sources.list.d/sources.list
+    apt-get update
+    apt-get -y install eatmydata
+    # just useful little tools
+    eatmydata apt-get -y install vim wget strace time ncdu gnupg curl procps netcat
+    eatmydata apt-get -y build-dep mrtrix3
+    # some external depends might have not been needed then
+    eatmydata apt-get -y install markdown html2text rapidjson-dev libboost-python-dev git clang valgrind lintian
+    chmod a+rX -R /etc/apt/sources.list.d
+    rm -rf /var/lib/apt/lists/*
+    apt-get clean

--- a/envs/populate.sh
+++ b/envs/populate.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# A rudimentary script to populate a set of Singularity files
+# for different development environments
+#
+set -eu
+
+for DEBRELEASE in unstable; do
+  for ARCH in amd64 i386; do
+     if [ $ARCH == amd64 ]; then
+         DOCKERARCHPREFIX=""  # it is the default one
+     else
+         DOCKERARCHPREFIX="$ARCH/"
+     fi
+     export DEBRELEASE ARCH DOCKERARCHPREFIX
+     eval "cat <<EOF
+$(cat "template.Singularity.debian-dev")
+EOF
+" >| Singularity.debian-dev-$DEBRELEASE-$ARCH
+  done
+done
+

--- a/envs/template.Singularity.debian-dev
+++ b/envs/template.Singularity.debian-dev
@@ -1,0 +1,24 @@
+BootStrap: docker
+From: ${DOCKERARCHPREFIX}debian:$DEBRELEASE
+
+# so if image is executed we just enter the environment
+%runscript
+    echo "Welcome to the Debian $DEBRELEASE mrtrix3 dev env. (Architecture: $ARCH)"
+    echo "Just cd to your mrtrix3 sources or"
+    echo " git clone http://github.com/MRtrix3/mrtrix3"
+    /bin/bash
+
+
+%post
+    echo "Configuring the environment"
+    sed -e  's,^deb ,deb-src ,g' /etc/apt/sources.list > /etc/apt/sources.list.d/sources.list
+    apt-get update
+    apt-get -y install eatmydata
+    # just useful little tools
+    eatmydata apt-get -y install vim wget strace time ncdu gnupg curl procps netcat
+    eatmydata apt-get -y build-dep mrtrix3
+    # some external depends might have not been needed then
+    eatmydata apt-get -y install markdown html2text rapidjson-dev libboost-python-dev git clang valgrind lintian
+    chmod a+rX -R /etc/apt/sources.list.d
+    rm -rf /var/lib/apt/lists/*
+    apt-get clean


### PR DESCRIPTION
To build an image locally (I guess a Debian system would be needed):

     cd envs
     sudo singularity build debian-dev-unstable-i386.simg Singularity.debian-dev-unstable-i386

and then just enter that environment by running `./debian-dev-unstable-i386.simg` or using `singularity run debian-dev-unstable-i386.simg` and then do you regular actions, e.g. here is an example run within demonstrating build issue #1517 

<details>
<summary>Build attempt within i386 singularity (click to expand)</summary>

```shell
hopa(debian-dev-unstable-i386.simg):~/deb/gits/pkg-exppsy/mrtrix3
$> ./configure -nooptim

MRtrix build type requested: release version with nooptim

Detecting OS: linux
Looking for compiler [clang++]: clang version 7.0.1-1 (tags/RELEASE_701/final)
Checking for C++11 compliance: ok
Checking shared library generation: ok
Detecting pointer size: 32 bit
Detecting byte order: little-endian
Checking for variable-length array support: ok
Checking for non-POD variable-length array support: ok
Checking for ::max_align_t: 8 bytes
Checking for std::max_align_t: 8 bytes
Checking for Eigen3 library: 3.3.5
Checking for zlib compression library: 1.2.11
Checking for "JSON for Modern C++" requirements: ok
Checking for TIFF library: not found - TIFF support disabled
Checking for FFTW library: fftw-3.3.8-sse2-avx
Checking for Qt moc: moc (version 4.8.7)
Checking for Qt qmake: qmake (version 4.8.7)
Checking for Qt rcc: rcc (version 4.8.7)
Checking for Qt: 4.8.7

writing configuration to file './config': ok

$> python build 
(  1/505) [CC] tmp/cmd/labelconvert.o
(  3/505) [CC] tmp/src/dwi/directions/file.o
(  2/505) [CC] tmp/src/dwi/tractography/tracking/method.o
(  4/505) [MOC] tmp/src/gui/opengl/lighting_moc.cpp
(  5/505) [CC] tmp/cmd/mrcalc.o
(  6/505) [CC] tmp/core/version.o
(  7/505) [CC] tmp/src/gui/projection.o
(  8/505) [CC] tmp/cmd/mrdump.o
(  9/505) [CC] tmp/core/file/dicom/tree.o
ERROR: (  7/505) [CC] tmp/src/gui/projection.o
sh: 1: /bin/zsh: not found

ERROR: (  7/505) [CC] tmp/src/gui/projection.o

clang++ -c -std=c++11 -DMRTRIX_BUILD_TYPE="release version with nooptim" -pthread -fPIC -DEIGEN_FFTW_DEFAULT -Wall -O0 -DNDEBUG -Isrc -I./core -Icmd -isystem /usr/include/eigen3 -DEIGEN_DONT_PARALLELIZE -pipe -Wall -W -D_REENTRANT -DQT_NO_DEBUG -DQT_SVG_LIB -DQT_OPENGL_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_SHARED -isystem /usr/share/qt4/mkspecs/linux-g++ -isystem /usr/include/qt4/QtCore -isystem /usr/include/qt4/QtGui -isystem /usr/include/qt4/QtOpenGL -isystem /usr/include/qt4/QtSvg -isystem /usr/include/qt4 -isystem /usr/X11R6/include src/gui/projection.cpp -o tmp/src/gui/projection.o

failed with output

In file included from src/gui/projection.cpp:16:
In file included from src/gui/projection.h:19:
In file included from src/gui/opengl/gl.h:29:
src/gui/opengl/gl_core_3_3.h:151:9: error: typedef redefinition with different types ('ptrdiff_t' (aka 'int') vs 'khronos_intptr_t' (aka 'long'))
                using GLintptr = ptrdiff_t;
                      ^
/usr/include/GL/glext.h:469:26: note: previous definition is here
typedef khronos_intptr_t GLintptr;
                         ^
In file included from src/gui/projection.cpp:16:
In file included from src/gui/projection.h:19:
In file included from src/gui/opengl/gl.h:29:
src/gui/opengl/gl_core_3_3.h:152:9: error: typedef redefinition with different types ('ptrdiff_t' (aka 'int') vs 'khronos_ssize_t' (aka 'long'))
                using GLsizeiptr = ptrdiff_t;
                      ^
/usr/include/GL/glext.h:468:25: note: previous definition is here
typedef khronos_ssize_t GLsizeiptr;
                        ^
2 errors generated.
(git)/home/yoh/deb/gits/pkg-exppsy/mrtrix3:[master]

```
</details>

I have tried to record [screencast](http://www.onerussian.com/tmp/screencast-singularity-mrtrix3-beginning.web) where I was enabling build on singularity hub but it was cut for some reason, at least it would give you the idea at the beginning how to enable it when you merge it into master. (in mycase it was trickier since I had to enable the build of the feature branch).  Anyways -- now the build is complete so you could also grab a test image from my branch on singularity hub:
https://www.singularity-hub.org/collections/2013
by getting it using `singularity pull shub://yarikoptic/mrtrix3:debian-dev-unstable-i386`
and running it `./yarikoptic-mrtrix3-enh-sing-debian-dev-unstable-i386.simg`
