### PR TITLE
Python: Use of kwargs for API functions

### DIFF
--- a/bin/dwibiascorrect
+++ b/bin/dwibiascorrect
@@ -50,7 +50,7 @@ def execute(): #pylint: disable=unused-variable
 
   # Generate a brain mask if required, or check the mask if provided by the user
   if app.ARGS.mask:
-    if not image.match('in.mif', 'mask.mif', 3):
+    if not image.match('in.mif', 'mask.mif', up_to_dim=3):
       raise MRtrixError('Provided mask image does not match input DWI')
   else:
     run.command('dwi2mask in.mif mask.mif')

--- a/bin/dwifslpreproc
+++ b/bin/dwifslpreproc
@@ -437,7 +437,7 @@ def execute(): #pylint: disable=unused-variable
   if app.ARGS.se_epi:
 
     # Newest version of eddy requires that topup field be on the same grid as the eddy input DWI
-    if not image.match(dwi_header, se_epi_header, 3):
+    if not image.match(dwi_header, se_epi_header, up_to_dim=3):
       app.console('DWIs and SE-EPI images used for inhomogeneity field estimation are defined on different image grids; '
                   'the latter will be automatically re-gridded to match the former')
       new_se_epi_path = 'se_epi_regrid.mif'
@@ -976,7 +976,7 @@ def execute(): #pylint: disable=unused-variable
     #   visualising the script intermediate files, and it gives the user a warning about an out-of-date FSL)
     field_map_image = fsl.find_image('field_map')
     field_map_header = image.Header(field_map_image)
-    if not image.match('topup_in.nii', field_map_header, 3):
+    if not image.match('topup_in.nii', field_map_header, up_to_dim=3):
       app.warn('topup output field image has erroneous header; recommend updating FSL to version 5.0.8 or later')
       new_field_map_image = 'field_map_fix.mif'
       run.command('mrtransform ' + field_map_image + ' -replace topup_in.nii ' + new_field_map_image)

--- a/lib/mrtrix3/image.py
+++ b/lib/mrtrix3/image.py
@@ -135,9 +135,13 @@ def mrinfo(image_path, field): #pylint: disable=unused-variable
 
 # Check to see whether the fundamental header properties of two images match
 # Inputs can be either _Header class instances, or file paths
-def match(image_one, image_two, up_to_dim=0): #pylint: disable=unused-variable, too-many-return-statements
+def match(image_one, image_two, **kwargs): #pylint: disable=unused-variable, too-many-return-statements
   import math
   from mrtrix3 import app, MRtrixError
+  up_to_dim = kwargs.pop('up_to_dim', 0)
+  check_transform = kwargs.pop('check_transform', True)
+  if kwargs:
+    raise TypeError('Unsupported keyword arguments passed to image.match(): ' + str(kwargs))
   if not isinstance(image_one, Header):
     if not isinstance(image_one, str):
       raise MRtrixError('Error trying to test \'' + str(image_one) + '\': Not an image header or file path')

--- a/lib/mrtrix3/path.py
+++ b/lib/mrtrix3/path.py
@@ -12,9 +12,13 @@ except ImportError:
 
 
 # List the content of a directory
-def all_in_dir(directory, dir_path=True, ignore_hidden_files=True): #pylint: disable=unused-variable
+def all_in_dir(directory, **kwargs): #pylint: disable=unused-variable
   import ctypes, os
   from mrtrix3 import utils
+  dir_path = kwargs.pop('dir_path', True)
+  ignore_hidden_files = kwargs.pop('ignore_hidden_files', True)
+  if kwargs:
+    raise TypeError('Unsupported keyword arguments passed to path.all_in_dir(): ' + str(kwargs))
   def is_hidden(directory, filename):
     if utils.is_windows():
       try:


### PR DESCRIPTION
Only two remaining functions within the Python API where it was considered more appropriate to use keyword arguments rather than ordered arguments. Was raised in #1736, but is ultimately downstream from #1449.

For any future additional capabilities in the API, experience suggests that keyword arguments should be used fairly liberally. Even if it initially looks like a function only needs one optional parameter, it only requires one new capability to be added to that function that itself requires an optional argument, and you then have argument order ambiguity.