### PR TITLE
mrview: overlay n dimensional data

### DIFF
--- a/src/gui/dialog/progress.cpp
+++ b/src/gui/dialog/progress.cpp
@@ -42,7 +42,7 @@ namespace MR
             p.data = new Timer;
           }
           else if (reinterpret_cast<Timer*>(p.data)->elapsed() > 1.0) {
-            Context::Grab context;
+            GL::Context::Grab context;
             if (!progress_dialog) {
               progress_dialog = new QProgressDialog ((p.text + p.ellipsis).c_str(), QString(), 0, p.multiplier ? 100 : 0, GUI::App::main_window);
               progress_dialog->setWindowModality (Qt::ApplicationModal);
@@ -61,7 +61,7 @@ namespace MR
           if (p.data) {
             assert (GUI::App::main_window);
             if (progress_dialog) {
-              Context::Grab context;
+              GL::Context::Grab context;
               delete progress_dialog;
               progress_dialog = nullptr;
             }

--- a/src/gui/dwi/render_frame.cpp
+++ b/src/gui/dwi/render_frame.cpp
@@ -44,7 +44,7 @@ namespace MR
         constexpr float AngleMax = 90.0f;
 
 
-        const Math::Versorf DefaultOrientation = Eigen::AngleAxisf (Math::pi_4, Eigen::Vector3f (0.0f, 0.0f, 1.0f)) * 
+        const Math::Versorf DefaultOrientation = Eigen::AngleAxisf (Math::pi_4, Eigen::Vector3f (0.0f, 0.0f, 1.0f)) *
                                                      Eigen::AngleAxisf (Math::pi/3.0f, Eigen::Vector3f (1.0f, 0.0f, 0.0f));
         QFont get_font (QWidget* parent) {
           QFont f = parent->font();
@@ -55,7 +55,7 @@ namespace MR
 
       RenderFrame::RenderFrame (QWidget* parent) :
         GL::Area (parent),
-        view_angle (AngleDefault), distance (DistDefault), scale (NaN), 
+        view_angle (AngleDefault), distance (DistDefault), scale (NaN),
         lmax_computed (0), lod_computed (0), mode (mode_t::SH), recompute_mesh (true), recompute_amplitudes (true),
         show_axes (true), hide_neg_values (true), color_by_dir (true), use_lighting (true),
         glfont (get_font (parent)), projection (this, glfont),
@@ -71,7 +71,7 @@ namespace MR
 
       RenderFrame::~RenderFrame()
       {
-        Context::Grab context (this);
+        GL::Context::Grab context (this);
         axes_VB.clear();
         axes_VAO.clear();
       }
@@ -97,6 +97,7 @@ namespace MR
 
       void RenderFrame::initializeGL ()
       {
+        GL::Context::Grab context (this);
         GL::init();
         glfont.initGL (false);
         renderer.initGL();
@@ -151,6 +152,7 @@ namespace MR
 
       void RenderFrame::resizeGL (int w, int h)
       {
+        GL::Context::Grab context (this);
         projection.set_viewport (*this, 0, 0, w, h);
       }
 
@@ -158,7 +160,8 @@ namespace MR
 
       void RenderFrame::paintGL ()
       {
-        gl::ColorMask (true, true, true, true); 
+        GL::Context::Grab context (this);
+        gl::ColorMask (true, true, true, true);
         gl::ClearColor (lighting->background_color[0], lighting->background_color[1], lighting->background_color[2], 0.0);
         gl::Clear (gl::COLOR_BUFFER_BIT | gl::DEPTH_BUFFER_BIT);
 
@@ -192,7 +195,7 @@ namespace MR
           if (std::isfinite (values[0])) {
             gl::Disable (gl::BLEND);
 
-            if (!std::isfinite (scale)) 
+            if (!std::isfinite (scale))
               scale = 2.0f / values.norm();
 
             renderer.set_mode (mode);
@@ -263,7 +266,7 @@ namespace MR
         // otherwise we get transparent windows...
 #if QT_VERSION >= 0x050400
         gl::ClearColor (0.0, 0.0, 0.0, 1.0);
-        gl::ColorMask (false, false, false, true); 
+        gl::ColorMask (false, false, false, true);
         gl::Clear (gl::COLOR_BUFFER_BIT);
 #endif
 
@@ -351,7 +354,7 @@ namespace MR
 
       void RenderFrame::snapshot ()
       {
-        makeCurrent();
+        GL::Context::Grab context (this);
         gl::PixelStorei (gl::PACK_ALIGNMENT, 1);
         gl::ReadPixels (0, 0, projection.width(), projection.height(), gl::RGB, gl::UNSIGNED_BYTE, framebuffer.get());
 

--- a/src/gui/dwi/renderer.cpp
+++ b/src/gui/dwi/renderer.cpp
@@ -373,7 +373,7 @@ namespace MR
 
       Renderer::SH::~SH()
       {
-        Renderer::GrabContext context (parent.context_);
+        GL::Context::Grab context (parent.context_);
         half_sphere.vertex_buffer.clear();
         half_sphere.index_buffer.clear();
         surface_buffer.clear();
@@ -383,7 +383,7 @@ namespace MR
       void Renderer::SH::initGL()
       {
         GL_CHECK_ERROR;
-        Renderer::GrabContext context (parent.context_);
+        GL::Context::Grab context (parent.context_);
         half_sphere.vertex_buffer.gen();
         surface_buffer.gen();
         half_sphere.index_buffer.gen();
@@ -421,7 +421,7 @@ namespace MR
         INFO ("updating ODF SH renderer transform...");
         QApplication::setOverrideCursor (Qt::BusyCursor);
         {
-          Renderer::GrabContext context (parent.context_);
+          GL::Context::Grab context (parent.context_);
           LOD = lod;
           half_sphere.LOD (LOD);
         }
@@ -502,7 +502,7 @@ namespace MR
 
       Renderer::Tensor::~Tensor()
       {
-        Renderer::GrabContext context (parent.context_);
+        GL::Context::Grab context (parent.context_);
         half_sphere.vertex_buffer.clear();
         half_sphere.index_buffer.clear();
         VAO.clear();
@@ -511,7 +511,7 @@ namespace MR
       void Renderer::Tensor::initGL()
       {
         GL_CHECK_ERROR;
-        Renderer::GrabContext context (parent.context_);
+        GL::Context::Grab context (parent.context_);
         half_sphere.vertex_buffer.gen();
         half_sphere.index_buffer.gen();
         VAO.gen();
@@ -537,7 +537,7 @@ namespace MR
         INFO ("updating tensor renderer...");
         QApplication::setOverrideCursor (Qt::BusyCursor);
         {
-          Renderer::GrabContext context (parent.context_);
+          GL::Context::Grab context (parent.context_);
           LOD = lod;
           half_sphere.LOD (LOD);
         }
@@ -581,7 +581,7 @@ namespace MR
 
       Renderer::Dixel::~Dixel()
       {
-        Renderer::GrabContext context (parent.context_);
+        GL::Context::Grab context (parent.context_);
         vertex_buffer.clear();
         value_buffer.clear();
         index_buffer.clear();
@@ -591,7 +591,7 @@ namespace MR
       void Renderer::Dixel::initGL()
       {
         GL_CHECK_ERROR;
-        Renderer::GrabContext context (parent.context_);
+        GL::Context::Grab context (parent.context_);
         vertex_buffer.gen();
         value_buffer.gen();
         index_buffer.gen();
@@ -620,7 +620,7 @@ namespace MR
         assert (data.size() == vertex_count);
 
         GL_CHECK_ERROR;
-        Renderer::GrabContext context (parent.context_);
+        GL::Context::Grab context (parent.context_);
         VAO.bind();
         value_buffer.bind (gl::ARRAY_BUFFER);
         gl::BufferData (gl::ARRAY_BUFFER, vertex_count*sizeof(GLfloat), &data[0], gl::STREAM_DRAW);
@@ -676,7 +676,7 @@ namespace MR
         }
 
         GL_CHECK_ERROR;
-        Renderer::GrabContext context (parent.context_);
+        GL::Context::Grab context (parent.context_);
         VAO.bind();
         vertex_buffer.bind (gl::ARRAY_BUFFER);
         gl::BufferData (gl::ARRAY_BUFFER, dirs.size()*sizeof(Eigen::Vector3f), &directions_data[0], gl::STATIC_DRAW);

--- a/src/gui/dwi/renderer.h
+++ b/src/gui/dwi/renderer.h
@@ -228,12 +228,6 @@ namespace MR
           } dixel;
 
         private:
-          class GrabContext : public Context::Grab
-          { NOMEMALIGN
-            public:
-              GrabContext (QGLWidget* context) :
-                  Context::Grab (context) { }
-          };
           QGLWidget* context_;
 
 

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -17,46 +17,12 @@
 #include <locale>
 #include <clocale>
 #include "gui/gui.h"
+#include "gui/opengl/gl.h"
 
 namespace MR
 {
   namespace GUI
   {
-
-
-    namespace Context
-    {
-#if QT_VERSION >= 0x050400
-        std::pair<QOpenGLContext*,QSurface*> current() {
-          QOpenGLContext* context = QOpenGLContext::currentContext();
-          QSurface* surface = context ? context->surface() : nullptr;
-          return { context, surface };
-        }
-
-        std::pair<QOpenGLContext*,QSurface*> get (QWidget* window) {
-          QOpenGLContext* context = reinterpret_cast<QOpenGLWidget*> (window)->context();
-          QSurface* surface = context ? context->surface() : nullptr;
-          return { context, surface };
-        }
-
-        std::pair<QOpenGLContext*,QSurface*> makeCurrent (QWidget* window) {
-          auto previous_context = current();
-          if (window)
-            reinterpret_cast<QOpenGLWidget*> (window)->makeCurrent();
-          return previous_context;
-        }
-
-        void restore (std::pair<QOpenGLContext*,QSurface*> previous_context) {
-          if (previous_context.first)
-            previous_context.first->makeCurrent (previous_context.second);
-        }
-#else
-        std::pair<int,int> current() { return { 0, 0 }; }
-        std::pair<int,int> get (QWidget*) { return { 0, 0 }; }
-        std::pair<int,int> makeCurrent (QWidget*) { return { 0, 0 }; }
-        void restore (std::pair<int,int>) { }
-#endif
-    }
 
 
 
@@ -80,10 +46,6 @@ namespace MR
       qApp->setAttribute (Qt::AA_DontCreateNativeWidgetSiblings);
     }
 
-
-    void App::set_main_window (QWidget* window) {
-      main_window = window;
-    }
 
 
   }

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -27,31 +27,6 @@ namespace MR
   {
 
 
-
-    namespace Context
-    {
-#if QT_VERSION >= 0x050400
-        std::pair<QOpenGLContext*,QSurface*> current();
-        std::pair<QOpenGLContext*,QSurface*> get (QWidget*);
-        std::pair<QOpenGLContext*,QSurface*> makeCurrent (QWidget*);
-        void restore (std::pair<QOpenGLContext*,QSurface*>);
-#else
-        std::pair<int,int> current();
-        std::pair<int,int> get (QWidget*);
-        std::pair<int,int> makeCurrent (QWidget*);
-        void restore (std::pair<int,int>);
-#endif
-
-
-      struct Grab { NOMEMALIGN
-        decltype (current()) previous_context;
-        Grab (QWidget* window = nullptr) : previous_context (makeCurrent (window)) { }
-        ~Grab () { restore (previous_context); }
-      };
-    }
-
-
-
     class App : public QObject { NOMEMALIGN
       Q_OBJECT
 
@@ -62,21 +37,15 @@ namespace MR
           delete qApp;
         }
 
-        static void set_main_window (QWidget* window);
+        static void set_main_window (QWidget* window, GL::Area* glarea) {
+          main_window = window;
+          GL::glwidget = glarea;
+        }
 
         static QWidget* main_window;
         static App* application;
     };
 
-#ifndef NDEBUG
-# define ASSERT_GL_CONTEXT_IS_CURRENT(window) { \
-  auto __current_context = ::MR::GUI::Context::current(); \
-  auto __expected_context = ::MR::GUI::Context::get (window); \
-  assert (__current_context == __expected_context); \
-}
-#else
-# define ASSERT_GL_CONTEXT_IS_CURRENT(window)
-#endif
 
 
   }

--- a/src/gui/mrview/gui_image.cpp
+++ b/src/gui/mrview/gui_image.cpp
@@ -41,7 +41,7 @@ namespace MR
 
       ImageBase::~ImageBase()
       {
-        MRView::GrabContext context;
+        GL::Context::Grab context;
         for (size_t axis = 0; axis != 3; ++axis) {
           if (texture2D[axis])
             texture2D[axis].clear();

--- a/src/gui/mrview/mode/base.cpp
+++ b/src/gui/mrview/mode/base.cpp
@@ -43,7 +43,7 @@ namespace MR
 
         void Base::paintGL ()
         {
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
           GL_CHECK_ERROR;
 
           projection.set_viewport (window(), 0, 0, width(), height());
@@ -149,7 +149,7 @@ namespace MR
 
 done_painting:
           update_overlays = false;
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 

--- a/src/gui/mrview/mode/base.h
+++ b/src/gui/mrview/mode/base.h
@@ -166,9 +166,9 @@ namespace MR
               for (int i = 0; i < tools.size(); ++i) {
                 Tool::Dock* dock = dynamic_cast<Tool::__Action__*>(tools[i])->dock;
                 if (dock) {
-                  ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+                  GL::assert_context_is_current();
                   dock->tool->draw (projection, is_3D, axis, slice);
-                  ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+                  GL::assert_context_is_current();
                 }
               }
             }

--- a/src/gui/mrview/mode/lightbox.cpp
+++ b/src/gui/mrview/mode/lightbox.cpp
@@ -129,7 +129,7 @@ namespace MR
 
         void LightBox::draw_plane_primitive (int axis, Displayable::Shader& shader_program, Projection& with_projection)
         {
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
           // Setup OpenGL environment:
           gl::Disable (gl::BLEND);
           gl::Disable (gl::DEPTH_TEST);
@@ -140,7 +140,7 @@ namespace MR
             image()->render3D (shader_program, with_projection, with_projection.depth_of (focus()));
 
           render_tools (with_projection, false, axis, slice (axis));
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
@@ -150,7 +150,7 @@ namespace MR
 
         void LightBox::paint (Projection&)
         {
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
           GLint x = projection.x_position(), y = projection.y_position();
           GLint w = projection.width(), h = projection.height();
           GLfloat dw = w / (float)n_cols, dh = h / (float)n_rows;
@@ -230,7 +230,7 @@ namespace MR
           }
 
 
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
@@ -240,7 +240,7 @@ namespace MR
 
         void LightBox::draw_grid()
         {
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
           if(n_cols < 1 && n_rows < 1)
             return;
 
@@ -311,7 +311,7 @@ namespace MR
           frame_program.start();
           gl::DrawArrays (gl::LINES, 0, num_points / 2);
           frame_program.stop();
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 

--- a/src/gui/mrview/mode/ortho.cpp
+++ b/src/gui/mrview/mode/ortho.cpp
@@ -33,7 +33,7 @@ namespace MR
 
         void Ortho::paint (Projection& projection)
         {
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
           // set up OpenGL environment:
           gl::Disable (gl::BLEND);
           gl::Disable (gl::DEPTH_TEST);
@@ -47,15 +47,15 @@ namespace MR
           // so need to guarantee depth test is off for subsequent plane.
           // Ideally, state should be restored by callee but this is safer
 
-          projections[0].set_viewport (window(), w, h, w, h); 
+          projections[0].set_viewport (window(), w, h, w, h);
           draw_plane (0, slice_shader, projections[0]);
 
           gl::Disable (gl::DEPTH_TEST);
-          projections[1].set_viewport (window(), 0, h, w, h); 
+          projections[1].set_viewport (window(), 0, h, w, h);
           draw_plane (1, slice_shader, projections[1]);
 
           gl::Disable (gl::DEPTH_TEST);
-          projections[2].set_viewport (window(), 0, 0, w, h); 
+          projections[2].set_viewport (window(), 0, 0, w, h);
           draw_plane (2, slice_shader, projections[2]);
 
           projection.set_viewport (window());
@@ -84,7 +84,7 @@ namespace MR
             };
             gl::BufferData (gl::ARRAY_BUFFER, sizeof(data), data, gl::STATIC_DRAW);
           }
-          else 
+          else
             frame_VAO.bind();
 
           if (!frame_program) {
@@ -108,14 +108,14 @@ namespace MR
           frame_program.stop();
 
           gl::Enable (gl::DEPTH_TEST);
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
 
 
 
-        const Projection* Ortho::get_current_projection () const  
+        const Projection* Ortho::get_current_projection () const
         {
           if (current_plane < 0 || current_plane > 2)
             return NULL;
@@ -126,22 +126,22 @@ namespace MR
 
         void Ortho::mouse_press_event ()
         {
-          if (window().mouse_position().x() < width()/2) 
-            if (window().mouse_position().y() >= height()/2) 
+          if (window().mouse_position().x() < width()/2)
+            if (window().mouse_position().y() >= height()/2)
               current_plane = 1;
-            else 
+            else
               current_plane = 2;
-          else 
+          else
             if (window().mouse_position().y() >= height()/2)
               current_plane = 0;
-            else 
+            else
               current_plane = -1;
         }
 
 
 
 
-        void Ortho::slice_move_event (float x) 
+        void Ortho::slice_move_event (float x)
         {
           const Projection* proj = get_current_projection();
           if (!proj) return;

--- a/src/gui/mrview/mode/slice.cpp
+++ b/src/gui/mrview/mode/slice.cpp
@@ -28,7 +28,7 @@ namespace MR
       {
 
 
-        std::string Slice::Shader::vertex_shader_source (const Displayable&) 
+        std::string Slice::Shader::vertex_shader_source (const Displayable&)
         {
           return
             "layout(location = 0) in vec3 vertpos;\n"
@@ -95,7 +95,7 @@ namespace MR
 
         void Slice::paint (Projection& with_projection)
         {
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
           // set up OpenGL environment:
           gl::Disable (gl::BLEND);
           gl::Disable (gl::DEPTH_TEST);
@@ -103,13 +103,13 @@ namespace MR
           gl::ColorMask (gl::TRUE_, gl::TRUE_, gl::TRUE_, gl::TRUE_);
 
           draw_plane (plane(), slice_shader, with_projection);
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
         // Draw without setting up matrices/no crosshairs/no orientation labels
         void Slice::draw_plane_primitive (int axis, Displayable::Shader& shader_program, Projection& with_projection)
         {
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
           // render image:
           if (visible) {
             if (snap_to_image())
@@ -119,18 +119,18 @@ namespace MR
           }
 
           render_tools (with_projection, false, axis, slice (axis));
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
         void Slice::draw_plane (int axis, Displayable::Shader& shader_program, Projection& with_projection)
         {
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
           setup_projection (axis, with_projection);
           draw_plane_primitive (axis, shader_program, with_projection);
           draw_crosshairs (with_projection);
           draw_orientation_labels (with_projection);
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 

--- a/src/gui/mrview/mode/volume.cpp
+++ b/src/gui/mrview/mode/volume.cpp
@@ -328,7 +328,7 @@ namespace MR
 
         void Volume::paint (Projection& projection)
         {
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
           GL_CHECK_ERROR;
           setup_projection (orientation(), projection);
           GL_CHECK_ERROR;
@@ -523,7 +523,7 @@ namespace MR
           GL_CHECK_ERROR;
           draw_orientation_labels (projection);
 
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
         inline Tool::View* Volume::get_view_tool () const

--- a/src/gui/mrview/tool/connectome/connectome.cpp
+++ b/src/gui/mrview/tool/connectome/connectome.cpp
@@ -723,8 +723,8 @@ namespace MR
           edge_colour_fixedcolour_button       ->setFixedHeight (height);
           edge_colour_colourmap_button         ->setFixedHeight (height);
 
-          MRView::GrabContext context;
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::Context::Grab context;
+          GL::assert_context_is_current();
 
           cube.generate();
           cube_VAO.gen();
@@ -760,7 +760,7 @@ namespace MR
           GL_CHECK_ERROR;
 
           enable_all (false);
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
@@ -769,7 +769,7 @@ namespace MR
 
         void Connectome::draw (const Projection& projection, bool /*is_3D*/, int /*axis*/, int /*slice*/)
         {
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
           if (hide_all_button->isChecked()) return;
 
           // If using transparency, only want to draw the close surface;
@@ -796,13 +796,13 @@ namespace MR
             gl::Disable (gl::CULL_FACE);
           else
             gl::Enable (gl::CULL_FACE);
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
         void Connectome::draw_colourbars()
         {
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
           if (!buffer) return;
           if (hide_all_button->isChecked()) return;
           if (((node_colour == node_colour_t::CONNECTOME && matrix_list_model->rowCount()) || node_colour == node_colour_t::VECTOR_FILE || node_colour == node_colour_t::MATRIX_FILE) && show_node_colour_bar)
@@ -815,7 +815,7 @@ namespace MR
                                                 edge_colour_lower_button->value(), edge_colour_upper_button->value(),
                                                 edge_colour_lower_button->value(), edge_colour_upper_button->value() - edge_colour_lower_button->value(),
                                                 edge_fixed_colour);
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
@@ -2381,7 +2381,7 @@ namespace MR
 
         void Connectome::draw_nodes (const Projection& projection)
         {
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
           if (node_visibility != node_visibility_t::NONE) {
 
             if (node_geometry == node_geometry_t::OVERLAY) {
@@ -2545,12 +2545,12 @@ namespace MR
 
           }
 
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
         void Connectome::draw_edges (const Projection& projection)
         {
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
           if (edge_visibility != edge_visibility_t::NONE) {
 
             edge_shader.start (*this);
@@ -2683,7 +2683,7 @@ namespace MR
 
             edge_shader.stop();
           }
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
@@ -3789,7 +3789,7 @@ namespace MR
           if (meshes.size() != nodes.size())
             throw Exception ("Mesh file contains " + str(meshes.size()) + " objects; expected " + str(nodes.size()));
           have_meshes = false;
-          MRView::GrabContext context;
+          GL::Context::Grab context;
           for (node_t i = 1; i <= num_nodes(); ++i)
             nodes[i].assign_mesh (meshes[i]);
           have_meshes = true;

--- a/src/gui/mrview/tool/connectome/edge.cpp
+++ b/src/gui/mrview/tool/connectome/edge.cpp
@@ -109,8 +109,8 @@ namespace MR
           data.push_back (parent.get_node_centre (0));
           data.push_back (parent.get_node_centre (1));
 
-          MRView::GrabContext context;
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::Context::Grab context;
+          GL::assert_context_is_current();
 
           vertex_buffer.gen();
           vertex_buffer.bind (gl::ARRAY_BUFFER);
@@ -130,12 +130,12 @@ namespace MR
           tangent_buffer.bind (gl::ARRAY_BUFFER);
           gl::EnableVertexAttribArray (1);
           gl::VertexAttribPointer (1, 3, gl::FLOAT, gl::FALSE_, 0, (void*)(0));
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
         Edge::Line::~Line()
         {
-          MRView::GrabContext context;
+          GL::Context::Grab context;
           vertex_buffer.clear();
           tangent_buffer.clear();
           vertex_array_object.clear();
@@ -143,14 +143,14 @@ namespace MR
 
         void Edge::Line::render() const
         {
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
           if (!vertex_buffer || !tangent_buffer || !vertex_array_object)
             return;
           vertex_buffer.bind (gl::ARRAY_BUFFER);
           tangent_buffer.bind (gl::ARRAY_BUFFER);
           vertex_array_object.bind();
           gl::DrawArrays (gl::LINES, 0, 2);
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
@@ -187,8 +187,8 @@ namespace MR
 
         Edge::Streamline::Streamline (const Exemplar& data)
         {
-          MRView::GrabContext context;
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::Context::Grab context;
+          GL::assert_context_is_current();
           assert (data.tangents.size() == data.vertices.size());
 
           count = data.vertices.size();
@@ -211,12 +211,12 @@ namespace MR
           tangent_buffer.bind (gl::ARRAY_BUFFER);
           gl::EnableVertexAttribArray (1);
           gl::VertexAttribPointer (1, 3, gl::FLOAT, gl::FALSE_, 0, (void*)(0));
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
         Edge::Streamline::~Streamline()
         {
-          MRView::GrabContext context;
+          GL::Context::Grab context;
           vertex_buffer.clear();
           tangent_buffer.clear();
           vertex_array_object.clear();
@@ -224,14 +224,14 @@ namespace MR
 
         void Edge::Streamline::render() const
         {
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
           if (!vertex_buffer || !tangent_buffer || !vertex_array_object)
             return;
           vertex_buffer.bind (gl::ARRAY_BUFFER);
           tangent_buffer.bind (gl::ARRAY_BUFFER);
           vertex_array_object.bind();
           gl::DrawArrays (gl::LINE_STRIP, 0, count);
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
@@ -246,8 +246,8 @@ namespace MR
         Edge::Streamtube::Streamtube (const Exemplar& data) :
             count (data.vertices.size())
         {
-          MRView::GrabContext context;
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::Context::Grab context;
+          GL::assert_context_is_current();
 
           assert (data.normals.size() == data.vertices.size());
           assert (data.binormals.size() == data.vertices.size());
@@ -303,12 +303,12 @@ namespace MR
           normal_buffer.bind (gl::ARRAY_BUFFER);
           gl::EnableVertexAttribArray (2);
           gl::VertexAttribPointer (2, 3, gl::FLOAT, gl::FALSE_, 0, (void*)(0));
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
         Edge::Streamtube::~Streamtube()
         {
-          MRView::GrabContext context;
+          GL::Context::Grab context;
           vertex_buffer.clear();
           tangent_buffer.clear();
           normal_buffer.clear();
@@ -317,7 +317,7 @@ namespace MR
 
         void Edge::Streamtube::render() const
         {
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
           if (!vertex_buffer || !tangent_buffer || !normal_buffer || !vertex_array_object)
             return;
           vertex_buffer.bind (gl::ARRAY_BUFFER);
@@ -325,7 +325,7 @@ namespace MR
           normal_buffer.bind (gl::ARRAY_BUFFER);
           vertex_array_object.bind();
           gl::MultiDrawElements (gl::TRIANGLE_STRIP, shared.element_counts, gl::UNSIGNED_INT, (const GLvoid* const*)shared.element_indices, count-1);
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 

--- a/src/gui/mrview/tool/connectome/node.cpp
+++ b/src/gui/mrview/tool/connectome/node.cpp
@@ -72,8 +72,8 @@ namespace MR
         Node::Mesh::Mesh (MR::Surface::Mesh& in) :
             count (3 * in.num_triangles())
         {
-          MRView::GrabContext context;
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::Context::Grab context;
+          GL::assert_context_is_current();
 
           vector<float> vertices;
           vertices.reserve (3 * in.num_vertices());
@@ -118,7 +118,7 @@ namespace MR
           index_buffer.bind();
           if (indices.size())
             gl::BufferData (gl::ELEMENT_ARRAY_BUFFER, indices.size() * sizeof (unsigned int), &indices[0], gl::STATIC_DRAW);
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
         Node::Mesh::Mesh (Mesh&& that) :
@@ -133,7 +133,7 @@ namespace MR
 
         Node::Mesh::~Mesh()
         {
-          MRView::GrabContext context;
+          GL::Context::Grab context;
           vertex_buffer.clear();
           normal_buffer.clear();
           vertex_array_object.clear();
@@ -153,13 +153,13 @@ namespace MR
         void Node::Mesh::render() const
         {
           assert (count);
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
           vertex_buffer.bind (gl::ARRAY_BUFFER);
           normal_buffer.bind (gl::ARRAY_BUFFER);
           vertex_array_object.bind();
           index_buffer.bind();
           gl::DrawElements (gl::TRIANGLES, count, gl::UNSIGNED_INT, (void*)0);
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 

--- a/src/gui/mrview/tool/connectome/shaders.cpp
+++ b/src/gui/mrview/tool/connectome/shaders.cpp
@@ -33,7 +33,7 @@ namespace MR
 
         void ShaderBase::recompile (const Connectome& parent)
         {
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
           if (*this != 0)
             clear();
           update (parent);
@@ -45,7 +45,7 @@ namespace MR
             attach (geometry_shader);
           attach (fragment_shader);
           link();
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 

--- a/src/gui/mrview/tool/connectome/shaders.h
+++ b/src/gui/mrview/tool/connectome/shaders.h
@@ -43,12 +43,12 @@ namespace MR
           virtual void update (const Connectome&) = 0;
 
           void start (const Connectome& parent) {
-            ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+            GL::assert_context_is_current();
             if (*this == 0 || need_update (parent)) {
               recompile (parent);
             }
             GL::Shader::Program::start();
-            ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+            GL::assert_context_is_current();
           }
 
         protected:
@@ -62,7 +62,7 @@ namespace MR
 
 
 
-      class NodeShader : public ShaderBase 
+      class NodeShader : public ShaderBase
       { MEMALIGN(NodeShader)
         public:
           NodeShader() : ShaderBase () { }

--- a/src/gui/mrview/tool/fixel/base_fixel.cpp
+++ b/src/gui/mrview/tool/fixel/base_fixel.cpp
@@ -53,7 +53,7 @@ namespace MR
 
         BaseFixel::~BaseFixel()
         {
-          MRView::GrabContext context;
+          GL::Context::Grab context;
           vertex_buffer.clear ();
           direction_buffer.clear ();
           vertex_array_object.clear ();
@@ -212,7 +212,7 @@ namespace MR
 
         void BaseFixel::render (const Projection& projection)
         {
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
           start (fixel_shader);
           projection.set (fixel_shader);
 
@@ -265,7 +265,7 @@ namespace MR
           }
 
           stop (fixel_shader);
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
@@ -294,7 +294,7 @@ namespace MR
                                                const MR::Header &fixel_header,
                                                const MR::Transform &transform)
         {
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
           // Code below "inspired" by ODF::draw
           Eigen::Vector3f p (Window::main->target());
           p += projection.screen_normal() * (projection.screen_normal().dot (Window::main->focus() - p));
@@ -368,7 +368,7 @@ namespace MR
           if(!regular_grid_buffer_pos.size())
             return;
 
-          MRView::GrabContext context;
+          GL::Context::Grab context;
 
           regular_grid_vao.bind ();
           regular_grid_vertex_buffer.bind (gl::ARRAY_BUFFER);
@@ -411,7 +411,7 @@ namespace MR
             gl::VertexAttribPointer (4, 1, gl::FLOAT, gl::FALSE_, 0, (void*)0);
           }
 
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
@@ -419,8 +419,8 @@ namespace MR
         {
           // Make sure to set graphics context!
           // We're setting up vertex array objects
-          MRView::GrabContext context;
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::Context::Grab context;
+          GL::assert_context_is_current();
 
           load_image_buffer ();
 
@@ -462,7 +462,7 @@ namespace MR
           gl::EnableVertexAttribArray (0);
           gl::VertexAttribPointer (0, 3, gl::FLOAT, gl::FALSE_, 0, (void*)0);
 
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
 
           dir_buffer_dirty = true;
           value_buffer_dirty = true;
@@ -473,8 +473,8 @@ namespace MR
 
         void BaseFixel::reload_directions_buffer ()
         {
-          MRView::GrabContext context;
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::Context::Grab context;
+          GL::assert_context_is_current();
 
           vertex_array_object.bind ();
 
@@ -484,14 +484,14 @@ namespace MR
           gl::EnableVertexAttribArray (1);
           gl::VertexAttribPointer (1, 3, gl::FLOAT, gl::FALSE_, 0, (void*)0);
 
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
         void BaseFixel::reload_values_buffer ()
         {
-          MRView::GrabContext context;
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::Context::Grab context;
+          GL::assert_context_is_current();
 
           if (scale_type == Unity)
             return;
@@ -507,14 +507,14 @@ namespace MR
           gl::EnableVertexAttribArray (2);
           gl::VertexAttribPointer (2, 1, gl::FLOAT, gl::FALSE_, 0, (void*)0);
 
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
         void BaseFixel::reload_colours_buffer ()
         {
-          MRView::GrabContext context;
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::Context::Grab context;
+          GL::assert_context_is_current();
 
           if (colour_type == Direction)
             return;
@@ -530,14 +530,14 @@ namespace MR
           gl::EnableVertexAttribArray (3);
           gl::VertexAttribPointer (3, 1, gl::FLOAT, gl::FALSE_, 0, (void*)0);
 
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
         void BaseFixel::reload_threshold_buffer ()
         {
-          MRView::GrabContext context;
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::Context::Grab context;
+          GL::assert_context_is_current();
 
           const auto& fixel_val = current_fixel_threshold_state ();
           const auto& val_buffer = fixel_val.buffer_store;
@@ -550,7 +550,7 @@ namespace MR
           gl::EnableVertexAttribArray (4);
           gl::VertexAttribPointer (4, 1, gl::FLOAT, gl::FALSE_, 0, (void*)0);
 
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
       }
     }

--- a/src/gui/mrview/tool/fixel/fixel.cpp
+++ b/src/gui/mrview/tool/fixel/fixel.cpp
@@ -259,13 +259,13 @@ namespace MR
 
         void Fixel::draw (const Projection& transform, bool is_3D, int, int)
         {
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
           not_3D = !is_3D;
           for (int i = 0; i < fixel_list_model->rowCount(); ++i) {
             if (fixel_list_model->items[i]->show && !hide_all_button->isChecked())
               dynamic_cast<BaseFixel*>(fixel_list_model->items[i].get())->render (transform);
           }
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
@@ -298,7 +298,7 @@ namespace MR
 
         void Fixel::render_fixel_colourbar (const Tool::BaseFixel& fixel)
         {
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
           float min_value = fixel.use_discard_lower() ?
                       fixel.scaling_min_thresholded() :
                       fixel.scaling_min();
@@ -311,7 +311,7 @@ namespace MR
                                               min_value, max_value,
                                               fixel.scaling_min(), fixel.display_range,
                                               Eigen::Array3f { fixel.colour[0] / 255.0f, fixel.colour[1] / 255.0f, fixel.colour[2] / 255.0f });
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
@@ -629,7 +629,7 @@ namespace MR
 
         void Fixel::on_crop_to_slice_slot (bool is_checked)
         {
-          do_crop_to_slice = is_checked;         
+          do_crop_to_slice = is_checked;
           lock_to_grid->setEnabled(do_crop_to_slice);
 
           window().updateGL();
@@ -771,7 +771,7 @@ namespace MR
 
 
         void Fixel::add_commandline_options (MR::App::OptionList& options)
-        { 
+        {
           using namespace MR::App;
           options
             + OptionGroup ("Fixel plot tool options")

--- a/src/gui/mrview/tool/odf/odf.cpp
+++ b/src/gui/mrview/tool/odf/odf.cpp
@@ -255,7 +255,7 @@ namespace MR
 
         void ODF::draw (const Projection& projection, bool is_3D, int, int)
         {
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
           if (is_3D)
             return;
 
@@ -369,7 +369,7 @@ namespace MR
             gl::Disable (gl::DEPTH_TEST);
             gl::DepthMask (gl::FALSE_);
           }
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
 
           update_preview();
         }

--- a/src/gui/mrview/tool/overlay.cpp
+++ b/src/gui/mrview/tool/overlay.cpp
@@ -658,6 +658,12 @@ namespace MR
               connect (vol_index, SIGNAL (valueChanged(int)), this, SLOT (onSetVolumeIndex()));
             }
           }
+          if (volume_index_layout->count() == 0) {
+            if (indices.size() != 1)
+              volume_index_layout->addWidget (new QLabel ("Requires single image selected"));
+            else
+              volume_index_layout->addWidget (new QLabel ("No volumes to select"));
+          }
 
           colourmap_button->set_colourmap_index(colourmap_index);
           opacity_slider->setValue (1.0e3f * opacity);

--- a/src/gui/mrview/tool/overlay.cpp
+++ b/src/gui/mrview/tool/overlay.cpp
@@ -245,10 +245,16 @@ namespace MR
         void Overlay::image_close_slot ()
         {
           QModelIndexList indexes = image_list_view->selectionModel()->selectedIndexes();
+          GL::Context::Grab context;
+          GL::assert_context_is_current();
           while (indexes.size()) {
+          GL::assert_context_is_current();
             image_list_model->remove_item (indexes.first());
+          GL::assert_context_is_current();
             indexes = image_list_view->selectionModel()->selectedIndexes();
+          GL::assert_context_is_current();
           }
+          GL::assert_context_is_current();
           updateGL();
         }
 
@@ -261,7 +267,7 @@ namespace MR
 
         void Overlay::draw (const Projection& projection, bool is_3D, int, int)
         {
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
           if (!is_3D) {
             // set up OpenGL environment:
             gl::Enable (gl::BLEND);
@@ -294,7 +300,7 @@ namespace MR
             gl::Enable (gl::DEPTH_TEST);
             gl::DepthMask (gl::TRUE_);
           }
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 

--- a/src/gui/mrview/tool/overlay.cpp
+++ b/src/gui/mrview/tool/overlay.cpp
@@ -119,20 +119,12 @@ namespace MR
 
             main_box->addWidget (image_list_view, 1);
 
-            layout = new HBoxLayout;
-            volume_label = new QLabel ("Volume: ");
-            volume_label->setEnabled (false);
-            layout->addWidget (volume_label);
-            volume_selecter = new SpinBox (this);
-            volume_selecter->setMinimum (0);
-            volume_selecter->setMaximum (0);
-            volume_selecter->setValue (0);
-            volume_selecter->setEnabled (false);
-            volume_selecter->setToolTip ("For 4D overlay images, select the 3D volume index");
-            connect (volume_selecter, SIGNAL (valueChanged(int)), this, SLOT(volume_changed(int)));
-            layout->addWidget (volume_selecter);
+            // Volume selecter
+            volume_box = new QGroupBox ("Volume indices (dimension: index)");
+            main_box->addWidget (volume_box);
+            volume_index_layout = new GridLayout;
+            volume_box->setLayout (volume_index_layout);
 
-            main_box->addLayout (layout, 0);
 
             QGroupBox* group_box = new QGroupBox (tr("Colour map and scaling"));
             main_box->addWidget (group_box);
@@ -460,13 +452,20 @@ namespace MR
         }
 
 
-        void Overlay::volume_changed (int)
+        void Overlay::onSetVolumeIndex ()
         {
           QModelIndexList indices = image_list_view->selectionModel()->selectedIndexes();
           if (indices.size() != 1) return;
           Image* overlay = dynamic_cast<Image*> (image_list_model->get_image (indices[0]));
           if (overlay->header().ndim() < 4) return;
-          overlay->image.index(3) = volume_selecter->value();
+          assert (overlay->header().ndim() == size_t(volume_index_layout->count()+3));
+
+          for (int i = 0; i < volume_index_layout->count(); ++i) {
+            auto* box = dynamic_cast<SpinBox*> (volume_index_layout->itemAt(i)->widget());
+            if (overlay->header().ndim() <= size_t(i+3))
+              break;
+            overlay->image.index(i+3) = box->value();
+          }
           if (overlay->show)
             updateGL();
         }
@@ -586,8 +585,8 @@ namespace MR
         void Overlay::update_selection ()
         {
           QModelIndexList indices = image_list_view->selectionModel()->selectedIndexes();
-          volume_label->setEnabled (false);
-          volume_selecter->setEnabled (false);
+          while (volume_index_layout->count())
+            delete volume_index_layout->takeAt (volume_index_layout->count()-1)->widget();
           colourmap_button->setEnabled (indices.size());
           max_value->setEnabled (indices.size());
           min_value->setEnabled (indices.size());
@@ -646,14 +645,17 @@ namespace MR
 
           if (indices.size() == 1) {
             Image* overlay = dynamic_cast<Image*> (image_list_model->get_image (indices[0]));
-            if (overlay->header().ndim() == 4 && overlay->header().size(3) > 1) {
-              volume_label->setEnabled (true);
-              volume_selecter->setMaximum (overlay->header().size(3)-1);
-              volume_selecter->setValue (overlay->image.index(3));
-              volume_selecter->setEnabled (true);
-            } else {
-              volume_selecter->setMaximum (0);
-              volume_selecter->setValue (0);
+
+            // volume_box->setVisible(overlay->header().ndim() > 3); // causes shift in FOV due to resizing of tool pane
+            for (size_t d = 3; d < overlay->image.ndim(); ++d) {
+              SpinBox* vol_index = new SpinBox (this);
+              vol_index->setMinimum (0);
+              vol_index->setPrefix (tr((str(d+1) + ": ").c_str()));;
+              vol_index->setValue (overlay->image.index(d));
+              vol_index->setMaximum (overlay->image.size(d) - 1);
+              vol_index->setEnabled (overlay->image.size(d) > 1);
+              volume_index_layout->addWidget (vol_index, volume_index_layout->count()/3, volume_index_layout->count()%3);
+              connect (vol_index, SIGNAL (valueChanged(int)), this, SLOT (onSetVolumeIndex()));
             }
           }
 

--- a/src/gui/mrview/tool/overlay.h
+++ b/src/gui/mrview/tool/overlay.h
@@ -63,7 +63,7 @@ namespace MR
             void toggle_shown_slot (const QModelIndex&, const QModelIndex&);
             void selection_changed_slot (const QItemSelection &, const QItemSelection &);
             void right_click_menu_slot (const QPoint&);
-            void volume_changed (int);
+            void onSetVolumeIndex ();
             void update_slot (int unused);
             void values_changed ();
             void upper_threshold_changed (int unused);
@@ -92,13 +92,13 @@ namespace MR
              QPushButton* hide_all_button;
              Model* image_list_model;
              QListView* image_list_view;
-             QLabel* volume_label;
-             SpinBox* volume_selecter;
              ColourMapButton* colourmap_button;
              AdjustButton *min_value, *max_value, *lower_threshold, *upper_threshold;
              QCheckBox *lower_threshold_check_box, *upper_threshold_check_box;
              InterpolateCheckBox* interpolate_check_box;
              QSlider *opacity_slider;
+             QGroupBox *volume_box;
+             GridLayout *volume_index_layout;
 
              void update_selection ();
              void updateGL() {

--- a/src/gui/mrview/tool/roi_editor/item.cpp
+++ b/src/gui/mrview/tool/roi_editor/item.cpp
@@ -77,31 +77,31 @@ namespace MR
           name << "ROI" << std::setfill('0') << std::setw(5) << new_roi_counter++ << ".mif";
           filename = name.str();
 
-          MRView::GrabContext context;
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::Context::Grab context;
+          GL::assert_context_is_current();
           bind();
           allocate();
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
 
         void ROI_Item::zero ()
         {
-          MRView::GrabContext context;
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::Context::Grab context;
+          GL::assert_context_is_current();
           bind();
           vector<GLubyte> data (header().size(0)*header().size(1));
           for (int n = 0; n < header().size(2); ++n)
             upload_data ({ { 0, 0, n } }, { { header().size(0), header().size(1), 1 } }, reinterpret_cast<void*> (&data[0]));
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
         void ROI_Item::load ()
         {
-          MRView::GrabContext context;
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::Context::Grab context;
+          GL::assert_context_is_current();
           bind();
           auto image = header().get_image<bool>();
           vector<GLubyte> data (image.size(0)*image.size(1));
@@ -114,7 +114,7 @@ namespace MR
             ++progress;
           }
           filename = header().name();
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 

--- a/src/gui/mrview/tool/roi_editor/model.cpp
+++ b/src/gui/mrview/tool/roi_editor/model.cpp
@@ -35,7 +35,7 @@ namespace MR
         {
           beginInsertRows (QModelIndex(), items.size(), items.size()+list.size());
           for (size_t i = 0; i < list.size(); ++i) {
-            MRView::GrabContext context;
+            GL::Context::Grab context;
             ROI_Item* roi = new ROI_Item (std::move (*list[i]));
             roi->load ();
             items.push_back (std::unique_ptr<Displayable> (roi));
@@ -47,7 +47,7 @@ namespace MR
         {
           beginInsertRows (QModelIndex(), items.size(), items.size()+1);
           {
-            MRView::GrabContext context;
+            GL::Context::Grab context;
             ROI_Item* roi = new ROI_Item (std::move (image));
             roi->zero ();
             items.push_back (std::unique_ptr<Displayable> (roi));

--- a/src/gui/mrview/tool/roi_editor/roi.cpp
+++ b/src/gui/mrview/tool/roi_editor/roi.cpp
@@ -339,12 +339,12 @@ namespace MR
         {
           vector<GLubyte> data (roi->header().size(0) * roi->header().size(1) * roi->header().size(2));
           {
-            MRView::GrabContext context;
-            ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+            GL::Context::Grab context;
+            GL::assert_context_is_current();
             roi->texture().bind();
             gl::PixelStorei (gl::PACK_ALIGNMENT, 1);
             gl::GetTexImage (gl::TEXTURE_3D, 0, gl::RED, gl::UNSIGNED_BYTE, (void*) (&data[0]));
-            ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+            GL::assert_context_is_current();
           }
 
           try {
@@ -550,7 +550,7 @@ namespace MR
 
         void ROI::draw (const Projection& projection, bool is_3D, int, int)
         {
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
           if (is_3D) return;
 
           if (!is_3D) {
@@ -579,7 +579,7 @@ namespace MR
             gl::Enable (gl::DEPTH_TEST);
             gl::DepthMask (gl::TRUE_);
           }
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 

--- a/src/gui/mrview/tool/roi_editor/undoentry.cpp
+++ b/src/gui/mrview/tool/roi_editor/undoentry.cpp
@@ -31,12 +31,12 @@ namespace MR
 
 
         std::unique_ptr<ROI_UndoEntry::Shared> ROI_UndoEntry::shared;
-            
+
 
         ROI_UndoEntry::Shared::Shared() :
             count (1)
         {
-          MRView::GrabContext context;
+          GL::Context::Grab context;
           GL::Shader::Vertex vertex_shader (
               "layout(location = 0) in ivec3 vertpos;\n"
               "void main() {\n"
@@ -81,7 +81,7 @@ namespace MR
         ROI_UndoEntry::Shared::~Shared()
         {
           assert (!count);
-          MRView::GrabContext context;
+          GL::Context::Grab context;
           program.clear();
           vertex_buffer.clear();
           vertex_array_object.clear();
@@ -114,8 +114,8 @@ namespace MR
           else { slice_axes[0] = 0; slice_axes[1] = 1; }
           tex_size = { { size[slice_axes[0]], size[slice_axes[1]] } };
 
-          MRView::GrabContext context;
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::Context::Grab context;
+          GL::assert_context_is_current();
 
           if (!shared)
             shared.reset (new Shared());
@@ -162,7 +162,7 @@ namespace MR
           gl::GetTexImage (gl::TEXTURE_2D, 0, gl::RED, gl::UNSIGNED_BYTE, (void*)(&before[0]));
           after = before;
           GL_CHECK_ERROR;
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
@@ -235,11 +235,11 @@ namespace MR
             }
           } while ((v - final_vox).abs().maxCoeff());
 
-          MRView::GrabContext context;
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::Context::Grab context;
+          GL::assert_context_is_current();
           roi.texture().bind();
           gl::TexSubImage3D (gl::TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], gl::RED, gl::UNSIGNED_BYTE, (void*) (&after[0]));
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
@@ -281,11 +281,11 @@ namespace MR
 
           } } }
 
-          MRView::GrabContext context;
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::Context::Grab context;
+          GL::assert_context_is_current();
           roi.texture().bind();
           gl::TexSubImage3D (gl::TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], gl::RED, gl::UNSIGNED_BYTE, (void*) (&after[0]));
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
@@ -316,11 +316,11 @@ namespace MR
                     Math::pow2 (roi.header().spacing(2) * (vox[2]-k)) < radius_sq)
                   after[i-from[0] + size[0] * (j-from[1] + size[1] * (k-from[2]))] = value;
 
-          MRView::GrabContext context;
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::Context::Grab context;
+          GL::assert_context_is_current();
           roi.texture().bind();
           gl::TexSubImage3D (gl::TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], gl::RED, gl::UNSIGNED_BYTE, (void*) (&after[0]));
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
@@ -349,11 +349,11 @@ namespace MR
               for (int i = a[0]; i <= b[0]; ++i)
                 after[i-from[0] + size[0] * (j-from[1] + size[1] * (k-from[2]))] = value;
 
-          MRView::GrabContext context;
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::Context::Grab context;
+          GL::assert_context_is_current();
           roi.texture().bind();
           gl::TexSubImage3D (gl::TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], gl::RED, gl::UNSIGNED_BYTE, (void*) (&after[0]));
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
@@ -393,43 +393,43 @@ namespace MR
               }
             }
           }
-          MRView::GrabContext context;
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::Context::Grab context;
+          GL::assert_context_is_current();
           roi.texture().bind();
           gl::TexSubImage3D (gl::TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], gl::RED, gl::UNSIGNED_BYTE, (void*) (&after[0]));
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
 
 
 
-        void ROI_UndoEntry::undo (ROI_Item& roi) 
+        void ROI_UndoEntry::undo (ROI_Item& roi)
         {
-          MRView::GrabContext context;
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::Context::Grab context;
+          GL::assert_context_is_current();
           roi.texture().bind();
           gl::TexSubImage3D (gl::TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], gl::RED, gl::UNSIGNED_BYTE, (void*) (&before[0]));
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
-        void ROI_UndoEntry::redo (ROI_Item& roi) 
+        void ROI_UndoEntry::redo (ROI_Item& roi)
         {
-          MRView::GrabContext context;
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::Context::Grab context;
+          GL::assert_context_is_current();
           roi.texture().bind();
           gl::TexSubImage3D (gl::TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], gl::RED, gl::UNSIGNED_BYTE, (void*) (&after[0]));
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
-        void ROI_UndoEntry::copy (ROI_Item& roi, ROI_UndoEntry& source) 
+        void ROI_UndoEntry::copy (ROI_Item& roi, ROI_UndoEntry& source)
         {
-          MRView::GrabContext context;
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::Context::Grab context;
+          GL::assert_context_is_current();
           after = source.before;
           roi.texture().bind();
           gl::TexSubImage3D (gl::TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], gl::RED, gl::UNSIGNED_BYTE, (void*) (&after[0]));
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 

--- a/src/gui/mrview/tool/tractography/tractogram.cpp
+++ b/src/gui/mrview/tool/tractography/tractogram.cpp
@@ -387,7 +387,7 @@ namespace MR
 
         Tractogram::~Tractogram ()
         {
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
           if (vertex_buffers.size())
             gl::DeleteBuffers (vertex_buffers.size(), &vertex_buffers[0]);
           if (vertex_array_objects.size())
@@ -398,7 +398,7 @@ namespace MR
             gl::DeleteBuffers (intensity_scalar_buffers.size(), &intensity_scalar_buffers[0]);
           if (threshold_scalar_buffers.size())
             gl::DeleteBuffers (threshold_scalar_buffers.size(), &threshold_scalar_buffers[0]);
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
@@ -406,7 +406,7 @@ namespace MR
 
         void Tractogram::render (const Projection& transform)
         {
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
           if (tractography_tool.do_crop_to_slab && tractography_tool.slab_thickness <= 0.0)
             return;
 
@@ -499,7 +499,7 @@ namespace MR
           }
 
           stop (track_shader);
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
@@ -507,7 +507,7 @@ namespace MR
 
         inline void Tractogram::render_streamlines ()
         {
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
           for (size_t buf = 0, N = vertex_buffers.size(); buf < N; ++buf) {
             gl::BindVertexArray (vertex_array_objects[buf]);
 
@@ -569,7 +569,7 @@ namespace MR
           }
 
           vao_dirty = false;
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
@@ -604,8 +604,8 @@ namespace MR
         {
           // Make sure to set graphics context!
           // We're setting up vertex array objects
-          MRView::GrabContext context;
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::Context::Grab context;
+          GL::assert_context_is_current();
 
           DWI::Tractography::Reader<float> file (filename, properties);
           DWI::Tractography::Streamline<float> tck;
@@ -647,7 +647,7 @@ namespace MR
           if (buffer.size())
             load_tracks_onto_GPU (buffer, starts, sizes, tck_count);
           file.close();
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
@@ -661,8 +661,8 @@ namespace MR
 
           // Make sure to set graphics context!
           // We're setting up vertex array objects
-          MRView::GrabContext context;
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::Context::Grab context;
+          GL::assert_context_is_current();
 
           erase_colour_data();
           size_t total_tck_counter = 0;
@@ -686,7 +686,7 @@ namespace MR
           assert (colour_buffers.size() == vertex_buffers.size());
           // Don't need this now that we've initialised the GPU buffers
           endpoint_tangents.clear();
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
@@ -697,8 +697,8 @@ namespace MR
         {
           // Make sure to set graphics context!
           // We're setting up vertex array objects
-          MRView::GrabContext context;
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::Context::Grab context;
+          GL::assert_context_is_current();
 
           erase_intensity_scalar_data ();
           value_min = std::numeric_limits<float>::infinity();
@@ -783,7 +783,7 @@ namespace MR
             greaterthan = value_max;
           if (!std::isfinite (lessthan))
             lessthan = value_min;
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
@@ -792,8 +792,8 @@ namespace MR
         {
           // Make sure to set graphics context!
           // We're setting up vertex array objects
-          MRView::GrabContext context;
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::Context::Grab context;
+          GL::assert_context_is_current();
 
           erase_threshold_scalar_data ();
           threshold_min = std::numeric_limits<float>::infinity();
@@ -876,20 +876,20 @@ namespace MR
           greaterthan = threshold_max;
           lessthan = threshold_min;
 
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
 
         void Tractogram::erase_colour_data()
         {
-          MRView::GrabContext context;
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::Context::Grab context;
+          GL::assert_context_is_current();
           if (colour_buffers.size()) {
             gl::DeleteBuffers (colour_buffers.size(), &colour_buffers[0]);
             colour_buffers.clear();
           }
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
@@ -897,14 +897,14 @@ namespace MR
 
         void Tractogram::erase_intensity_scalar_data ()
         {
-          MRView::GrabContext context;
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::Context::Grab context;
+          GL::assert_context_is_current();
           if (intensity_scalar_buffers.size()) {
             gl::DeleteBuffers (intensity_scalar_buffers.size(), &intensity_scalar_buffers[0]);
             intensity_scalar_buffers.clear();
           }
           intensity_scalar_filename.clear();
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
@@ -912,8 +912,8 @@ namespace MR
 
         void Tractogram::erase_threshold_scalar_data ()
         {
-          MRView::GrabContext context;
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::Context::Grab context;
+          GL::assert_context_is_current();
           if (threshold_scalar_buffers.size()) {
             gl::DeleteBuffers (threshold_scalar_buffers.size(), &threshold_scalar_buffers[0]);
             threshold_scalar_buffers.clear();
@@ -922,7 +922,7 @@ namespace MR
           threshold_min = threshold_max = NaN;
           set_use_discard_lower (false);
           set_use_discard_upper (false);
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
@@ -964,7 +964,7 @@ namespace MR
             vector<GLint>& sizes,
             size_t& tck_count)
         {
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
 
           GLuint vertex_array_object;
           gl::GenVertexArrays (1, &vertex_array_object);
@@ -987,12 +987,12 @@ namespace MR
           starts.clear();
           sizes.clear();
           tck_count = 0;
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
         void Tractogram::load_end_colours_onto_GPU (vector<Eigen::Vector3f>& buffer)
         {
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
 
           GLuint vertexbuffer;
           gl::GenBuffers (1, &vertexbuffer);
@@ -1003,7 +1003,7 @@ namespace MR
 
           colour_buffers.push_back (vertexbuffer);
           buffer.clear();
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
@@ -1012,7 +1012,7 @@ namespace MR
 
         void Tractogram::load_intensity_scalars_onto_GPU (vector<float>& buffer, size_t& tck_count)
         {
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
 
           assert (num_tracks_per_buffer[intensity_scalar_buffers.size()] == tck_count);
 
@@ -1027,7 +1027,7 @@ namespace MR
           buffer.clear();
           tck_count = 0;
 
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
@@ -1035,7 +1035,7 @@ namespace MR
 
         void Tractogram::load_threshold_scalars_onto_GPU (vector<float>& buffer, size_t& tck_count)
         {
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
 
           assert (num_tracks_per_buffer[threshold_scalar_buffers.size()] == tck_count);
 
@@ -1050,7 +1050,7 @@ namespace MR
           buffer.clear();
           tck_count = 0;
 
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 

--- a/src/gui/mrview/tool/tractography/tractography.cpp
+++ b/src/gui/mrview/tool/tractography/tractography.cpp
@@ -313,14 +313,14 @@ namespace MR
 
         void Tractography::draw (const Projection& transform, bool is_3D, int, int)
         {
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
           not_3D = !is_3D;
           for (int i = 0; i < tractogram_list_model->rowCount(); ++i) {
             Tractogram* tractogram = dynamic_cast<Tractogram*>(tractogram_list_model->items[i].get());
             if (tractogram->show && !hide_all_button->isChecked())
               tractogram->render (transform);
           }
-          ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+          GL::assert_context_is_current();
         }
 
 
@@ -407,7 +407,7 @@ namespace MR
 
         void Tractography::tractogram_close_slot ()
         {
-          MRView::GrabContext context;
+          GL::Context::Grab context;
           QModelIndexList indexes = tractogram_list_view->selectionModel()->selectedIndexes();
           while (indexes.size()) {
             tractogram_list_model->remove_item (indexes.first());

--- a/src/gui/mrview/tool/view.cpp
+++ b/src/gui/mrview/tool/view.cpp
@@ -534,9 +534,10 @@ namespace MR
           for (size_t d = 3; d < image->image.ndim(); ++d) {
             SpinBox* vol_index = new SpinBox (this);
             vol_index->setMinimum (0);
-            vol_index->setPrefix (tr((str(d+1) + ": ").c_str()));;
+            vol_index->setPrefix (tr((str(d+1) + ": ").c_str()));
             vol_index->setValue (image->image.index(d));
             vol_index->setMaximum (image->image.size(d) - 1);
+            vol_index->setEnabled (image->image.size(d) > 1);
             volume_index_layout->addWidget (vol_index, volume_index_layout->count()/3, volume_index_layout->count()%3);
             connect (vol_index, SIGNAL (valueChanged(int)), this, SLOT (onSetVolumeIndex()));
           }

--- a/src/gui/mrview/volume.cpp
+++ b/src/gui/mrview/volume.cpp
@@ -28,7 +28,7 @@ namespace MR
 
 
       Volume::~Volume() {
-        MRView::GrabContext context;
+        GL::Context::Grab context;
         _texture.clear();
         vertex_buffer.clear();
         vertex_array_object.clear();

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -241,7 +241,7 @@ namespace MR
         show_FPS (false),
         current_option (0) {
           main = this;
-          GUI::App::set_main_window (this);
+          GUI::App::set_main_window (this, glarea);
           GUI::Dialog::init();
 
           setDockOptions (AllowTabbedDocks | VerticalTabs);
@@ -1465,7 +1465,7 @@ namespace MR
 
       void Window::paintGL ()
       {
-        ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+        GL::assert_context_is_current();
         GL_CHECK_ERROR;
         gl::ClearColor (background_colour[0], background_colour[1], background_colour[2], 1.0);
 
@@ -1474,9 +1474,9 @@ namespace MR
 
         GL_CHECK_ERROR;
 
-        ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+        GL::assert_context_is_current();
         mode->paintGL();
-        ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+        GL::assert_context_is_current();
         GL_CHECK_ERROR;
 
         if (show_FPS) {
@@ -1517,13 +1517,13 @@ namespace MR
         glColorMask (true, true, true, true);
 #endif
         GL_CHECK_ERROR;
-        ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+        GL::assert_context_is_current();
       }
 
 
       void Window::initGL ()
       {
-        ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+        GL::assert_context_is_current();
         GL::init ();
 
         font.initGL();
@@ -1536,7 +1536,7 @@ namespace MR
         mode.reset (dynamic_cast<Mode::__Action__*> (mode_group->actions()[0])->create());
         set_mode_features();
 
-        ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT;
+        GL::assert_context_is_current();
       }
 
 

--- a/src/gui/mrview/window.h
+++ b/src/gui/mrview/window.h
@@ -338,19 +338,6 @@ namespace MR
       };
 
 
-      class GrabContext : private Context::Grab { NOMEMALIGN
-        public:
-          GrabContext () : Context::Grab (Window::main->glarea) { }
-      };
-
-
-#ifndef NDEBUG
-# define ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT ASSERT_GL_CONTEXT_IS_CURRENT (::MR::GUI::MRView::Window::main->glwidget())
-#else
-# define ASSERT_GL_MRVIEW_CONTEXT_IS_CURRENT
-#endif
-
-
     }
   }
 }

--- a/src/gui/opengl/gl.cpp
+++ b/src/gui/opengl/gl.cpp
@@ -14,6 +14,7 @@
  * For more details, see http://www.mrtrix.org/.
  */
 
+#include "gui/gui.h"
 #include "gui/opengl/gl.h"
 #include "file/config.h"
 
@@ -24,13 +25,21 @@ namespace MR
     namespace GL
     {
 
+      Area* glwidget = nullptr;
+
+      void __assert_context_is_current (QWidget* glarea) {
+        auto __current_context = Context::current();
+        auto __expected_context = Context::get (glarea ? glarea : glwidget);
+        assert (__current_context == __expected_context);
+      }
+
 
       void set_default_context () {
         //CONF option: VSync
         //CONF default: 0 (false)
         //CONF Whether the screen update should synchronise with the monitor's
         //CONF vertical refresh (to avoid tearing artefacts).
-        
+
         //CONF option: NeedOpenGLCoreProfile
         //CONF default: 1 (true)
         //CONF Whether the creation of an OpenGL 3.3 context requires it to be
@@ -54,7 +63,7 @@ namespace MR
           f.setVersion (3,3);
           f.setProfile (GL::Format::CoreProfile);
         }
-        
+
         f.setDepthBufferSize (24);
         f.setRedBufferSize (8);
         f.setGreenBufferSize (8);
@@ -65,7 +74,7 @@ namespace MR
         f.setSwapInterval (swap_interval);
 
         int nsamples = File::Config::get_int ("MSAA", 0);
-        if (nsamples > 1) 
+        if (nsamples > 1)
           f.setSamples (nsamples);
 
         GL::Format::setDefaultFormat (f);
@@ -81,7 +90,7 @@ namespace MR
         INFO ("GL renderer:  " + std::string ( (const char*) gl::GetString (gl::RENDERER)));
         INFO ("GL version:   " + std::string ( (const char*) gl::GetString (gl::VERSION)));
         INFO ("GL vendor:    " + std::string ( (const char*) gl::GetString (gl::VENDOR)));
-        
+
         GLint gl_version (0), gl_version_major (0);
         gl::GetIntegerv (gl::MAJOR_VERSION, &gl_version_major);
         gl::GetIntegerv (gl::MINOR_VERSION, &gl_version);
@@ -109,7 +118,7 @@ namespace MR
         */
       }
 
-      const char* ErrorString (GLenum errorcode) 
+      const char* ErrorString (GLenum errorcode)
       {
         switch (errorcode) {
           case gl::INVALID_ENUM: return "invalid value for enumerated argument";

--- a/src/gui/opengl/gl.cpp
+++ b/src/gui/opengl/gl.cpp
@@ -27,11 +27,13 @@ namespace MR
 
       Area* glwidget = nullptr;
 
+#ifndef NDEBUG
       void __assert_context_is_current (QWidget* glarea) {
         auto __current_context = Context::current();
         auto __expected_context = Context::get (glarea ? glarea : glwidget);
         assert (__current_context == __expected_context);
       }
+#endif
 
 
       void set_default_context () {

--- a/src/gui/opengl/gl.h
+++ b/src/gui/opengl/gl.h
@@ -69,22 +69,17 @@ namespace MR
 
       using Area = QOpenGLWidget;
       using Format = QSurfaceFormat;
-      struct CheckContext { NOMEMALIGN
-# ifndef NDEBUG
-        CheckContext () : __context (nullptr) { }
-        void grab_context () {
-          __context = QOpenGLContext::currentContext();
-        }
-        void check_context () const {
-          assert (QOpenGLContext::currentContext());
-          assert (__context == QOpenGLContext::currentContext());
-        }
-        QOpenGLContext* __context;
-# else
-        void grab_context () { }
-        void check_context () const { }
-# endif
-      };
+
+#ifndef NDEBUG
+      void __assert_context_is_current (QWidget* glarea);
+#endif
+
+      inline void assert_context_is_current(QWidget* glarea = nullptr) {
+#ifndef NDEBUG
+        __assert_context_is_current (glarea);
+#endif
+      }
+
 #else
       class Area : public QGLWidget { NOMEMALIGN
         public:
@@ -93,10 +88,6 @@ namespace MR
       };
 
       using Format = QGLFormat;
-      struct CheckContext { NOMEMALIGN
-        void grab_context () { }
-        void check_context () const { }
-      };
 #endif
 
       void init ();
@@ -113,7 +104,67 @@ namespace MR
       }
 
 
-      class Texture : CheckContext { NOMEMALIGN
+
+      extern Area* glwidget;
+
+
+      namespace Context
+      {
+#if QT_VERSION >= 0x050400
+        inline std::pair<QOpenGLContext*,QSurface*> current() {
+          QOpenGLContext* context = QOpenGLContext::currentContext();
+          QSurface* surface = context ? context->surface() : nullptr;
+          return { context, surface };
+        }
+
+        inline std::pair<QOpenGLContext*,QSurface*> get (QWidget* window) {
+          QOpenGLContext* context = reinterpret_cast<QOpenGLWidget*> (window)->context();
+          QSurface* surface = context ? context->surface() : nullptr;
+          return { context, surface };
+        }
+
+        inline std::pair<QOpenGLContext*,QSurface*> makeCurrent (QWidget* window) {
+          auto previous_context = current();
+          if (window)
+            reinterpret_cast<QOpenGLWidget*> (window)->makeCurrent();
+          return previous_context;
+        }
+
+        inline void restore (std::pair<QOpenGLContext*,QSurface*> previous_context) {
+          if (previous_context.first)
+            previous_context.first->makeCurrent (previous_context.second);
+        }
+#else
+        inline std::pair<int,int> current() { return { 0, 0 }; }
+        inline std::pair<int,int> get (QWidget*) { return { 0, 0 }; }
+        inline std::pair<int,int> makeCurrent (QWidget*) { return { 0, 0 }; }
+        inline void restore (std::pair<int,int>) { }
+#endif
+
+        struct Grab { NOMEMALIGN
+          decltype (current()) previous_context;
+          Grab (QWidget* window = nullptr) : previous_context (makeCurrent (window ? window : GL::glwidget)) {
+            assert_context_is_current (window);
+          }
+          ~Grab () { restore (previous_context); }
+        };
+
+#ifndef NDEBUG
+        struct Checker { NOMEMALIGN
+          decltype (current()) original_context;
+          void set () { original_context = current(); }
+          void operator() () const { assert (current() == original_context); }
+        };
+#else
+        struct Checker { NOMEMALIGN
+          void operator() () const { }
+        };
+#endif
+      }
+
+
+
+      class Texture { NOMEMALIGN
         public:
           Texture () : id (0), tex_type (0) { }
           ~Texture () { clear(); }
@@ -124,7 +175,7 @@ namespace MR
           operator GLuint () const { return id; }
           void gen (GLenum target, GLint interp_type = gl::LINEAR) {
             if (!id) {
-              grab_context();
+              check_context.set();
               tex_type = target;
               gl::GenTextures (1, &id);
               GL_DEBUG ("created OpenGL texture ID " + str(id));
@@ -162,12 +213,13 @@ namespace MR
           }
           void set_interp_on (bool interpolate) const { set_interp (interpolate ? gl::LINEAR : gl::NEAREST); }
         protected:
+          Context::Checker check_context;
           GLuint id;
           GLenum tex_type;
       };
 
 
-      class VertexBuffer : CheckContext { NOMEMALIGN
+      class VertexBuffer { NOMEMALIGN
         public:
           VertexBuffer () : id (0) { }
           ~VertexBuffer () { clear(); }
@@ -177,7 +229,7 @@ namespace MR
           operator GLuint () const { return id; }
           void gen () {
             if (!id) {
-              grab_context();
+              check_context.set();
               gl::GenBuffers (1, &id);
               GL_DEBUG ("created OpenGL vertex buffer ID " + str(id));
             }
@@ -197,11 +249,12 @@ namespace MR
             gl::BindBuffer (target, id);
           }
         protected:
+          Context::Checker check_context;
           GLuint id;
       };
 
 
-      class VertexArrayObject : CheckContext { NOMEMALIGN
+      class VertexArrayObject { NOMEMALIGN
         public:
           VertexArrayObject () : id (0) { }
           ~VertexArrayObject () { clear(); }
@@ -211,7 +264,7 @@ namespace MR
           operator GLuint () const { return id; }
           void gen () {
             if (!id) {
-              grab_context();
+              check_context.set();
               gl::GenVertexArrays (1, &id);
               GL_DEBUG ("created OpenGL vertex array ID " + str(id));
             }
@@ -230,11 +283,12 @@ namespace MR
             gl::BindVertexArray (id);
           }
         protected:
+          Context::Checker check_context;
           GLuint id;
       };
 
 
-      class IndexBuffer : CheckContext { NOMEMALIGN
+      class IndexBuffer { NOMEMALIGN
         public:
           IndexBuffer () : id (0) { }
           ~IndexBuffer () { clear(); }
@@ -244,7 +298,7 @@ namespace MR
           operator GLuint () const { return id; }
           void gen () {
             if (!id) {
-              grab_context();
+              check_context.set();
               gl::GenBuffers (1, &id);
               GL_DEBUG ("created OpenGL index buffer ID " + str(id));
             }
@@ -264,12 +318,13 @@ namespace MR
             gl::BindBuffer (gl::ELEMENT_ARRAY_BUFFER, id);
           }
         protected:
+          Context::Checker check_context;
           GLuint id;
       };
 
 
 
-      class FrameBuffer : CheckContext { NOMEMALIGN
+      class FrameBuffer { NOMEMALIGN
         public:
           FrameBuffer () : id (0) { }
           ~FrameBuffer () { clear(); }
@@ -279,7 +334,7 @@ namespace MR
           operator GLuint () const { return id; }
           void gen () {
             if (!id) {
-              grab_context();
+              check_context.set();
               gl::GenFramebuffers (1, &id);
               GL_DEBUG ("created OpenGL framebuffer ID " + str(id));
             }
@@ -311,26 +366,29 @@ namespace MR
 
 
           void attach_color (Texture& tex, size_t attachment) const {
-            assert (id);
             assert (tex);
             bind();
             GL_DEBUG ("texture ID " + str (tex) + " attached to framebuffer ID " + str(id) + " at color attachement " + str(attachment));
             gl::FramebufferTexture (gl::FRAMEBUFFER, GLenum (size_t (gl::COLOR_ATTACHMENT0) + attachment), tex, 0);
           }
           void draw_buffers (size_t first) const {
+            check_context();
             GLenum list[1] = { GLenum (size_t (gl::COLOR_ATTACHMENT0) + first) };
             gl::DrawBuffers (1 , list);
           }
           void draw_buffers (size_t first, size_t second) const {
+            check_context();
             GLenum list[2] = { GLenum (size_t(gl::COLOR_ATTACHMENT0) + first), GLenum (size_t (gl::COLOR_ATTACHMENT0) + second) };
             gl::DrawBuffers (2 , list);
           }
 
           void check() const {
+            check_context();
             if (gl::CheckFramebufferStatus (gl::FRAMEBUFFER) != gl::FRAMEBUFFER_COMPLETE)
               throw Exception ("FIXME: framebuffer is not complete");
           }
         protected:
+          Context::Checker check_context;
           GLuint id;
       };
 

--- a/src/gui/opengl/gl.h
+++ b/src/gui/opengl/gl.h
@@ -70,16 +70,6 @@ namespace MR
       using Area = QOpenGLWidget;
       using Format = QSurfaceFormat;
 
-#ifndef NDEBUG
-      void __assert_context_is_current (QWidget* glarea);
-#endif
-
-      inline void assert_context_is_current(QWidget* glarea = nullptr) {
-#ifndef NDEBUG
-        __assert_context_is_current (glarea);
-#endif
-      }
-
 #else
       class Area : public QGLWidget { NOMEMALIGN
         public:
@@ -104,6 +94,13 @@ namespace MR
       }
 
 
+
+#ifndef NDEBUG
+      void __assert_context_is_current (QWidget* glarea);
+      inline void assert_context_is_current(QWidget* glarea = nullptr) { __assert_context_is_current (glarea); }
+#else
+      inline void assert_context_is_current(QWidget* = nullptr) { }
+#endif
 
       extern Area* glwidget;
 
@@ -157,6 +154,7 @@ namespace MR
         };
 #else
         struct Checker { NOMEMALIGN
+          void set () { }
           void operator() () const { }
         };
 #endif

--- a/src/gui/shview/render_window.cpp
+++ b/src/gui/shview/render_window.cpp
@@ -226,6 +226,7 @@ namespace MR
 
         render_frame = new RenderFrame (this);
         setCentralWidget (render_frame);
+        GUI::App::set_main_window (this, render_frame);
 
         render_frame->set_lmax (0);
         render_frame->set_LOD (5);


### PR DESCRIPTION
I ported the changes in 33dc1403b869f8c0de0eca32 to add support for n-dimensional images in the overlay tool in mrview (fixes issue #1513).

Compared to the previous behaviour, the volume index spin boxes are removed when multiple images are selected as they do not apply to all images. I kept the bounding box though as removing that can change the FOV due to resizing of the overlay tool which I find distracting especially for screenshots. In place of the empty Volume indices box a text is shown indicating the reason why volumes can not be changed.

10D image selected:
![image](https://user-images.githubusercontent.com/10046944/61631152-8134f180-ac81-11e9-99d1-40169d109cd8.png)

3D image selected:
![image](https://user-images.githubusercontent.com/10046944/61631186-94e05800-ac81-11e9-9919-e9ddbe06af52.png)

Multi-selection:
![image](https://user-images.githubusercontent.com/10046944/61631228-bb05f800-ac81-11e9-9ced-45595b8dd49c.png)