### PR TITLE
Progressbar fix quiet

### DIFF
--- a/core/progressbar.cpp
+++ b/core/progressbar.cpp
@@ -155,6 +155,7 @@ namespace MR
   std::condition_variable ProgressBar::notifier;
   std::mutex ProgressBar::mutex;
   void* ProgressBar::data = nullptr;
+  bool ProgressBar::progressbar_active = false;
 
   ProgressBar::SwitchToMultiThreaded::SwitchToMultiThreaded () {
     ProgressBar::previous_display_func = ProgressBar::display_func;

--- a/core/progressbar.cpp
+++ b/core/progressbar.cpp
@@ -51,23 +51,23 @@ namespace MR
     void display_func_terminal (const ProgressBar& p)
     {
       __need_newline = true;
-      if (p.multiplier)
+      if (p.show_percent())
         __print_stderr (printf (WRAP_OFF_CODE "\r%s: [%3" PRI_SIZET "%%] %s%s" CLEAR_LINE_CODE WRAP_ON_CODE,
-              App::NAME.c_str(), p.value, p.text.c_str(), p.ellipsis.c_str()));
+              App::NAME.c_str(), p.value(), p.text().c_str(), p.ellipsis().c_str()));
       else
         __print_stderr (printf (WRAP_OFF_CODE "\r%s: [%s] %s%s" CLEAR_LINE_CODE WRAP_ON_CODE,
-              App::NAME.c_str(), busy[p.value%6], p.text.c_str(), p.ellipsis.c_str()));
+              App::NAME.c_str(), busy[p.value()%6], p.text().c_str(), p.ellipsis().c_str()));
     }
 
 
     void done_func_terminal (const ProgressBar& p)
     {
-      if (p.multiplier)
+      if (p.show_percent())
         __print_stderr (printf ("\r%s: [100%%] %s" CLEAR_LINE_CODE "\n",
-              App::NAME.c_str(), p.text.c_str()));
+              App::NAME.c_str(), p.text().c_str()));
       else
         __print_stderr (printf ("\r%s: [done] %s" CLEAR_LINE_CODE "\n",
-              App::NAME.c_str(), p.text.c_str()));
+              App::NAME.c_str(), p.text().c_str()));
       __need_newline = false;
     }
 
@@ -82,18 +82,18 @@ namespace MR
       static size_t count = 0;
       static size_t next_update_at = 0;
       // need to update whole line since text may have changed:
-      if (p.text_has_been_modified) {
+      if (p.text_has_been_modified()) {
         __need_newline = false;
-        if (p.value == 0 && p.current_val == 0)
+        if (p.value() == 0 && p.count() == 0)
           count = next_update_at = 0;
         if (count++ == next_update_at) {
-          if (p.multiplier) {
+          if (p.show_percent()) {
             __print_stderr (printf ("%s: [%3" PRI_SIZET "%%] %s%s\n",
-                  App::NAME.c_str(), p.value, p.text.c_str(), p.ellipsis.c_str()));;
+                  App::NAME.c_str(), p.value(), p.text().c_str(), p.ellipsis().c_str()));;
           }
           else {
             __print_stderr (printf ("%s: [%s] %s%s\n",
-                  App::NAME.c_str(), busy[p.value%6], p.text.c_str(), p.ellipsis.c_str()));
+                  App::NAME.c_str(), busy[p.value()%6], p.text().c_str(), p.ellipsis().c_str()));
           }
           if (next_update_at)
             next_update_at *= 2;
