### PR TITLE
mrmath/mrstats more precise variance calculation

### DIFF
--- a/cmd/mrmath.cpp
+++ b/cmd/mrmath.cpp
@@ -191,22 +191,25 @@ class NORM2 { NOMEMALIGN
 };
 
 
+// Welford's algorithm to avoid catastrophic cancellation
 class Var { NOMEMALIGN
   public:
-    Var () : sum (0.0), sum_sqr (0.0), count (0) { }
+    Var () : delta (0.0), delta2 (0.0), mean (0.0), m2 (0.0), count (0) { }
     void operator() (value_type val) {
       if (std::isfinite (val)) {
-        sum += val;
-        sum_sqr += Math::pow2 (val);
         ++count;
+        delta = val - mean;
+        mean += delta / count;
+        delta2 = val - mean;
+        m2 += delta * delta2;
       }
     }
     value_type result () const {
       if (count < 2)
         return NAN;
-      return  (sum_sqr - Math::pow2 (sum) / static_cast<double> (count)) / (static_cast<double> (count) - 1.0);
+      return m2 / (static_cast<double> (count) - 1.0);
     }
-    double sum, sum_sqr;
+    double delta, delta2, mean, m2;
     size_t count;
 };
 

--- a/core/stats.cpp
+++ b/core/stats.cpp
@@ -24,12 +24,15 @@ namespace MR
 
     using namespace App;
 
