### PR TITLE
Fix sh precomputer again

### DIFF
--- a/core/math/SH.h
+++ b/core/math/SH.h
@@ -434,7 +434,7 @@ namespace MR
                 ValueType c = c0 * cp - s0 * sp;
                 ValueType s = s0 * cp + c0 * sp;
                 for (int l = ( (m&1) ? m+1 : m); l <= lmax; l+=2)
-                  v += get (f,l,m) * (c * val[index (l,m)] + s * val[index (l,-m)]);
+                  v += get (f,l,m) * Math::sqrt2 * (c * val[index (l,m)] + s * val[index (l,-m)]);
                 c0 = c;
                 s0 = s;
               }

--- a/testing/cmd/testing_sh_precomputer.cpp
+++ b/testing/cmd/testing_sh_precomputer.cpp
@@ -1,0 +1,58 @@
+/* Copyright (c) 2008-2019 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Covered Software is provided under this License on an "as is"
+ * basis, without warranty of any kind, either expressed, implied, or
+ * statutory, including, without limitation, warranties that the
+ * Covered Software is free of defects, merchantable, fit for a
+ * particular purpose or non-infringing.
+ * See the Mozilla Public License v. 2.0 for more details.
+ *
+ * For more details, see http://www.mrtrix.org/.
+ */
+
+#include <sstream>
+
+#include "command.h"
+#include "math/SH.h"
+
+
+using namespace MR;
+using namespace App;
+
+
+void usage ()
+{
+  AUTHOR = "J-Donald Tournier (jdtournier@gmail.com)";
+
+  SYNOPSIS = "Test the accuracy of the spherical harmonic precomputer";
+
+  REQUIRES_AT_LEAST_ONE_ARGUMENT = false;
+}
+
+using value_type = float;
+using coefs_type = Eigen::Matrix<value_type,Eigen::Dynamic,1>;
+using dir_type = Eigen::Matrix<value_type,3,1>;
+
+
+
+void run ()
+{
+  using namespace Math::SH;
+
+  const int lmax = 8;
+
+  coefs_type coefs = coefs_type::Random (NforL (lmax));
+  PrecomputedAL<value_type> precomputer (lmax);
+
+  for (size_t n = 0; n < 10000; ++n) {
+    dir_type direction = dir_type::Random().normalized();
+    if (std::abs (value (coefs, direction, lmax) - precomputer.value (coefs, direction)) > 1e-3)
+      throw Exception ("difference exceeds tolerance");
+  }
+
+}
+

--- a/testing/tests/sh_precomputer
+++ b/testing/tests/sh_precomputer
@@ -1,0 +1,1 @@
+testing_sh_precomputer


### PR DESCRIPTION
Seems the SH precomputer was still wrong, even after #1206...

The fix we did then made it work for the `Math::SH::get_peak()` call, but screwed up the `PrecomputedAL::value()` call... This is because the √2 factor had originally been absorbed in the precomputed Associated Legendre polynomials, which wasn't taken into account in the `get_peak()` call, but was taken into account by the `value()` call. This PR now ensures the precomputed Associated Legendre polynomials still _don't_ have the additional √2, so that they are interchangeable with the non-precomputed ones, but fixes the `value()` call so that that factor is correctly taken into account there. 

On the funny side, it looks like there had actually been no problem with the tracking until we decided to 'fix' it with #1206... 🤦‍♂ 

I've added a small test command to check for regression to make sure we don't bork this yet again in future. In the meantime, this is likely to change the tracking behaviour yet again... 