### PR TITLE
Build remove outdated bin

### DIFF
--- a/build
+++ b/build
@@ -246,7 +246,32 @@ def get_real_name (path):
   return path
 
 
+def _get_expected_bin_filenames (exe_suffix, cmd_directory=cmd_dir):
+  binary_apps = set()
+  for entry in os.listdir(cmd_directory):
+    if entry.endswith(cpp_suffix):
+      binary_apps.add (entry[:-len(cpp_suffix)] + exe_suffix)
+  return binary_apps
 
+
+def list_expected_bin_files (exe_suffix, cmd_directory=cmd_dir, bin_directory=bin_dir):
+  bin_files = []
+  binary_apps = _get_expected_bin_filenames(exe_suffix, cmd_directory=cmd_directory)
+  for app in sorted(binary_apps):
+    if os.path.isfile(os.path.join(bin_directory, app)):
+      bin_files.append(os.path.join(bin_directory, app))
+  return bin_files
+
+
+def list_unexpected_bin_files (exe_suffix, cmd_directory=cmd_dir, bin_directory=bin_dir):
+  unexpected = []
+  if os.path.isdir(bin_directory):
+    binary_apps = _get_expected_bin_filenames(exe_suffix, cmd_directory=cmd_directory)
+    for filename in sorted(os.listdir(bin_directory)):
+      filepath = os.path.normpath(os.path.join(bin_directory, filename))
+      if os.path.isfile(filepath) and filename not in binary_apps and not is_likely_text(filepath):
+        unexpected.append(filepath)
+  return unexpected
 
 
 def list_untracked_bin_files (directory = '.'):
@@ -257,8 +282,8 @@ def list_untracked_bin_files (directory = '.'):
   return []
 
 
