### PR TITLE
connectome2tck: Fix assertion failure / segfault

### DIFF
--- a/cmd/connectome2tck.cpp
+++ b/cmd/connectome2tck.cpp
@@ -160,7 +160,7 @@ void run ()
   auto opt = get_options ("prefix_tck_weights_out");
   const std::string weights_prefix = opt.size() ? std::string (opt[0][0]) : "";
 
-  INFO ("Maximum node index is " + str(max_node_index));
+  INFO ("Maximum node index in assignments file is " + str(max_node_index));
 
   const node_t first_node = get_options ("keep_unassigned").size() ? 0 : 1;
   const bool keep_self = get_options ("keep_self").size();
@@ -211,10 +211,17 @@ void run ()
     for (auto i = Loop() (image); i; ++i) {
       const node_t index = image.value();
       if (index) {
-        assert (index <= max_node_index);
+        while (index >= COMs.size()) {
+          COMs.push_back (Eigen::Vector3f (0.0f, 0.0f, 0.0f));
+          volumes.push_back (0);
+        }
         COMs[index] += Eigen::Vector3f (image.index(0), image.index(1), image.index(2));
         ++volumes[index];
       }
+    }
+    if (COMs.size() > max_node_index + 1) {
+      WARN ("Parcellation image \"" + std::string (opt[0][0]) + "\" provided via -exemplars option contains more nodes (" + str(COMs.size()-1) + ") than are present in input assignments file \"" + std::string (argument[1]) + "\" (" + str(max_node_index) + ")");
+      max_node_index = COMs.size()-1;
     }
     Transform transform (image);
     for (node_t index = 1; index <= max_node_index; ++index) {


### PR DESCRIPTION
Memory for node volumes and centres of mass when generating exemplars was initialised based on the maximal node index observed in the assignments file. In the rare circumstance where one or more of the highest-valued nodes in a parcellation did not have any streamlines assigned to it, this would lead to a buffer over-run when compiled in release mode. This change introduces an explicit check for such, and issues a warning to the user.

Closes #1581.

Testing proposed changes compiled in debug+assert mode:

```
$ connectome2tck tracks.tck assignments.csv test/ -exemplars parc.mif -files single
connectome2tck: [done] reading streamline assignments file
connectome2tck: [100%] generating exemplars for connectome
connectome2tck: [100%] finalizing exemplars
$ mrstats parc.mif -output max
84
$ mredit parc.mif parc85.mif -voxel 127,127,127 85
$ connectome2tck tracks.tck assignments.csv test2/ -exemplars parc85.mif -files single
connectome2tck: [done] reading streamline assignments file
connectome2tck: [WARNING] Parcellation image "parc85.mif" provided via -exemplars option contains more nodes (85) than are present in input assignments file "assignments.csv" (84)
connectome2tck: [100%] generating exemplars for connectome
connectome2tck: [100%] finalizing exemplars
```