### PR TITLE
Mrview fix dixel odf render

### DIFF
--- a/src/gui/dwi/renderer.cpp
+++ b/src/gui/dwi/renderer.cpp
@@ -130,10 +130,6 @@ namespace MR
           "layout(location = 1) in float value;\n";
         }
 
-        std::string VSout = "";
-        if (mode_ == mode_t::DIXEL)
-          VSout = "_GSin";
-
         source +=
           "uniform float scale;\n"
           "uniform int reverse;\n"
@@ -147,32 +143,29 @@ namespace MR
           "uniform vec3 dec;\n";
         }
 
-        source +=
-          "out vec3 position"+VSout+", color"+VSout+";\n";
-
         if (mode_ == mode_t::SH || mode_ == mode_t::TENSOR) {
           source +=
-          "out vec3 vert_normal;\n";
+          "out vec3 vertex_position, vertex_color, vertex_normal;\n"
+          "out float amplitude;\n";
         } else if (mode_ == mode_t::DIXEL) {
           source +=
-          "out vec3 vert_dir;\n"
-          "out vec3 vert_pos;\n";
+          "out vec3 vertex_orig_direction, vertex_orig_position, vertex_orig_color;\n"
+          "out float orig_amplitude;\n";
         }
 
         source +=
-          "out float amplitude"+VSout+";\n"
           "void main () {\n";
 
         if (mode_ == mode_t::SH) {
           source +=
-          "  amplitude"+VSout+" = r_del_daz[0];\n";
+          "  amplitude = r_del_daz[0];\n";
         } else if (mode_ == mode_t::TENSOR) {
           source +=
           "  vec3 new_vertex = tensor * vertex;\n"
-          "  amplitude"+VSout+" = length(new_vertex);\n";
+          "  amplitude = length(new_vertex);\n";
         } else if (mode_ == mode_t::DIXEL) {
           source +=
-          "  amplitude"+VSout+" = value;\n";
+          "  orig_amplitude = value;\n";
         }
 
         if (use_lighting_ && (mode_ == mode_t::SH || mode_ == mode_t::TENSOR)) {
@@ -189,51 +182,51 @@ namespace MR
           "  vec3 d2 = vec3 (-r_del_daz[1]*caz*sel - r_del_daz[0]*caz*cel,\n"
           "                  -r_del_daz[1]*saz*sel - r_del_daz[0]*saz*cel,\n"
           "                  -r_del_daz[1]*cel     + r_del_daz[0]*sel);\n"
-          "  vert_normal = cross (d1, d2);\n";
+          "  vertex_normal = cross (d1, d2);\n";
           } else if (mode_ == mode_t::TENSOR) {
           source +=
-          "  vert_normal = normalize (inv_tensor * vertex);\n";
+          "  vertex_normal = normalize (inv_tensor * vertex);\n";
           }
           source +=
           "  if (reverse != 0)\n"
-          "    vert_normal = -vert_normal;\n"
-          "  vert_normal = normalize (mat3(MV) * vert_normal);\n";
+          "    vertex_normal = -vertex_normal;\n"
+          "  vertex_normal = normalize (mat3(MV) * vertex_normal);\n";
         }
 
         if (colour_by_direction_) {
           if (mode_ == mode_t::TENSOR) {
           source +=
-          "  color = dec;\n";
+          "  vertex_color = dec;\n";
           } else {
           source +=
-          "  color"+VSout+" = abs (vertex.xyz);\n";
+          "  vertex_" + std::string ( mode_ == mode_t::DIXEL ? "orig_" : "" ) + "color = abs (vertex.xyz);\n";
           }
         } else {
           source +=
-          "  color"+VSout+" = constant_color;\n";
+          "  vertex_" + std::string ( mode_ == mode_t::DIXEL ? "orig_" : "" ) + "color = constant_color;\n";
         }
 
         if (mode_ == mode_t::SH || mode_ == mode_t::TENSOR) {
           source +=
-          "  vec3 pos = " + std::string(mode_ == mode_t::TENSOR ? "new_vertex" : "vertex * amplitude"+VSout) + " * scale;\n"
+          "  vec3 pos = " + std::string(mode_ == mode_t::TENSOR ? "new_vertex" : "vertex * amplitude" ) + " * scale;\n"
           "  if (reverse != 0)\n"
           "    pos = -pos;\n";
           if (orthographic_) {
             source +=
-          "  position"+VSout+" = vec3(0.0, 0.0, 1.0);\n";
+          "  vertex_position = vec3(0.0, 0.0, 1.0);\n";
           } else {
             source +=
-          "  position"+VSout+" = -(MV * vec4 (pos, 1.0)).xyz;\n";
+          "  vertex_position = -(MV * vec4 (pos, 1.0)).xyz;\n";
           }
           source +=
           "  gl_Position = MVP * vec4 (pos + origin, 1.0);\n";
         } else if (mode_ == mode_t::DIXEL) {
           source +=
-          "  vert_dir = vertex;\n"
-          "  vert_pos = vertex * amplitude"+VSout+";\n"
+          "  vertex_orig_direction = vertex;\n"
+          "  vertex_orig_position = vertex * orig_amplitude;\n"
           "  if (reverse != 0) {\n"
-          "     vert_dir = -vert_dir;\n"
-          "     vert_pos = -vert_pos;\n"
+          "     vertex_orig_direction = -vertex_orig_direction;\n"
+          "     vertex_orig_position = -vertex_orig_position;\n"
           "  }\n";
         }
 
