### PR TITLE
JSON handling changes

### DIFF
--- a/cmd/mrinfo.cpp
+++ b/cmd/mrinfo.cpp
@@ -22,6 +22,7 @@
 #include "phase_encoding.h"
 #include "types.h"
 #include "file/json.h"
+#include "file/json_utils.h"
 #include "dwi/gradient.h"
 
 
@@ -191,39 +192,6 @@ void print_properties (const Header& header, const std::string& key, const size_
   }
 }
 
-template <class JSON>
-void keyval2json (const Header& header, JSON& json)
-{
-  for (const auto& kv : header.keyval()) {
-    // Text entries that in fact contain matrix / vector data will be
-    //   converted to numerical matrices / vectors and written as such
-    try {
-      const auto M = parse_matrix (kv.second);
-      if (M.rows() == 1 && M.cols() == 1)
-        throw Exception ("Single scalar value rather than a matrix");
-      for (ssize_t row = 0; row != M.rows(); ++row) {
-        vector<default_type> data (M.cols());
-        for (ssize_t i = 0; i != M.cols(); ++i)
-          data[i] = M (row, i);
-        if (json.find (kv.first) == json.end())
-          json[kv.first] = { data };
-        else
-          json[kv.first].push_back (data);
-      }
-    } catch (...) {
-      if (json.find (kv.first) == json.end()) {
-        json[kv.first] = kv.second;
-      } else if (json[kv.first] != kv.second) {
-        // If the value for this key differs between images, turn the JSON entry into an array
-        if (json[kv.first].is_array())
-          json[kv.first].push_back (kv.second);
-        else
-          json[kv.first] = { json[kv.first], kv.second };
-      }
-    }
-  }
-}
-
 void header2json (const Header& header, nlohmann::json& json)
 {
   // Capture _all_ header fields, not just the optional key-value pairs
@@ -249,7 +217,7 @@ void header2json (const Header& header, nlohmann::json& json)
                         { T(2,0), T(2,1), T(2,2), T(2,3) },
                         {    0.0,    0.0,    0.0,    1.0 } };
   // Load key-value entries into a nested keyval.* member
-  keyval2json (header, json["keyval"]);
+  File::JSON::write (header, json["keyval"], false);
 }
 
 
@@ -271,6 +239,9 @@ void run ()
 
   std::unique_ptr<nlohmann::json> json_keyval (get_options ("json_keyval").size() ? new nlohmann::json : nullptr);
   std::unique_ptr<nlohmann::json> json_all    (get_options ("json_all").size() ? new nlohmann::json : nullptr);
+
+  if (json_all && argument.size() > 1)
+    throw Exception ("Cannot use -json_all option with multiple input images");
 
   if (get_options ("norealign").size())
     Header::do_not_realign_transform = true;
@@ -323,7 +294,7 @@ void run ()
     PhaseEncoding::export_commandline (header);
 
     if (json_keyval)
-      keyval2json (header, *json_keyval);
+      File::JSON::write (header, *json_keyval, false);
 
     if (json_all)
       header2json (header, *json_all);

