### PR TITLE
Supporting multiple input .tck files

### DIFF
--- a/cmd/afdconnectivity.cpp
+++ b/cmd/afdconnectivity.cpp
@@ -155,7 +155,7 @@ value_type AFDConnectivity::get (const std::string& path)
 
   Tractography::Properties properties;
   Tractography::Reader<value_type> reader (path, properties);
-  const size_t track_count = (properties.find ("count") == properties.end() ? 0 : to<size_t>(properties["count"]));
+  const size_t track_count = properties.value_or_default<size_t>("count",0);
   DWI::Tractography::Mapping::TrackLoader loader (reader, track_count, "summing apparent fibre density within track");
 
   // If WBFT is provided, this is the sum of (volume/length) across streamlines

--- a/cmd/fixel2tsf.cpp
+++ b/cmd/fixel2tsf.cpp
@@ -85,7 +85,7 @@ void run ()
   float angular_threshold = get_option_value ("angle", DEFAULT_ANGULAR_THRESHOLD);
   const float angular_threshold_dp = cos (angular_threshold * (Math::pi / 180.0));
 
-  const size_t num_tracks = properties["count"].empty() ? 0 : to<int> (properties["count"]);
+  const size_t num_tracks = properties.value_or_default<size_t>("count",0);
 
   DWI::Tractography::Mapping::TrackMapperBase mapper (in_index_image);
   mapper.set_use_precise_mapping (true);

--- a/cmd/fixelcfestats.cpp
+++ b/cmd/fixelcfestats.cpp
@@ -284,7 +284,7 @@ void run() {
   DWI::Tractography::Properties properties;
   DWI::Tractography::Reader<float> track_file (track_filename, properties);
   // Read in tracts, and compute whole-brain fixel-fixel connectivity
-  const size_t num_tracks = properties["count"].empty() ? 0 : to<size_t> (properties["count"]);
+  const size_t num_tracks = properties.value_or_default<size_t>("count",0);
   if (!num_tracks)
     throw Exception ("no tracks found in input file");
   if (num_tracks < 1000000)

--- a/cmd/tck2connectome.cpp
+++ b/cmd/tck2connectome.cpp
@@ -110,7 +110,7 @@ void execute (Image<node_t>& node_image, const node_t max_node_index, const std:
   Tractography::Reader<float> reader (argument[0], properties);
 
   // Initialise classes in preparation for multi-threading
-  Mapping::TrackLoader loader (reader, properties["count"].empty() ? 0 : to<size_t>(properties["count"]), "Constructing connectome");
+  Mapping::TrackLoader loader (reader, properties.value_or_default<size_t>("count",0), "Constructing connectome");
   Tractography::Connectome::Mapper mapper (*tck2nodes, metric);
   Tractography::Connectome::Matrix<T> connectome (max_node_index, statistic, vector_output, track_assignments);
 

--- a/cmd/tck2fixel.cpp
+++ b/cmd/tck2fixel.cpp
@@ -158,7 +158,7 @@ void run ()
   DWI::Tractography::Properties properties;
   DWI::Tractography::Reader<float> track_file (track_filename, properties);
   // Read in tracts, and compute whole-brain fixel-fixel connectivity
-  const size_t num_tracks = properties["count"].empty() ? 0 : to<int> (properties["count"]);
+  const size_t num_tracks = properties.value_or_default<size_t>("count",0);
   if (!num_tracks)
     throw Exception ("no tracks found in input file");
 

--- a/cmd/tckdfc.cpp
+++ b/cmd/tckdfc.cpp
@@ -305,7 +305,7 @@ void run ()
     // TODO Constructor for properties using the file path?
     Tractography::Reader<float> tck_file (tck_path, properties);
   }
-  const size_t num_tracks = properties["count"].empty() ? 0 : to<size_t> (properties["count"]);
+  const size_t num_tracks = properties.value_or_default<size_t>("count",0);
 
   Image<float> fmri_image (Image<float>::open (argument[1]).with_direct_io(3));
 

--- a/cmd/tckedit.cpp
+++ b/cmd/tckedit.cpp
@@ -86,15 +86,6 @@ void usage ()
 }
 
 
