### PR TITLE
foreach fixes

### DIFF
--- a/bin/foreach
+++ b/bin/foreach
@@ -144,8 +144,7 @@ def execute(): #pylint: disable=unused-variable
       self.input_text = input_text
       self.sub_in = input_text
       self.sub_name = os.path.basename(input_text)
-      self.sub_pre = self.sub_name.rstrip('.gz')
-      self.sub_pre = os.path.splitext(self.sub_pre)[0]
+      self.sub_pre = os.path.splitext(self.sub_name.rstrip('.gz'))[0]
       if common_suffix:
         self.sub_uni = input_text[len(common_prefix):-len(common_suffix)]
       else:

--- a/bin/foreach
+++ b/bin/foreach
@@ -14,7 +14,7 @@ def usage(cmdline): #pylint: disable=unused-variable
   cmdline.add_description('This script greatly simplifies various forms of batch processing by enabling the execution of a command (or set of commands) independently for each of a set of inputs. Part of the way that this is achieved is by providing basic text substitutions, which simplify the formation of valid command strings based on the unique components of the input strings on which the script is instructed to execute. The available substitutions are listed below (note that the -test command-line option can be used to ensure correct command string formation prior to actually executing the commands):')
   cmdline.add_description('   - IN:   The full matching pattern, including leading folders. For example, if the target list contains a file "folder/image.mif", any occurrence of "IN" will be substituted with "folder/image.mif".')
   cmdline.add_description('   - NAME: The basename of the matching pattern. For example, if the target list contains a file "folder/image.mif", any occurrence of "NAME" will be substituted with "image.mif".')
-  cmdline.add_description('   - PRE:  The prefix of the basename. For example, if the target list contains a file "folder/image.mif", any occurrence of "PRE" will be substituted with "image".')
+  cmdline.add_description('   - PRE:  The prefix of the input pattern (the basename stripped of its extension). For example, if the target list contains a file "folder/my.image.mif.gz", any occurrence of "PRE" will be substituted with "my.image".')
   cmdline.add_description('   - UNI:  The unique part of the input after removing any common prefix and common suffix. For example, if the target list contains files: "folder/001dwi.mif", "folder/002dwi.mif", "folder/003dwi.mif", any occurrence of "UNI" will be substituted with "001", "002", "003".')
   cmdline.add_description('Note that due to a limitation of the Python "argparse" module, any command-line OPTIONS that the user intends to provide specifically to the foreach script must appear BEFORE providing the list of inputs on which foreach is intended to operate. While command-line options provided as such will be interpreted specifically by the foreach script, any command-line options that are provided AFTER the COLON separator will form part of the executed COMMAND, and will therefore be interpreted as command-line options having been provided to that underlying command.')
   cmdline.add_example_usage('Demonstration of basic usage syntax',
@@ -146,7 +146,7 @@ def execute(): #pylint: disable=unused-variable
       self.sub_name = os.path.basename(input_text)
       self.sub_pre = self.sub_name.rstrip('.gz')
       self.sub_pre = os.path.splitext(self.sub_pre)[0]
-      if len(common_suffix):
+      if common_suffix:
         self.sub_uni = input_text[len(common_prefix):-len(common_suffix)]
       else:
         self.sub_uni = input_text[len(common_prefix):]

--- a/bin/foreach
+++ b/bin/foreach
@@ -144,8 +144,12 @@ def execute(): #pylint: disable=unused-variable
       self.input_text = input_text
       self.sub_in = input_text
       self.sub_name = os.path.basename(input_text)
-      self.sub_pre = self.sub_name.split('.')[0]
-      self.sub_uni = input_text[len(common_prefix):-len(common_suffix)]
+      self.sub_pre = self.sub_name.rstrip('.gz')
+      self.sub_pre = os.path.splitext(self.sub_pre)[0]
+      if len(common_suffix):
+        self.sub_uni = input_text[len(common_prefix):-len(common_suffix)]
+      else:
+        self.sub_uni = input_text[len(common_prefix):]
 
       self.substitutions = { 'IN': self.sub_in, 'NAME': self.sub_name, 'PRE': self.sub_pre, 'UNI': self.sub_uni }
       app.debug('Input text: ' + input_text)

--- a/docs/reference/commands/foreach.rst
+++ b/docs/reference/commands/foreach.rst
@@ -28,7 +28,7 @@ This script greatly simplifies various forms of batch processing by enabling the
 
    - NAME: The basename of the matching pattern. For example, if the target list contains a file "folder/image.mif", any occurrence of "NAME" will be substituted with "image.mif".
 
-   - PRE:  The prefix of the basename. For example, if the target list contains a file "folder/image.mif", any occurrence of "PRE" will be substituted with "image".
+   - PRE:  The prefix of the input pattern (the basename stripped of its extension). For example, if the target list contains a file "folder/my.image.mif.gz", any occurrence of "PRE" will be substituted with "my.image".
 
    - UNI:  The unique part of the input after removing any common prefix and common suffix. For example, if the target list contains files: "folder/001dwi.mif", "folder/002dwi.mif", "folder/003dwi.mif", any occurrence of "UNI" will be substituted with "001", "002", "003".
 


### PR DESCRIPTION
- change to PRE: now removes .gz if present then splits off extension instead of truncating after the first '.'
- fix to UNI: if the common suffix is empty (common for directories without common name suffix) the output was emtpy, now it defaults everything after the common prefix