--- a/core/file/json_utils.cpp
+++ b/core/file/json_utils.cpp
@@ -161,7 +161,7 @@ namespace MR
           try {
             auto M_float = parse_matrix<default_type> (kv.second);
             if (M_float.cols() == 1)
-              M_float = M_float.transpose();
+              M_float.transposeInPlace();
             nlohmann::json temp;
             bool noninteger = false;
             for (ssize_t row = 0; row != M_float.rows(); ++row) {
@@ -185,7 +185,7 @@ namespace MR
               // Write the data natively as integers
               auto M_int = parse_matrix<int> (kv.second);
               if (M_int.cols() == 1)
-                M_int = M_int.transpose();
+                M_int.transposeInPlace();
               temp[kv.first] = nlohmann::json({});
               for (ssize_t row = 0; row != M_int.rows(); ++row) {
                 vector<int> data (M_int.cols());

--- a/core/file/json_utils.cpp
+++ b/core/file/json_utils.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <fstream>
+#include <sstream>
 
 #include "file/json_utils.h"
 #include "file/nifti_utils.h"
@@ -47,14 +48,34 @@ namespace MR
         } catch (std::logic_error& e) {
           throw Exception ("Error parsing JSON file \"" + path + "\": " + e.what());
         }
+        read (json, H, true);
+      }
+
+
+
+      void save (const Header& H, const std::string& path)
+      {
+        nlohmann::json json;
+        write (H, json, true);
+        File::OFStream out (path);
+        out << json.dump(4);
+      }
+
+
+
+
+
+      KeyValues read (const nlohmann::json& json)
+      {
+        KeyValues result;
         for (auto i = json.cbegin(); i != json.cend(); ++i) {
 
           if (i->is_boolean()) {
-            H.keyval().insert (std::make_pair (i.key(), i.value() ? "1" : "0"));
+            result.insert (std::make_pair (i.key(), i.value() ? "1" : "0"));
           } else if (i->is_number_integer()) {
-            H.keyval().insert (std::make_pair (i.key(), str<int>(i.value())));
+            result.insert (std::make_pair (i.key(), str<int>(i.value())));
           } else if (i->is_number_float()) {
-            H.keyval().insert (std::make_pair (i.key(), str<float>(i.value())));
+            result.insert (std::make_pair (i.key(), str<float>(i.value())));
           } else if (i->is_array()) {
             vector<std::string> s;
             for (auto j = i->cbegin(); j != i->cend(); ++j) {
@@ -67,15 +88,21 @@ namespace MR
                 s.push_back (str(*j));
               }
             }
-            H.keyval().insert (std::make_pair (i.key(), join(s, "\n")));
+            result.insert (std::make_pair (i.key(), join(s, "\n")));
           } else if (i->is_string()) {
             const std::string s = i.value();
-            H.keyval().insert (std::make_pair (i.key(), s));
+            result.insert (std::make_pair (i.key(), s));
           }
-
         }
+        return result;
+      }
 
