### PR TITLE
TravisCI: Move docs testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,18 +28,18 @@ matrix:
     ###############################################
     # All subsequent tests are performed on Linux #
     ###############################################
-    #####################################################################
-    # Build binaries, run tests and check documentation: Clang, Python3 #
-    # (Note: Run this one first, since it'll be the longest job)        #
-    #####################################################################
+    #############################################################
+    # Build binaries and run tests: Clang, Python3               #
+    # (Note: Run this one first, since it'll be the longest job) #
+    ##############################################################
     - os: linux
       env: CFLAGS="-Werror" TRAVIS_CXX=clang++-8 py=python3 test=run
     #######################################################################
-    # Build binaries (without optimisation): GCC, Python2                 #
+    # Build binaries (without optimisation) and check docs: GCC, Python2  #
     # (Also ensures both Python 2 and 3 are tested for configure & build) #
     #######################################################################
     - os: linux
-      env: CFLAGS="-Werror" TRAVIS_CXX=g++-9 py=python2 test=build
+      env: CFLAGS="-Werror" TRAVIS_CXX=g++-9 py=python2 test=build_docs
     #######################################################################
     # Generate documentation through Sphinx; Use both Python2 and Python3 #
     #######################################################################
@@ -95,7 +95,7 @@ install:
         fi
     fi
   - |
-    if [[ "${test}" == "build" || "${test}" == "run" ]]; then
+    if [[ "${test}" == "build_docs" || "${test}" == "run" ]]; then
         export EIGEN_CFLAGS="-idirafter `pwd`/../eigen";
         ( cd ..; git clone https://github.com/eigenteam/eigen-git-mirror.git eigen; cd eigen; git checkout branches/3.3 )
     fi
@@ -124,14 +124,14 @@ after_failure:
       "pylint")
         cat pylint.log
         ;;
-      "build")
+      "build_docs")
         cat configure.log
         cat build.log
+        cat gitdiff.log
         ;;
       *)
         cat configure.log
         cat build.log
         cat testing.log
-        cat gitdiff.log
     esac
   - sleep 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ install:
         fi
     fi
   - |
-    if [[ "${test}" == "build_docs" || "${test}" == "run" ]]; then
+    if [[ "${test}" == "build" || "${test}" == "build_docs" || "${test}" == "run" ]]; then
         export EIGEN_CFLAGS="-idirafter `pwd`/../eigen";
         ( cd ..; git clone https://github.com/eigenteam/eigen-git-mirror.git eigen; cd eigen; git checkout branches/3.3 )
     fi
@@ -128,6 +128,10 @@ after_failure:
         cat configure.log
         cat build.log
         cat gitdiff.log
+        ;;
+      "build")
+        cat configure.log
+        cat build.log
         ;;
       *)
         cat configure.log

--- a/travis.sh
+++ b/travis.sh
@@ -19,6 +19,9 @@ case  $test in
   "build_docs")
     $py ./configure -nooptim && $py ./build -nowarnings -persistent -nopaginate && ./docs/generate_user_docs.sh && git diff --exit-code docs/ > gitdiff.log
     ;;
+  "build")
+    $py ./configure -nooptim && $py ./build -nowarnings -persistent -nopaginate
+    ;;
   "run")
     $py ./configure -assert && $py ./build -nowarnings -persistent -nopaginate && ./run_tests
     ;;

--- a/travis.sh
+++ b/travis.sh
@@ -16,11 +16,11 @@ case  $test in
     echo "__version__ = 'pylint testing' #pylint: disable=unused-variable" > ./lib/mrtrix3/_version.py
     PYTHON=$py ./run_pylint
     ;;
-  "build")
-    $py ./configure -nooptim && $py ./build -nowarnings -persistent -nopaginate
+  "build_docs")
+    $py ./configure -nooptim && $py ./build -nowarnings -persistent -nopaginate && ./docs/generate_user_docs.sh && git diff --exit-code docs/ > gitdiff.log
     ;;
   "run")
-    $py ./configure -assert && $py ./build -nowarnings -persistent -nopaginate && ./run_tests && ./docs/generate_user_docs.sh && git diff --exit-code docs/ > gitdiff.log
+    $py ./configure -assert && $py ./build -nowarnings -persistent -nopaginate && ./run_tests
     ;;
   *)
     echo "Envvar \"test\" not defined";


### PR DESCRIPTION
Move documentation generation and comparison with repository contents from "`run`" test to "`build`" (renamed "`build_docs`"); this will hopefully make any issues regarding documentation mismatches easier and faster to diagnose, as the offending non-zero `git diff` will no longer be buried after the massive output from the "`run_tests`" script.