### PR TITLE
run.command(): Don't validate input type

### DIFF
--- a/lib/mrtrix3/run.py
+++ b/lib/mrtrix3/run.py
@@ -238,15 +238,13 @@ def command(cmd, **kwargs): #pylint: disable=unused-variable
         cmdsplit.extend(entry)
       else:
         raise TypeError('When run.command() is provided with a list as input, entries in the list must be either strings or lists of strings')
-  elif isinstance(cmd, str):
+  else:
     cmdstring = cmd
     # Split the command string by spaces, preserving anything encased within quotation marks
     if os.sep == '/': # Cheap POSIX compliance check
       cmdsplit = shlex.split(cmd)
     else: # Native Windows Python
       cmdsplit = [ entry.strip('\"') for entry in shlex.split(cmd, posix=False) ]
-  else:
-    raise TypeError('run.command() function only operates on strings, or lists of strings')
 
   if shared.get_continue():
     if shared.trigger_continue(cmdsplit):


### PR DESCRIPTION
Because of the difficulties associated with types in which string data can be stored between Python2 and Python3, it is easiest to simply assume that if the input to `run.command()` is not a list, it is a type for which string-based operations can be performed.

Issue was observed running `dwishellmath` on Python2, as it constructs `run.command()` calls based on the output of `image.mrinfo()`, which comes out as `unicode` (yet my Python2 doesn't seem to recognise '`unicode`' as a builtin keyword...).