-        if (!Header::do_not_realign_transform) {
+
+
+      void read (const nlohmann::json& json, Header& header, const bool realign)
+      {
+        header.keyval() = read (json);
+        if (realign && !Header::do_not_realign_transform) {
 
           // The corresponding header may have been rotated on image load prior to the JSON
           //   being loaded. If this is the case, any fields that indicate an image axis
@@ -83,10 +110,10 @@ namespace MR
 
           size_t perm[3];
           bool flip[3];
-          Axes::get_permutation_to_make_axial (H.transform(), perm, flip);
+          Axes::get_permutation_to_make_axial (header.transform(), perm, flip);
           if (perm[0] != 0 || perm[1] != 1 || perm[2] != 2 || flip[0] || flip[1] || flip[2]) {
 
-            auto pe_scheme = PhaseEncoding::get_scheme (H);
+            auto pe_scheme = PhaseEncoding::get_scheme (header);
             if (pe_scheme.rows()) {
               for (ssize_t row = 0; row != pe_scheme.rows(); ++row) {
                 Eigen::VectorXd new_line = pe_scheme.row (row);
@@ -94,12 +121,12 @@ namespace MR
                   new_line[perm[axis]] = flip[perm[axis]] ? pe_scheme(row,axis) : -pe_scheme(row,axis);
                 pe_scheme.row (row) = new_line;
               }
-              PhaseEncoding::set_scheme (H, pe_scheme);
+              PhaseEncoding::set_scheme (header, pe_scheme);
               INFO ("Phase encoding information read from JSON file modified according to expected input image header transform realignment");
             }
 
-            auto slice_encoding_it = H.keyval().find ("SliceEncodingDirection");
-            if (slice_encoding_it != H.keyval().end()) {
+            auto slice_encoding_it = header.keyval().find ("SliceEncodingDirection");
+            if (slice_encoding_it != header.keyval().end()) {
               const Eigen::Vector3 orig_dir (Axes::id2dir (slice_encoding_it->second));
               Eigen::Vector3 new_dir;
               for (size_t axis = 0; axis != 3; ++axis)
@@ -114,40 +141,140 @@ namespace MR
 
 
 
-      void save (const Header& H, const std::string& path)
-      {
-        nlohmann::json json;
-        auto pe_scheme = PhaseEncoding::get_scheme (H);
-        vector<size_t> order;
-        File::NIfTI::adjust_transform (H, order);
-        Header H_adj (H);
-        const bool axes_adjusted = (order[0] != 0 || order[1] != 1 || order[2] != 2 || H.stride(0) < 0 || H.stride(1) < 0 || H.stride(2) < 0);
-        if (pe_scheme.rows() && axes_adjusted) {
-          // Assume that image being written to disk is going to have its transform adjusted,
-          //   so modify the phase encoding scheme appropriately before writing to JSON
-          for (ssize_t row = 0; row != pe_scheme.rows(); ++row) {
-            Eigen::VectorXd new_line = pe_scheme.row (row);
-            for (ssize_t axis = 0; axis != 3; ++axis)
-              new_line[axis] = H.stride (order[axis]) > 0 ? pe_scheme(row, order[axis]) : -pe_scheme(row, order[axis]);
-            pe_scheme.row (row) = new_line;
-          }
-          PhaseEncoding::set_scheme (H_adj, pe_scheme);
-          INFO ("Phase encoding information written to JSON file modified according to expected output NIfTI header transform realignment");
+      namespace {
+        template <typename T>
+        bool attempt_scalar (const std::pair<std::string, std::string>& kv, nlohmann::json& json)
+        {
+          try {
+            std::stringstream stream (kv.second);
+            T temp;
+            stream >> temp;
+            if (stream && stream.eof()) {
+              json[kv.first] = temp;
+              return true;
+            }
+          } catch (...) { }
+          return false;
         }
-        auto slice_encoding_it = H_adj.keyval().find ("SliceEncodingDirection");
-        if (slice_encoding_it != H_adj.keyval().end() && axes_adjusted) {
-          const Eigen::Vector3 orig_dir (Axes::id2dir (slice_encoding_it->second));
-          Eigen::Vector3 new_dir;
-          for (size_t axis = 0; axis != 3; ++axis)
-            new_dir[order[axis]] = H.stride (order[axis]) > 0 ? orig_dir[order[axis]] : -orig_dir[order[axis]];
-          slice_encoding_it->second = Axes::dir2id (new_dir);
-          INFO ("Slice encoding direction written to JSON file modified according to expected output NIfTI header transform realignment");
+        bool attempt_matrix (const std::pair<std::string, std::string>& kv, nlohmann::json& json)
+        {
+          try {
+            auto M_float = parse_matrix<default_type> (kv.second);
+            if (M_float.cols() == 1)
+              M_float = M_float.transpose();
+            nlohmann::json temp;
+            bool noninteger = false;
+            for (ssize_t row = 0; row != M_float.rows(); ++row) {
+              vector<default_type> data (M_float.cols());
+              for (ssize_t i = 0; i != M_float.cols(); ++i) {
+                data[i] = M_float (row, i);
+                if (std::floor (data[i]) != data[i])
+                  noninteger = true;
+              }
+              if (row)
+                temp[kv.first].push_back (data);
+              else if (M_float.rows() == 1)
+                temp[kv.first] = data;
+              else
+                temp[kv.first] = { data };
+            }
+            if (noninteger) {
+              json[kv.first] = temp[kv.first];
+            } else {
+              // No non-integer values found;
+              // Write the data natively as integers
+              auto M_int = parse_matrix<int> (kv.second);
+              if (M_int.cols() == 1)
+                M_int = M_int.transpose();
+              temp[kv.first] = nlohmann::json({});
+              for (ssize_t row = 0; row != M_int.rows(); ++row) {
+                vector<int> data (M_int.cols());
+                for (ssize_t i = 0; i != M_int.cols(); ++i)
+                  data[i] = M_int (row, i);
+                if (row)
+                  temp[kv.first].push_back (data);
+                else if (M_int.rows() == 1)
+                  temp[kv.first] = data;
+                else
+                  temp[kv.first] = { data };
+              }
+              json[kv.first] = temp[kv.first];
+            }
+            return true;
+          } catch (...) { return false; }
         }
-        for (const auto& kv : H_adj.keyval())
-          json[kv.first] = kv.second;
-        File::OFStream out (path);
-        out << json.dump(4);
       }
+
+
+      void write (const KeyValues& keyval, nlohmann::json& json)
+      {
+        auto write_string = [] (const std::pair<std::string, std::string>& kv,
+                                nlohmann::json& json)
+        {
+          const auto lines = split_lines (kv.second);
+          if (lines.size() > 1)
+            json[kv.first] = lines;
+          else
+            json[kv.first] = kv.second;
+        };
+
+        for (const auto& kv : keyval) {
+
+          if (attempt_scalar<int> (kv, json)) continue;
+          if (attempt_scalar<default_type> (kv, json)) continue;
+          if (attempt_scalar<bool> (kv, json)) continue;
+          if (attempt_matrix (kv, json)) continue;
+          if (json.find (kv.first) == json.end()) {
+            write_string (kv, json);
+          } else {
+            nlohmann::json temp;
+            write_string (kv, temp);
+            if (json[kv.first] != temp[kv.first])
+              json[kv.first] = "variable";
+          }
+        }
+      }
+
+
+
+      void write (const Header& header, nlohmann::json& json, const bool realign)
+      {
+        if (realign && !Header::do_not_realign_transform) {
+          auto pe_scheme = PhaseEncoding::get_scheme (header);
+          vector<size_t> order;
+          File::NIfTI::adjust_transform (header, order);
+          Header H_adj (header);
+          const bool axes_adjusted = (order[0] != 0 || order[1] != 1 || order[2] != 2 || header.stride(0) < 0 || header.stride(1) < 0 || header.stride(2) < 0);
+          if (pe_scheme.rows() && axes_adjusted) {
+            // Assume that image being written to disk is going to have its transform adjusted,
+            //   so modify the phase encoding scheme appropriately before writing to JSON
+            for (ssize_t row = 0; row != pe_scheme.rows(); ++row) {
+              Eigen::VectorXd new_line = pe_scheme.row (row);
+              for (ssize_t axis = 0; axis != 3; ++axis)
+                new_line[axis] = header.stride (order[axis]) > 0 ? pe_scheme(row, order[axis]) : -pe_scheme(row, order[axis]);
+              pe_scheme.row (row) = new_line;
+            }
+            PhaseEncoding::set_scheme (H_adj, pe_scheme);
+            INFO ("Phase encoding information written to JSON file modified according to expected output NIfTI header transform realignment");
+          }
+          auto slice_encoding_it = H_adj.keyval().find ("SliceEncodingDirection");
+          if (slice_encoding_it != H_adj.keyval().end() && axes_adjusted) {
+            const Eigen::Vector3 orig_dir (Axes::id2dir (slice_encoding_it->second));
+            Eigen::Vector3 new_dir;
+            for (size_t axis = 0; axis != 3; ++axis)
+              new_dir[order[axis]] = header.stride (order[axis]) > 0 ? orig_dir[order[axis]] : -orig_dir[order[axis]];
+            slice_encoding_it->second = Axes::dir2id (new_dir);
+            INFO ("Slice encoding direction written to JSON file modified according to expected output NIfTI header transform realignment");
+          }
+          write (H_adj.keyval(), json);
+        } else {
+          write (header.keyval(), json);
+        }
+      }
+
+
+
+
 
 
 

--- a/core/file/json_utils.h
+++ b/core/file/json_utils.h
@@ -18,6 +18,7 @@
 #define __file_json_utils_h__
 
 #include "file/json.h"
+#include "file/key_value.h"
 
 namespace MR
 {
@@ -30,6 +31,16 @@ namespace MR
 
       void load (Header&, const std::string&);
       void save (const Header&, const std::string&);
+
+      KeyValues read (const nlohmann::json& json);
+      void read (const nlohmann::json& json,
+                 Header& header,
+                 const bool realign);
+
+      void write (const KeyValues& keyval, nlohmann::json& json);
+      void write (const Header& header,
+                  nlohmann::json& json,
+                  const bool realign);
 
     }
   }


### PR DESCRIPTION
Well that was tremendous fun. Details in 2d279b2. Related to attempting to resolve BIDS-Apps/MRtrix3_connectome#59 via #1735.

`master`:
```json
{
    "EchoTime": "0.028",
    "FlipAngle": "90",
    "MultibandAccelerationFactor": "1",
    "PhaseEncodingDirection": "j-",
    "RepetitionTime": "3.93",
    "SliceEncodingDirection": "k",
    "SliceTiming": [
        [
            1.96500003,
            0.0,
            2.03250003,
            0.0675000027,
            2.09750009,
            0.132499993,
            2.1624999,
            0.197500005,
            2.22749996,
            0.262499988,
            2.29250002,
            0.327499986,
            2.3599999,
            0.395000011,
            2.42499995,
            0.460000008,
            2.49000001,
            0.524999976,
            2.55500007,
            0.589999974,
            2.61999989,
            0.654999971,
            2.68499994,
            0.722500026,
            2.75250006,
            0.787500024,
            2.81750011,
            0.852500021,
            2.88249993,
            0.917500019,
            2.94749999,
            0.982500017,
            3.01250005,
            1.04999995,
            3.07999992,
            1.11500001,
            3.14499998,
            1.17999995,
            3.21000004,
            1.245,
            3.2750001,
            1.30999994,
            3.33999991,
            1.37750006,
            3.40750003,
            1.4425,
            3.47250009,
            1.50750005,
            3.5374999,
            1.57249999,
            3.60249996,
            1.63750005,
            3.66750002,
            1.70500004,
            3.7349999,
            1.76999998,
            3.79999995,
            1.83500004,
            3.86500001,
            1.89999998
        ]
    ],
    "TotalReadoutTime": "0.0447",
    "comments": "ORIENTATION TEST (2016_10_05) [MR] ep2d_se AXIAL A-P\nstudy: BRI_PROTOCOLS VE11A Post 08-03-2016 SB.2002.060RS EPI - ROB - 20 [ ORIGINAL PRIMARY M ND NORM ]\nDOB: 01/01/1975\nDOS: 06/10/2016 14:09:38"
}
```

This branch:
```json
{
    "EchoTime": 0.028,
    "FlipAngle": 90,
    "MultibandAccelerationFactor": 1,
    "PhaseEncodingDirection": "j-",
    "RepetitionTime": 3.93,
    "SliceEncodingDirection": "k",
    "SliceTiming": [
        1.96500003,
        0.0,
        2.03250003,
        0.0675000027,
        2.09750009,
        0.132499993,
        2.1624999,
        0.197500005,
        2.22749996,
        0.262499988,
        2.29250002,
        0.327499986,
        2.3599999,
        0.395000011,
        2.42499995,
        0.460000008,
        2.49000001,
        0.524999976,
        2.55500007,
        0.589999974,
        2.61999989,
        0.654999971,
        2.68499994,
        0.722500026,
        2.75250006,
        0.787500024,
        2.81750011,
        0.852500021,
        2.88249993,
        0.917500019,
        2.94749999,
        0.982500017,
        3.01250005,
        1.04999995,
        3.07999992,
        1.11500001,
        3.14499998,
        1.17999995,
        3.21000004,
        1.245,
        3.2750001,
        1.30999994,
        3.33999991,
        1.37750006,
        3.40750003,
        1.4425,
        3.47250009,
        1.50750005,
        3.5374999,
        1.57249999,
        3.60249996,
        1.63750005,
        3.66750002,
        1.70500004,
        3.7349999,
        1.76999998,
        3.79999995,
        1.83500004,
        3.86500001,
        1.89999998
    ],
    "TotalReadoutTime": 0.0447,
    "comments": [
        "ORIENTATION TEST (2016_10_05) [MR] ep2d_se AXIAL A-P",
        "study: BRI_PROTOCOLS VE11A Post 08-03-2016 SB.2002.060RS EPI - ROB - 20 [ ORIGINAL PRIMARY M ND NORM ]",
        "DOB: 01/01/1975",
        "DOS: 06/10/2016 14:09:38"
    ]
}
```

Note in `master`:

- Quotation marks around numerical values;

- Erroneous double-nesting of `SliceTiming` (which `dwipreproc` is currently *assuming* is present, hence #1735 being to `master`);

- `comments` being a single string containing newline characters, rather than an array of strings.

Needs to go to `dev` since it's behaviour-changing.