-def has_shebang(filename, nbytes=1024):
-  """try to detect if file has a shebang
+def is_likely_text(filename, nbytes=1024):
+  """ detects if file has a shebang or is utf-8 encoded, empty file is deemed non-text
   :arg filename
   :arg nbytes sample size to analyse
   """
@@ -270,15 +295,16 @@ def has_shebang(filename, nbytes=1024):
     log('could not read file ' + filename + '\n' + str(e) + '\n')
 
   if chunk:
-    line = chunk.split(b'\n', 1)[0]
-    try:
-      line = str(line.decode('utf-8'))
-    except UnicodeDecodeError:
-      return False
-    line = line.strip()
-    if len(line) > 2 and line[0:2] == '#!':
-      log('has_shebang: ' + filename + ' line: ' + line + '\n')
+    if chunk.startswith(b'\x23\x21'):  # starts with shebang '#!'
+      log('is_likely_text: ' + filename + ': starts with shebang \n')
       return True
+
+    try:
+      chunk.decode('utf-8')
+      log('is_likely_text: ' + filename + 'utf-8 encoded \n')
+      return True
+    except UnicodeDecodeError:
+      pass
   return False
 
 
@@ -479,6 +505,48 @@ activate_build (active_config_core, mrtrix_dir)
 
 
 
+############################################################################
+#                          LOAD CONFIGURATION FILE                         #
+############################################################################
+
+if config_file is None:
+  config_file = os.path.normpath (os.path.join (mrtrix_dir[-1], 'config'))
+
+# prevent pylint from generating a huge number of undefined variable / non-iterable warnings
+PATH = obj_suffix = exe_suffix = lib_prefix = lib_suffix = \
+cpp = ld = runpath = ld_enabled = ld_lib = moc = rcc = nogui = None
+cpp_flags = ld_flags = ld_lib_flags = eigen_cflags = qt_cflags = qt_ldflags = [ ]
+
+try:
+  log ('reading configuration from "' + config_file + '"...' + os.linesep)
+  exec (codecs.open (config_file, mode='r', encoding='utf-8').read()) # pylint: disable=exec-used
+except IOError:
+  fail ('''no configuration file found!
+please run "./configure" prior to invoking this script
+
+''')
+
+if separate_project:
+  cpp_flags += [ '-DMRTRIX_PROJECT' ]
+
+environ = os.environ.copy()
+environ.update ({ 'PATH': PATH })
+
+target_bin_dir = os.path.join (mrtrix_dir[0], bin_dir)
+purged_bin_dir = os.path.join (target_bin_dir, 'purged_files')
+
+system = platform.system().lower()
+if system.startswith('mingw') or system.startswith('msys'):
+  target_lib_dir = os.path.join (mrtrix_dir[-1], bin_dir)
+else:
+  target_lib_dir = os.path.join (mrtrix_dir[-1], 'lib')
+lib_dir = os.path.join (mrtrix_dir[-1], lib_dir)
+
+if ld_enabled and runpath:
+  ld_flags += [ runpath+os.path.relpath (target_lib_dir,target_bin_dir) ]
+
+
+
 
 ############################################################################
 #                            BUILD CLEAN                                   #
@@ -510,12 +578,24 @@ if 'clean' in targets:
     except OSError as excp:
       disp ('error deleting folder "' + f + '": ' + os.strerror (excp.errno))
 
-  for filename in list_untracked_bin_files():
+  for filename in list_expected_bin_files(exe_suffix):
     disp ('delete file: ' + filename + '\n')
     try:
       os.remove (filename)
     except OSError as excp:
       disp ('error deleting file "' + filename + '": ' + os.strerror (excp.errno))
+
+  for filepath in list_unexpected_bin_files(exe_suffix):
+    if not os.path.exists(purged_bin_dir):
+      os.makedirs(purged_bin_dir)
+    move_to = os.path.join(purged_bin_dir, os.path.split(filepath)[1])
+    while os.path.isfile(move_to):
+      move_to = move_to + '_'
+    disp ('WARNING: moving unexpected file ' + filepath + ' to ' + move_to + '\n')
+    try:
+      shutil.move(filepath, move_to)
+    except OSError as excp:
+      disp ('error moving file "' + filepath + '": ' + os.strerror (excp.errno))
 
   for filename in glob.glob (os.path.join ('lib', 'libmrtrix*')):
     if os.path.isfile (filename):
@@ -526,51 +606,6 @@ if 'clean' in targets:
         disp ('error deleting file "' + filename + '": ' + os.strerror (excp.errno))
 
   sys.exit (0)
-
-
-
-
-
-
-############################################################################
-#                          LOAD CONFIGURATION FILE                         #
-############################################################################
-
-if config_file is None:
-  config_file = os.path.normpath (os.path.join (mrtrix_dir[-1], 'config'))
-
-# prevent pylint from generating a huge number of undefined variable / non-iterable warnings
-PATH = obj_suffix = exe_suffix = lib_prefix = lib_suffix = \
-cpp = ld = runpath = ld_enabled = ld_lib = moc = rcc = nogui = None
-cpp_flags = ld_flags = ld_lib_flags = eigen_cflags = qt_cflags = qt_ldflags = [ ]
-
-try:
-  log ('reading configuration from "' + config_file + '"...' + os.linesep)
-  exec (codecs.open (config_file, mode='r', encoding='utf-8').read()) # pylint: disable=exec-used
-except IOError:
-  fail ('''no configuration file found!
-please run "./configure" prior to invoking this script
-
-''')
-
-if separate_project:
-  cpp_flags += [ '-DMRTRIX_PROJECT' ]
-
-environ = os.environ.copy()
-environ.update ({ 'PATH': PATH })
-
-target_bin_dir = os.path.join (mrtrix_dir[0], bin_dir)
-
-system = platform.system().lower()
-if system.startswith('mingw') or system.startswith('msys'):
-  target_lib_dir = os.path.join (mrtrix_dir[-1], bin_dir)
-else:
-  target_lib_dir = os.path.join (mrtrix_dir[-1], 'lib')
-lib_dir = os.path.join (mrtrix_dir[-1], lib_dir)
-
-if ld_enabled and runpath:
-  ld_flags += [ runpath+os.path.relpath (target_lib_dir,target_bin_dir) ]
-
 
 
 
@@ -606,18 +641,18 @@ for entry in glob.glob (os.path.normpath (os.path.join (target_lib_dir, '*' + li
     disp ('WARNING: removing "' + entry + '" - most likely left over from a previous installation\n')
     os.remove (entry)
 
-# in the target bin directory:
-if os.path.isdir(target_bin_dir):
-  binary_apps = set()
-  for entry in os.listdir (cmd_dir):
-    if entry.endswith(cpp_suffix):
-      binary_apps.add (os.path.normpath (os.path.join (target_bin_dir, entry[:-len(cpp_suffix)] + exe_suffix)))
-  for filename in sorted(os.listdir(target_bin_dir)):
-    possible_binary = os.path.normpath(os.path.join(target_bin_dir, filename))
-    if possible_binary not in binary_apps:
-      if not has_shebang(possible_binary):
-        disp ('WARNING: removing orphaned non-script lacking a corresponding ' + cpp_suffix + ' file: ' + possible_binary + '\n')
-        os.remove(possible_binary)
+# move unexpected binary files out of the target bin directory:
+for filepath in list_unexpected_bin_files(exe_suffix):
+  if not os.path.exists(purged_bin_dir):
+    os.makedirs(purged_bin_dir)
+  move_to = os.path.join(purged_bin_dir, os.path.split(filepath)[1])
+  while os.path.isfile(move_to):
+    move_to = move_to + '_'
+  disp ('WARNING: moving unexpected binary file ' + filepath + ' to ' + move_to + '\n')
+  try:
+    shutil.move(filepath, move_to)
+  except OSError as excp:
+    disp ('error moving file "' + filepath + '": ' + os.strerror (excp.errno))
 
 
 ###########################################################################

--- a/build
+++ b/build
@@ -257,6 +257,75 @@ def list_untracked_bin_files (directory = '.'):
   return []
 
 
+def is_binary_file(filename, nbytes=1024, check_encoding=True):
+  """try to detect if file is binary
+  :arg filename
+  :arg nbytes sample size to analyse
+  :arg check_encoding if file seems binary, check if non-ascii encoding seems likely. Might yield false negatives.
+  A file is deemed binary if it starts with a high ratio of ASCII control characters and low ratio of high ASCII
+  characters, or alternatively if it consists of high proportions of high and low characters.
+  The default is non-binary if the file is empty or not readable.
+  heavily inspired by https://github.com/audreyr/binaryornot
+  """
+
+  try:
+    with open(filename, 'rb') as f:
+      chunk = f.read(nbytes)
+  except IOError as e:
+    log('could not read file ' + filename + '\n' + str(e))
+    return False
+
+  if not chunk:
+    return False
+
+  _control_chars = b'\n\r\t\f\b'
+  ints2byte = (lambda x: bytes(x)) if sys.version_info[0] == 3 else (lambda x: b''.join(map(chr, x)))
+
+  printable_ascii = _control_chars + ints2byte(range(32, 127))
+  printable_high_ascii = ints2byte(range(127, 256))
+
+  lo_ratio = float(len(chunk.translate(None, printable_ascii))) / float(len(chunk))
+  hi_ratio = float(len(chunk.translate(None, printable_high_ascii))) / float(len(chunk))
+
+  binary_encoding = (lo_ratio > 0.3 and hi_ratio < 0.05) \
+                    or (lo_ratio > 0.5 and hi_ratio > 0.5)  # changed both from 0.8 to 0.5 due to false negatives
+  if not binary_encoding:
+    log('is_binary_file: ' + filename + ' ' + str(binary_encoding) + ' lo:%.3f hi:%.3f' % (lo_ratio, hi_ratio) + '\n')
+    return False
+
+  # check if file has detectable encoding
+  if check_encoding:
+    import chardet
+    encoding = chardet.detect(chunk)
+    if encoding['confidence'] > 0.95 and encoding['encoding'] != 'ascii':
+      log('is_binary_file: ' + filename + ' False. encoding: ' +
+          encoding['encoding'] + ' confidence ' + str(encoding['confidence']) + '\n')
+      return False
+
+    # check if file is possibly UTF encoded
+    if b'\x00' in chunk:
+      with open(filename, 'rb') as f:
+        try:
+          fcontent = f.read()
+        except IOError as e:
+          log('could not read file ' + filename + '\n' + str(e))
+          return False
+      try:
+        fcontent.decode('utf-8')
+        log('is_binary_file: ' + filename + ' False. utf-8\n')
+        return False
+      except UnicodeDecodeError:
+        pass
+      try:
+        fcontent.decode('utf-16')
+        log('is_binary_file: ' + filename + ' False. utf-16\n')
+        return False
+      except UnicodeDecodeError:
+        pass
+
+  return True
+
+
 
 
 def modify_path (name, tmp=False, strip=None, add=None):
@@ -274,6 +343,7 @@ def modify_path (name, tmp=False, strip=None, add=None):
       relname = os.sep.join (split_path (relname)[1:])
     name = os.path.normpath (os.path.join (project_dir, relname))
     return name
+
 
 
 
@@ -507,7 +577,6 @@ if 'clean' in targets:
 
 
 
-
 ############################################################################
 #                          LOAD CONFIGURATION FILE                         #
 ############################################################################
@@ -581,6 +650,18 @@ for entry in glob.glob (os.path.normpath (os.path.join (target_lib_dir, '*' + li
   if os.path.basename (entry) != libname:
     disp ('WARNING: removing "' + entry + '" - most likely left over from a previous installation\n')
     os.remove (entry)
+
+# in the target bin directory:
+binary_apps = set()
+for entry in os.listdir (cmd_dir):
+  if entry.endswith(cpp_suffix):
+    binary_apps.add (os.path.normpath (os.path.join (target_bin_dir, entry[:-len(cpp_suffix)] + exe_suffix)))
+for filename in sorted(os.listdir(target_bin_dir)):
+  possible_binary = os.path.normpath(os.path.join(target_bin_dir, filename))
+  if possible_binary not in binary_apps:
+    if is_binary_file(possible_binary):
+      disp ('WARNING: removing orphaned binary lacking a corresponding ' + cpp_suffix + ' file: ' + possible_binary + '\n')
+      os.remove(possible_binary)
 
 
 ###########################################################################

--- a/build
+++ b/build
@@ -257,71 +257,30 @@ def list_untracked_bin_files (directory = '.'):
   return []
 
 
-def is_binary_file(filename, nbytes=1024, check_encoding=True):
-  """try to detect if file is binary
+def has_shebang(filename, nbytes=1024):
+  """try to detect if file has a shebang
   :arg filename
   :arg nbytes sample size to analyse
-  :arg check_encoding if file seems binary, check if non-ascii encoding seems likely. Might yield false negatives.
-  A file is deemed binary if it starts with a high ratio of ASCII control characters and low ratio of high ASCII
-  characters, or alternatively if it consists of high proportions of high and low characters.
-  The default is non-binary if the file is empty or not readable.
-  heavily inspired by https://github.com/audreyr/binaryornot
   """
