### PR TITLE
Tractography::Writer: Preserve order

### DIFF
--- a/cmd/connectome2tck.cpp
+++ b/cmd/connectome2tck.cpp
@@ -279,11 +279,11 @@ void run ()
       std::mutex mutex;
       ProgressBar progress ("generating exemplars for connectome", count);
       if (assignments_pairs.size()) {
-        auto loader = [&] (Tractography::Connectome::Streamline_nodepair& out) { if (!reader (out)) return false; out.set_nodes (assignments_pairs[out.index]); return true; };
+        auto loader = [&] (Tractography::Connectome::Streamline_nodepair& out) { if (!reader (out)) return false; out.set_nodes (assignments_pairs[out.get_index()]); return true; };
         auto worker = [&] (const Tractography::Connectome::Streamline_nodepair& in) { generator (in); std::lock_guard<std::mutex> lock (mutex); ++progress; return true; };
         Thread::run_queue (loader, Thread::batch (Tractography::Connectome::Streamline_nodepair()), Thread::multi (worker));
       } else {
-        auto loader = [&] (Tractography::Connectome::Streamline_nodelist& out) { if (!reader (out)) return false; out.set_nodes (assignments_lists[out.index]); return true; };
+        auto loader = [&] (Tractography::Connectome::Streamline_nodelist& out) { if (!reader (out)) return false; out.set_nodes (assignments_lists[out.get_index()]); return true; };
         auto worker = [&] (const Tractography::Connectome::Streamline_nodelist& in) { generator (in); std::lock_guard<std::mutex> lock (mutex); ++progress; return true; };
         Thread::run_queue (loader, Thread::batch (Tractography::Connectome::Streamline_nodelist()), Thread::multi (worker));
       }
