### PR TITLE
BitSet::resize(): Bug fix

### DIFF
--- a/core/bitset.cpp
+++ b/core/bitset.cpp
@@ -63,8 +63,10 @@ namespace MR {
       if (new_bytes > bytes) {
         memcpy (new_data, data, bytes);
         memset (new_data + bytes, (allocator ? 0xFF : 0x00), new_bytes - bytes);
-        const uint8_t mask = 0xFF << excess_bits();
-        data[bytes - 1] = allocator ? (data[bytes - 1] | mask) : (data[bytes - 1] & ~mask);
+        if (excess_bits()) {
+          const uint8_t mask = 0xFF << excess_bits();
+          new_data[bytes - 1] = allocator ? (data[bytes - 1] | mask) : (data[bytes - 1] & ~mask);
+        }
       } else {
         memcpy (new_data, data, new_bytes);
       }


### PR DESCRIPTION
As discovered in the process of #1543 (specifically 7273d35b) & verified using the unit tests in 543081f9.

No implications in the repository here: the function's only used in one place, and in that instance the instance is zeroed first so the relevant code never executes. But it's a bug nonetheless, so should go to `master` in case of external library use.