-void erase_if_present (Tractography::Properties& p, const std::string s)
-{
-  auto i = p.find (s);
-  if (i != p.end())
-    p.erase (i);
-}
-
-
-
 void run ()
 {
 
@@ -156,10 +147,10 @@ void run ()
   // Due to the potential use of masking, we have no choice but to clear the
   //   properties class of any fields that would otherwise propagate through
   //   and be applied as part of this editing
-  erase_if_present (properties, "min_dist");
-  erase_if_present (properties, "max_dist");
-  erase_if_present (properties, "min_weight");
-  erase_if_present (properties, "max_weight");
+  properties.erase_if_present("min_dist");
+  properties.erase_if_present("max_dist");
+  properties.erase_if_present("min_weight");
+  properties.erase_if_present("max_weight");
   Editing::load_properties (properties);
 
   // Parameters that the worker threads need to be aware of, but do not appear in Properties

--- a/cmd/tckinfo.cpp
+++ b/cmd/tckinfo.cpp
@@ -51,20 +51,19 @@ void run ()
     std::cout << "***********************************\n";
     std::cout << "  Tracks file: \"" << argument[i] << "\"\n";
 
-    for (Tractography::Properties::iterator i = properties.begin(); i != properties.end(); ++i) {
-      std::string S (i->first + ':');
+    for (auto& p: properties) {
+      std::string S (p.first + ':');
       S.resize (22, ' ');
-      std::cout << "    " << S << i->second << "\n";
+      std::cout << "    " << S << p.second << "\n";
     }
 
-    if (properties.comments.size()) {
+    if (! properties.comments.empty()) {
       std::cout << "    Comments:             ";
-      for (vector<std::string>::iterator i = properties.comments.begin(); i != properties.comments.end(); ++i)
-        std::cout << (i == properties.comments.begin() ? "" : "                       ") << *i << "\n";
+      std::cout << join( properties.comments, "\n " ) << "\n";
     }
 
-    for (std::multimap<std::string,std::string>::const_iterator i = properties.roi.begin(); i != properties.roi.end(); ++i)
-      std::cout << "    ROI:                  " << i->first << " " << i->second << "\n";
+    for (auto& r: properties.roi)
+      std::cout << "    ROI:                  " << r.first << " " << r.second << "\n";
 
 
 

--- a/cmd/tckinfo.cpp
+++ b/cmd/tckinfo.cpp
@@ -59,7 +59,7 @@ void run ()
 
     if (! properties.comments.empty()) {
       std::cout << "    Comments:             ";
-      std::cout << join( properties.comments, "\n " ) << "\n";
+      std::cout << join( properties.comments, "\n                          " ) << "\n";
     }
 
     for (auto& r: properties.roi)

--- a/cmd/tckmap.cpp
+++ b/cmd/tckmap.cpp
@@ -266,7 +266,7 @@ void run () {
   Tractography::Properties properties;
   Tractography::Reader<float> file (argument[0], properties);
 
-  const size_t num_tracks = properties["count"].empty() ? 0 : to<size_t> (properties["count"]);
+  const size_t num_tracks = properties.value_or_default<size_t>("count",0);
 
   vector<default_type> voxel_size = get_option_value ("vox", vector<default_type>());
 

--- a/cmd/tckresample.cpp
+++ b/cmd/tckresample.cpp
@@ -115,7 +115,7 @@ void run ()
 
   const std::unique_ptr<Resampling::Base> resampler (Resampling::get_resampler());
 
-  const float old_step_size = get_step_size (properties);
+  const float old_step_size = properties.get_step_size();
   if (!std::isfinite (old_step_size)) {
     INFO ("Do not have step size information from input track file");
   }
@@ -131,9 +131,7 @@ void run ()
   }
   properties["output_step_size"] = std::isfinite (new_step_size) ? str(new_step_size) : "variable";
 
-  auto downsample = properties.find ("downsample_factor");
-  if (downsample != properties.end())
-    properties.erase (downsample);
+  properties.erase_if_present("downsample_factor");
 
   Worker worker (resampler);
   Receiver receiver (argument[1], properties);

--- a/cmd/tcksample.cpp
+++ b/cmd/tcksample.cpp
@@ -464,9 +464,7 @@ void run ()
   if (nointerp && precise)
     throw Exception ("Option -nointerp and -precise are mutually exclusive");
   const interp_type interp = nointerp ? interp_type::NEAREST : (precise ? interp_type::PRECISE : interp_type::LINEAR);
-  const size_t num_tracks = properties.find("count") == properties.end() ?
-                            0 :
-                            to<size_t>(properties["count"]);
+  const size_t num_tracks = properties.value_or_default<size_t>("count",0);
 
   if (statistic == stat_tck::NONE && interp == interp_type::PRECISE)
     throw Exception ("Precise streamline mapping may only be used with per-streamline statistics");

--- a/cmd/tckstats.cpp
+++ b/cmd/tckstats.cpp
@@ -119,11 +119,10 @@ void run ()
     Tractography::Properties properties;
     Tractography::Reader<float> reader (argument[0], properties);
 
-    if (properties.find ("count") != properties.end())
-      header_count = to<size_t> (properties["count"]);
+    header_count = properties.value_or_default<size_t>("count",0);
 
     if (!get_options ("explicit").size()) {
-      step_size = get_step_size (properties);
+      step_size = properties.get_step_size();
       if (!std::isfinite (step_size) || !step_size) {
         INFO ("Streamline step size undefined in header; lengths will be calculated manually");
         if (get_options ("histogram").size()) {

--- a/core/app.cpp
+++ b/core/app.cpp
@@ -1085,7 +1085,7 @@ namespace MR
         }
         if (i.arg->type == ArgDirectoryOut)
           check_overwrite (text);
-        if (i.arg->type == TracksIn && !Path::has_suffix (text, ".tck"))
+        if (i.arg->type == TracksIn && !Path::has_suffix (text, ".tck") && !Path::has_suffix (text, ".lst"))
           throw Exception ("input file \"" + text + "\" is not a valid track file");
         if (i.arg->type == TracksOut && !Path::has_suffix (text, ".tck"))
           throw Exception ("output track file \"" + text + "\" must use the .tck suffix");
@@ -1113,7 +1113,7 @@ namespace MR
           }
           if (arg.type == ArgDirectoryOut)
             check_overwrite (text);
-          if (arg.type == TracksIn && !Path::has_suffix (text, ".tck"))
+          if (arg.type == TracksIn && !Path::has_suffix (text, ".tck") && !Path::has_suffix (text, ".lst"))
             throw Exception ("input file \"" + text + "\" for option \"-" + std::string(i.opt->id) + "\" is not a valid track file");
           if (arg.type == TracksOut && !Path::has_suffix (text, ".tck"))
             throw Exception ("output track file \"" + text + "\" for option \"-" + std::string(i.opt->id) + "\" must use the .tck suffix");

--- a/core/file/utils.h
+++ b/core/file/utils.h
@@ -172,7 +172,7 @@ namespace MR
 
 
 
-    inline size_t readlines(const std::string& name, std::vector<std::string>& lines)
+    inline size_t readlines(const std::string& name, vector<std::string>& lines)
     {
       std::string line;
       std::ifstream in(name.c_str());

--- a/core/file/utils.h
+++ b/core/file/utils.h
@@ -172,6 +172,25 @@ namespace MR
 
 
 
+    inline size_t readlines(const std::string& name, std::vector<std::string>& lines)
+    {
+      std::string line;
+      std::ifstream in(name.c_str());
+      size_t count = 0;
+
+      if (!in)
+        throw Exception("cannot open file \"" + name + "\": " + strerror(errno));
+
+      while (getline(in,line)) {
+        lines.push_back(line);
+        ++count;
+      }
+
+      in.close();
+      return count;
+    }
+
+
 
     inline std::string create_tempfile (int64_t size = 0, const char* suffix = NULL)
     {

--- a/src/dwi/tractography/file.h
+++ b/src/dwi/tractography/file.h
@@ -24,6 +24,7 @@
 #include "file/config.h"
 #include "file/key_value.h"
 #include "file/ofstream.h"
+#include "file/utils.h"
 #include "dwi/tractography/file_base.h"
 #include "dwi/tractography/properties.h"
 #include "dwi/tractography/streamline.h"
@@ -60,7 +61,7 @@ namespace MR
           virtual bool operator() (const Streamline<ValueType>&) = 0;
           virtual ~WriterInterface() { }
       };
-
+      
 
 
       //! A class to read streamlines data
@@ -70,64 +71,50 @@ namespace MR
         public:
 
           //! open the \c file for reading and load header into \c properties
-          Reader (const std::string& file, Properties& properties) :
-            current_index (0) {
-              open (file, "tracks", properties);
-              auto opt = App::get_options ("tck_weights_in");
-              if (opt.size()) {
-                weights_file.reset (new std::ifstream (str(opt[0][0]).c_str(), std::ios_base::in));
-                if (!weights_file->good())
-                  throw Exception ("Unable to open streamlines weights file " + str(opt[0][0]));
-              }
+          Reader (const std::string& file, Properties& prop) 
+          {
+            std::vector<std::string> files;
+            if (Path::has_suffix(file, ".lst")){
+              File::readlines( file, files );
+              INFO("opening list of " + str(files.size()) + " .tck file(s)");
             }
+            else
+              files.push_back(file);
+              
+            construct( files, prop );
+          }
+
+          Reader(const std::vector<std::string>& files, Properties& prop) 
+            { construct(files, prop); }
+
+          ~Reader()
+            { close_current_files(false); clear(); }
 
 
-            //! fetch next track from file
-            bool operator() (Streamline<ValueType>& tck) {
-              tck.clear();
 
-              if (!in.is_open())
-                return false;
 
-              do {
-                auto p = get_next_point();
-                if (std::isinf (p[0])) {
-                  in.close();
-                  check_excess_weights();
-                  return false;
-                }
-                if (in.eof()) {
-                  in.close();
-                  check_excess_weights();
-                  return false;
-                }
+          //! reset member properties
+          void clear() 
+          {
+            std::ifstream a, b; // dummy streams
 
-                if (std::isnan (p[0])) {
-                  tck.index = current_index++;
+            file_index = 0;
+            track_index = sub_count = 0;
+            dtype = DataType::Undefined;
+            in.swap(a);
+            inw.swap(b);
+            tck_files.clear();
+            weights_files.clear();
+          }
 
-                  if (weights_file) {
 
-                    (*weights_file) >> tck.weight;
-                    if (weights_file->fail()) {
-                      WARN ("Streamline weights file contains less entries than .tck file; only read " + str(current_index-1) + " streamlines");
-                      in.close();
-                      tck.clear();
-                      return false;
-                    }
 
-                  } else {
-                    tck.weight = 1.0;
-                  }
 
-                  return true;
-                }
+          //! fetch next track from file
+          inline bool operator() (Streamline<ValueType>& tck) {
+            return get_next_track(tck);
+          }
 
-                tck.push_back (p);
-              } while (in.good());
-
-              in.close();
-              return false;
-            }
 
 
 
@@ -135,57 +122,201 @@ namespace MR
           using __ReaderBase__::in;
           using __ReaderBase__::dtype;
 
-          uint64_t current_index;
-          std::unique_ptr<std::ifstream> weights_file;
+          size_t file_index;
+          uint64_t track_index, sub_count;
+          std::ifstream inw;
 
-          //! takes care of byte ordering issues
+          std::vector<std::string> tck_files, weights_files;
 
-            Eigen::Matrix<ValueType,3,1> get_next_point ()
-            {
-              using namespace ByteOrder;
-              switch (dtype()) {
-                case DataType::Float32LE:
-                  {
-                    float p[3];
-                    in.read ((char*) p, sizeof (p));
-                    return { ValueType(LE(p[0])), ValueType(LE(p[1])), ValueType(LE(p[2])) };
-                  }
-                case DataType::Float32BE:
-                  {
-                    float p[3];
-                    in.read ((char*) p, sizeof (p));
-                    return { ValueType(BE(p[0])), ValueType(BE(p[1])), ValueType(BE(p[2])) };
-                  }
-                case DataType::Float64LE:
-                  {
-                    double p[3];
-                    in.read ((char*) p, sizeof (p));
-                    return { ValueType(LE(p[0])), ValueType(LE(p[1])), ValueType(LE(p[2])) };
-                  }
-                case DataType::Float64BE:
-                  {
-                    double p[3];
-                    in.read ((char*) p, sizeof (p));
-                    return { ValueType(BE(p[0])), ValueType(BE(p[1])), ValueType(BE(p[2])) };
-                  }
-                default:
-                  assert (0);
-                  break;
-              }
-              return { NaN, NaN, NaN };
-            }
 
-          //! Check that the weights file does not contain excess entries
-          void check_excess_weights()
+
+
+          //! initialise current reader instance
+          void construct( const std::vector<std::string>& files, Properties& prop ) 
           {
-            if (!weights_file)
+            clear();
+
+            if (files.empty())
               return;
-            float temp;
-            (*weights_file) >> temp;
-            if (!weights_file->fail())
-              WARN ("Streamline weights file contains more entries than .tck file");
+
+            // assign properties (also checks that input files are valid .tck files)
+            properties_consensus(files, "tracks", prop);
+            tck_files = files;
+
+            // try to find associated weights
+            auto opt = App::get_options ("tck_weights_in");
+            std::string weights;
+
+            if (opt.size()) {
+
+              weights = str(opt[0][0]);
+
+              if ( files.size()>1 && !Path::has_suffix(weights,".lst") )
+                throw Exception("When reading several .tck files, the weights file should be a list with extension .lst, containing one filename per line.");
+
+              if (Path::has_suffix(weights,".lst"))
+                File::readlines(weights, weights_files);
+              else 
+                weights_files.push_back(weights);
+
+              // check that number of files matches
+              if (weights_files.size() != tck_files.size())
+                throw Exception("Mismatch between number of .tck files and number of streamline weights files."); 
+            }
           }
 
+
+
+
+          //! close currently opened files
+          void close_current_files(bool check_excess=true) 
+          {
+            // close tck file
+            close();
+
+            // close weights file
+            float temp;
+            if (inw.is_open()) {
+              if (check_excess) {
+                inw >> temp;
+                if (!inw.fail())
+                  WARN ("Streamline weights file contains more entries than .tck file");
+              }
+
+              inw.close();
+            }
+
+          }
+
+
+
+
+          //! open next file from file list
+          bool open_next_files() 
+          {
+            close_current_files(false);
+
+            if (file_index >= tck_files.size())
+              return false;
+
+            Properties dummy;
+            open( tck_files[file_index], "tracks", dummy );
+
+            if (!weights_files.empty()) 
+            {
+              inw.open( weights_files[file_index].c_str(), std::ios_base::in );
+              if (!inw)
+                throw Exception ("Unable to open streamlines weights file " + weights_files[file_index]);
+            }
+
+            ++file_index;
+            sub_count = 0;
+            return true;
+          }
+
+
+
+
+          //! get next track in currently opened file
+          bool get_next_track( Streamline<ValueType>& tck )
+          {
+            tck.clear();
+
+            if ( !in.is_open() && !open_next_files() )
+              return false;
+
+            // keep adding points to current streamline
+            do {
+
+              auto p = get_next_point();
+
+              // if we hit eof or Inf value, call again to open next file
+              if ( in.eof() || std::isinf(p[0]) ) {
+                close_current_files();
+                return get_next_track(tck);
+              }
+
+              // end of streamline: set tck index and weight, and return
+              if (std::isnan(p[0])) {
+                
+                tck.index = track_index;
+                ++track_index;
+                ++sub_count;
+
+                if (inw.is_open()) {
+
+                  inw >> tck.weight;
+                  if (inw.fail()) {
+                    --track_index;
+                    --sub_count;
+                    close_current_files(false);
+
+                    WARN ("Streamline weights file contains fewer entries than .tck file; only read " + str(sub_count) + " streamlines.");
+                    return get_next_track(tck);
+                  }
+
+                } else {
+                  tck.weight = 1.0;
+                }
+
+                return true;
+              }
+
+              // otherwise add point and iterate
+              tck.push_back (p);
+
+            } while ( in.good() );
+
+            WARN ("Streamline-parsing from tracks file ended prematurely.");
+            close_current_files();
+            return get_next_track(tck);
+          }
+
+
+
+
+
+          //! takes care of byte ordering issues
+          Eigen::Matrix<ValueType,3,1> get_next_point ()
+          {
+            using namespace ByteOrder;
+            switch (dtype()) {
+              case DataType::Float32LE:
+                {
+                  float p[3];
+                  in.read ((char*) p, sizeof (p));
+                  return { ValueType(LE(p[0])), ValueType(LE(p[1])), ValueType(LE(p[2])) };
+                }
+              case DataType::Float32BE:
+                {
+                  float p[3];
+                  in.read ((char*) p, sizeof (p));
+                  return { ValueType(BE(p[0])), ValueType(BE(p[1])), ValueType(BE(p[2])) };
+                }
+              case DataType::Float64LE:
+                {
+                  double p[3];
+                  in.read ((char*) p, sizeof (p));
+                  return { ValueType(LE(p[0])), ValueType(LE(p[1])), ValueType(LE(p[2])) };
+                }
+              case DataType::Float64BE:
+                {
+                  double p[3];
+                  in.read ((char*) p, sizeof (p));
+                  return { ValueType(BE(p[0])), ValueType(BE(p[1])), ValueType(BE(p[2])) };
+                }
+              default:
+                assert (0);
+                break;
+            }
+            return { NaN, NaN, NaN };
+          }
+
+
+
+
+
+          //! copy construction explicitly disabled
           Reader (const Reader&) = delete;
 
       };

--- a/src/dwi/tractography/file.h
+++ b/src/dwi/tractography/file.h
@@ -73,7 +73,7 @@ namespace MR
           //! open the \c file for reading and load header into \c properties
           Reader (const std::string& file, Properties& prop) 
           {
-            std::vector<std::string> files;
+            vector<std::string> files;
             if (Path::has_suffix(file, ".lst")){
               File::readlines( file, files );
               INFO("opening list of " + str(files.size()) + " .tck file(s)");
@@ -84,7 +84,7 @@ namespace MR
             construct( files, prop );
           }
 
-          Reader(const std::vector<std::string>& files, Properties& prop) 
+          Reader(const vector<std::string>& files, Properties& prop) 
             { construct(files, prop); }
 
           ~Reader()
@@ -126,13 +126,13 @@ namespace MR
           uint64_t track_index, sub_count;
           std::ifstream inw;
 
-          std::vector<std::string> tck_files, weights_files;
+          vector<std::string> tck_files, weights_files;
 
 
 
 
           //! initialise current reader instance
-          void construct( const std::vector<std::string>& files, Properties& prop ) 
+          void construct( const vector<std::string>& files, Properties& prop ) 
           {
             clear();
 

--- a/src/dwi/tractography/file_base.cpp
+++ b/src/dwi/tractography/file_base.cpp
@@ -21,63 +21,139 @@ namespace MR {
     namespace Tractography {
 
 
-      void __ReaderBase__::open (const std::string& file, const std::string& type, Properties& properties)
+      void __ReaderBase__::open (const std::string& file, const std::string& type, Properties& prop)
       {
-        properties.clear();
-        dtype = DataType::Undefined;
+        TrackFileInfo info( file, type, prop );
+        dtype = info.dtype;
 
-        const std::string firstline ("mrtrix " + type);
-        File::KeyValue kv (file, firstline.c_str());
-        std::string data_file;
+        in.open (info.path.c_str(), std::ios::in | std::ios::binary);
+        if (!in)
+          throw Exception ("error opening " + type  + " data file \"" + info.path + "\": " + strerror(errno));
+        in.seekg (info.offset);
+      }
 
+
+
+
+      void TrackFileInfo::check_dtype() 
+      {
+        if (dtype == DataType::Undefined)
+          throw Exception ("no datatype specified for tracks file \"" + path + "\"");
+        if (dtype != DataType::Float32LE && dtype != DataType::Float32BE &&
+            dtype != DataType::Float64LE && dtype != DataType::Float64BE)
+          throw Exception ("only supported datatype for tracks file are "
+              "Float32LE, Float32BE, Float64LE & Float64BE (in " + type  + " file \"" + path + "\")");
+      }
+
+
+
+
+      void TrackFileInfo::parse( const std::string& file, const std::string& file_type, Properties& prop ) 
+      {
+        clear();
+        prop.clear();
+        type = file_type;
+
+        // initialise KeyValue instance to parse metadata
+        const std::string magic ("mrtrix " + type);
+        File::KeyValue kv (file, magic.c_str());
+
+        // parse key/value pairs
         while (kv.next()) {
           const std::string key = lowercase (kv.key());
           if (key == "roi") {
             try {
               vector<std::string> V (split (kv.value(), " \t", true, 2));
-              properties.roi.insert (std::pair<std::string,std::string> (V[0], V[1]));
+              prop.roi.insert (std::pair<std::string,std::string> (V[0], V[1]));
             }
             catch (...) {
               WARN ("invalid ROI specification in " + type  + " file \"" + file + "\" - ignored");
             }
           }
-          else if (key == "comment") properties.comments.push_back (kv.value());
-          else if (key == "file") data_file = kv.value();
-          else if (key == "datatype") dtype = DataType::parse (kv.value());
-          else properties[kv.key()] = kv.value();
+          else if (key == "comment")    prop.comments.push_back (kv.value());
+          else if (key == "file")       path = kv.value();
+          else if (key == "datatype")   dtype = DataType::parse (kv.value());
+          else                          prop[kv.key()] = kv.value();
         }
 
-        if (dtype == DataType::Undefined)
-          throw Exception ("no datatype specified for tracks file \"" + file + "\"");
-        if (dtype != DataType::Float32LE && dtype != DataType::Float32BE &&
-            dtype != DataType::Float64LE && dtype != DataType::Float64BE)
-          throw Exception ("only supported datatype for tracks file are "
-              "Float32LE, Float32BE, Float64LE & Float64BE (in " + type  + " file \"" + file + "\")");
+        // check field "datatype"
+        check_dtype();
 
-        if (data_file.empty())
-          throw Exception ("missing \"files\" specification for " + type  + " file \"" + file + "\"");
+        // field "file" should be defined
+        if (path.empty())
+          throw Exception ("missing \"file\" specification for " + type  + " file \"" + file + "\"");
 
-        std::istringstream files_stream (data_file);
-        std::string fname;
-        files_stream >> fname;
-        int64_t offset = 0;
-        if (files_stream.good()) {
-          try { files_stream >> offset; }
+        // its value should be: "filename offset" (no spaces in filename!)
+        std::istringstream file_val (path);
+        std::string path_val;
+        file_val >> path_val;
+
+        if (file_val.good()) {
+          try { file_val >> offset; }
           catch (...) {
             throw Exception ("invalid offset specified for file \""
-                + fname + "\" in " + type  + " file \"" + file + "\"");
+                + path_val + "\" in " + type  + " file \"" + file + "\"");
           }
         }
 
-        if (fname != ".")
-          fname = Path::join (Path::dirname (file), fname);
+        // value "." interpreted as "this file"
+        if (path_val != ".")
+          path = Path::join (Path::dirname (file), path_val);
         else
-          fname = file;
+          path = file;
+      }
 
-        in.open (fname.c_str(), std::ios::in | std::ios::binary);
-        if (!in)
-          throw Exception ("error opening " + type  + " data file \"" + fname + "\": " + strerror(errno));
-        in.seekg (offset);
+
+
+      void properties_consensus( const std::vector<std::string>& files, const std::string& type, Properties& prop )
+      {
+        // ensure there is at least one file
+        size_t n_files = files.size();
+        if (n_files == 0)
+          throw Exception("empty list of files for consensus!");
+
+        // read first file
+        TrackFileInfo info_ref( files[0], type, prop );
+
+        // create comments buffer and summary counts
+        std::unordered_set<std::string> comments_buffer( prop.comments.begin(), prop.comments.end() );
+        uint64_t count = prop.value_or_default<uint64_t>("count",0);
+        uint64_t total_count = prop.value_or_default<uint64_t>("total_count",0);
+
+        // iterate over remaining files
+        TrackFileInfo info_tmp;
+        Properties prop_tmp;
+        for ( size_t k=1; k < n_files; ++k ) {
+
+          info_tmp.parse( files[k], type, prop_tmp );
+          if ( info_tmp.dtype != info_ref.dtype )
+            throw Exception("datatype mismatch between " + type  + " files \"" + files[0] + "\" and \"" + files[k] + "\"");
+
+          for (auto& c: prop_tmp.comments)
+            if ( comments_buffer.find(c) == comments_buffer.end() ) {
+              prop.comments.push_back(c);
+              comments_buffer.insert(c);
+            }
+
+          for (auto& p: prop_tmp)
+            if (p.first == "count")
+              count += to<uint64_t>(p.second);
+            else if (p.first == "total_count")
+              total_count += to<uint64_t>(p.second);
+            else {
+              auto existing = prop.find (p.first);
+              if (existing == prop.end())
+                prop.insert(p);
+              else if (p.second != existing->second) {
+                INFO("variable property \"" + p.first + "\" across " + type + " files");
+                existing->second = "variable";
+              }
+            }
+        }
+
+        // final counts
+        prop["count"] = str(count);
+        prop["total_count"] = str(total_count);
       }
 
     }

--- a/src/dwi/tractography/file_base.cpp
+++ b/src/dwi/tractography/file_base.cpp
@@ -105,7 +105,7 @@ namespace MR {
 
 
 
-      void properties_consensus( const std::vector<std::string>& files, const std::string& type, Properties& prop )
+      void properties_consensus( const vector<std::string>& files, const std::string& type, Properties& prop )
       {
         // ensure there is at least one file
         size_t n_files = files.size();

--- a/src/dwi/tractography/file_base.h
+++ b/src/dwi/tractography/file_base.h
@@ -17,7 +17,7 @@
 #define __dwi_tractography_file_base_h__
 
 #include <iomanip>
-#include <map>
+#include <unordered_set>
 
 #include "types.h"
 #include "datatype.h"
@@ -36,24 +36,70 @@ namespace MR
     namespace Tractography
     {
 
+
+      // JH: information about .tck or .tsf file
+      struct TrackFileInfo
+      {
+        std::string   path, type;
+        uint64_t      offset;
+        DataType      dtype;
+
+        TrackFileInfo() 
+          { clear(); }
+
+        TrackFileInfo( const std::string& file, const std::string& type, Properties& prop )
+          { clear(); parse(file,type,prop); }
+
+
+        void clear() {
+          dtype = DataType::Undefined;
+          offset = 0;
+          path = "";
+          type = "";
+        }
+
+
+        inline bool empty() 
+          { return type.empty() || path.empty(); }
+
+
+        void check_dtype();
+
+
+        void parse( const std::string& file, const std::string& type, Properties& prop );
+
+
+      };
+
+
+
+      // combine properties across several .tck files
+      void properties_consensus( const std::vector<std::string>& files, const std::string& type, Properties& prop );
+
+
+
       //! \cond skip
       class __ReaderBase__
       { NOMEMALIGN
         public:
-          ~__ReaderBase__ () {
-            if (in.is_open())
-              in.close();
-          }
 
-          void open (const std::string& file, const std::string& firstline, Properties& properties);
+          ~__ReaderBase__ () 
+            { close(); }
 
-          void close () { in.close(); }
+          
+          void close () 
+            { if (in.is_open()) in.close(); }
+
+
+          void open (const std::string& file, const std::string& type, Properties& prop);
+          
 
         protected:
 
           std::ifstream  in;
           DataType  dtype;
       };
+
 
 
       template <typename ValueType = float>

--- a/src/dwi/tractography/file_base.h
+++ b/src/dwi/tractography/file_base.h
@@ -20,6 +20,7 @@
 #include <map>
 
 #include "types.h"
+#include "datatype.h"
 #include "file/key_value.h"
 #include "file/ofstream.h"
 #include "file/path.h"

--- a/src/dwi/tractography/file_base.h
+++ b/src/dwi/tractography/file_base.h
@@ -39,7 +39,8 @@ namespace MR
 
       // JH: information about .tck or .tsf file
       struct TrackFileInfo
-      {
+      { NOMEMALIGN
+      
         std::string   path, type;
         uint64_t      offset;
         DataType      dtype;
@@ -74,7 +75,7 @@ namespace MR
 
 
       // combine properties across several .tck files
-      void properties_consensus( const std::vector<std::string>& files, const std::string& type, Properties& prop );
+      void properties_consensus( const vector<std::string>& files, const std::string& type, Properties& prop );
 
 
 

--- a/src/dwi/tractography/properties.cpp
+++ b/src/dwi/tractography/properties.cpp
@@ -34,6 +34,69 @@ namespace MR {
         roi.clear();
       }
 
+
+
+
+
+      void check_compatible (const Properties& a, const Properties& b, const std::string& type)
+      {
+        if ( a.get_step_size() != b.get_step_size() )
+          WARN ("mismatch between " + type + " properties (step-size)");
+
+        for (auto& p: {"source","act","method","threshold"})
+          if (a.has(p) && b.has(p) && a.get(p) != b.get(p))
+            WARN ("mismatch between " + type + " properties (" + p + ")");
+      }
+
+      
+      
+
+      void check_timestamps (const Properties& a, const Properties& b, const std::string& type)
+      {
+        auto stamp_a = a.find ("timestamp");
+        auto stamp_b = b.find ("timestamp");
+        if (stamp_a == a.end() || stamp_b == b.end())
+          throw Exception ("unable to verify " + type + " pair: missing timestamp");
+        if (stamp_a->second != stamp_b->second)
+          throw Exception ("invalid " + type + " combination - timestamps do not match");
+      }
+
+
+
+
+      void check_counts (const Properties& a, const Properties& b, const std::string& type, bool abort_on_fail)
+      {
+        auto count_a = a.find ("count");
+        auto count_b = b.find ("count");
+        if ((count_a == a.end()) || (count_b == b.end())) {
+          std::string mesg = "unable to validate " + type + " pair: missing count field";
+          if (abort_on_fail) throw Exception (mesg);
+          else WARN (mesg);
+        }
+        if (to<size_t>(count_a->second) != to<size_t>(count_b->second)) {
+          std::string mesg = type + " files do not contain same number of elements";
+          if (abort_on_fail) throw Exception (mesg);
+          else WARN (mesg);
+        }
+      }
+
+
+
+
+      std::ostream& operator<< (std::ostream& stream, const Properties& P)
+      {
+        stream << "seeds: " << P.seeds;
+        stream << "include: " << P.include << ", exclude: " << P.exclude << ", mask: " << P.mask << ", dict: ";
+        for (auto& Pk: P)
+          stream << "[ " << Pk.first << ": " << Pk.second << " ], ";
+
+        stream << "comments: ";
+        for (auto& c: P.comments)
+          stream << "\"" << c << "\", ";
+
+        return stream;
+      }
+
     }
   }
 }

--- a/src/dwi/tractography/properties.h
+++ b/src/dwi/tractography/properties.h
@@ -17,6 +17,7 @@
 #define __dwi_tractography_properties_h__
 
 #include <map>
+#include "mrtrix.h"
 #include "timer.h"
 #include "dwi/tractography/roi.h"
 #include "dwi/tractography/seeding/list.h"
@@ -66,79 +67,63 @@ namespace MR
             roi.clear();
           }
 
-          template <typename T> void set (T& variable, const std::string& name) {
+          bool has(const std::string& name) const {
+            return this->find(name) != this->end();
+          }
+
+
+          std::string get(const std::string& name) const {
+            auto p = this->find(name);
+            if (p == this->end())
+              throw Exception("Undefined property: \"" + name + "\"");
+            else 
+              return p->second;
+          }
+
+          template <typename T> 
+          T value_or_default(const std::string& name, const T& defval) const {
+            auto p = this->find(name);
+            return p == this->end() ? defval : to<T>(p->second);
+          }
+
+          template <typename T> 
+          void set (T& variable, const std::string& name) {
             if ((*this)[name].empty()) (*this)[name] = str (variable);
             else variable = to<T> ((*this)[name]);
+          }
+
+          void erase_if_present(const std::string& name) {
+            auto p = this->find(name);
+            if (p != this->end())
+              this->erase(p);
+          }
+
+          inline float get_step_size() const {
+            return value_or_default<float>( "output_step_size", value_or_default<float>( "step_size", NaN ) );
           }
 
           void load_ROIs ();
       };
 
 
-      inline void check_timestamps (const Properties& a, const Properties& b, const std::string& type)
-      {
-        Properties::const_iterator stamp_a = a.find ("timestamp");
-        Properties::const_iterator stamp_b = b.find ("timestamp");
-        if (stamp_a == a.end() || stamp_b == b.end())
-          throw Exception ("unable to verify " + type + " pair: missing timestamp");
-        if (stamp_a->second != stamp_b->second)
-          throw Exception ("invalid " + type + " combination - timestamps do not match");
+      // JH: kept for now, but should be removed in favour of: p.get_step_size()
+      inline float get_step_size (const Properties& p) { 
+        DEBUG( "Function get_step_size is deprecated. Call properties.get_step_size() instead." );
+        return p.get_step_size(); 
       }
 
 
+      // JH: unused for now
+      void check_compatible(const Properties& a, const Properties& b, const std::string& type);
 
 
-      inline void check_counts (const Properties& a, const Properties& b, const std::string& type, bool abort_on_fail)
-      {
-        Properties::const_iterator count_a = a.find ("count");
-        Properties::const_iterator count_b = b.find ("count");
-        if ((count_a == a.end()) || (count_b == b.end())) {
-          std::string mesg = "unable to validate " + type + " pair: missing count field";
-          if (abort_on_fail) throw Exception (mesg);
-          else WARN (mesg);
-        }
-        if (to<size_t>(count_a->second) != to<size_t>(count_b->second)) {
-          std::string mesg = type + " files do not contain same number of elements";
-          if (abort_on_fail) throw Exception (mesg);
-          else WARN (mesg);
-        }
-      }
+      void check_timestamps (const Properties& a, const Properties& b, const std::string& type);
 
 
+      void check_counts (const Properties& a, const Properties& b, const std::string& type, bool abort_on_fail);
 
 
-      inline float get_step_size (const Properties& p)
-      {
-        for (size_t index = 0; index != 2; ++index) {
-          const std::string key (index ? "step_size" : "output_step_size");
-          auto it = p.find (key);
-          if (it != p.end()) {
-            try {
-              return to<float> (it->second);
-            } catch (...) { }
-          }
-        }
-        return NaN;
-      }
-
-
-
-
-
-      inline std::ostream& operator<< (std::ostream& stream, const Properties& P)
-      {
-        stream << "seeds: " << P.seeds;
-        stream << "include: " << P.include << ", exclude: " << P.exclude << ", mask: " << P.mask << ", dict: ";
-        for (std::map<std::string, std::string>::const_iterator i = P.begin(); i != P.end(); ++i)
-          stream << "[ " << i->first << ": " << i->second << " ], ";
-        stream << "comments: ";
-        for (vector<std::string>::const_iterator i = P.comments.begin(); i != P.comments.end(); ++i)
-          stream << "\"" << *i << "\", ";
-        return (stream);
-      }
-
-
-
+      std::ostream& operator<< (std::ostream& stream, const Properties& P);
 
     }
   }

--- a/src/dwi/tractography/roi.h
+++ b/src/dwi/tractography/roi.h
@@ -18,7 +18,6 @@
 
 #include "app.h"
 #include "image.h"
-#include "image.h"
 #include "interp/linear.h"
 #include "math/rng.h"
 


### PR DESCRIPTION
This PR is an enhancement of the existing code to support multiple input `.tck` files for commands that currently accept `.tck` files:
 
 - This is done by introducing a new file type with extension `.lst` (for "list"), containing one filename per line. These can be used either in place of `.tck` arguments, or in place of weights files (e.g. option `-tck_weights_in`).
 - The changes are completely transparent AFAICT: the behaviour of the software remains unchanged when `.lst` files are not involved. 

## Implementation

The changes mainly consist in a re-write of the class `Tractography::Reader`, which now holds a `std::vector` of tracks filenames (and optionally of weights filenames too). The `ReaderInterface` is preserved: the `operator()` method implemented in `Reader` simply reads the data off the currently open file(s), and switches to the next file(s) when reaching EOF.

The main challenge in this implementation is to find a consensus between the headers of the multiple `.tck` files. The proposed implementation mimicks the strategy currently found in `tckedit`, namely:

 - accumulate properties `count` and `total_count`;
 - aggregate other properties and comments as long as they are the same (or not present) across headers;
 - assign the value `"variable"` in case of conflict.

In addition, the proposed consensus fails if the datatypes varies across files.

## Limitations

The intention behind the changes introduced is to avoid unnecessary merge operations, and to provide a seamless capability to handle multiple tracks sources in input. This does **not** apply to the output; `.lst` files will not be recognised as output arguments, and any output will still be written to a single file (as before). 

This can be seen as a limitation, espectially when the output is meant to be used as an input to a subsequent command. For example, in the case of `tcksift2` followed by `tck2connectome`, when the output weights are used to compute a structural connectome matrix. In that case, at present, the weights file must be _manually_ split into as many files as present in the `.lst` file; and a _new_ `.lst` file must be created, listing the previous split weights files, and fed to the `-tck_weights_in` option. This is relatively easy to implement in Python, and I would be happy to provide an example if needed.

Alternatively, a split-output behaviour could potentially be implemented within the `Writer` class, by specifying output names within an `.lst` file as well (although this might not be relevant for all commands, and implementing a distinction might be cumbersome).

## Possible future work

The consensus implemented in `tckedit` should be replaced with the new implementation in `tractography/file_base`.

The changes introduced make the implementations of `Tractography::Editing:Loader` and `Tractography::Mapping::Loader` somewhat redundant. I think these loader-classes should be merged into a single implementation, in order to assess whether or not they are really needed, given the new capabilities of `Tractography::Reader`.
