### PR TITLE
warpcorrect: added option to specify out of bounds value or vector

### DIFF
--- a/cmd/warpcorrect.cpp
+++ b/cmd/warpcorrect.cpp
@@ -50,7 +50,7 @@ void usage ()
 
 using value_type = float;
 
-class BoundsCheck {
+class BoundsCheck { MEMALIGN(BoundsCheck)
   public:
     BoundsCheck (value_type tolerance, const Eigen::Matrix<value_type, 3, 1>& marker, size_t& total_count):
      precision (tolerance),

--- a/docs/reference/commands/warpcorrect.rst
+++ b/docs/reference/commands/warpcorrect.rst
@@ -6,7 +6,7 @@ warpcorrect
 Synopsis
 --------
 
-Replaces voxels in a deformation field that point to 0,0,0 with nan,nan,nan
+Replaces voxels in a deformation field that point to a specific out of bounds location with nan,nan,nan
 
 Usage
 --------
@@ -25,6 +25,10 @@ This can be used in conjunction with the warpinit command to compute a MRtrix co
 
 Options
 -------
+
+-  **-marker coordinates** single value or a comma separated list of values that define out of bounds voxels in the input warp image. Default: (0,0,0).
+
+-  **-tolerance value** numerical precision used for L2 matrix norm comparison. Default: 9.99999975e-06.
 
 Standard options
 ^^^^^^^^^^^^^^^^
@@ -47,7 +51,7 @@ Standard options
 
 
 
-**Author:** David Raffelt (david.raffelt@florey.edu.au)
+**Author:** David Raffelt (david.raffelt@florey.edu.au) & Max Pietsch (mail@maxpietsch.com)
 
 **Copyright:** Copyright (c) 2008-2019 the MRtrix3 contributors.
 

--- a/docs/reference/commands_list.rst
+++ b/docs/reference/commands_list.rst
@@ -227,6 +227,6 @@ List of MRtrix3 commands
     :ref:`voxel2mesh`, "Generate a surface mesh representation from a voxel image"
     :ref:`warp2metric`, "Compute fixel-wise or voxel-wise metrics from a 4D deformation field"
     :ref:`warpconvert`, "Convert between different representations of a non-linear warp"
-    :ref:`warpcorrect`, "Replaces voxels in a deformation field that point to 0,0,0 with nan,nan,nan"
+    :ref:`warpcorrect`, "Replaces voxels in a deformation field that point to a specific out of bounds location with nan,nan,nan"
     :ref:`warpinit`, "Create an initial warp image, representing an identity transformation"
     :ref:`warpinvert`, "Invert a non-linear warp field"


### PR DESCRIPTION
Added two options that allow specifying the marker values of out of bounds values either as floating point number or as a 3D vector (`-marker coordinates`) and the numerical precision used for the floating point comparison (` -tolerance value`).

The default behaviour of `warpcorrect` has not changed other than that it uses floating point comparison with numerical precision of 1e-5 instead of the check for equality.

I added a warning if no out of bounds value was found (related to #1551) and an info-level statement as to how many voxels were modified.