@@ -243,7 +236,8 @@ namespace MR
         return source;
       }
 
-      std::string Renderer::Shader::geometry_shader_source() const{
+      std::string Renderer::Shader::geometry_shader_source() const
+      {
         std::string source;
         if (mode_ == mode_t::DIXEL) {
           source +=
@@ -253,46 +247,38 @@ namespace MR
             "uniform vec3 origin;\n"
             "uniform float scale;\n"
             "uniform int reverse;\n"
-            "in vec3 vert_dir[], vert_pos[];\n"
-            "in vec3 position_GSin[], color_GSin[];\n"
-            "flat out vec3 face_normal;\n"
-            "out vec3 position_GSout, color_GSout;\n"
-            "in float amplitude_GSin[];\n"
-            "out float amplitude_GSout;\n"
+            "in vec3 vertex_orig_direction[], vertex_orig_position[], vertex_orig_color[];\n"
+            "in float orig_amplitude[];\n"
+            "out vec3 vertex_position, vertex_color, vertex_normal;\n"
+            "out float amplitude;\n"
             "void main() {\n"
-            "  vec3 mean_dir = normalize (vert_dir[0] + vert_dir[1] + vert_dir[2]);\n"
+            "  vec3 mean_dir = normalize (vertex_orig_direction[0] + vertex_orig_direction[1] + vertex_orig_direction[2]);\n"
             "  vec3 vertices[3];\n"
-            "  vec3 positions[3];\n";
-          for (size_t vertex = 0; vertex != 3; ++vertex) {
-            const std::string v = str(vertex);
-            source +=
-            "  if (dot (mean_dir, vert_dir["+v+"]) > 0.0) {\n"
-            "    vertices["+v+"] = vert_pos["+v+"];\n"
-            "    positions["+v+"] = position_GSin["+v+"];\n"
-            "  } else {\n"
-            "    vertices["+v+"] = -vert_pos["+v+"];\n"
-            "    positions["+v+"] = -position_GSin["+v+"];\n"
-            "  }\n";
-          }
-          source +=
-            "  face_normal = normalize (cross (vertices[1]-vertices[0], vertices[2]-vertices[1]));\n"
+            "  vec3 positions[3];\n"
+            "  for (int v = 0; v < 3; ++v) {\n"
+            "    if (dot (mean_dir, vertex_orig_direction[v]) > 0.0)\n"
+            "      vertices[v] = vertex_orig_position[v];\n"
+            "    else\n"
+            "      vertices[v] = -vertex_orig_position[v];\n"
+            "  }\n"
+            "  vertex_normal = normalize (cross (vertices[1]-vertices[0], vertices[2]-vertices[1]));\n"
             "  if (reverse != 0)\n"
-            "    face_normal = -face_normal;\n"
-            "  face_normal = normalize (mat3(MV) * face_normal);\n";
+            "    vertex_normal = -vertex_normal;\n"
+            "  vertex_normal = mat3(MV) * vertex_normal;\n";
           for (size_t vertex = 0; vertex != 3; ++vertex) {
             const std::string v = str(vertex);
             source +=
             "  gl_Position = MVP * vec4 (origin + (vertices["+v+"] * scale), 1.0);\n";
             if (orthographic_) {
               source +=
-            "  position_GSout = vec3(0.0, 0.0, 1.0);\n";
+            "  vertex_position = vec3(0.0, 0.0, 1.0);\n";
             } else {
               source +=
-            "  position_GSout = -(MV * vec4 (vertices["+v+"] * scale, 1.0)).xyz;\n";
+            "  vertex_position = -(MV * vec4 (vertices["+v+"] * scale, 1.0)).xyz;\n";
             }
             source +=
-            "  color_GSout = color_GSin["+v+"];\n"
-            "  amplitude_GSout = amplitude_GSin["+v+"];\n"
+            "  vertex_color = vertex_orig_color["+v+"];\n"
+            "  amplitude = orig_amplitude["+v+"];\n"
             "  EmitVertex();\n";
           }
           source +=
@@ -305,27 +291,14 @@ namespace MR
       std::string Renderer::Shader::fragment_shader_source() const
       {
         std::string source;
-        std::string FSin = "";
-        if (mode_ == mode_t::DIXEL)
-          FSin = "_GSout";
         source +=
           "uniform float ambient, diffuse, specular, shine;\n"
           "uniform vec3 light_pos;\n"
-          "in float amplitude"+FSin+";\n"
-          "in vec3 position"+FSin+", color"+FSin+";\n";
-
-        if (mode_ == mode_t::SH || mode_ == mode_t::TENSOR) {
-          source +=
-          "in vec3 vert_normal;\n";
-        } else if (mode_ == mode_t::DIXEL) {
-          source +=
-          "flat in vec3 face_normal;\n";
-        }
-
-        source +=
+          "in float amplitude;\n"
+          "in vec3 vertex_position, vertex_color, vertex_normal;\n"
           "out vec3 final_color;\n"
           "void main() {\n"
-          "  if (amplitude"+FSin+" < 0.0) {\n";
+          "  if (amplitude < 0.0) {\n";
 
         if (hide_neg_values_) {
           source +=
@@ -337,21 +310,16 @@ namespace MR
 
         source +=
           "  }\n"
-          "  else final_color = color"+FSin+";\n";
+          "  else final_color = vertex_color;\n";
 
         if (use_lighting_) {
-          if (mode_ == mode_t::SH || mode_ == mode_t::TENSOR) {
           source +=
-          "  vec3 norm = normalize (vert_normal);\n";
-          } else if (mode_ == mode_t::DIXEL) {
+          "  vec3 norm = normalize (vertex_normal);\n";
           source +=
-          "  vec3 norm = face_normal;\n";
-          }
-          source +=
-          "  if (amplitude"+FSin+" < 0.0)\n"
+          "  if (amplitude < 0.0)\n"
           "    norm = -norm;\n"
           "  final_color *= ambient + diffuse * clamp (dot (norm, light_pos), 0, 1);\n"
-          "  final_color += specular * pow (clamp (dot (reflect (-light_pos, norm), normalize(position"+FSin+")), 0, 1), shine);\n";
+          "  final_color += specular * pow (clamp (dot (reflect (-light_pos, norm), normalize(vertex_position)), 0, 1), shine);\n";
         }
 
         source +=

--- a/src/gui/dwi/renderer.cpp
+++ b/src/gui/dwi/renderer.cpp
@@ -264,24 +264,18 @@ namespace MR
             "  vertex_normal = normalize (cross (vertices[1]-vertices[0], vertices[2]-vertices[1]));\n"
             "  if (reverse != 0)\n"
             "    vertex_normal = -vertex_normal;\n"
-            "  vertex_normal = mat3(MV) * vertex_normal;\n";
-          for (size_t vertex = 0; vertex != 3; ++vertex) {
-            const std::string v = str(vertex);
+            "  vertex_normal = mat3(MV) * vertex_normal;\n"
+            "  for (int v = 0; v < 3; ++v) {\n"
+            "    gl_Position = MVP * vec4 (origin + (vertices[v] * scale), 1.0);\n";
+            if (orthographic_)
+              source += "    vertex_position = vec3(0.0, 0.0, 1.0);\n";
+            else
+              source += "    vertex_position = -(MV * vec4 (vertices[v] * scale, 1.0)).xyz;\n";
             source +=
-            "  gl_Position = MVP * vec4 (origin + (vertices["+v+"] * scale), 1.0);\n";
-            if (orthographic_) {
-              source +=
-            "  vertex_position = vec3(0.0, 0.0, 1.0);\n";
-            } else {
-              source +=
-            "  vertex_position = -(MV * vec4 (vertices["+v+"] * scale, 1.0)).xyz;\n";
-            }
-            source +=
-            "  vertex_color = vertex_orig_color["+v+"];\n"
-            "  amplitude = orig_amplitude["+v+"];\n"
-            "  EmitVertex();\n";
-          }
-          source +=
+            "    vertex_color = vertex_orig_color[v];\n"
+            "    amplitude = orig_amplitude[v];\n"
+            "    EmitVertex();\n"
+            "  }\n"
             "  EndPrimitive();\n"
             "}";
         }


### PR DESCRIPTION
Reported by @bjeurissen due to crashes on macOS using ATI hardware & drivers. The error message was:
```
mrview: [ERROR] GLSL log [OpenGL shader program]: ERROR: Input of geometry shader 'position_GSin' not written by vertex shader

Qt has caught an exception thrown from an event handler. Throwing
exceptions from an event handler is not supported in Qt.
You must not let any exception whatsoever propagate through Qt code.
If that is not possible, in Qt 5 you must at least reimplement
QCoreApplication::notify() and catch all exceptions there.

mrview: [ERROR] error linking OpenGL shader program ID 21

mrview: [SYSTEM FATAL CODE: SIGSEGV (11)] Segmentation fault: Invalid memory access
```
Looking at the shaders generated, that is in fact correct - even though it should have no effect on the render itself since all the geometry shader did was to assign those values to other variables that were themselves unused... 

In any case, I've had a go at cleaning up the implementation a bit, since I thought it was probably a bit too complex. Difficulty here is that the dixel plot requires a geometry shader, whereas the others don't, meaning the variable names have to change between render modes. Hopefully I've no messed this up - seems to work fine on my system in all combinations (any of SH, tensor or dixel renders, with/without hide negative lobes, colour by direction or lighting). 