### PR TITLE
Docs: Add MRtrix3 publication reference

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,9 +1,13 @@
-Welcome to the MRtrix user documentation!
-=========================================
+Welcome to the *MRtrix3* user documentation!
+============================================
 
-*MRtrix* provides a large suite of tools for image processing, analysis and visualisation, with a focus on the analysis of white matter using diffusion-weighted MRI. Features include the estimation of fibre orientation distributions using constrained spherical deconvolution ([Tournier2004]_; [Tournier2007]_; [Jeurissen2014]_), visualisation of these via directionally-encoded colour maps ([Dhollander2015a]_) and panchromatic sharpening ([Dhollander2015b]_), a probabilisitic streamlines algorithm for fibre tractography of white matter ([Tournier2012]_), fixel-based analysis of apparent fibre density and fibre cross-section ([Raffelt2012]_; [Raffelt2015]_; [Raffelt2017]_), quantitative structural connectivity analysis ([Smith2012]_; [Smith2013]_; [Smith2015]_; [Christiaens2015]_), and non-linear spatial registration of fibre orientation distribution images ([Raffelt2011]_).
+*MRtrix3* provides a large suite of tools for image processing, analysis and visualisation, with a focus on the analysis of white matter using diffusion-weighted MRI ([Tournier2019]_). Features include the estimation of fibre orientation distributions using constrained spherical deconvolution ([Tournier2004]_; [Tournier2007]_; [Jeurissen2014]_), visualisation of these via directionally-encoded colour maps ([Dhollander2015a]_) and panchromatic sharpening ([Dhollander2015b]_), a probabilisitic streamlines algorithm for fibre tractography of white matter ([Tournier2012]_), fixel-based analysis of apparent fibre density and fibre cross-section ([Raffelt2012]_; [Raffelt2015]_; [Raffelt2017]_), quantitative structural connectivity analysis ([Smith2012]_; [Smith2013]_; [Smith2015]_; [Christiaens2015]_), and non-linear spatial registration of fibre orientation distribution images ([Raffelt2011]_).
 
 These applications have been written from scratch in C++, using the functionality provided by `Eigen`_, and `Qt`_. The software is currently capable of handling DICOM, NIfTI and AnalyseAVW image formats, amongst others. The source code is distributed under the `Mozilla Public License`_.
+
+Use of the *MRtrix3* software package in published works should be accompanied by the following citation:
+
+    J.-D. Tournier, R. E. Smith, D. Raffelt, R. Tabbara, T. Dhollander, M. Pietsch, D. Christiaens, B. Jeurissen, C.-H. Yeh, and A. Connelly. *MRtrix3*: A fast, flexible and open software framework for medical image processing and visualisation. NeuroImage, 202 (2019), pp. 116–37.
 
 
 .. _Eigen: http://eigen.tuxfamily.org/

--- a/docs/reference/references.rst
+++ b/docs/reference/references.rst
@@ -127,6 +127,11 @@ References
    *Determination of the appropriate b value and number of gradient directions for high-angular-resolution diffusion-weighted imaging.*
    NMR Biomed., 26 (2013), pp. 1775–86.
    [`full text link <https://onlinelibrary.wiley.com/doi/abs/10.1002/nbm.3017>`__\ ]
+   
+.. [Tournier2019] J.-D. Tournier, R. E. Smith, D. Raffelt, R. Tabbara, T. Dhollander, M. Pietsch, D. Christiaens, B. Jeurissen, C.-H. Yeh, and A. Connelly.
+   *MRtrix3: A fast, flexible and open software framework for medical image processing and visualisation.*
+   NeuroImage, 202 (2019), pp. 116–37.
+   [`fulltext link <https://www.sciencedirect.com/science/article/pii/S1053811919307281>`__\ ]
 
 .. [Veraart2016a] J. Veraart, E. Fieremans, and D.S. Novikov.
    *Diffusion MRI noise mapping using random matrix theory.*


### PR DESCRIPTION
In addition to having the citation on the front page of the online documentation, we should also add it to the front page of the website, and probably make a follow-up announcement about it as well, just to make sure people are aware that success of that manuscript is what will help us keep the software going.