@@ -370,14 +370,14 @@ void run ()
     if (assignments_pairs.size()) {
       Tractography::Connectome::Streamline_nodepair tck;
       while (reader (tck)) {
-        tck.set_nodes (assignments_pairs[tck.index]);
+        tck.set_nodes (assignments_pairs[tck.get_index()]);
         writer (tck);
         ++progress;
       }
     } else {
       Tractography::Connectome::Streamline_nodelist tck;
       while (reader (tck)) {
-        tck.set_nodes (assignments_lists[tck.index]);
+        tck.set_nodes (assignments_lists[tck.get_index()]);
         writer (tck);
         ++progress;
       }

--- a/cmd/fixel2tsf.cpp
+++ b/cmd/fixel2tsf.cpp
@@ -24,9 +24,11 @@
 
 #include "dwi/tractography/file.h"
 #include "dwi/tractography/scalar_file.h"
+#include "dwi/tractography/streamline.h"
 
-#include "dwi/tractography/mapping/mapper.h"
 #include "dwi/tractography/mapping/loader.h"
+#include "dwi/tractography/mapping/mapper.h"
+
 
 
 using namespace MR;
@@ -93,14 +95,17 @@ void run ()
 
   ProgressBar progress ("mapping fixel values to streamline points", num_tracks);
   DWI::Tractography::Streamline<float> tck;
+  DWI::Tractography::TrackScalar<float> scalars;
 
-  Transform transform (in_index_image);
+  const Transform transform (in_index_image);
   Eigen::Vector3 voxel_pos;
 
   while (reader (tck)) {
     SetVoxelDir dixels;
     mapper (tck, dixels);
-    vector<float> scalars (tck.size(), 0.0f);
+    scalars.clear();
+    scalars.set_index (tck.get_index());
+    scalars.resize (tck.size(), 0.0f);
     for (size_t p = 0; p < tck.size(); ++p) {
       voxel_pos = transform.scanner2voxel * tck[p].cast<default_type> ();
       for (SetVoxelDir::const_iterator d = dixels.begin(); d != dixels.end(); ++d) {

--- a/cmd/tckconvert.cpp
+++ b/cmd/tckconvert.cpp
@@ -175,6 +175,7 @@ class VTKReader: public ReaderInterface<float> { MEMALIGN(VTKReader)
       int number_of_points = 0;
       number_of_lines = 0;
       number_of_line_indices = 0;
+      tck_counter = 0;
       while ( std::getline(input,line) ) {
         if ( line.find ( "ASCII" ) == 0 ) {
           throw Exception("VTK Reader only supports BINARY input");
@@ -217,6 +218,7 @@ class VTKReader: public ReaderInterface<float> { MEMALIGN(VTKReader)
           tck.push_back(f);
           lineIdx++;
         }
+        tck.set_index (tck_counter++);
         return true;
       }
       return false;
@@ -233,6 +235,7 @@ class VTKReader: public ReaderInterface<float> { MEMALIGN(VTKReader)
     int lineIdx;
     int number_of_lines;
     int number_of_line_indices;
+    size_t tck_counter;
 
 };
 
@@ -253,7 +256,7 @@ class ASCIIReader: public ReaderInterface<float> { MEMALIGN(ASCIIReader)
         auto t = load_matrix<float>(list[item].name());
         for (size_t i = 0; i < size_t(t.rows()); i++)
           tck.push_back(Eigen::Vector3f(t.row(i)));
-        item++;
+        tck.set_index (item++);
         return true;
       }
       return false;

--- a/cmd/tckedit.cpp
+++ b/cmd/tckedit.cpp
@@ -53,9 +53,7 @@ void usage ()
   DESCRIPTION
   + "This command can be used to perform various types of manipulations "
     "on track data. A range of such manipulations are demonstrated in the "
-    "examples provided below."
-
-  + DWI::Tractography::preserve_track_order_desc;
+    "examples provided below.";
 
   EXAMPLES
   + Example ("Concatenate data from multiple track files into one",

--- a/cmd/tckedit.cpp
+++ b/cmd/tckedit.cpp
@@ -103,8 +103,9 @@ void usage ()
   + WeightsOption
 
   + OptionGroup ("Other options specific to tckedit")
-  + Option ("inverse", "output the inverse selection of streamlines based on the criteria provided, "
-                       "i.e. only those streamlines that fail at least one criterion will be written to file.")
+  + Option ("inverse", "output the inverse selection of streamlines based on the criteria provided; "
+                       "i.e. only those streamlines that fail at least one criterion, "
+                       "and/or vertices that are outside masks if provided, will be written to file")
 
   + Option ("ends_only", "only test the ends of each streamline against the provided include/exclude ROIs")
 

--- a/cmd/tckresample.cpp
+++ b/cmd/tckresample.cpp
@@ -47,9 +47,7 @@ void usage ()
   DESCRIPTION
   + "This may be either increasing or decreasing the number of samples along "
     "each streamline, or changing the positions of the samples according to "
-    "some specified trajectory."
-
-  + DWI::Tractography::preserve_track_order_desc;
+    "some specified trajectory.";
 
   ARGUMENTS
   + Argument ("in_tracks",  "the input track file").type_tracks_in()

--- a/cmd/tcksample.cpp
+++ b/cmd/tcksample.cpp
@@ -79,7 +79,7 @@ void usage ()
             "processing a whole-brain tractogram, and images for which the "
             "quantiative parameter is additive)");
 
-  
+
   // TODO add support for SH amplitude along tangent
   // TODO add support for reading from fixel image
   //   (this would supersede fixel2tsf when used without -precise or -stat_tck options)
@@ -127,7 +127,7 @@ class TDI : public Image<value_type> { MEMALIGN(TDI)
 
 
 template <class Interp>
-class SamplerNonPrecise 
+class SamplerNonPrecise
 { MEMALIGN (SamplerNonPrecise<Interp>)
   public:
     SamplerNonPrecise (Image<value_type>& image, const stat_tck statistic, MR::copy_ptr<TDI>& precalc_tdi) :
@@ -143,7 +143,7 @@ class SamplerNonPrecise
     bool operator() (DWI::Tractography::Streamline<>& tck, std::pair<size_t, value_type>& out)
     {
       assert (statistic != stat_tck::NONE);
-      out.first = tck.index;
+      out.first = tck.get_index();
 
       std::pair<size_t, vector_type> values;
       (*this) (tck, values);
@@ -190,7 +190,7 @@ class SamplerNonPrecise
 
     bool operator() (const DWI::Tractography::Streamline<>& tck, std::pair<size_t, vector_type>& out)
     {
-      out.first = tck.index;
+      out.first = tck.get_index();
       out.second.resize (tck.size());
       for (size_t i = 0; i != tck.size(); ++i) {
         if (interp.scanner (tck[i]))
@@ -220,7 +220,7 @@ class SamplerNonPrecise
 
 
 
-class SamplerPrecise 
+class SamplerPrecise
 { MEMALIGN (SamplerPrecise)
   public:
     SamplerPrecise (Image<value_type>& image, const stat_tck statistic, MR::copy_ptr<TDI>& precalc_tdi) :
@@ -235,7 +235,7 @@ class SamplerPrecise
 
     bool operator() (DWI::Tractography::Streamline<>& tck, std::pair<size_t, value_type>& out)
     {
-      out.first = tck.index;
+      out.first = tck.get_index();
       value_type sum_lengths = value_type(0);
 
       DWI::Tractography::Mapping::SetVoxel voxels;

--- a/cmd/tcktransform.cpp
+++ b/cmd/tcktransform.cpp
@@ -68,7 +68,7 @@ class Warper { MEMALIGN(Warper)
 
     bool operator () (const TrackType& in, TrackType& out) {
       out.clear();
-      out.index = in.index;
+      out.set_index (in.get_index());
       out.weight = in.weight;
       for (size_t n = 0; n < in.size(); ++n) {
         auto vertex = pos(in[n]);

--- a/cmd/tsfdivide.cpp
+++ b/cmd/tsfdivide.cpp
@@ -17,6 +17,7 @@
 #include "command.h"
 #include "dwi/tractography/properties.h"
 #include "dwi/tractography/scalar_file.h"
+#include "dwi/tractography/streamline.h"
 
 
 using namespace MR;
@@ -29,8 +30,8 @@ void usage ()
   SYNOPSIS = "Divide corresponding values in track scalar files";
 
   ARGUMENTS
-  + Argument ("input",  "the input track scalar file.").type_file_in()
-  + Argument ("input",  "the input track scalar file.").type_file_in()
+  + Argument ("input1", "the first input track scalar file.").type_file_in()
+  + Argument ("input2", "the second input track scalar file.").type_file_in()
   + Argument ("output", "the output track scalar file").type_file_out();
 }
 
@@ -39,30 +40,37 @@ using value_type = float;
 
 void run ()
 {
-  DWI::Tractography::Properties properties1;
+  DWI::Tractography::Properties properties1, properties2;
   DWI::Tractography::ScalarReader<value_type> reader1 (argument[0], properties1);
-  DWI::Tractography::Properties properties2;
   DWI::Tractography::ScalarReader<value_type> reader2 (argument[1], properties2);
-  DWI::Tractography::ScalarWriter<value_type> writer (argument[2], properties1);
-
   DWI::Tractography::check_properties_match (properties1, properties2, "scalar", false);
 
-  vector<value_type> tck_scalar1;
-  vector<value_type> tck_scalar2;
+  DWI::Tractography::ScalarWriter<value_type> writer (argument[2], properties1);
+  DWI::Tractography::TrackScalar<value_type> tck_scalar1, tck_scalar2, tck_scalar_output;
   while (reader1 (tck_scalar1)) {
-    if (!reader2 (tck_scalar2))
+    if (!reader2 (tck_scalar2)) {
+      WARN ("No more track scalars left in input file \"" + std::string(argument[1]) +
+            "\" after " + str(tck_scalar1.get_index()+1) + " streamlines; " +
+            "but more data are present in input file \"" + std::string(argument[0]) + "\"");
       break;
+    }
     if (tck_scalar1.size() != tck_scalar2.size())
-      throw Exception ("track scalar length mismatch");
+      throw Exception ("track scalar length mismatch at streamline index " + str(tck_scalar1.get_index()));
 
-    vector<value_type> tck_scalar_output (tck_scalar1.size());
+    tck_scalar_output.set_index (tck_scalar1.get_index());
+    tck_scalar_output.resize (tck_scalar1.size());
     for (size_t i = 0; i < tck_scalar1.size(); ++i) {
-      if (tck_scalar2[i] == 0.0)
-        tck_scalar_output[i] = 0;
+      if (tck_scalar2[i] == value_type(0))
+        tck_scalar_output[i] = value_type(0);
       else
         tck_scalar_output[i] = tck_scalar1[i] / tck_scalar2[i];
     }
     writer (tck_scalar_output);
+  }
+  if (reader2 (tck_scalar2)) {
+    WARN ("No more track scalars left in input file \"" + std::string(argument[0]) +
+          "\" after " + str(tck_scalar1.get_index()+1) + " streamlines; " +
+          "but more data are present in input file \"" + std::string(argument[1]) + "\"");
   }
 }
 

--- a/cmd/tsfinfo.cpp
+++ b/cmd/tsfinfo.cpp
@@ -17,8 +17,9 @@
 #include "command.h"
 #include "progressbar.h"
 #include "file/ofstream.h"
-#include "dwi/tractography/scalar_file.h"
 #include "dwi/tractography/properties.h"
+#include "dwi/tractography/scalar_file.h"
+#include "dwi/tractography/streamline.h"
 
 using namespace MR;
 using namespace MR::DWI;
@@ -79,7 +80,7 @@ void run ()
 
 
     if (actual_count) {
-      vector<float > tck;
+      DWI::Tractography::TrackScalar<> tck;
       size_t count = 0;
       {
         ProgressBar progress ("counting tracks in file");
@@ -93,12 +94,11 @@ void run ()
 
     if (opt.size()) {
       ProgressBar progress ("writing track scalar data to ascii files");
-      vector<float> tck;
-      size_t count = 0;
+      DWI::Tractography::TrackScalar<> tck;
       while (file (tck)) {
         std::string filename (opt[0][0]);
         filename += "-000000.txt";
-        std::string num (str (count));
+        std::string num (str (tck.get_index()));
         filename.replace (filename.size()-4-num.size(), num.size(), num);
 
         File::OFStream out (filename);
@@ -106,7 +106,6 @@ void run ()
           out << (*i) << "\n";
         out.close();
 
-        count++;
         ++progress;
       }
     }

--- a/cmd/tsfmult.cpp
+++ b/cmd/tsfmult.cpp
@@ -29,8 +29,8 @@ void usage ()
   SYNOPSIS = "Multiply corresponding values in track scalar files";
 
   ARGUMENTS
-  + Argument ("input",  "the input track scalar file.").type_file_in()
-  + Argument ("input",  "the input track scalar file.").type_file_in()
+  + Argument ("input1", "the first input track scalar file.").type_file_in()
+  + Argument ("input1", "the second input track scalar file.").type_file_in()
   + Argument ("output", "the output track scalar file").type_file_out();
 }
 
@@ -39,27 +39,34 @@ using value_type = float;
 
 void run ()
 {
-  DWI::Tractography::Properties properties1;
+  DWI::Tractography::Properties properties1, properties2;
   DWI::Tractography::ScalarReader<value_type> reader1 (argument[0], properties1);
-  DWI::Tractography::Properties properties2;
   DWI::Tractography::ScalarReader<value_type> reader2 (argument[1], properties2);
-  DWI::Tractography::ScalarWriter<value_type> writer (argument[2], properties1);
-
   DWI::Tractography::check_properties_match (properties1, properties2, "scalar", false);
 
-  vector<value_type> tck_scalar1;
-  vector<value_type> tck_scalar2;
+  DWI::Tractography::ScalarWriter<value_type> writer (argument[2], properties1);
+  DWI::Tractography::TrackScalar<> tck_scalar1, tck_scalar2, tck_scalar_output;
   while (reader1 (tck_scalar1)) {
-    if (!reader2 (tck_scalar2))
+    if (!reader2 (tck_scalar2)) {
+      WARN ("No more track scalars left in input file \"" + std::string(argument[1]) +
+            "\" after " + str(tck_scalar1.get_index()+1) + " streamlines; " +
+            "but more data are present in input file \"" + std::string(argument[0]) + "\"");
       break;
+    }
     if (tck_scalar1.size() != tck_scalar2.size())
-      throw Exception ("track scalar length mismatch");
+      throw Exception ("track scalar length mismatch at streamline index " + str(tck_scalar1.get_index()));
 
-    vector<value_type> tck_scalar_output (tck_scalar1.size());
+    tck_scalar_output.set_index (tck_scalar1.get_index());
+    tck_scalar_output.resize (tck_scalar1.size());
     for (size_t i = 0; i < tck_scalar1.size(); ++i) {
       tck_scalar_output[i] = tck_scalar1[i] * tck_scalar2[i];
     }
     writer (tck_scalar_output);
+  }
+  if (reader2 (tck_scalar2)) {
+    WARN ("No more track scalars left in input file \"" + std::string(argument[0]) +
+          "\" after " + str(tck_scalar1.get_index()+1) + " streamlines; " +
+          "but more data are present in input file \"" + std::string(argument[1]) + "\"");
   }
 }
 

--- a/cmd/tsfsmooth.cpp
+++ b/cmd/tsfsmooth.cpp
@@ -52,7 +52,7 @@ void run ()
   DWI::Tractography::ScalarWriter<value_type> writer (argument[1], properties);
 
   float stdev = get_option_value ("stdev", DEFAULT_SMOOTHING);
-  
+
   vector<float> kernel (2 * ceil(2.5 * stdev) + 1, 0);
   float norm_factor = 0.0;
   float radius = (kernel.size() - 1.0) / 2.0;
@@ -63,9 +63,10 @@ void run ()
   for (size_t c = 0; c < kernel.size(); c++)
     kernel[c] /= norm_factor;
 
-  vector<value_type> tck_scalar;
+  DWI::Tractography::TrackScalar<value_type> tck_scalar;
   while (reader (tck_scalar)) {
-    vector<value_type> tck_scalars_smoothed (tck_scalar.size());
+    DWI::Tractography::TrackScalar<value_type> tck_scalars_smoothed (tck_scalar.size());
+    tck_scalars_smoothed.set_index (tck_scalar.get_index());
 
     for (int i = 0; i < (int)tck_scalar.size(); ++i) {
       float norm_factor = 0.0;

--- a/cmd/tsfthreshold.cpp
+++ b/cmd/tsfthreshold.cpp
@@ -30,7 +30,7 @@ void usage ()
 
   ARGUMENTS
   + Argument ("input",  "the input track scalar file.").type_file_in()
-  + Argument ("N",      "the desired threshold").type_float ()
+  + Argument ("T",      "the desired threshold").type_float ()
   + Argument ("output", "the binary output track scalar file").type_file_out();
 
 
@@ -51,20 +51,21 @@ void run ()
   DWI::Tractography::ScalarReader<value_type> reader (argument[0], properties);
   DWI::Tractography::ScalarWriter<value_type> writer (argument[2], properties);
 
-  vector<value_type> tck_scalar;
+  DWI::Tractography::TrackScalar<value_type> tck_scalar;
   while (reader (tck_scalar)) {
-    vector<value_type> tck_mask (tck_scalar.size());
+    DWI::Tractography::TrackScalar<value_type> tck_mask (tck_scalar.size());
+    tck_mask.set_index (tck_scalar.get_index());
     for (size_t i = 0; i < tck_scalar.size(); ++i) {
       if (invert) {
         if (tck_scalar[i] > threshold)
-          tck_mask[i] = 0.0;
+          tck_mask[i] = value_type(0);
         else
-          tck_mask[i] = 1.0;
+          tck_mask[i] = value_type(1);
       } else {
         if (tck_scalar[i] > threshold)
-          tck_mask[i] = 1.0;
+          tck_mask[i] = value_type(1);
         else
-          tck_mask[i] = 0.0;
+          tck_mask[i] = value_type(0);
       }
     }
     writer (tck_mask);

--- a/cmd/tsfvalidate.cpp
+++ b/cmd/tsfvalidate.cpp
@@ -74,7 +74,7 @@ void run ()
   }
 
   Streamline<value_type> track;
-  vector<value_type> scalar;
+  TrackScalar<value_type> scalar;
   size_t tck_counter = 0, tsf_counter = 0, length_mismatch_count = 0;
 
   {

--- a/docs/reference/commands/tckedit.rst
+++ b/docs/reference/commands/tckedit.rst
@@ -86,7 +86,7 @@ Thresholds pertaining to per-streamline weighting
 Other options specific to tckedit
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
--  **-inverse** output the inverse selection of streamlines based on the criteria provided, i.e. only those streamlines that fail at least one criterion will be written to file.
+-  **-inverse** output the inverse selection of streamlines based on the criteria provided; i.e. only those streamlines that fail at least one criterion, and/or vertices that are outside masks if provided, will be written to file
 
 -  **-ends_only** only test the ends of each streamline against the provided include/exclude ROIs
 

--- a/docs/reference/commands/tckedit.rst
+++ b/docs/reference/commands/tckedit.rst
@@ -23,8 +23,6 @@ Description
 
 This command can be used to perform various types of manipulations on track data. A range of such manipulations are demonstrated in the examples provided below.
 
-Note that if multi-threading is used in this command, the ordering of tracks in the output file is unlikely to match the order of the incoming data. If your application explicitly requires that the order of tracks not change, you should run this command with the option -nthreads 0.
-
 Example usages
 --------------
 

--- a/docs/reference/commands/tckresample.rst
+++ b/docs/reference/commands/tckresample.rst
@@ -23,8 +23,6 @@ Description
 
 This may be either increasing or decreasing the number of samples along each streamline, or changing the positions of the samples according to some specified trajectory.
 
-Note that if multi-threading is used in this command, the ordering of tracks in the output file is unlikely to match the order of the incoming data. If your application explicitly requires that the order of tracks not change, you should run this command with the option -nthreads 0.
-
 Options
 -------
 

--- a/docs/reference/commands/tsfdivide.rst
+++ b/docs/reference/commands/tsfdivide.rst
@@ -13,10 +13,10 @@ Usage
 
 ::
 
-    tsfdivide [ options ]  input input output
+    tsfdivide [ options ]  input1 input2 output
 
--  *input*: the input track scalar file.
--  *input*: the input track scalar file.
+-  *input1*: the first input track scalar file.
+-  *input2*: the second input track scalar file.
 -  *output*: the output track scalar file
 
 Options

--- a/docs/reference/commands/tsfmult.rst
+++ b/docs/reference/commands/tsfmult.rst
@@ -13,10 +13,10 @@ Usage
 
 ::
 
-    tsfmult [ options ]  input input output
+    tsfmult [ options ]  input1 input1 output
 
--  *input*: the input track scalar file.
--  *input*: the input track scalar file.
+-  *input1*: the first input track scalar file.
+-  *input1*: the second input track scalar file.
 -  *output*: the output track scalar file
 
 Options

--- a/docs/reference/commands/tsfthreshold.rst
+++ b/docs/reference/commands/tsfthreshold.rst
@@ -13,10 +13,10 @@ Usage
 
 ::
 
-    tsfthreshold [ options ]  input N output
+    tsfthreshold [ options ]  input T output
 
 -  *input*: the input track scalar file.
--  *N*: the desired threshold
+-  *T*: the desired threshold
 -  *output*: the binary output track scalar file
 
 Options

--- a/src/dwi/tractography/SIFT/model.h
+++ b/src/dwi/tractography/SIFT/model.h
@@ -333,8 +333,8 @@ namespace MR
       template <class Fixel>
       bool Model<Fixel>::TrackMappingWorker::operator() (const Tractography::Streamline<>& in)
       {
-        assert (in.index < master.contributions.size());
-        assert (!master.contributions[in.index]);
+        assert (in.get_index() < master.contributions.size());
+        assert (!master.contributions[in.get_index()]);
 
         try {
 
@@ -359,7 +359,7 @@ namespace MR
             }
           }
 
-          master.contributions[in.index] = new TrackContribution (masked_contributions, total_contribution, total_length);
+          master.contributions[in.get_index()] = new TrackContribution (masked_contributions, total_contribution, total_length);
 
           TD_sum += total_contribution;
           for (vector<Track_fixel_contribution>::const_iterator i = masked_contributions.begin(); i != masked_contributions.end(); ++i)

--- a/src/dwi/tractography/SIFT/sifter.cpp
+++ b/src/dwi/tractography/SIFT/sifter.cpp
@@ -317,14 +317,16 @@ namespace MR
         Tractography::Reader<float> reader (input_path, p);
         p["SIFT_mu"] = str (mu());
         Tractography::Writer<float> writer (output_path, p);
-        track_t tck_counter = 0;
+        track_t in_counter = 0, out_counter = 0;
         Tractography::Streamline<> tck;
         ProgressBar progress ("Writing filtered tracks output file", contributions.size());
-        while (reader (tck) && tck_counter < contributions.size()) {
-          if (contributions[tck_counter++])
+        while (reader (tck) && in_counter < contributions.size()) {
+          if (contributions[in_counter++]) {
+            tck.set_index (out_counter++);
             writer (tck);
-          else
+          } else {
             writer.skip();
+          }
           ++progress;
         }
         reader.close();

--- a/src/dwi/tractography/connectome/exemplar.cpp
+++ b/src/dwi/tractography/connectome/exemplar.cpp
@@ -82,7 +82,7 @@ void Exemplar::add (const Connectome::Streamline_nodelist& in)
   Tractography::Streamline<float> subtck;
   for (size_t i = first; i <= last; ++i)
     subtck.push_back (in[i]);
-  subtck.index  = in.index;
+  subtck.set_index (in.get_index());
   subtck.weight = in.weight;
   add (in, is_reversed);
 }

--- a/src/dwi/tractography/connectome/mapper.h
+++ b/src/dwi/tractography/connectome/mapper.h
@@ -47,7 +47,7 @@ class Mapper
     bool operator() (const Tractography::Streamline<float>& in, Mapped_track_nodepair& out)
     {
       assert (tck2nodes.provides_pair());
-      out.set_track_index (in.index);
+      out.set_track_index (in.get_index());
       out.set_nodes (tck2nodes (in));
       out.set_factor (metric (in, out.get_nodes()));
       out.set_weight (in.weight);
@@ -57,7 +57,7 @@ class Mapper
     bool operator() (const Tractography::Streamline<float>& in, Mapped_track_nodelist& out)
     {
       assert (!tck2nodes.provides_pair());
-      out.set_track_index (in.index);
+      out.set_track_index (in.get_index());
       vector<node_t> nodes;
       tck2nodes (in, nodes);
       out.set_nodes (std::move (nodes));

--- a/src/dwi/tractography/connectome/metric.h
+++ b/src/dwi/tractography/connectome/metric.h
@@ -83,9 +83,9 @@ class Metric { MEMALIGN(Metric)
       else if (scale_by_invlength)
         result = (tck.size() > 1 ? (result / tck.calc_length()) : 0.0);
       if (scale_by_file) {
-        if (tck.index >= size_t(file_values.size()))
+        if (tck.get_index() >= size_t(file_values.size()))
           throw Exception ("File " + file_path + " does not contain enough entries for this tractogram");
-        result *= file_values[tck.index];
+        result *= file_values[tck.get_index()];
       }
       return result;
     }

--- a/src/dwi/tractography/editing/receiver.cpp
+++ b/src/dwi/tractography/editing/receiver.cpp
@@ -63,7 +63,7 @@ namespace MR {
               if (p.allFinite()) {
                 temp.push_back (p);
               } else if (temp.size()) {
-                temp.index = in.index;
+                temp.set_index (in.get_index());
                 temp.weight = in.weight;
                 writer (temp);
                 ++segments;

--- a/src/dwi/tractography/editing/receiver.h
+++ b/src/dwi/tractography/editing/receiver.h
@@ -61,7 +61,7 @@ namespace MR {
             }
 
 
-            bool operator() (const Streamline<>&);
+            bool operator() (Streamline<>&);
 
 
           private:

--- a/src/dwi/tractography/editing/worker.cpp
+++ b/src/dwi/tractography/editing/worker.cpp
@@ -29,7 +29,7 @@ namespace MR {
         {
 
           out.clear();
-          out.index = in.index;
+          out.set_index (in.get_index());
           out.weight = in.weight;
 
           if (!thresholds (in)) {

--- a/src/dwi/tractography/file.h
+++ b/src/dwi/tractography/file.h
@@ -104,7 +104,7 @@ namespace MR
                 }
 
                 if (std::isnan (p[0])) {
-                  tck.index = current_index++;
+                  tck.set_index (current_index++);
 
                   if (weights_file) {
 

--- a/src/dwi/tractography/file.h
+++ b/src/dwi/tractography/file.h
@@ -71,16 +71,16 @@ namespace MR
         public:
 
           //! open the \c file for reading and load header into \c properties
-          Reader (const std::string& file, Properties& properties) :
-            current_index (0) {
-              open (file, "tracks", properties);
-              auto opt = App::get_options ("tck_weights_in");
-              if (opt.size()) {
-                weights_file.reset (new std::ifstream (str(opt[0][0]).c_str(), std::ios_base::in));
-                if (!weights_file->good())
-                  throw Exception ("Unable to open streamlines weights file " + str(opt[0][0]));
-              }
+          Reader (const std::string& file, Properties& properties)
+          {
+            open (file, "tracks", properties);
+            auto opt = App::get_options ("tck_weights_in");
+            if (opt.size()) {
+              weights_file.reset (new std::ifstream (str(opt[0][0]).c_str(), std::ios_base::in));
+              if (!weights_file->good())
+                throw Exception ("Unable to open streamlines weights file " + str(opt[0][0]));
             }
+          }
 
 
             //! fetch next track from file
@@ -135,8 +135,8 @@ namespace MR
         protected:
           using __ReaderBase__::in;
           using __ReaderBase__::dtype;
+            using __ReaderBase__::current_index;
 
-          uint64_t current_index;
           std::unique_ptr<std::ifstream> weights_file;
 
           //! takes care of byte ordering issues

--- a/src/dwi/tractography/file.h
+++ b/src/dwi/tractography/file.h
@@ -386,18 +386,14 @@ namespace MR
 
           //! commits any remaining data to file
           ~Writer() {
-            add_reorder_cache();
-            if (reorder.size()) {
-              WARN ("The last " + str(reorder.size()) + " streamlines in file " + name + " were not identified as being in correct order");
-              add_reorder_cache (true); // Flush all remaining data
-            }
+            add_reorder_cache (true);
             commit();
           }
 
           //! add track to the output
           bool operator() (const Streamline<ValueType>& tck) {
             assert (tck.get_index() != tck.invalid);
-            if (tck.get_index() == count) {
+            if (tck.get_index() == total_count) {
               add_streamline (tck, tck.weight);
               add_weight (tck.weight);
               add_reorder_cache();
@@ -465,11 +461,11 @@ namespace MR
           {
             while (reorder.size()) {
               auto i = reorder.begin();
-              if (force || i->get_index() == count) {
-                add_streamline (*i, i->weight);
-                add_weight (i->weight);
-                reorder.erase (i);
-              }
+              if (!force && i->get_index() != total_count)
+                return;
+              add_streamline (*i, i->weight);
+              add_weight (i->weight);
+              reorder.erase (i);
             }
           }
 

--- a/src/dwi/tractography/file_base.h
+++ b/src/dwi/tractography/file_base.h
@@ -71,14 +71,14 @@ namespace MR
               dtype (DataType::from<ValueType>()),
               count_offset (0),
               open_success (false)
-          {
-            dtype.set_byte_order_native();
-            if (dtype != DataType::Float32LE && dtype != DataType::Float32BE &&
-                dtype != DataType::Float64LE && dtype != DataType::Float64BE)
-              throw Exception ("only supported datatype for tracks file are "
-                  "Float32LE, Float32BE, Float64LE & Float64BE");
-            App::check_overwrite (name);
-          }
+            {
+              dtype.set_byte_order_native();
+              if (dtype != DataType::Float32LE && dtype != DataType::Float32BE &&
+                  dtype != DataType::Float64LE && dtype != DataType::Float64BE)
+                throw Exception ("only supported datatype for tracks file are "
+                                 "Float32LE, Float32BE, Float64LE & Float64BE");
+              App::check_overwrite (name);
+            }
 
             ~__WriterBase__()
             {
@@ -148,31 +148,6 @@ namespace MR
               verify_stream (out);
             }
         };
-
-
-
-      // TODO A class for writing track / scalar data to file in the correct
-      //   order even if the data are provided out of order (e.g. due to
-      //   multi-threading)
-      template <class ClassType>
-      class WriterReorder
-      { NOMEMALIGN
-        public:
-          bool operator() (ClassType&&) const;
-
-        private:
-          mutable std::set<ClassType> buffer;
-          virtual void commit (const ClassType&) = 0;
-      };
-
-      template <class ClassType>
-      bool WriterReorder<ClassType>::operator() (ClassType&& in) const
-      {
-        return true;
-      }
-
-
-
       //! \endcond
 
 

--- a/src/dwi/tractography/file_base.h
+++ b/src/dwi/tractography/file_base.h
@@ -41,6 +41,7 @@ namespace MR
       class __ReaderBase__
       { NOMEMALIGN
         public:
+            __ReaderBase__() : current_index (0) { }
           ~__ReaderBase__ () {
             if (in.is_open())
               in.close();
@@ -51,9 +52,9 @@ namespace MR
           void close () { in.close(); }
 
         protected:
-
           std::ifstream  in;
           DataType  dtype;
+          uint64_t current_index;
       };
 
 

--- a/src/dwi/tractography/file_base.h
+++ b/src/dwi/tractography/file_base.h
@@ -19,6 +19,7 @@
 
 #include <iomanip>
 #include <map>
+#include <set>
 
 #include "types.h"
 #include "file/key_value.h"
@@ -146,6 +147,31 @@ namespace MR
               verify_stream (out);
             }
         };
+
+
+
+      // TODO A class for writing track / scalar data to file in the correct
+      //   order even if the data are provided out of order (e.g. due to
+      //   multi-threading)
+      template <class ClassType>
+      class WriterReorder
+      { NOMEMALIGN
+        public:
+          bool operator() (ClassType&&) const;
+
+        private:
+          mutable std::set<ClassType> buffer;
+          virtual void commit (const ClassType&) = 0;
+      };
+
+      template <class ClassType>
+      bool WriterReorder<ClassType>::operator() (ClassType&& in) const
+      {
+        return true;
+      }
+
+
+
       //! \endcond
 
 

--- a/src/dwi/tractography/mapping/gaussian/mapper.h
+++ b/src/dwi/tractography/mapping/gaussian/mapper.h
@@ -68,7 +68,7 @@ namespace MR {
               bool operator() (Streamline<>& in, Cont& out) const
               {
                 out.clear();
-                out.index = in.index;
+                out.index = in.get_index();
                 out.weight = in.weight;
                 if (in.empty())
                   return true;

--- a/src/dwi/tractography/mapping/loader.h
+++ b/src/dwi/tractography/mapping/loader.h
@@ -48,7 +48,7 @@ namespace MR {
                 progress.reset();
                 return false;
               }
-              if (tracks_to_load && out.index >= tracks_to_load) {
+              if (tracks_to_load && out.get_index() >= tracks_to_load) {
                 out.clear();
                 progress.reset();
                 return false;

--- a/src/dwi/tractography/mapping/mapper.cpp
+++ b/src/dwi/tractography/mapping/mapper.cpp
@@ -154,8 +154,8 @@ void TrackMapperTWI::set_factor (const Streamline<>& tck, SetVoxelExtras& out) c
 
     case VECTOR_FILE:
       assert (vector_data);
-      assert (tck.index < size_t(vector_data->size()));
-      out.factor = (*vector_data)[tck.index];
+      assert (tck.get_index() < size_t(vector_data->size()));
+      out.factor = (*vector_data)[tck.get_index()];
       break;
 
     default:

--- a/src/dwi/tractography/mapping/mapper.h
+++ b/src/dwi/tractography/mapping/mapper.h
@@ -112,7 +112,7 @@ namespace MR {
               bool operator() (const Streamline<>& in, Cont& out) const
               {
                 out.clear();
-                out.index = in.index;
+                out.index = in.get_index();
                 out.weight = in.weight;
                 if (in.empty())
                   return true;

--- a/src/dwi/tractography/resampling/arc.cpp
+++ b/src/dwi/tractography/resampling/arc.cpp
@@ -31,7 +31,7 @@ namespace MR {
           assert (in.size());
           assert (planes.size());
           out.clear();
-          out.index = in.index;
+          out.set_index (in.get_index());
           out.weight = in.weight;
 
           // Determine which points on the streamline correspond to the endpoints of the arc

--- a/src/dwi/tractography/resampling/downsampler.cpp
+++ b/src/dwi/tractography/resampling/downsampler.cpp
@@ -49,7 +49,7 @@ namespace MR {
         bool Downsampler::operator() (const Streamline<>& in, Streamline<>& out) const
         {
           out.clear();
-          out.index = in.index;
+          out.set_index (in.get_index());
           out.weight = in.weight;
           if (ratio <= 1 || in.empty())
             return false;

--- a/src/dwi/tractography/resampling/endpoints.cpp
+++ b/src/dwi/tractography/resampling/endpoints.cpp
@@ -27,7 +27,7 @@ namespace MR {
         bool Endpoints::operator() (const Streamline<>& in, Streamline<>& out) const
         {
           out.resize (2);
-          out.index = in.index;
+          out.set_index (in.get_index());
           out.weight = in.weight;
           out[0] = in.front();
           out[1] = in.back();

--- a/src/dwi/tractography/resampling/fixed_num_points.cpp
+++ b/src/dwi/tractography/resampling/fixed_num_points.cpp
@@ -32,7 +32,7 @@ namespace MR {
           // From this, derive the spline position of each sample
           assert (in.size() > 1);
           out.clear();
-          out.index = in.index;
+          out.set_index (in.get_index());
           out.weight = in.weight;
           value_type length = 0.0;
           vector<value_type> steps;

--- a/src/dwi/tractography/resampling/fixed_step_size.cpp
+++ b/src/dwi/tractography/resampling/fixed_step_size.cpp
@@ -29,7 +29,7 @@ namespace MR {
         bool FixedStepSize::operator() (const Streamline<>& in, Streamline<>& out) const
         {
           out.clear();
-          out.index = in.index;
+          out.set_index (in.get_index());
           out.weight = in.weight;
           Math::Hermite<value_type> interp (hermite_tension);
           // Extensions required to enable Hermite interpolation in last streamline segment at either end

--- a/src/dwi/tractography/resampling/upsampler.cpp
+++ b/src/dwi/tractography/resampling/upsampler.cpp
@@ -34,7 +34,7 @@ namespace MR {
             return true;
           }
           out.clear();
-          out.index = in.index;
+          out.set_index (in.get_index());
           out.weight = in.weight;
           Streamline<> in_padded (in);
           interp_prepare (in_padded);

--- a/src/dwi/tractography/scalar_file.h
+++ b/src/dwi/tractography/scalar_file.h
@@ -200,6 +200,7 @@ namespace MR
           }
 
           ~ScalarWriter() {
+            add_reorder_cache (true);
             commit();
           }
 
@@ -264,10 +265,10 @@ namespace MR
           {
             while (reorder.size()) {
               auto i = reorder.begin();
-              if (force || i->get_index() == count) {
-                add_streamline (*i);
-                reorder.erase (i);
-              }
+              if (!force && i->get_index() != total_count)
+                return;
+              add_streamline (*i);
+              reorder.erase (i);
             }
           }
 

--- a/src/dwi/tractography/scalar_file.h
+++ b/src/dwi/tractography/scalar_file.h
@@ -136,7 +136,7 @@ namespace MR
                 assert (0);
                 break;
             }
-            return (value_type (NAN));
+            return (value_type (NaN));
           }
 
           ScalarReader (const ScalarReader&) = delete;

--- a/src/dwi/tractography/seeding/dynamic.cpp
+++ b/src/dwi/tractography/seeding/dynamic.cpp
@@ -168,7 +168,7 @@ namespace MR
 
       bool Dynamic::get_seed (Eigen::Vector3f&) const { return false; }
 
-      bool Dynamic::get_seed (Eigen::Vector3f& p, Eigen::Vector3f& d) 
+      bool Dynamic::get_seed (Eigen::Vector3f& p, Eigen::Vector3f& d)
       {
 
         uint64_t this_attempts = 0;
@@ -367,12 +367,12 @@ namespace MR
 
         bool WriteKernelDynamic::operator() (const Tracking::GeneratedTrack& in, Tractography::Streamline<>& out)
         {
-          out.index = writer.count;
-          out.weight = 1.0;
+          out.set_index (writer.count);
+          out.weight = 1.0f;
           if (!WriteKernel::operator() (in)) {
             out.clear();
             // Flag to indicate that tracking has completed, and threads should therefore terminate
-            out.weight = 0.0;
+            out.weight = 0.0f;
             // Actually need to pass this down the queue so that the seeder thread receives it and knows to terminate
             return true;
           }

--- a/src/dwi/tractography/streamline.h
+++ b/src/dwi/tractography/streamline.h
@@ -43,6 +43,7 @@ namespace MR
           DataIndex (DataIndex&& i) : index (i.index) { i.index = invalid; }
           DataIndex& operator= (const DataIndex& i) { index = i.index; return *this; }
           DataIndex& operator= (DataIndex&& i) { index = i.index; i.index = invalid; return *this; }
+          void swap (DataIndex& i) { const size_t temp = index; index = i.index; i.index = temp; }
           void set_index (const size_t i) { index = i; }
           size_t get_index() const { return index; }
           void clear() { index = invalid; }
@@ -66,6 +67,7 @@ namespace MR
             vector<value_type> (std::move (that)),
             DataIndex (std::move (that)) { }
           TrackScalar& operator= (const TrackScalar& that) = default;
+          void swap (TrackScalar& that) { (*this).vector<ValueType>::swap (that); (*this).DataIndex::swap (that); }
           void clear() { vector<ValueType>::clear(); DataIndex::clear(); }
       };
 
@@ -112,6 +114,11 @@ namespace MR
             return *this;
           }
 
+          void swap (Streamline& that) {
+            (*this).vector<Eigen::Matrix<ValueType,3,1>>::swap (that);
+            (*this).DataIndex::swap (that);
+            std::swap (weight, that.weight);
+          }
 
           void clear()
           {

--- a/src/dwi/tractography/streamline.h
+++ b/src/dwi/tractography/streamline.h
@@ -55,6 +55,19 @@ namespace MR
 
 
 
+      // A class for track scalars
+      template <typename ValueType = float>
+      class TrackScalar : public vector<ValueType>, public DataIndex
+      { MEMALIGN(TrackScalar)
+        public:
+          using value_type = ValueType;
+          using vector<ValueType>::vector;
+          void clear() { vector<ValueType>::clear(); DataIndex::clear(); }
+      };
+
+
+
+
       template <typename ValueType = float>
         class Streamline : public vector<Eigen::Matrix<ValueType,3,1>>, public DataIndex
       { MEMALIGN(Streamline<ValueType>)

--- a/src/dwi/tractography/streamline.h
+++ b/src/dwi/tractography/streamline.h
@@ -33,7 +33,6 @@ namespace MR
 
 
       // Base class for storing an index alongside either streamline vertex or track scalar data
-      //
       class DataIndex
       { NOMEMALIGN
         public:
@@ -62,6 +61,11 @@ namespace MR
         public:
           using value_type = ValueType;
           using vector<ValueType>::vector;
+          TrackScalar (const TrackScalar&) = default;
+          TrackScalar (TrackScalar&& that) :
+            vector<value_type> (std::move (that)),
+            DataIndex (std::move (that)) { }
+          TrackScalar& operator= (const TrackScalar& that) = default;
           void clear() { vector<ValueType>::clear(); DataIndex::clear(); }
       };
 

--- a/src/dwi/tractography/tracking/generated_track.h
+++ b/src/dwi/tractography/tracking/generated_track.h
@@ -37,7 +37,6 @@ namespace MR
         class GeneratedTrack : public vector<Eigen::Vector3f>
         { MEMALIGN(GeneratedTrack)
 
-
           public:
 
             using BaseType = vector<Eigen::Vector3f>;

--- a/src/gui/mrview/tool/connectome/connectome.cpp
+++ b/src/gui/mrview/tool/connectome/connectome.cpp
@@ -3810,8 +3810,8 @@ namespace MR
           ProgressBar progress ("Importing connection exemplars", num_edges());
           MR::DWI::Tractography::Streamline<float> tck;
           while (reader (tck)) {
-            edges[tck.index].load_exemplar (tck);
-            edges[tck.index].create_streamline();
+            edges[tck.get_index()].load_exemplar (tck);
+            edges[tck.get_index()].create_streamline();
             ++progress;
           }
           have_exemplars = true;

--- a/src/gui/mrview/tool/tractography/tractogram.cpp
+++ b/src/gui/mrview/tool/tractography/tractogram.cpp
@@ -704,7 +704,7 @@ namespace MR
           value_min = std::numeric_limits<float>::infinity();
           value_max = -std::numeric_limits<float>::infinity();
           vector<float> buffer;
-          vector<float> tck_scalar;
+          DWI::Tractography::TrackScalar<float> tck_scalar;
 
           if (Path::has_suffix (filename, ".tsf")) {
             DWI::Tractography::Properties scalar_properties;
@@ -799,7 +799,7 @@ namespace MR
           threshold_min = std::numeric_limits<float>::infinity();
           threshold_max = -std::numeric_limits<float>::infinity();
           vector<float> buffer;
-          vector<float> tck_scalar;
+          DWI::Tractography::TrackScalar<float> tck_scalar;
 
           if (Path::has_suffix (filename, ".tsf")) {
             DWI::Tractography::Properties scalar_properties;

--- a/testing/cmd/testing_diff_tsf.cpp
+++ b/testing/cmd/testing_diff_tsf.cpp
@@ -18,6 +18,7 @@
 #include "progressbar.h"
 #include "datatype.h"
 #include "dwi/tractography/scalar_file.h"
+#include "dwi/tractography/streamline.h"
 
 using namespace MR;
 using namespace App;
@@ -31,11 +32,11 @@ void usage ()
   ARGUMENTS
   + Argument ("tsf1", "a track scalar file.").type_file_in()
   + Argument ("tsf2", "another track scalar file.").type_file_in();
-  
+
   OPTIONS
-  + Option ("abs", "specify an absolute tolerance") 
+  + Option ("abs", "specify an absolute tolerance")
     + Argument ("tolerance").type_float (0.0)
-  + Option ("frac", "specify a fractional tolerance") 
+  + Option ("frac", "specify a fractional tolerance")
     + Argument ("tolerance").type_float (0.0);
 }
 
@@ -46,17 +47,15 @@ void run ()
   DWI::Tractography::Properties properties1, properties2;
   DWI::Tractography::ScalarReader<value_type> reader1 (argument[0], properties1);
   DWI::Tractography::ScalarReader<value_type> reader2 (argument[1], properties2);
-
   DWI::Tractography::check_properties_match (properties1, properties2, "scalar", false);
 
-  vector<value_type> tck_scalar1;
-  vector<value_type> tck_scalar2;
-  
+  DWI::Tractography::TrackScalar<value_type> tck_scalar1, tck_scalar2;
+
   auto opt = get_options ("frac");
   if (opt.size()) {
-  
+
     const double tol = opt[0][0];
-  
+
     while (reader1 (tck_scalar1)) {
       if (!reader2 (tck_scalar2))
         throw Exception ("readable number of tracks mismatch - test FAILED");
@@ -69,14 +68,14 @@ void run ()
                            + " (" + str(cdouble (tck_scalar1[i])) + " vs " + str(cdouble (tck_scalar2[i])) + ")");
       }
     }
-    
+
   } else {
-  
+
     double tol = 0.0;
     opt = get_options ("abs");
     if (opt.size())
       tol = opt[0][0];
-  
+
     while (reader1 (tck_scalar1)) {
       if (!reader2 (tck_scalar2))
         throw Exception ("readable number of tracks mismatch - test FAILED");
@@ -89,10 +88,10 @@ void run ()
                            + " (" + str(cdouble (tck_scalar1[i])) + " vs " + str(cdouble (tck_scalar2[i])) + ")");
       }
     }
-  
+
   }
-  
-  
+
+
   CONSOLE ("track scalar files checked OK");
 }
 

--- a/testing/tests/tckconvert
+++ b/testing/tests/tckconvert
@@ -2,7 +2,7 @@ tckconvert tracks.tck tmp.vtk -force && awk '/POINTS/{s=1;next}/LINES/{s=0}s' tm
 tckconvert tracks.tck tmp.vtk -force && awk '/LINES/,0' tmp.vtk >tmplines1.txt && awk '/LINES/,0' tckconvert/out0.vtk >tmplines2.txt && diff tmplines1.txt tmplines2.txt
 tckconvert tracks.tck -scanner2voxel dwi.mif tmp.vtk -force && awk '/POINTS/{s=1;next}/LINES/{s=0}s' tmp.vtk >tmppoints1.txt && awk '/POINTS/{s=1;next}/LINES/{s=0}s' tckconvert/out1.vtk >tmppoints2.txt && testing_diff_matrix tmppoints1.txt tmppoints2.txt -abs 1e-4
 tckconvert tracks.tck -scanner2voxel dwi.mif tmp.vtk -force && awk '/LINES/,0' tmp.vtk >tmplines1.txt && awk '/LINES/,0' tckconvert/out1.vtk >tmplines2.txt && diff tmplines1.txt tmplines2.txt
-tckedit tracks.tck -number 10 tmp.tck -nthread 0 && tckconvert tmp.tck tmp-[].txt && cat tmp-*.txt > tmp-all.txt && testing_diff_matrix tmp-all.txt tckconvert/out2-all.txt -abs 1e-4
+tckedit tracks.tck -number 10 tmp.tck -nthreads 0 && tckconvert tmp.tck tmp-[].txt && cat tmp-*.txt > tmp-all.txt && testing_diff_matrix tmp-all.txt tckconvert/out2-all.txt -abs 1e-4
 tckconvert tckconvert/out2-[2:9].txt tmp.tck -force && testing_diff_tck tmp.tck tckconvert/out3.tck 1e-4
 echo 1 2 3 > tmp.txt && tckconvert -force -quiet tmp.txt tmp.tck && tckconvert -quiet -force tmp.tck tmp.rib && [ $(wc -l < tmp.rib ) == 4 ]
 tckconvert -force -quiet tckconvert/empty.vtk tmp.tck

--- a/testing/tests/tckedit
+++ b/testing/tests/tckedit
@@ -1,0 +1,16 @@
+tckedit tckedit/in.tck -include SIFT_phantom/upper.mif tmp.tck -force && testing_diff_tck tmp.tck tckedit/upper.tck 1e-4
+tckedit tckedit/in.tck -include SIFT_phantom/lower.mif tmp.tck -force && testing_diff_tck tmp.tck tckedit/lower.tck 1e-4
+tckedit tckedit/in.tck -exclude SIFT_phantom/upper.mif tmp.tck -force && testing_diff_tck tmp.tck tckedit/lower.tck 1e-4
+tckedit tckedit/in.tck -exclude SIFT_phantom/lower.mif tmp.tck -force && testing_diff_tck tmp.tck tckedit/upper.tck 1e-4
+tckedit tckedit/in.tck -include SIFT_phantom/upper.mif -inverse tmp.tck -force && testing_diff_tck tmp.tck tckedit/lower.tck 1e-4
+tckedit tckedit/in.tck -include SIFT_phantom/lower.mif -inverse tmp.tck -force && testing_diff_tck tmp.tck tckedit/upper.tck 1e-4
+tckedit tckedit/in.tck -exclude SIFT_phantom/upper.mif -inverse tmp.tck -force && testing_diff_tck tmp.tck tckedit/upper.tck 1e-4
+tckedit tckedit/in.tck -exclude SIFT_phantom/lower.mif -inverse tmp.tck -force && testing_diff_tck tmp.tck tckedit/lower.tck 1e-4
+tckedit tckedit/in.tck -minlength 10 tmp.tck -force && testing_diff_tck tmp.tck tckedit/upper.tck 1e-4
+tckedit tckedit/in.tck -maxlength 10 tmp.tck -force && testing_diff_tck tmp.tck tckedit/lower.tck 1e-4
+tckedit tckedit/in.tck -mask tckedit/mask.mif tmp.tck -force && testing_diff_tck tmp.tck tckedit/mask.tck 1e-4
+tckedit tckedit/in.tck -mask tckedit/mask.mif -inverse tmp.tck -force && testing_diff_tck tmp.tck tckedit/invmask.tck 1e-4
+tckedit tckedit/in.tck -include SIFT_phantom/upper.mif -mask tckedit/mask.mif tmp.tck -force && testing_diff_tck tmp.tck tckedit/maskupper.tck 1e-4
+tckedit tckedit/in.tck -include SIFT_phantom/lower.mif -mask tckedit/mask.mif tmp.tck -force && testing_diff_tck tmp.tck tckedit/masklower.tck 1e-4
+tckedit tckedit/in.tck -include SIFT_phantom/upper.mif -mask tckedit/mask.mif -inverse tmp.tck -force && testing_diff_tck tmp.tck tckedit/invmasklower.tck 1e-4
+tckedit tckedit/in.tck -include SIFT_phantom/lower.mif -mask tckedit/mask.mif -inverse tmp.tck -force && testing_diff_tck tmp.tck tckedit/invmaskupper.tck 1e-4


### PR DESCRIPTION
Closes #502.

Closes #1576.

Listing as draft PR in order to show progress.

However something that chipped away at me during the course of this is the magnitude of overlap between the classes used for streamline vertex read/write vs. track scalar read/write. While they do currently derive from common base classes, there's a lot of functionality common between them that is instead duplicated between the two specialisations; and that fraction of overlap is accentuated by the changes made here. So I'm quietly wondering if more functionality should be shifted to the base classes, with the separation in functionality between 1 / 3 values per vertex handled via eg. template specialisations.

Also have not yet decided whether to shift the per-streamline weights to set/get functions rather than a public member variable, as has happened here for the streamline index.

FYI The way I've disambiguated between an empty streamline (used to indicate that the streamline shouldn't be written) and a streamline with no vertices that should nevertheless be written (e.g. `tcktransform` but the entire streamline is outside the FoV) is, by assigning to any streamline that should not be written to file, a *non-finite weight* (even if SIFT2 weights are not provided / derived, the weight is nevertheless an embedded member variable of the Streamline class).