### PR TITLE
Prevent new compiler warnings on Clang8

### DIFF
--- a/core/header.h
+++ b/core/header.h
@@ -202,7 +202,7 @@ namespace MR
           NDimProxy (vector<Axis>& axes) : axes (axes) { }
           NDimProxy (NDimProxy&&) = default;
           NDimProxy (const NDimProxy&) = delete;
-          NDimProxy& operator=(NDimProxy&&) = default;
+          NDimProxy& operator=(NDimProxy&&) = delete;
           NDimProxy& operator=(const NDimProxy&) = delete;
 
           operator size_t () const { return axes.size(); }
@@ -240,7 +240,7 @@ namespace MR
           DataTypeProxy (Header& H) : DataType (H.datatype_), H (H) { }
           DataTypeProxy (DataTypeProxy&&) = default;
           DataTypeProxy (const DataTypeProxy&) = delete;
-          DataTypeProxy& operator=(DataTypeProxy&&) = default;
+          DataTypeProxy& operator=(DataTypeProxy&&) = delete;
           DataTypeProxy& operator=(const DataTypeProxy&) = delete;
 
           uint8_t operator()() const { return DataType::operator()(); }

--- a/core/image_io/default.h
+++ b/core/image_io/default.h
@@ -28,11 +28,10 @@ namespace MR
     class Default : public Base
     { NOMEMALIGN
       public:
-        Default (const Header& header) : 
+        Default (const Header& header) :
           Base (header),
           bytes_per_segment (0) { }
         Default (Default&&) noexcept = default;
-        Default& operator=(Default&&) = default;
 
       protected:
         vector<std::shared_ptr<File::MMap> > mmaps;

--- a/core/transform.h
+++ b/core/transform.h
@@ -35,8 +35,8 @@ namespace MR
 
       Transform (const Transform&) = default;
       Transform (Transform&&) = default;
-      Transform& operator= (const Transform&) = default;
-      Transform& operator= (Transform&&) = default;
+      Transform& operator= (const Transform&) = delete;
+      Transform& operator= (Transform&&) = delete;
 
       const Eigen::DiagonalMatrix<default_type, 3> voxelsize;
       const transform_type voxel2scanner, scanner2voxel, image2scanner, scanner2image;


### PR DESCRIPTION
Relevant warning: `-Wdefaulted-function-deleted`

- Can't have default move constructor in a class that has a reference member variable

- Can't have assignment operator in a class that has `const` member variables

--------

Full warnings:

```
./core/header.h:205:22: warning: explicitly defaulted move assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
          NDimProxy& operator=(NDimProxy&&) = default;
                     ^
./core/header.h:215:25: note: move assignment operator of 'NDimProxy' is implicitly deleted because field 'axes' is of reference type 'vector<MR::Header::Axis> &'
          vector<Axis>& axes;
                        ^
./core/header.h:243:26: warning: explicitly defaulted move assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
          DataTypeProxy& operator=(DataTypeProxy&&) = default;
                         ^
./core/header.h:252:19: note: move assignment operator of 'DataTypeProxy' is implicitly deleted because field 'H' is of reference type 'MR::Header &'
          Header& H;
                  ^


./core/image_io/default.h:35:18: warning: explicitly defaulted move assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
        Default& operator=(Default&&) = default;
                 ^
./core/image_io/default.h:28:21: note: move assignment operator of 'Default' is implicitly deleted because base class 'MR::ImageIO::Base' has a deleted move assignment operator
    class Default : public Base
                    ^
./core/image_io/base.h:49:15: note: 'operator=' has been explicitly marked deleted here
        Base& operator=(const Base&) = delete;
                                       ^


./core/transform.h:38:18: warning: explicitly defaulted copy assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
      Transform& operator= (const Transform&) = default;
                 ^
./core/transform.h:41:52: note: copy assignment operator of 'Transform' is implicitly deleted because field 'voxelsize' has no copy assignment operator
      const Eigen::DiagonalMatrix<default_type, 3> voxelsize;
                                                   ^
./core/transform.h:39:18: warning: explicitly defaulted move assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
      Transform& operator= (Transform&&) = default;
                 ^
./core/transform.h:41:52: note: move assignment operator of 'Transform' is implicitly deleted because field 'voxelsize' has no move assignment operator
      const Eigen::DiagonalMatrix<default_type, 3> voxelsize;
                                                   ^
```
