### PR TITLE
Prevent deep multi-threading

### DIFF
--- a/core/algo/random_threaded_loop.h
+++ b/core/algo/random_threaded_loop.h
@@ -147,7 +147,7 @@ namespace MR
         template <class Functor>
           void run_outer (Functor&& functor, const double voxel_density, const vector<size_t>& dimensions)
           {
-            if (Thread::number_of_threads() == 0) {
+            if (Thread::threads_to_execute() == 0) {
               for (auto i = outer_loop (iterator); i; ++i){
                 // std::cerr << "outer: " << str(iterator) << " " << voxel_density << " " << dimensions << std::endl;
                 functor (iterator);

--- a/core/algo/stochastic_threaded_loop.h
+++ b/core/algo/stochastic_threaded_loop.h
@@ -107,7 +107,7 @@ namespace MR
         template <class Functor>
           void run_outer (Functor&& functor, const double voxel_density)
           {
-            if (Thread::number_of_threads() == 0) {
+            if (Thread::threads_to_execute() == 0) {
               for (auto i = outer_loop (iterator); i; ++i){
                 // std::cerr << "outer: " << str(iterator) << " " << voxel_density << std::endl;
                 functor (iterator);

--- a/core/algo/threaded_loop.h
+++ b/core/algo/threaded_loop.h
@@ -314,7 +314,7 @@ namespace MR
         template <class Functor>
           void run_outer (Functor&& functor)
           {
-            if (Thread::number_of_threads() == 0) {
+            if (Thread::threads_to_execute() == 0) {
               for (auto i = outer_loop (iterator); i; ++i)
                 functor (iterator);
               return;

--- a/core/thread.cpp
+++ b/core/thread.cpp
@@ -34,9 +34,7 @@ namespace MR
 
     }
 
-    //CONF option: NumberOfThreads
-    //CONF default: number of threads provided by hardware
-    //CONF Set the default number of CPU threads to use for multi-threading.
+
 
     size_t number_of_threads ()
     {
@@ -62,6 +60,9 @@ namespace MR
         return __number_of_threads;
       }
 
+      //CONF option: NumberOfThreads
+      //CONF default: number of threads provided by hardware
+      //CONF Set the default number of CPU threads to use for multi-threading.
       if (File::Config::get ("NumberOfThreads").size()) {
         const int i = File::Config::get_int ("NumberOfThreads", -1);
         if (i >= 0) {
@@ -79,6 +80,12 @@ namespace MR
     nthreads_t type_nthreads()
     {
       return __nthreads_type;
+    }
+
+
+    size_t threads_to_execute()
+    {
+      return (__Backend::valid() ? 0 : number_of_threads());
     }
 
 

--- a/core/thread.h
+++ b/core/thread.h
@@ -78,6 +78,8 @@ namespace MR
           }
         }
 
+        static bool valid() { return backend; }
+
         static void thread_print_func (const std::string& msg);
         static void thread_report_to_user_func (const std::string& msg, int type);
 
@@ -238,7 +240,7 @@ namespace MR
      *
      * @{ */
 
-    /*! the number of cores to use for multi-threading, as specified in the
+    /*! the number of cores available for multi-threading, as specified in the
      * variable NumberOfThreads in the MRtrix configuration file, or set using
      * the -nthreads command-line option */
     size_t number_of_threads ();
@@ -250,18 +252,25 @@ namespace MR
     enum class nthreads_t { UNINITIALISED, EXPLICIT, IMPLICIT };
     nthreads_t type_nthreads ();
 
+    /*! the number of threads to execute for a particular task
+     * if some higher-level process has already executed multiple threads,
+     * do not want the lower-level process querying this function to also
+     * generate a large number of threads; instead the lower-level function
+     * should run explicitly single-threaded. */
+    size_t threads_to_execute ();
+
 
 
     //! used to request multiple threads of the corresponding functor
     /*! This function is used in combination with Thread::run or
      * Thread::run_queue to request that the functor \a object be run in
      * parallel using \a number threads of execution (defaults to
-     * Thread::number_of_threads()).
+     * Thread::threads_to_execute()).
      * \sa Thread::run()
      * \sa Thread::run_queue() */
     template <class Functor>
       inline __Multi<typename std::remove_reference<Functor>::type>
-      multi (Functor&& functor, size_t nthreads = number_of_threads())
+      multi (Functor&& functor, size_t nthreads = threads_to_execute())
       {
         return { functor, nthreads };
       }

--- a/core/thread_queue.h
+++ b/core/thread_queue.h
@@ -1016,7 +1016,7 @@ namespace MR
           Sink&& sink,
           size_t capacity = MRTRIX_QUEUE_DEFAULT_CAPACITY)
       {
-        if (number_of_threads() == 0) {
+        if (threads_to_execute() == 0) {
           typename __item<Type>::type item;
           while (__job<Source>::functor (source) (item))
             if (!__job<Sink>::functor (sink) (item))
@@ -1092,7 +1092,7 @@ namespace MR
           Sink&& sink,
           size_t capacity = MRTRIX_QUEUE_DEFAULT_CAPACITY)
       {
-        if (number_of_threads() == 0) {
+        if (threads_to_execute() == 0) {
           typename __item<Type1>::type item1;
           typename __item<Type2>::type item2;
           while (__job<Source>::functor (source) (item1)) {
@@ -1138,7 +1138,7 @@ namespace MR
           Sink&& sink,
           size_t capacity = MRTRIX_QUEUE_DEFAULT_CAPACITY)
       {
-        if (number_of_threads() == 0) {
+        if (threads_to_execute() == 0) {
           typename __item<Type1>::type item1;
           typename __item<Type2>::type item2;
           typename __item<Type3>::type item3;


### PR DESCRIPTION
Partially addresses #263.

@jdtournier: Querying the number of threads currently being used and then executing however many more are available might lead to race conditions, so I just went with the simple solution of either multi-threading or not.