-
   chunk = b''
   try:
     with open(filename, 'rb') as f:
       chunk = f.read(nbytes)
   except IOError as e:
-    log('could not read file ' + filename + '\n' + str(e))
+    log('could not read file ' + filename + '\n' + str(e) + '\n')
 
-  if not chunk:
-    return False
+  if chunk:
+    line = chunk.split(b'\n', 1)[0]
+    try:
+      line = str(line.decode('utf-8'))
+    except UnicodeDecodeError:
+      return False
+    line = line.strip()
+    if len(line) > 2 and line[0:2] == '#!':
+      log('has_shebang: ' + filename + ' line: ' + line + '\n')
+      return True
+  return False
 
-  _control_chars = b'\n\r\t\f\b'
-  ints2byte = bytes if sys.version_info[0] == 3 else (lambda x: b''.join(map(chr, x)))
-
-  printable_ascii = _control_chars + ints2byte(range(32, 127))
-  printable_high_ascii = ints2byte(range(127, 256))
-
-  lo_ratio = float(len(chunk.translate(None, printable_ascii))) / float(len(chunk))
-  hi_ratio = float(len(chunk.translate(None, printable_high_ascii))) / float(len(chunk))
-
-  binary_encoding = (lo_ratio > 0.3 and hi_ratio < 0.05) \
-                    or (lo_ratio > 0.5 and hi_ratio > 0.5)  # changed both from 0.8 to 0.5 due to false negatives
-  if not binary_encoding:
-    log('is_binary_file: ' + filename + ' ' + str(binary_encoding) + ' lo:%.3f hi:%.3f' % (lo_ratio, hi_ratio) + '\n')
-    binary_encoding = False
-
-  # check if file has detectable encoding
-  if binary_encoding and check_encoding:
-    import chardet
-    encoding = chardet.detect(chunk)
-    if encoding['confidence'] > 0.95 and encoding['encoding'] != 'ascii':
-      log('is_binary_file: ' + filename + ' False. encoding: ' +
-          encoding['encoding'] + ' confidence ' + str(encoding['confidence']) + '\n')
-      binary_encoding = False
-
-    # check if file is UTF encoded
-    if binary_encoding and b'\x00' in chunk:
-      with open(filename, 'rb') as f:
-        try:
-          fcontent = f.read()
-        except IOError as e:
-          log('could not read file ' + filename + '\n' + str(e))
-          binary_encoding = False
-
-      for enc in ['utf-8', 'utf-16']:
-        if binary_encoding:
-          try:
-            fcontent.decode(enc)
-            log('is_binary_file: ' + filename + ' False. '+enc+'\n')
-            binary_encoding = False
-            break
-          except UnicodeDecodeError:
-            pass
-
-  return binary_encoding
 
 
 def modify_path (name, tmp=False, strip=None, add=None):