-    const char * field_choices[] = { "mean", "median", "std", "min", "max", "count", NULL };
+    const char * field_choices[] = { "mean", "median", "std", "std_rv", "min", "max", "count", NULL };
 
     const OptionGroup Options = OptionGroup ("Statistics options")
     + Option ("output",
         "output only the field specified. Multiple such options can be supplied if required. "
-        "Choices are: " + join (field_choices, ", ") + ". Useful for use in scripts.").allow_multiple()
+        "Choices are: " + join (field_choices, ", ") + ". Useful for use in scripts. "
+        "Both std options refer to the unbiased (sample) standard deviation. "
+        "For complex data, min, max and std are calculated separately for real and imaginary parts, "
+        "std_rv is based on the real valued variance (equals sqrt of sum of variances of imaginary and real parts).").allow_multiple()
     + Argument ("field").type_choice (field_choices)
 
     + Option ("mask",

--- a/core/stats.h
+++ b/core/stats.h
@@ -43,7 +43,8 @@ namespace MR
             delta (0.0, 0.0),
             delta2 (0.0, 0.0),
             m2 (0.0, 0.0),
-            std (0.0),
+            std (0.0, 0.0),
+            std_rv (0.0, 0.0),
             min (INFINITY, INFINITY),
             max (-INFINITY, -INFINITY),
             count (0),
@@ -53,7 +54,6 @@ namespace MR
 
         void operator() (complex_type val) {
           if (std::isfinite (val.real()) && std::isfinite (val.imag()) && !(ignore_zero && val.real() == 0.0 && val.imag() == 0.0)) {
-            // std += cdouble (val.real()*val.real(), val.imag()*val.imag());
             if (min.real() > val.real()) min = complex_type (val.real(), min.imag());
             if (min.imag() > val.imag()) min = complex_type (min.real(), val.imag());
             if (max.real() < val.real()) max = complex_type (val.real(), max.imag());
@@ -71,11 +71,11 @@ namespace MR
 
         template <class ImageType> void print (ImageType& ima, const vector<std::string>& fields) {
 
-          if (count > 1)
-            std = cdouble(sqrt (m2.real() / double (count)), sqrt (m2.imag() / double (count)));
-
-          std::sort (values.begin(), values.end());
-
+          if (count > 1) {
+            std = complex_type(sqrt (m2.real() / value_type (count - 1)), sqrt (m2.imag() / value_type (count - 1)));
+            std_rv = complex_type(sqrt((m2.real() + m2.imag()) / value_type (count - 1)));
+            std::sort (values.begin(), values.end());
+          }
           if (fields.size()) {
             if (!count) {
               if (fields.size() == 1 && fields.front() == "count") {
@@ -87,11 +87,13 @@ namespace MR
             }
             for (size_t n = 0; n < fields.size(); ++n) {
               if (fields[n] == "mean") std::cout << str(mean) << " ";
-              else if (fields[n] == "median") std::cout << Math::median (values) << " ";
+              else if (fields[n] == "median") std::cout << ( values.size() > 0 ? str(Math::median (values)) : "N/A" ) << " ";
               else if (fields[n] == "std") std::cout << ( count > 1 ? str(std) : "N/A" ) << " ";
+              else if (fields[n] == "std_rv") std::cout << ( count > 1 ? str(std_rv) : "N/A" ) << " ";
               else if (fields[n] == "min") std::cout << str(min) << " ";
               else if (fields[n] == "max") std::cout << str(max) << " ";
               else if (fields[n] == "count") std::cout << count << " ";
+              else throw Exception("stats type not supported: " + fields[n]);
             }
             std::cout << "\n";
 
@@ -123,8 +125,7 @@ namespace MR
         }
 
       private:
-        cdouble mean, delta, delta2, m2, std;
-        complex_type min, max;
+        complex_type mean, delta, delta2, m2, std, std_rv, min, max;
         size_t count;
         const bool is_complex, ignore_zero;
         vector<float> values;
@@ -139,7 +140,7 @@ namespace MR
         << " " << std::setw(width) << std::right << "mean";
       if (!is_complex)
         std::cout << " " << std::setw(width) << std::right << "median";
-      std::cout  << " " << std::setw(width) << std::right << "stdev"
+      std::cout  << " " << std::setw(width) << std::right << "std"
         << " " << std::setw(width) << std::right << "min"
         << " " << std::setw(width) << std::right << "max"
         << " " << std::setw(10) << std::right << "count" << "\n";

--- a/docs/reference/commands/mrstats.rst
+++ b/docs/reference/commands/mrstats.rst
@@ -23,7 +23,7 @@ Options
 Statistics options
 ^^^^^^^^^^^^^^^^^^
 
--  **-output field**  *(multiple uses permitted)* output only the field specified. Multiple such options can be supplied if required. Choices are: mean, median, std, min, max, count. Useful for use in scripts.
+-  **-output field**  *(multiple uses permitted)* output only the field specified. Multiple such options can be supplied if required. Choices are: mean, median, std, std_rv, min, max, count. Useful for use in scripts. Both std options refer to the unbiased (sample) standard deviation. For complex data, min, max and std are calculated separately for real and imaginary parts, std_rv is based on the real valued variance (equals sqrt of sum of variances of imaginary and real parts).
 
 -  **-mask image** only perform computation within the specified binary mask image.
 

--- a/testing/tests/mrstats
+++ b/testing/tests/mrstats
@@ -1,2 +1,3 @@
-mrstats dwi.mif -output mean -output median -output std -output min -output max -output count > tmp.txt && testing_diff_matrix tmp.txt mrstats/out.txt -frac 1e-5
-mrstats dwi.mif -output mean -output median -output std -output min -output max -output count -mask mask.mif > tmp.txt && testing_diff_matrix tmp.txt mrstats/masked.txt -frac 1e-5
+mrstats dwi.mif -output mean -output median -output std -output std_rv -output min -output max -output count > tmp.txt && testing_diff_matrix tmp.txt mrstats/out.txt -frac 1e-5
+mrstats dwi.mif -output mean -output median -output std -output std_rv -output min -output max -output count -mask mask.mif > tmp.txt && testing_diff_matrix tmp.txt mrstats/masked.txt -frac 1e-5
+mrcalc dwi_mean.mif noise.mif -complex - | mrstats - -output mean -output std -output std_rv -output min -output max -output count > tmp.txt && testing_diff_matrix tmp.txt mrstats/complex.txt


### PR DESCRIPTION
I reimplemented the variance kernel using Welford's online algorithm to fix catastrophic cancellation:

## precision test with random noise:
```
mrconvert  image.mif -coord 3 0 - | mrcalc - 0 -mult rand 1000 -mult -add large.mif -force
mrstats large.mif 
      volume       mean     median      stdev        min        max      count
       [ 0 ]    499.789 500.431824    288.816 0.00315811    999.994     902629
```
### old
```
mrcat large.mif large.mif large.mif -axis 3 - | mrmath - var -axis 3 - | mrstats -
      volume       mean     median      stdev        min        max      count
       [ 0 ] -3.72367e-06 2.20043717e-09  0.0157959 -0.0468736  0.0468749     902629
```
### new
      volume       mean     median      stdev        min        max      count
       [ 0 ]          0          0          0          0          0     902629

## test against numpy with b1000 90 dir image, float32:

```
mrstats 1k.mif 
      volume       mean     median      stdev        min        max      count
       [ 0 ]    346.971          0    641.885   -134.515    4366.91     902629
       [ 1 ]    332.922          0    615.249   -122.857    4396.99     902629
       [ 2 ]    349.577          0    644.673    -138.88    4989.46     902629
       [ 3 ]    339.598          0    628.063   -129.644    4064.88     902629
       [ 4 ]    345.108          0    636.355   -126.902    4334.92     902629
       [ 5 ]    347.219          0    641.879   -123.496    4797.42     902629
       [ 6 ]    341.361          0    630.904   -136.148    4907.52     902629
...
      [ 88 ]    344.547          0    636.797    -121.31    4348.49     902629
      [ 89 ]    345.772          0    637.696   -129.747    4646.53     902629
```

### numpy:
`numpy.var(IMAGE1K.astype(np.float64), axis=3, ddof=1) --> var_1k_np64b.mif`

### old
```
mrmath 1k.mif var -axis 3 - | mrcalc var_1k_np64b.mif - -sub - | mrstats -
      volume       mean     median      stdev        min        max      count
       [ 0 ] -1.01356e-05          0 0.00351362    -0.0625  0.0703125     902629
```
### new
```
      volume       mean     median      stdev        min        max      count
       [ 0 ]          0          0          0          0          0     902629
```

## 18 identical b0s

Difference between variance of 18 identical b0s between numpy.var and old mrmath var (min, max intensity: -561.946, 14416):
![image](https://user-images.githubusercontent.com/10046944/62730663-57692200-ba18-11e9-82b4-16abdc8aa3e1.png)

The difference between numpy and the proposed changes is zero.
