### PR TITLE
permute_axes adapter: fix handling of additional axes

### DIFF
--- a/core/adapter/permute_axes.h
+++ b/core/adapter/permute_axes.h
@@ -40,7 +40,7 @@ namespace MR
             axes_ (axes) {
               for (int i = 0; i < static_cast<int> (parent().ndim()); ++i) {
                 for (size_t a = 0; a < axes_.size(); ++a) {
-                  if (size_t (axes_[a]) >= parent().ndim())
+                  if (axes_[a] >= int (parent().ndim()))
                     throw Exception ("axis " + str(axes_[a]) + " exceeds image dimensionality");
                   if (axes_[a] == i)
                     goto next_axis;

--- a/testing/tests/mrconvert
+++ b/testing/tests/mrconvert
@@ -10,4 +10,5 @@ mrconvert mrconvert/in.mif -strides 3,2,1 tmp.mgh  && testing_diff_image tmp.mgh
 mrconvert mrconvert/in.mif -strides 1,3,2 -datatype int16 tmp.mgz  && testing_diff_image tmp.mgz mrconvert/in.mif
 mrconvert dwi.mif tmp-[].mif -force && testing_diff_image dwi.mif tmp-[].mif
 mrconvert dwi.mif tmp-[]-[].mif -force && testing_diff_image dwi.mif tmp-[]-[].mif
+mrconvert dwi.mif -coord 3 1:2:end -axes 0:2,-1,3 - | testing_diff_image - mrconvert/dwi_select_axes.mif
 


### PR DESCRIPTION
This allows the correct interpretation of negative axis indices in the specification of the new axes, which is required to insert additional axes (e.g. going from dimensions [ X Y Z 3 ] to [ X Y Z 1 3 ]). This behaviour is required and documented for mrconvert's -axes option, which currently doesn't work as stated (fixed with this change).