@@ -656,8 +615,8 @@ if os.path.isdir(target_bin_dir):
   for filename in sorted(os.listdir(target_bin_dir)):
     possible_binary = os.path.normpath(os.path.join(target_bin_dir, filename))
     if possible_binary not in binary_apps:
-      if is_binary_file(possible_binary):
-        disp ('WARNING: removing orphaned binary lacking a corresponding ' + cpp_suffix + ' file: ' + possible_binary + '\n')
+      if not has_shebang(possible_binary):
+        disp ('WARNING: removing orphaned non-script lacking a corresponding ' + cpp_suffix + ' file: ' + possible_binary + '\n')
         os.remove(possible_binary)
 
 

--- a/build
+++ b/build
@@ -247,7 +247,7 @@ def get_real_name (path):
 
 
 def _get_expected_bin_filenames (exe_suffix, cmd_directory=cmd_dir):
-  binary_apps = set()
+  binary_apps = { 'mrtrix.dll' } if exe_suffix else { }
   for entry in os.listdir(cmd_directory):
     if entry.endswith(cpp_suffix):
       binary_apps.add (entry[:-len(cpp_suffix)] + exe_suffix)

--- a/build
+++ b/build
@@ -247,7 +247,7 @@ def get_real_name (path):
 
 
 def _get_expected_bin_filenames (exe_suffix, cmd_directory=cmd_dir):