@@ -104,21 +104,21 @@ namespace MR
       // text is static - can simply append to the current line:
       else {
         __need_newline = true;
-        if (p.multiplier) {
-          if (p.value == 0) {
+        if (p.show_percent()) {
+          if (p.value() == 0) {
             __print_stderr (printf ("%s: %s%s [",
-                  App::NAME.c_str(), p.text.c_str(), p.ellipsis.c_str()));;
+                  App::NAME.c_str(), p.text().c_str(), p.ellipsis().c_str()));;
           }
-          else if (p.value%2 == 0) {
+          else if (p.value()%2 == 0) {
             __print_stderr (printf ("="));
           }
         }
         else {
-          if (p.value == 0) {
+          if (p.value() == 0) {
             __print_stderr (printf ("%s: %s%s ",
-                  App::NAME.c_str(), p.text.c_str(), p.ellipsis.c_str()));;
+                  App::NAME.c_str(), p.text().c_str(), p.ellipsis().c_str()));;
           }
-          else if (!(p.value & (p.value-1))) {
+          else if (!(p.value() & (p.value()-1))) {
             __print_stderr (".");
           }
         }
@@ -128,16 +128,16 @@ namespace MR
 
     void done_func_redirect (const ProgressBar& p)
     {
-      if (p.text_has_been_modified) {
-        if (p.multiplier) {
-          __print_stderr (printf ("%s: [100%%] %s\n", App::NAME.c_str(), p.text.c_str()));;
+      if (p.text_has_been_modified()) {
+        if (p.show_percent()) {
+          __print_stderr (printf ("%s: [100%%] %s\n", App::NAME.c_str(), p.text().c_str()));;
         }
         else {
-          __print_stderr (printf ("%s: [done] %s\n", App::NAME.c_str(), p.text.c_str()));
+          __print_stderr (printf ("%s: [done] %s\n", App::NAME.c_str(), p.text().c_str()));
         }
       }
       else {
-        if (p.multiplier)
+        if (p.show_percent())
           __print_stderr (printf ("]\n"));
         else
           __print_stderr (printf (" done\n"));

--- a/core/progressbar.cpp
+++ b/core/progressbar.cpp
@@ -44,7 +44,8 @@ namespace MR
 
     void display_func_multithreaded (const ProgressBar& p)
     {
-      p.notifier.notify_all();
+      ProgressBar::notification_is_genuine = true;
+      ProgressBar::notifier.notify_all();
     }
 
 
@@ -153,6 +154,7 @@ namespace MR
   void (*ProgressBar::previous_display_func) (const ProgressBar& p) = nullptr;
 
   std::condition_variable ProgressBar::notifier;
+  bool ProgressBar::notification_is_genuine = false;
   std::mutex ProgressBar::mutex;
   void* ProgressBar::data = nullptr;
   bool ProgressBar::progressbar_active = false;

--- a/core/progressbar.h
+++ b/core/progressbar.h
@@ -64,7 +64,6 @@ namespace MR
 
       FORCE_INLINE ~ProgressBar  () {
         done();
-        progressbar_active = false;
       }
 
       //! Create a new ProgressBar, displaying the specified text.
@@ -136,8 +135,10 @@ namespace MR
       FORCE_INLINE void operator++ (int) { ++ (*this); }
 
       FORCE_INLINE void done () {
-        if (show)
+        if (show) {
           done_func (*this);
+          progressbar_active = false;
+        }
       }
 
       template <class ThreadType>
@@ -193,8 +194,10 @@ namespace MR
     next_time (0.0),
     _multiplier (0.0),
     _text_has_been_modified (false) {
-      set_max (target);
-      progressbar_active = true;
+      if (show) {
+        set_max (target);
+        progressbar_active = true;
+      }
     }
 
 

--- a/core/progressbar.h
+++ b/core/progressbar.h
@@ -62,7 +62,10 @@ namespace MR
       ProgressBar (const ProgressBar& p) = delete;
       ProgressBar (ProgressBar&& p) = default;
 
-      FORCE_INLINE ~ProgressBar  () { done(); }
+      FORCE_INLINE ~ProgressBar  () {
+        done();
+        progressbar_active = false;
+      }
 
       //! Create a new ProgressBar, displaying the specified text.
       /*! If \a target is unspecified or set to zero, the ProgressBar will
@@ -167,6 +170,8 @@ namespace MR
       bool _text_has_been_modified;
 
       FORCE_INLINE void display_now () { display_func (*this); }
+
+      static bool progressbar_active;
   };
 
 
@@ -179,7 +184,7 @@ namespace MR
 
 
   FORCE_INLINE ProgressBar::ProgressBar (const std::string& text, size_t target, int log_level) :
-    show (App::log_level >= log_level),
+    show (!progressbar_active && App::log_level >= log_level),
     _text (text),
     _ellipsis ("... "),
     _value (0),
@@ -189,6 +194,7 @@ namespace MR
     _multiplier (0.0),
     _text_has_been_modified (false) {
       set_max (target);
+      progressbar_active = true;
     }
 
 

--- a/core/progressbar.h
+++ b/core/progressbar.h
@@ -126,7 +126,8 @@ namespace MR
       FORCE_INLINE void operator++ (int) { ++ (*this); }
 
       FORCE_INLINE void done () {
-        done_func (*this);
+        if (show)
+          done_func (*this);
       }
 
       template <class ThreadType>
@@ -186,6 +187,8 @@ namespace MR
 
   inline void ProgressBar::set_max (size_t target)
   {
+    if (!show)
+      return;
     if (target) {
       multiplier = 0.01 * target;
       next_percent = multiplier;
@@ -203,6 +206,8 @@ namespace MR
 
   FORCE_INLINE void ProgressBar::set_text (const std::string& new_text)
   {
+    if (!show)
+      return;
     text_has_been_modified = true;
     if (new_text.size()) {
 #ifdef MRTRIX_WINDOWS
@@ -223,6 +228,8 @@ namespace MR
   template <class TextFunc>
     FORCE_INLINE void ProgressBar::update (TextFunc&& text_func, const bool increment)
     {
+      if (!show)
+        return;
       double time = timer.elapsed();
       if (increment && multiplier) {
         if (++current_val >= next_percent) {
@@ -254,6 +261,8 @@ namespace MR
 
   FORCE_INLINE void ProgressBar::operator++ ()
   {
+    if (!show)
+      return;
     if (multiplier) {
       if (++current_val >= next_percent) {
         value = std::round (current_val / multiplier);
@@ -279,6 +288,8 @@ namespace MR
   template <class ThreadType>
     inline void ProgressBar::run_update_thread (const ThreadType& threads) const
     {
+      if (!show)
+        return;
       std::unique_lock<std::mutex> lock (mutex);
       while (!threads.finished()) {
         notifier.wait (lock, []{ return true; });

--- a/src/gui/dialog/progress.cpp
+++ b/src/gui/dialog/progress.cpp
@@ -36,7 +36,7 @@ namespace MR
         void display (const ::MR::ProgressBar& p)
         {
           if (!p.data) {
-            INFO (MR::App::NAME + ": " + p.text);
+            INFO (MR::App::NAME + ": " + p.text());
             assert (GUI::App::main_window);
             GUI::App::main_window->setUpdatesEnabled (false);
             p.data = new Timer;
@@ -44,12 +44,12 @@ namespace MR
           else if (reinterpret_cast<Timer*>(p.data)->elapsed() > 1.0) {
             GL::Context::Grab context;
             if (!progress_dialog) {
-              progress_dialog = new QProgressDialog ((p.text + p.ellipsis).c_str(), QString(), 0, p.multiplier ? 100 : 0, GUI::App::main_window);
+              progress_dialog = new QProgressDialog ((p.text() + p.ellipsis()).c_str(), QString(), 0, p.show_percent() ? 100 : 0, GUI::App::main_window);
               progress_dialog->setWindowModality (Qt::ApplicationModal);
               progress_dialog->show();
               qApp->processEvents();
             }
-            progress_dialog->setValue (p.value);
+            progress_dialog->setValue (p.value());
             qApp->processEvents();
           }
         }
@@ -57,7 +57,7 @@ namespace MR
 
         void done (const ::MR::ProgressBar& p)
         {
-          INFO (MR::App::NAME + ": " + p.text + " [done]");
+          INFO (MR::App::NAME + ": " + p.text() + " [done]");
           if (p.data) {
             assert (GUI::App::main_window);
             if (progress_dialog) {


### PR DESCRIPTION
Closes #1700 

I think this should do it.... The first commit here is the actual fix (silly mistake on my part). The second commit cleans up the implementation a bit (better encapsulation, but really mostly cosmetic). The last commit actively prevents a ProgressBar from displaying if another is already active - which should mean there is no need to use a loglevel latch to keep nested ProgressBars quiet... 