### PR TITLE
dwiintensitynorm: Fix bug introduced in #1389

### DIFF
--- a/bin/dwiintensitynorm
+++ b/bin/dwiintensitynorm
@@ -103,7 +103,8 @@ progress = app.progressBar('Intensity normalising subject images', len(input_lis
 file.makeDir('wm_mask_warped')
 for i in input_list:
   run.command('mrtransform template_wm_mask.mif -interp nearest -warp_full ' + os.path.join('population_template', 'warps', i.prefix + '.mif') + ' ' + os.path.join('wm_mask_warped', i.prefix + '.mif') + ' -from 2 -template ' + os.path.join('fa', i.prefix + '.mif'))
-  run.command('dwinormalise ' + abspath(i.directory, i.filename) + ' ' + os.path.join('wm_mask_warped', i.prefix + '.mif') + ' ' + path.fromUser(os.path.join(app.args.output_dir, i.filename), True) + app.mrconvertOutputOption(path.fromUser(os.path.join(inputDir, i.filename), True)))
+  run.command('dwinormalise ' + abspath(i.directory, i.filename) + ' ' + os.path.join('wm_mask_warped', i.prefix + '.mif') + ' - | ' + \
+              'mrconvert - ' + path.fromUser(os.path.join(app.args.output_dir, i.filename), True) + app.mrconvertOutputOption(path.fromUser(os.path.join(inputDir, i.filename), True)))
   progress.increment()
 progress.done()
 


### PR DESCRIPTION
Function `app.mrconvertOutputOption()` can only be applied when `run.command()` is calling `mrconvert`; the command-line options it exploits are not present in other binaries.