### PR TITLE
dwigradcheck: Fix -force option

### DIFF
--- a/bin/dwigradcheck
+++ b/bin/dwigradcheck
@@ -209,7 +209,7 @@ if grad_export_option:
     grad_import_option = ' -grad grad' + suffix + '.b'
   elif best[3] == 'image':
     grad_import_option = ' -fslgrad bvecs' + suffix + ' bvals'
-  run.command('mrinfo data.mif' + grad_import_option + grad_export_option)
+  run.command('mrinfo data.mif' + grad_import_option + grad_export_option + (' -force' if app.forceOverwrite else ''))
 
 
 app.complete()


### PR DESCRIPTION
Script failed to overwrite existing gradient table text files regardless of the presence of the `-force` command-line option.

Closes #1647.