### PR TITLE
Script updates for recent PRs

### DIFF
--- a/cmd/mrthreshold.cpp
+++ b/cmd/mrthreshold.cpp
@@ -232,7 +232,7 @@ default_type calculate (Image<value_type>& in,
                          size_t(bottom) - 1 :
                          (ssize_t(data.size()) - ssize_t(top)));
     if (index < 0 || index >= ssize_t(data.size()))
-      throw Exception ("Number of valid input image values (" + str(data.size()) + ") less than number of voxels requested via -" + (bottom >= 0 ? "bottom" : "top") + " option (" + str(index) + ")");
+      throw Exception ("Number of valid input image values (" + str(data.size()) + ") less than number of voxels requested via -" + (bottom >= 0 ? "bottom" : "top") + " option (" + str(bottom >= 0 ? bottom : top) + ")");
     std::nth_element (data.begin(), data.begin() + index, data.end());
     const value_type threshold_float = data[index];
     if (index) {

--- a/lib/mrtrix3/_5ttgen/freesurfer.py
+++ b/lib/mrtrix3/_5ttgen/freesurfer.py
@@ -53,7 +53,7 @@ def execute(): #pylint: disable=unused-variable
     image = 'indices.mif'
   else:
     image = 'indices_cropped.mif'
-    run.command('mrthreshold indices.mif - -abs 0.5 | maskfilter - dilate - | mrgrid indices.mif crop ' + image + ' -mask -')
+    run.command('mrthreshold indices.mif - -abs 0.5 | mrgrid indices.mif crop ' + image + ' -mask -')
 
   # Convert into the 5TT format for ACT
   run.command('mrcalc ' + image + ' 1 -eq cgm.mif')

--- a/lib/mrtrix3/_5ttgen/fsl.py
+++ b/lib/mrtrix3/_5ttgen/fsl.py
@@ -212,6 +212,6 @@ def execute(): #pylint: disable=unused-variable
   if app.ARGS.nocrop:
     run.function(os.rename, 'combined_precrop.mif', 'result.mif')
   else:
-    run.command('mrmath combined_precrop.mif sum - -axis 3 | mrthreshold - - -abs 0.5 | maskfilter - dilate - | mrgrid combined_precrop.mif crop result.mif -mask -')
+    run.command('mrmath combined_precrop.mif sum - -axis 3 | mrthreshold - - -abs 0.5 | mrgrid combined_precrop.mif crop result.mif -mask -')
 
   run.command('mrconvert result.mif ' + path.from_user(app.ARGS.output), mrconvert_keyval=path.from_user(app.ARGS.input), force=app.FORCE_OVERWRITE)

--- a/lib/mrtrix3/_5ttgen/gif.py
+++ b/lib/mrtrix3/_5ttgen/gif.py
@@ -48,6 +48,6 @@ def execute(): #pylint: disable=unused-variable
   if app.ARGS.nocrop:
     run.function(os.rename, '5tt.mif', 'result.mif')
   else:
-    run.command('mrmath 5tt.mif sum - -axis 3 | mrthreshold - - -abs 0.5 | maskfilter - dilate - | mrgrid 5tt.mif crop result.mif -mask -')
+    run.command('mrmath 5tt.mif sum - -axis 3 | mrthreshold - - -abs 0.5 | mrgrid 5tt.mif crop result.mif -mask -')
 
   run.command('mrconvert result.mif ' + path.from_user(app.ARGS.output), mrconvert_keyval=path.from_user(app.ARGS.input), force=app.FORCE_OVERWRITE)

--- a/lib/mrtrix3/dwi2response/tournier.py
+++ b/lib/mrtrix3/dwi2response/tournier.py
@@ -79,8 +79,9 @@ def execute(): #pylint: disable=unused-variable
     run.command('mrcalc ' + prefix + 'first_peaks.mif -sqrt 1 ' + prefix + 'second_peaks.mif ' + prefix + 'first_peaks.mif -div -sub 2 -pow -mult '+ prefix + 'CF.mif')
     app.cleanup(prefix + 'first_peaks.mif')
     app.cleanup(prefix + 'second_peaks.mif')
+    voxel_count = int(image.statistic(prefix + 'CF.mif', 'count'))
     # Select the top-ranked voxels
-    run.command('mrthreshold ' + prefix + 'CF.mif -top ' + str(app.ARGS.sf_voxels) + ' ' + prefix + 'SF.mif')
+    run.command('mrthreshold ' + prefix + 'CF.mif -top ' + str(min([app.ARGS.sf_voxels, voxel_count])) + ' ' + prefix + 'SF.mif')
     # Generate a new response function based on this selection
     run.command('amp2response dwi.mif ' + prefix + 'SF.mif ' + prefix + 'first_dir.mif ' + prefix + 'RF.txt' + iter_lmax_option)
     app.cleanup(prefix + 'first_dir.mif')
@@ -102,7 +103,7 @@ def execute(): #pylint: disable=unused-variable
 
     # Select a greater number of top single-fibre voxels, and dilate (within bounds of initial mask);
     #   these are the voxels that will be re-tested in the next iteration
-    run.command('mrthreshold ' + prefix + 'CF.mif -top ' + str(app.ARGS.iter_voxels) + ' - | maskfilter - dilate - -npass ' + str(app.ARGS.dilate) + ' | mrcalc mask.mif - -mult ' + prefix + 'SF_dilated.mif')
+    run.command('mrthreshold ' + prefix + 'CF.mif -top ' + str(min([app.ARGS.iter_voxels, voxel_count])) + ' - | maskfilter - dilate - -npass ' + str(app.ARGS.dilate) + ' | mrcalc mask.mif - -mult ' + prefix + 'SF_dilated.mif')
     app.cleanup(prefix + 'CF.mif')
 
     iteration += 1


### PR DESCRIPTION
- `mrthreshold`: Fix erroneous exception message introduced in #1636.

- `dwi2response msmt_5tt`: Compatibility fix for low-resolution data (ie. few voxels), when running `dwi2response tournier`, based on new `mrthreshold -top` implementation in #1636.

- `5ttgen`: Fixes to FoV cropping due to behaviour of `mrgrid crop`, which deviated from former command `mrcrop` in #1609 but was restored to previous behaviour in #1678.