### PR TITLE
mrhistmatch: Enable operation on 4D images

### DIFF
--- a/cmd/mrhistmatch.cpp
+++ b/cmd/mrhistmatch.cpp
@@ -22,6 +22,7 @@
 #include "header.h"
 #include "image.h"
 
+#include "adapter/replicate.h"
 #include "algo/histogram.h"
 #include "algo/loop.h"
 
@@ -75,29 +76,27 @@ void match_linear (Image<float>& input,
   vector<float> input_data, target_data;
   {
     ProgressBar progress ("Loading & sorting image data", 4);
-    if (mask_input.valid()) {
-      for (auto l = Loop(input) (input, mask_input); l; ++l) {
-        if (mask_input.value() && std::isfinite (static_cast<float>(input.value())))
-          input_data.push_back (input.value());
+
+    auto fill = [] (Image<float>& image, Image<bool>& mask) {
+      vector<float> data;
+      if (mask.valid()) {
+        Adapter::Replicate<Image<bool>> mask_replicate (mask, image);
+        for (auto l = Loop(image) (image, mask_replicate); l; ++l) {
+          if (mask_replicate.value() && std::isfinite (static_cast<float>(image.value())))
+            data.push_back (image.value());
+        }
+      } else {
+        for (auto l = Loop(image) (image); l; ++l) {
+          if (std::isfinite (static_cast<float>(image.value())))
+            data.push_back (image.value());
+        }
       }
-    } else {
-      for (auto l = Loop(input) (input); l; ++l) {
-        if (std::isfinite (static_cast<float>(input.value())))
-          input_data.push_back (input.value());
-      }
-    }
+      return data;
+    };
+
+    input_data  = fill (input,  mask_input);
     ++progress;
-    if (mask_target.valid()) {
-      for (auto l = Loop(target) (target, mask_target); l; ++l) {
-        if (mask_target.value() && std::isfinite (static_cast<float>(target.value())))
-          target_data.push_back (target.value());
-      }
-    } else {
-      for (auto l = Loop(target) (target); l; ++l) {
-        if (std::isfinite (static_cast<float>(target.value())))
-          target_data.push_back (target.value());
-      }
-    }
+    target_data = fill (target, mask_target);
     ++progress;
     std::sort (input_data.begin(), input_data.end());
     ++progress;
@@ -195,19 +194,17 @@ void run ()
 {
   auto input  = Image<float>::open (argument[1]);
   auto target = Image<float>::open (argument[2]);
-  if (input.ndim() > 3 || target.ndim() > 3)
-    throw Exception ("mrhistmatch currently only works on 3D images");
 
   Image<bool> mask_input, mask_target;
   auto opt = get_options ("mask_input");
   if (opt.size()) {
     mask_input = Image<bool>::open (opt[0][0]);
-    check_dimensions (input, mask_input);
+    check_dimensions (input, mask_input, 0, 3);
   }
   opt = get_options ("mask_target");
   if (opt.size()) {
     mask_target = Image<bool>::open (opt[0][0]);
-    check_dimensions (target, mask_target);
+    check_dimensions (target, mask_target, 0, 3);
   }
 
   switch (int(argument[0])) {


### PR DESCRIPTION
Re-submission of #1627: Both branch name and name of command in commit message were incorrect.

> Small tweak to mrhistmatch to enable operation on 4D images.

> By merging this prior to #1626, that script will be able to operate using all b=0 data from each image series, rather than having to collapse them into a mean b=0 image per series. Therefore will merge this PR first, then make the corresponding change in #1626.