### PR TITLE
mrview Lightbox: Don't modify GL elements in wrong context

### DIFF
--- a/src/gui/mrview/mode/lightbox.cpp
+++ b/src/gui/mrview/mode/lightbox.cpp
@@ -39,7 +39,8 @@ namespace MR
 
 
 
-        LightBox::LightBox ()
+        LightBox::LightBox () :
+            frames_dirty (true)
         {
           Image* img = image();
 
@@ -57,8 +58,7 @@ namespace MR
         void LightBox::set_rows (size_t rows)
         {
           n_rows = rows;
-          frame_VB.clear();
-          frame_VAO.clear();
+          frames_dirty = true;
           updateGL();
         }
 
@@ -68,8 +68,7 @@ namespace MR
         void LightBox::set_cols (size_t cols)
         {
           n_cols = cols;
-          frame_VB.clear();
-          frame_VAO.clear();
+          frames_dirty = true;
           updateGL();
         }
 
@@ -250,7 +249,7 @@ namespace MR
           GL::mat4 P = GL::ortho (0, width(), 0, height(), -1.0, 1.0);
           projection.set (MV, P);
 
-          if (!frame_VB || !frame_VAO) {
+          if (frames_dirty) {
             frame_VB.gen();
             frame_VAO.gen();
 
@@ -286,6 +285,8 @@ namespace MR
             }
 
             gl::BufferData (gl::ARRAY_BUFFER, sizeof(data), data, gl::STATIC_DRAW);
+
+            frames_dirty = false;
           }
           else
             frame_VAO.bind();

--- a/src/gui/mrview/mode/lightbox.h
+++ b/src/gui/mrview/mode/lightbox.h
@@ -91,6 +91,7 @@ namespace MR
             GL::VertexBuffer frame_VB;
             GL::VertexArrayObject frame_VAO;
             GL::Shader::Program frame_program;
+            bool frames_dirty;
           signals:
             void slice_increment_reset();
         };


### PR DESCRIPTION
Don't know whether or not this would be causing the software to crash sporadically, but it was certainly failing assertions, and in the past I'm sure I've had random crashes with lightbox mode when compiled for release.