### PR TITLE
Improve build versioning when git not present

### DIFF
--- a/build
+++ b/build
@@ -1042,65 +1042,116 @@ def build_next ():
 
 
 
-
-def get_git_version (folder):
+def version_from_git (folder):
   try:
-    return get_git_version.version
+    log ('fetching version information from git in folder "' + folder + '": ')
+    with open (os.devnull) as devnull:
+      tag = subprocess.check_output ([ 'git', 'describe', '--abbrev=0' ], cwd=folder, stderr=devnull).decode(errors='ignore').strip()
+      commit = subprocess.check_output ([ 'git', 'describe', '--abbrev=8', '--dirty', '--always' ], cwd=folder, stderr=devnull).decode(errors='ignore').strip()
+    log (tag + ', ' + commit + '\n')
+    return [ tag, commit ]
+  except (OSError, subprocess.CalledProcessError):
+    log ('not found\n')
+    raise LookupError
+
+
+
+def version_from_file (version_file, version_macro):
+  log ('fetching version information from "' + version_macro + '" in "' + version_file + '": ')
+  try:
+    with open (version_file) as fd:
+      for line in fd:
+        line = line.split ("//")[0]
+        if version_macro in line:
+          tag = line.split(version_macro)[1].strip().strip('"')
+          log (tag + '\n')
+          return tag
+    if not len (tag):
+      raise NameError
+  except (OSError, NameError):
+    log ('not found\n')
+    raise LookupError
+
+
+
+
+def mrtrix_version ():
+  try:
+    return mrtrix_version.version
   except AttributeError:
     pass
 
   log ('''
-getting git version in folder "''' + folder + '"...\n')
-
-  log ('  reading from core/version.h: ')
+getting MRtrix version from folder "''' + mrtrix_dir[-1] + '"...\n  ')
   try:
-    with open (os.path.join (lib_dir, 'version.h')) as fd:
-      for line in fd:
-        line = line.split ("//")[0]
-        if 'MRTRIX_BASE_VERSION' in line:
-          hard_coded_version = line.split('MRTRIX_BASE_VERSION')[1].strip().strip('"')
-          log (hard_coded_version + '\n')
-    if not len (hard_coded_version):
-      raise NameError
-  except ( OSError, NameError ):
-    fail ("ERROR: failed to read version information\n")
+    tag = version_from_file (os.path.join (lib_dir, 'version.h'), 'MRTRIX_BASE_VERSION')
+  except LookupError:
+    fail ('ERROR: failed to read version information from file "' + os.path.join (lib_dir, 'version.h') + '"\n')
 
-  log ('  fetching from git: ')
   try:
