### PR TITLE
mrinfo: transform doc

### DIFF
--- a/cmd/mrinfo.cpp
+++ b/cmd/mrinfo.cpp
@@ -81,7 +81,7 @@ void usage ()
     +   Option ("strides", "data strides i.e. order and direction of axes data layout")
     +   Option ("offset", "image intensity offset")
     +   Option ("multiplier", "image intensity multiplier")
-    +   Option ("transform", "the voxel to image transformation")
+    +   Option ("transform", "the transformation from image coordinates [mm] to scanner / real world coordinates [mm]")
 
     + NoRealignOption
 

--- a/docs/reference/commands/mrinfo.rst
+++ b/docs/reference/commands/mrinfo.rst
@@ -47,7 +47,7 @@ Options
 
 -  **-multiplier** image intensity multiplier
 
--  **-transform** the voxel to image transformation
+-  **-transform** the transformation from image coordinates [mm] to scanner / real world coordinates [mm]
 
 -  **-norealign** do not realign transform to near-default RAS coordinate system (the default behaviour on image load). This is useful to inspect the image and/or header contents as they are actually stored in the header, rather than as MRtrix interprets them.
 


### PR DESCRIPTION
changes the description of `-transform` from  "the voxel to image transformation" to " the transformation from image coordinates [mm] to scanner / real world coordinates [mm]".