### PR TITLE
configure: fix Python decode error on Windows

### DIFF
--- a/configure
+++ b/configure
@@ -151,7 +151,8 @@ system = platform.system().lower()
 # on Windows, need to use MSYS2 version of python - not MinGW version:
 if sys.executable[0].isalpha() and sys.executable[1] == ':':
   python_cmd = subprocess.check_output ([ 'cygpath.exe', '-w', '/usr/bin/python' ]).splitlines()[0].strip()
-  sys.exit (subprocess.call ([ python_cmd ] + sys.argv))
+  sys.exit (subprocess.call ([ python_cmd.decode(errors='ignore') ] + sys.argv))
+
 
 
 debug = False


### PR DESCRIPTION
As discussed in https://community.mrtrix.org/t/error-linking-qt-application/1690/12?u=jdtournier