-  binary_apps = { 'mrtrix.dll' } if exe_suffix else { }
+  binary_apps = { 'mrtrix.dll' } if exe_suffix else set()
   for entry in os.listdir(cmd_directory):
     if entry.endswith(cpp_suffix):
       binary_apps.add (entry[:-len(cpp_suffix)] + exe_suffix)

--- a/build
+++ b/build
@@ -268,18 +268,18 @@ def is_binary_file(filename, nbytes=1024, check_encoding=True):
   heavily inspired by https://github.com/audreyr/binaryornot
   """
 
+  chunk = b''
   try:
     with open(filename, 'rb') as f:
       chunk = f.read(nbytes)
   except IOError as e:
     log('could not read file ' + filename + '\n' + str(e))
-    return False
 
   if not chunk:
     return False
 
   _control_chars = b'\n\r\t\f\b'
-  ints2byte = (lambda x: bytes(x)) if sys.version_info[0] == 3 else (lambda x: b''.join(map(chr, x)))
+  ints2byte = bytes if sys.version_info[0] == 3 else (lambda x: b''.join(map(chr, x)))
 
   printable_ascii = _control_chars + ints2byte(range(32, 127))
   printable_high_ascii = ints2byte(range(127, 256))
@@ -291,41 +291,37 @@ def is_binary_file(filename, nbytes=1024, check_encoding=True):
                     or (lo_ratio > 0.5 and hi_ratio > 0.5)  # changed both from 0.8 to 0.5 due to false negatives
   if not binary_encoding:
     log('is_binary_file: ' + filename + ' ' + str(binary_encoding) + ' lo:%.3f hi:%.3f' % (lo_ratio, hi_ratio) + '\n')
-    return False
+    binary_encoding = False
 
   # check if file has detectable encoding
-  if check_encoding:
+  if binary_encoding and check_encoding:
     import chardet
     encoding = chardet.detect(chunk)
     if encoding['confidence'] > 0.95 and encoding['encoding'] != 'ascii':
       log('is_binary_file: ' + filename + ' False. encoding: ' +
           encoding['encoding'] + ' confidence ' + str(encoding['confidence']) + '\n')
-      return False
+      binary_encoding = False
 
-    # check if file is possibly UTF encoded
-    if b'\x00' in chunk:
+    # check if file is UTF encoded
+    if binary_encoding and b'\x00' in chunk:
       with open(filename, 'rb') as f:
         try:
           fcontent = f.read()
         except IOError as e:
           log('could not read file ' + filename + '\n' + str(e))
-          return False
-      try:
-        fcontent.decode('utf-8')
-        log('is_binary_file: ' + filename + ' False. utf-8\n')
-        return False
-      except UnicodeDecodeError:
-        pass
-      try:
-        fcontent.decode('utf-16')
-        log('is_binary_file: ' + filename + ' False. utf-16\n')
-        return False
-      except UnicodeDecodeError:
-        pass
+          binary_encoding = False
 
-  return True
+      for enc in ['utf-8', 'utf-16']:
+        if binary_encoding:
+          try:
+            fcontent.decode(enc)
+            log('is_binary_file: ' + filename + ' False. '+enc+'\n')
+            binary_encoding = False
+            break
+          except UnicodeDecodeError:
+            pass
 
-
+  return binary_encoding
 
 
 def modify_path (name, tmp=False, strip=None, add=None):
@@ -652,16 +648,17 @@ for entry in glob.glob (os.path.normpath (os.path.join (target_lib_dir, '*' + li
     os.remove (entry)
 
 # in the target bin directory:
-binary_apps = set()
-for entry in os.listdir (cmd_dir):
-  if entry.endswith(cpp_suffix):
-    binary_apps.add (os.path.normpath (os.path.join (target_bin_dir, entry[:-len(cpp_suffix)] + exe_suffix)))
-for filename in sorted(os.listdir(target_bin_dir)):
-  possible_binary = os.path.normpath(os.path.join(target_bin_dir, filename))
-  if possible_binary not in binary_apps:
-    if is_binary_file(possible_binary):
-      disp ('WARNING: removing orphaned binary lacking a corresponding ' + cpp_suffix + ' file: ' + possible_binary + '\n')
-      os.remove(possible_binary)
+if os.path.isdir(target_bin_dir):
+  binary_apps = set()
+  for entry in os.listdir (cmd_dir):
+    if entry.endswith(cpp_suffix):
+      binary_apps.add (os.path.normpath (os.path.join (target_bin_dir, entry[:-len(cpp_suffix)] + exe_suffix)))
+  for filename in sorted(os.listdir(target_bin_dir)):
+    possible_binary = os.path.normpath(os.path.join(target_bin_dir, filename))
+    if possible_binary not in binary_apps:
+      if is_binary_file(possible_binary):
+        disp ('WARNING: removing orphaned binary lacking a corresponding ' + cpp_suffix + ' file: ' + possible_binary + '\n')
+        os.remove(possible_binary)
 
 
 ###########################################################################


### PR DESCRIPTION
Addresses #1042: remove binary files in the target bin folder if no corresponding `.cpp` file can be found. The check whether a file is binary should be conservative but `check_encoding` makes it a rather expensive operation and could be relaxed if need be.

Removal is triggered for every build, irrespective of the build target.