### PR TITLE
dwi2response dhollander: add option to select version

### DIFF
--- a/lib/mrtrix3/dwi2response/dhollander.py
+++ b/lib/mrtrix3/dwi2response/dhollander.py
@@ -14,6 +14,7 @@ def usage(base_parser, subparsers): #pylint: disable=unused-variable
   options.add_argument('-sfwm', type=float, default=0.5, help='Final number of single-fibre WM voxels to select, as a percentage of refined WM. (default: 0.5 per cent)')
   options.add_argument('-gm', type=float, default=2.0, help='Final number of GM voxels to select, as a percentage of refined GM. (default: 2 per cent)')
   options.add_argument('-csf', type=float, default=10.0, help='Final number of CSF voxels to select, as a percentage of refined CSF. (default: 10 per cent)')
+  options.add_argument('-algo', type=int, default=2016, help='Select version of algorithm to use, based on year of corresponding publication: 2016 or 2019 (default: 2016).')
 
 
 
@@ -44,6 +45,9 @@ def execute(): #pylint: disable=unused-variable
 
   # CHECK INPUTS AND OPTIONS
   app.console('-------')
+
+  if app.ARGS.algo not in [ 2016, 2019 ]:
+    raise MRtrixError ('valid values for -algo are 2016 or 2019')
 
   # Get b-values and number of volumes per b-value.
   bvalues = [ int(round(float(x))) for x in image.mrinfo('dwi.mif', 'shell_bvalues').split() ]
@@ -203,28 +207,33 @@ def execute(): #pylint: disable=unused-variable
 
   # Get final voxels for single-fibre WM response function estimation from refined WM.
   app.console('* single-fibre WM:')
-  app.console(' * Selecting final voxels (' + str(app.ARGS.sfwm) + '% of refined WM)...')
+  app.console(' * Selecting final voxels (' + str(app.ARGS.sfwm) + '% of refined WM) using ' + str(app.ARGS.algo) + ' version of algorithm...')
   voxsfwmcount = int(round(statrefwmcount * app.ARGS.sfwm / 100.0))
-  run.command('mrmath dwi.mif mean mean_sig.mif -axis 3', show=False)
-  refwmcoef = image.statistic('mean_sig.mif', 'median', '-mask refined_wm.mif') * math.sqrt(4.0 * math.pi)
-  if sfwm_lmax:
-    isiso = [ lm == 0 for lm in sfwm_lmax ]
+
+  if app.ARGS.algo == 2016:
+    run.command('dwi2response tournier dwi.mif _respsfwmss.txt -mask refined_wm.mif -sf_voxels ' + str(voxsfwmcount) + ' -iter_voxels ' + str(10*voxsfwmcount) + ' -voxels voxels_sfwm.mif -scratch ' + app.SCRATCH_DIR, show=False)
   else:
-    isiso = [ bv < bzero_threshold for bv in bvalues ]
-  with open('ewmrf.txt', 'w') as ewr:
-    for iis in isiso:
-      if iis:
-        ewr.write("%s 0 0 0\n" % refwmcoef)
-      else:
-        ewr.write("%s -%s %s -%s\n" % (refwmcoef, refwmcoef, refwmcoef, refwmcoef))
-  run.command('dwi2fod msmt_csd dwi.mif ewmrf.txt abs_ewm2.mif response_csf.txt abs_csf2.mif -mask refined_wm.mif -lmax 2,0' + bvalues_option, show=False)
-  run.command('mrconvert abs_ewm2.mif - -coord 3 0 | mrcalc - abs_csf2.mif -add abs_sum2.mif', show=False)
-  run.command('sh2peaks abs_ewm2.mif - -num 1 -mask refined_wm.mif | peaks2amp - - | mrcalc - abs_sum2.mif -divide - | mrconvert - metric_sfwm2.mif -coord 3 0 -axes 0,1,2', show=False)
-  run.command('mrcalc refined_wm.mif metric_sfwm2.mif 0 -if - | mrthreshold - - -top ' + str(voxsfwmcount * 2) + ' -ignorezero | mrcalc refined_wm.mif - 0 -if - -datatype bit | mrconvert - refined_sfwm.mif -axes 0,1,2', show=False)
-  run.command('dwi2fod msmt_csd dwi.mif ewmrf.txt abs_ewm6.mif response_csf.txt abs_csf6.mif -mask refined_sfwm.mif -lmax 6,0' + bvalues_option, show=False)
-  run.command('mrconvert abs_ewm6.mif - -coord 3 0 | mrcalc - abs_csf6.mif -add abs_sum6.mif', show=False)
-  run.command('sh2peaks abs_ewm6.mif - -num 1 -mask refined_sfwm.mif | peaks2amp - - | mrcalc - abs_sum6.mif -divide - | mrconvert - metric_sfwm6.mif -coord 3 0 -axes 0,1,2', show=False)
-  run.command('mrcalc refined_sfwm.mif metric_sfwm6.mif 0 -if - | mrthreshold - - -top ' + str(voxsfwmcount) + ' -ignorezero | mrcalc refined_sfwm.mif - 0 -if - -datatype bit | mrconvert - voxels_sfwm.mif -axes 0,1,2', show=False)
+    run.command('mrmath dwi.mif mean mean_sig.mif -axis 3', show=False)
+    refwmcoef = image.statistic('mean_sig.mif', 'median', '-mask refined_wm.mif') * math.sqrt(4.0 * math.pi)
+    if sfwm_lmax:
+      isiso = [ lm == 0 for lm in sfwm_lmax ]
+    else:
+      isiso = [ bv < bzero_threshold for bv in bvalues ]
+    with open('ewmrf.txt', 'w') as ewr:
+      for iis in isiso:
+        if iis:
+          ewr.write("%s 0 0 0\n" % refwmcoef)
+        else:
+          ewr.write("%s -%s %s -%s\n" % (refwmcoef, refwmcoef, refwmcoef, refwmcoef))
+    run.command('dwi2fod msmt_csd dwi.mif ewmrf.txt abs_ewm2.mif response_csf.txt abs_csf2.mif -mask refined_wm.mif -lmax 2,0' + bvalues_option, show=False)
+    run.command('mrconvert abs_ewm2.mif - -coord 3 0 | mrcalc - abs_csf2.mif -add abs_sum2.mif', show=False)
+    run.command('sh2peaks abs_ewm2.mif - -num 1 -mask refined_wm.mif | peaks2amp - - | mrcalc - abs_sum2.mif -divide - | mrconvert - metric_sfwm2.mif -coord 3 0 -axes 0,1,2', show=False)
+    run.command('mrcalc refined_wm.mif metric_sfwm2.mif 0 -if - | mrthreshold - - -top ' + str(voxsfwmcount * 2) + ' -ignorezero | mrcalc refined_wm.mif - 0 -if - -datatype bit | mrconvert - refined_sfwm.mif -axes 0,1,2', show=False)
+    run.command('dwi2fod msmt_csd dwi.mif ewmrf.txt abs_ewm6.mif response_csf.txt abs_csf6.mif -mask refined_sfwm.mif -lmax 6,0' + bvalues_option, show=False)
+    run.command('mrconvert abs_ewm6.mif - -coord 3 0 | mrcalc - abs_csf6.mif -add abs_sum6.mif', show=False)
+    run.command('sh2peaks abs_ewm6.mif - -num 1 -mask refined_sfwm.mif | peaks2amp - - | mrcalc - abs_sum6.mif -divide - | mrconvert - metric_sfwm6.mif -coord 3 0 -axes 0,1,2', show=False)
+    run.command('mrcalc refined_sfwm.mif metric_sfwm6.mif 0 -if - | mrthreshold - - -top ' + str(voxsfwmcount) + ' -ignorezero | mrcalc refined_sfwm.mif - 0 -if - -datatype bit | mrconvert - voxels_sfwm.mif -axes 0,1,2', show=False)
+
   statvoxsfwmcount = image.statistic('voxels_sfwm.mif', 'count', '-mask voxels_sfwm.mif')
   app.console('   [ WM: ' + str(statrefwmcount) + ' -> ' + str(statvoxsfwmcount) + ' (single-fibre) ]')
   # Estimate SF WM response function