-    process = subprocess.Popen ([ 'git', 'describe', '--abbrev=0' ], cwd=folder, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    git_version = process.communicate()[0]
-    if process.returncode == 0:
-      git_version = git_version.decode(errors='ignore').strip()
-      log (git_version + '\n')
-      if git_version != hard_coded_version:
-        fail ("ERROR: git version stored in core/version.h does not match tag name\n")
+    log ('  ')
+    version = version_from_git (mrtrix_dir[-1])
+    if version[0] != tag:
+        fail ('ERROR: version stored in "' + os.path.join (lib_dir, 'version.h') + '" does not match git tag name\n')
+    mrtrix_version.version = version[1]
+  except LookupError:
+    mrtrix_version.version = tag
 
-    log ('  fetching full version from git: ')
-    process = subprocess.Popen ([ 'git', 'describe', '--abbrev=8', '--dirty', '--always' ], cwd=folder, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    git_version = process.communicate()[0]
-    if process.returncode == 0:
-      get_git_version.version = git_version.decode(errors='ignore').strip()
-      log (get_git_version.version + '\n')
-  except OSError:
-    get_git_version.version = hard_coded_version
-
-  return get_git_version.version
+  log ('Using MRtrix version "' + mrtrix_version.version + '"\n')
+  return mrtrix_version.version
 
 
-def update_git_version (folder, git_version_file, contents):
-  git_version = get_git_version (folder)
-  version_file_contents = contents.replace ('%%%', git_version)
-  current_version_file_contents = ''
+
+
+def project_version ():
   try:
-    with open (git_version_file) as fd:
+    return project_version.version
+  except AttributeError:
+    pass
+
+  project_version.version = None
+
+  log ('''
+getting MRtrix project version from current folder...\n  ''')
+  try:
+    tag = version_from_file (os.path.join (misc_dir, 'project_version.h'), 'MRTRIX_PROJECT_VERSION')
+  except LookupError:
+    tag = None
+
+  try:
+    log ('  ')
+    version = version_from_git ('.')
+    if tag and version[0] != tag:
+        fail ('ERROR: project version stored in "' + os.path.join (misc_dir, 'project_version.h') + '" does not match tag name\n')
+    project_version.version = version[1]
+  except LookupError:
+    project_version.version = tag
+
+  log ('Using MRtrix project version "' + ( project_version.version  or 'unknown' ) + '"\n')
+  return project_version.version
+
+
+
+
+
+def update_version (version, version_file, template):
+  version_file_contents = template.replace ('%%%', version or "unknown")
+
+  try:
+    with open (version_file) as fd:
       current_version_file_contents = fd.read()
+    if ( version is None ) or ( version_file_contents == current_version_file_contents ):
+      log ('version file "' + version_file + '" is up to date\n')
+      return
   except (IOError, OSError):
     pass
 
-  if not current_version_file_contents or (version_file_contents != current_version_file_contents and git_version != 'unknown'):
-    log ('version file "' + git_version_file + '" is out of date - updating\n')
-    with open (git_version_file, 'w') as fd:
-      fd.write (version_file_contents)
+  log ('version file "' + version_file + '" is out of date - updating\n')
+  with open (version_file, 'w') as fd:
+    fd.write (version_file_contents)
+
+
+
 
 
 def update_bash_completion ():
@@ -1181,7 +1232,7 @@ def update_user_docs ():
 ###########################################################################
 
 with open (os.path.join(mrtrix_dir[-1], script_dir, '_version.py'),'w') as vfile:
-  vfile.write('__version__ = "'+get_git_version (mrtrix_dir[-1])+'"\n')
+  vfile.write('__version__ = "'+ mrtrix_version() +'"\n')
 
 
 ###########################################################################
@@ -1195,7 +1246,7 @@ if not targets:
 
 
 # get git version info:
-update_git_version (mrtrix_dir[-1], os.path.join (lib_dir, 'version.cpp'), '''
+update_version (mrtrix_version(), os.path.join (lib_dir, 'version.cpp'), '''
 namespace MR {
   namespace App {
     const char* mrtrix_version = "%%%";
@@ -1204,7 +1255,7 @@ namespace MR {
 }
 ''')
 
-update_git_version (mrtrix_dir[-1], os.path.join (mrtrix_dir[-1], misc_dir, 'exec_version.cpp'), '''
+update_version (mrtrix_version(), os.path.join (mrtrix_dir[-1], misc_dir, 'exec_version.cpp'), '''
 namespace MR {
   namespace App {
     extern const char* executable_uses_mrtrix_version;
@@ -1216,8 +1267,7 @@ namespace MR {
 if separate_project:
   if not os.path.exists (misc_dir):
     os.mkdir (misc_dir)
-  git_version_file = os.path.join (misc_dir, 'project_version.cpp')
-  update_git_version ('.', git_version_file, '''
+  update_version (project_version(), os.path.join (misc_dir, 'project_version.cpp'), '''
 namespace MR {
   namespace App {
     extern const char* project_version;
@@ -1229,12 +1279,6 @@ namespace MR {
   }
 }
 ''')
-
-  if not os.path.exists (git_version_file):
-    with open (git_version_file, 'w'):
-      pass
-
-
 
 
 

--- a/build
+++ b/build
@@ -1066,11 +1066,12 @@ def version_from_file (version_file, version_macro):
           tag = line.split(version_macro)[1].strip().strip('"')
           log (tag + '\n')
           return tag
-    if not len (tag):
+    if not tag:
       raise NameError
   except (OSError, NameError):
     log ('not found\n')
     raise LookupError
+  return None
 
 
 
@@ -1092,7 +1093,7 @@ getting MRtrix version from folder "''' + mrtrix_dir[-1] + '"...\n  ')
     log ('  ')
     version = version_from_git (mrtrix_dir[-1])
     if version[0] != tag:
-        fail ('ERROR: version stored in "' + os.path.join (lib_dir, 'version.h') + '" does not match git tag name\n')
+      fail ('ERROR: version stored in "' + os.path.join (lib_dir, 'version.h') + '" does not match git tag name\n')
     mrtrix_version.version = version[1]
   except LookupError:
     mrtrix_version.version = tag
@@ -1122,7 +1123,7 @@ getting MRtrix project version from current folder...\n  ''')
     log ('  ')
     version = version_from_git ('.')
     if tag and version[0] != tag:
-        fail ('ERROR: project version stored in "' + os.path.join (misc_dir, 'project_version.h') + '" does not match tag name\n')
+      fail ('ERROR: project version stored in "' + os.path.join (misc_dir, 'project_version.h') + '" does not match tag name\n')
     project_version.version = version[1]
   except LookupError:
     project_version.version = tag

--- a/build
+++ b/build
@@ -1044,21 +1044,47 @@ def build_next ():
 
 
 def get_git_version (folder):
-  log ('''
-getting git version in folder "''' + folder + '"... ')
-
   try:
-    process = subprocess.Popen ([ 'git', 'describe', '--abbrev=8', '--dirty', '--always' ], cwd=folder, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    return get_git_version.version
+  except AttributeError:
+    pass
+
+  log ('''
+getting git version in folder "''' + folder + '"...\n')
+
+  log ('  reading from core/version.h: ')
+  try:
+    with open (os.path.join (lib_dir, 'version.h')) as fd:
+      for line in fd:
+        line = line.split ("//")[0]
+        if 'MRTRIX_BASE_VERSION' in line:
+          hard_coded_version = line.split('MRTRIX_BASE_VERSION')[1].strip().strip('"')
+          log (hard_coded_version + '\n')
+    if not len (hard_coded_version):
+      raise NameError
+  except ( OSError, NameError ):
+    fail ("ERROR: failed to read version information\n")
+
+  log ('  fetching from git: ')
+  try:
+    process = subprocess.Popen ([ 'git', 'describe', '--abbrev=0' ], cwd=folder, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     git_version = process.communicate()[0]
     if process.returncode == 0:
       git_version = git_version.decode(errors='ignore').strip()
       log (git_version + '\n')
-      return git_version
-  except OSError:
-    pass
+      if git_version != hard_coded_version:
+        fail ("ERROR: git version stored in core/version.h does not match tag name\n")
 
-  log ('not found\n')
-  return 'unknown'
+    log ('  fetching full version from git: ')
+    process = subprocess.Popen ([ 'git', 'describe', '--abbrev=8', '--dirty', '--always' ], cwd=folder, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    git_version = process.communicate()[0]
+    if process.returncode == 0:
+      get_git_version.version = git_version.decode(errors='ignore').strip()
+      log (get_git_version.version + '\n')
+  except OSError:
+    get_git_version.version = hard_coded_version
+
+  return get_git_version.version
 
 
 def update_git_version (folder, git_version_file, contents):

--- a/core/version.h
+++ b/core/version.h
@@ -1,0 +1,15 @@
+#ifndef __version_h__
+#define __version_h__
+
+// update this with the tag name every time the code is tagged
+// for example:
+//   set MRTRIX_BASE_VERSION to "3.3"
+//   git add core/version.h
+//   git commit
+//   git tag -s 3.3
+//   git push
+
+#define MRTRIX_BASE_VERSION "3.0_RC3"
+
+#endif
+


### PR DESCRIPTION
This allows version information to be added to the repo itself, and it'll be used in the event that `git` isn't present or the code was downloaded as an archive - addresses #1514. The version string must be set to the corresponding tag. When `git` can be used, the `build` script will check that the version information stored in the repo matches the version string produced by git (`git describe --abbrev=0`), and fail if it doesn't match. This means when a new version is to be released, the version string will need to be updated and then that commit tagged with the same version string before pushing with tags. 

This will need a bit of finessing when merging to `master`. Mostly likely strategy will be to force a fast-forward merge of a manual non-fast-forward merge - if that makes sense to anyone... 