### PR TITLE
Python help: Example usage fix

### DIFF
--- a/lib/mrtrix3/app.py
+++ b/lib/mrtrix3/app.py
@@ -807,7 +807,8 @@ class Parser(argparse.ArgumentParser):
       text += bold('EXAMPLE USAGES') + '\n'
       text += '\n'
       for example in self._examples:
-        text += wrapper_other.fill(underline(example[0] + ':')) + '\n'
+        for line in wrapper_other.fill(example[0] + ':').splitlines():
+          text += ' '*(len(line) - len(line.lstrip())) + underline(line.lstrip()) + '\n'
         text += ' '*7 + '$ ' + example[1] + '\n'
         if example[2]:
           text += wrapper_other.fill(example[2]) + '\n'


### PR DESCRIPTION
Minor hiccup with #1449.

Old:

```
EXAMPLE USAGES

     To compute the mean
     diffusion-weighted
     signal in each b-value
     shell:
       $ dwishellmath dwi.mif mean shellmeans.mif
```

New:

```
EXAMPLE USAGES

     To compute the mean diffusion-weighted signal in each b-value shell:
       $ dwishellmath dwi.mif mean shellmeans.mif
```