### PR TITLE
progressbar: disable line wrapping while updating terminal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,9 +78,9 @@ install:
     if [[ "${test}" == "sphinx" ]]; then
         if [[ "${py}" == "python2" ]]; then
             pip install urllib3[secure];
-            pip install --user recommonmark sphinx sphinx-rtd-theme;
+            pip install --user recommonmark sphinx sphinx-rtd-theme typing;
         else
-            pip3 install --user recommonmark sphinx sphinx-rtd-theme;
+            pip3 install --user recommonmark sphinx sphinx-rtd-theme typing;
         fi
     fi
   - |

--- a/core/progressbar.cpp
+++ b/core/progressbar.cpp
@@ -19,6 +19,8 @@
 
 // MSYS2 supports VT100, and file redirection is handled explicitly so this can be used globally
 #define CLEAR_LINE_CODE "\033[0K"
+#define WRAP_ON_CODE "\033[?7h"
+#define WRAP_OFF_CODE "\033[?7l"
 
 namespace MR
 {
@@ -43,10 +45,10 @@ namespace MR
     {
       __need_newline = true;
       if (p.multiplier)
-        __print_stderr (printf ("\r%s: [%3" PRI_SIZET "%%] %s%s" CLEAR_LINE_CODE,
+        __print_stderr (printf (WRAP_OFF_CODE "\r%s: [%3" PRI_SIZET "%%] %s%s" CLEAR_LINE_CODE WRAP_ON_CODE,
               App::NAME.c_str(), p.value, p.text.c_str(), p.ellipsis.c_str()));
       else
-        __print_stderr (printf ("\r%s: [%s] %s%s" CLEAR_LINE_CODE,
+        __print_stderr (printf (WRAP_OFF_CODE "\r%s: [%s] %s%s" CLEAR_LINE_CODE WRAP_ON_CODE,
               App::NAME.c_str(), busy[p.value%6], p.text.c_str(), p.ellipsis.c_str()));
     }
 


### PR DESCRIPTION
Prompted by discussion in #263...

This means the terminal doesn't get clogged up with the same line repeated over and over again when the progressbar line width exceeds the terminal's width... 