### PR DESCRIPTION
This is not supposed to be final, but we need to be able to use the previous implementation of `dwi2response dhollander`, and to default to the previous behaviour until we've had a chance to properly review and assess the recent improvements made by @thijsdhollander. Unfortunately, these changes made it onto `dev` without proper review, due to their inclusion into #1449 (the extensive changes to the Python scripting library), which was reviewed purely on the basis that the changes were necessary to port existing commands to the new API, rather than changing behaviour as such. My mistake on that one, I hadn't cottoned on to the fact that the improvements being proposed to this algorithm (on #1545) were more than merely cosmetic.
 
All this PR does is add a `-algo` option to allow choosing the particular version to be used (2016 or 2019, the dates of the respective abstracts), and sets the default to 2016 for now. The default is not set in stone, and I'd like to review it properly ASAP: if these changes are theoretically sound and lead to genuine improvements in the response produced and the subsequent MSMT-CSD outputs, we should use them by default (I note the computation is also quicker, which would be an added bonus). I note the results produced are not identical to `master` (presumably due to other more minor refinements), but they're close enough that I wouldn't be worried about them. 

These improvements were presented at ISMRM 2019, but I for one didn't feel I understood the rationale sufficiently to make an informed decision. I'd like to review the changes in line with the discussions we had back in #422 & #426 (which incidentally, the changes under discussion here supersede). As far as I can tell, the changes are more or less entirely self-contained to 2e825418...?

While this PR can be merged as-is for the time being, there are two issues to discuss:

- the interface to select the version of the algorithm to be used. I've added a `-algo` option with a default of 2016, but this can be done a number of ways. We could have a single `-improved` (or similar) option with no argument to switch to the new behaviour. Maybe more interesting would be to add the new single-fibre response estimator (which @thijsdhollander's changes effectively introduce) as a full-blown algorithm in its own right, and add a `-sfwm_estimator` option (or similar) to the `dhollander` algorithm, defaulting (for now) to `tournier`. Personally, I reckon this last approach would do the most justice to @thijsdhollander's work on this.

- the actual inner workings of the new single-fibre response estimator, the rationale behind the decisions made, evidence that the responses obtained are indeed better, and evidence that it is at least as robust as the current approach on a wide range of inputs. This is the bulk of what I would have liked to have seen discussed prior to merging these changes in the first place. 

@thijsdhollander, your input here is obviously critical. I expect you won't be ecstatic at the prospect of having to provide all this additional validation, but I really think it's important to provide as much evidence as is necessary so we can all be confident of the methodology and be happy to endorse it as the default (assuming that's the eventual outcome), and to document it openly for any interested users. It's a bit late in the day for this to be included as the default in the next release, but there is still scope for it if we can move on this quickly. We can certainly change the handling of the algorithm switch (as per the first issue to discuss above) if my proposal isn't deemed adequate. 