### PR TITLE
Fix two buffer overruns

### DIFF
--- a/core/adapter/replicate.h
+++ b/core/adapter/replicate.h
@@ -26,7 +26,7 @@ namespace MR
     {
 
     template <class ImageType>
-      class Replicate : 
+      class Replicate :
         public Base<Replicate<ImageType>,ImageType>
     { MEMALIGN(Replicate<ImageType>)
       public:
@@ -44,6 +44,8 @@ namespace MR
             pos_ (std::max<size_t> (parent().ndim(), header_.ndim()), 0)
           {
             for (size_t n = 0; n < std::min<size_t> (parent().ndim(), header_.ndim()); ++n) {
+              if (n < parent().ndim())
+                parent().index(n) = 0;
               if (parent().size(n) > 1 && parent().size(n) != header_.size(n))
                 throw Exception ("cannot replicate over non-singleton dimensions");
             }

--- a/core/image.h
+++ b/core/image.h
@@ -97,7 +97,11 @@ namespace MR
         friend std::ostream& operator<< (std::ostream& stream, const Image& V) {
           stream << "\"" << V.name() << "\", datatype " << DataType::from<Image::value_type>().specifier() << ", index [ ";
           for (size_t n = 0; n < V.ndim(); ++n) stream << V.index(n) << " ";
-          stream << "], current offset = " << V.offset() << ", value = " << V.value();
+          stream << "], current offset = " << V.offset() << ", ";
+          if (is_out_of_bounds(V))
+            stream << "outside FoV";
+          else
+            stream << "value = " << V.value();
           if (!V.data_pointer) stream << " (using indirect IO)";
           else stream << " (using direct IO, data at " << V.data_pointer << ")";
           return stream;


### PR DESCRIPTION
- In `Adapter::Replicate`, if the adapter is constructed based on an image whose voxel locations are not zero (e.g. the image has already been used in a loop), it is possible for the value accessed through the adapter to be based on the prior voxel location of the image from which it was constructed, rather than its own zero-filled axis locations. If that location is outside the image FoV, particularly if this leads to a data offset beyond the size of the allocated array, this leads to a buffer overrun.

- If printing the contents of an Image class using the `<<` operator, only print the value underlying the current voxel location if that location is within the image FoV.

Discovered in trying to merge `dev` into `stats_enhancements` in order for CI to pass on #1639 / #1543, but these two identified issues are present on `master`.