### PR TITLE
Fixes to multiple square bracket image path notation

### DIFF
--- a/core/formats/mrtrix_utils.h
+++ b/core/formats/mrtrix_utils.h
@@ -92,7 +92,7 @@ namespace MR
 
         if (vox.empty())
           throw Exception ("missing \"vox\" specification for MRtrix image \"" + H.name() + "\"");
-        if (vox.size() < 3)
+        if (vox.size() < std::min (size_t(3), dim.size()))
           throw Exception ("too few entries in \"vox\" specification for MRtrix image \"" + H.name() + "\"");
         for (size_t n = 0; n < std::min<size_t> (vox.size(), H.ndim()); n++) {
           if (vox[n] < 0.0)

--- a/core/header.cpp
+++ b/core/header.cpp
@@ -235,7 +235,7 @@ namespace MR
       for (size_t n = 0; n < Pdim.size(); ++n) {
         while (a < int(H.ndim()) && H.stride(a))
           a++;
-        Pdim[n] = Hdim[a];
+        Pdim[n] = Hdim[a++];
       }
       parser.calculate_padding (Pdim);
 

--- a/core/image_io/default.cpp
+++ b/core/image_io/default.cpp
@@ -42,9 +42,9 @@ namespace MR
       if (files.size() * double (bytes_per_segment) >= double (std::numeric_limits<size_t>::max()))
         throw Exception ("image \"" + header.name() + "\" is larger than maximum accessible memory");
 
-      if (files.size() > MAX_FILES_PER_IMAGE) 
+      if (files.size() > MAX_FILES_PER_IMAGE)
         copy_to_mem (header);
-      else 
+      else
         map_files (header);
     }
 
@@ -58,7 +58,7 @@ namespace MR
 
         if (writable) {
           for (size_t n = 0; n < files.size(); n++) {
-            File::OFStream out (files[n].name, std::ios::out | std::ios::binary);
+            File::OFStream out (files[n].name, std::ios::in | std::ios::out | std::ios::binary);
             out.seekp (files[n].start, out.beg);
             out.write ((char*) (addresses[0].get() + n*bytes_per_segment), bytes_per_segment);
             if (!out.good())
@@ -94,7 +94,7 @@ namespace MR
       DEBUG ("loading image \"" + header.name() + "\"...");
       addresses.resize (files.size() > 1 && header.datatype().bits() *segsize != 8*size_t (bytes_per_segment) ? files.size() : 1);
       addresses[0].reset (new uint8_t [files.size() * bytes_per_segment]);
-      if (!addresses[0]) 
+      if (!addresses[0])
         throw Exception ("failed to allocate memory for image \"" + header.name() + "\"");
 
       if (is_new) memset (addresses[0].get(), 0, files.size() * bytes_per_segment);

--- a/testing/tests/mrconvert
+++ b/testing/tests/mrconvert
@@ -8,4 +8,6 @@ mrconvert mrconvert/in.mif tmp.nii  && testing_diff_image tmp.nii mrconvert/in.m
 mrconvert mrconvert/in.mif -datatype float32 tmp.nii.gz  && testing_diff_image tmp.nii.gz mrconvert/in.mif
 mrconvert mrconvert/in.mif -strides 3,2,1 tmp.mgh  && testing_diff_image tmp.mgh mrconvert/in.mif
 mrconvert mrconvert/in.mif -strides 1,3,2 -datatype int16 tmp.mgz  && testing_diff_image tmp.mgz mrconvert/in.mif
-mrconvert dwi.mif tmp-[].mif; testing_diff_image dwi.mif tmp-[].mif
+mrconvert dwi.mif tmp-[].mif -force && testing_diff_image dwi.mif tmp-[].mif
+mrconvert dwi.mif tmp-[]-[].mif -force && testing_diff_image dwi.mif tmp-[]-[].mif
+


### PR DESCRIPTION
Resolving issues described in #1618.

- Prevent loading of MRtrix format images with less than 3 dimensions from throwing an exception due to voxel size specification.

- Fix bug in designation of square bracket usages to image axes on output image creation.

- For default image IO handler, prevent throwing of exception due to pre-existing files without `-force` / wiping of header information with `-force` at writeback in cases where image header and data are stored in the same file.