### PR TITLE
core/app: fix abbreviated option parsing

### DIFF
--- a/core/app.cpp
+++ b/core/app.cpp
@@ -18,6 +18,7 @@
 #include <fcntl.h>
 #include <locale>
 #include <clocale>
+#include <algorithm>
 
 
 #include "app.h"
@@ -938,6 +939,11 @@ namespace MR
         for (size_t i = 0; i < candidates.size(); ++i)
           if (root == candidates[i]->id)
             return candidates[i];
+
+        // check if there is only one *unique* candidate
+        const auto cid = candidates[0]->id;
+        if ( std::all_of(++candidates.begin(), candidates.end(), [& cid](const Option* cand){return cand->id == cid;}) )
+          return candidates[0];
 
         // report something useful:
         root = "several matches possible for option \"-" + root + "\": \"-" + candidates[0]->id;


### PR DESCRIPTION
fix abbreviated option parsing with identically named options 
example in mrfilter `-std` gets mapped to the first `-stdev` option.
Prior to these changes `mrfilter -std` fails with:
`[ERROR] several matches possible for option "-std": "-stdev", "-stdev"`