### PR TITLE
tcken: Revert default maximum angle calculation

### DIFF
--- a/cmd/tckgen.cpp
+++ b/cmd/tckgen.cpp
@@ -60,7 +60,7 @@ void usage ()
       "to seed from new random locations until the target number of "
       "streamlines have been selected (in other words, after all inclusion & "
       "exclusion criteria have been applied), or the maximum number of seeds "
-      "has been exceeded (by default, this is 1000× the desired number of selected "
+      "has been exceeded (by default, this is 1000 x the desired number of selected "
       "streamlines). Use the -select and/or -seeds options to modify as "
       "required. See also the Seeding options section for alternative seeding "
       "strategies."

--- a/docs/reference/commands/tckgen.rst
+++ b/docs/reference/commands/tckgen.rst
@@ -21,7 +21,7 @@ Usage
 Description
 -----------
 
-By default, tckgen produces a fixed number of streamlines, by attempting to seed from new random locations until the target number of streamlines have been selected (in other words, after all inclusion & exclusion criteria have been applied), or the maximum number of seeds has been exceeded (by default, this is 1000× the desired number of selected streamlines). Use the -select and/or -seeds options to modify as required. See also the Seeding options section for alternative seeding strategies.
+By default, tckgen produces a fixed number of streamlines, by attempting to seed from new random locations until the target number of streamlines have been selected (in other words, after all inclusion & exclusion criteria have been applied), or the maximum number of seeds has been exceeded (by default, this is 1000 x the desired number of selected streamlines). Use the -select and/or -seeds options to modify as required. See also the Seeding options section for alternative seeding strategies.
 
 Below is a list of available tracking algorithms, the input image data that they require, and a brief description of their behaviour:
 
@@ -55,7 +55,7 @@ Streamlines tractography options
 
 -  **-step size** set the step size of the algorithm in mm (default is 0.1 x voxelsize; for iFOD2: 0.5 x voxelsize).
 
--  **-angle theta** set the maximum angle between successive steps: default is chosen such that minimum radius of curvature is one voxel; interpretation depends on order of integration (see Description).
+-  **-angle theta** set the maximum angle between successive steps (default is 90deg x stepsize / voxelsize)
 
 -  **-minlength value** set the minimum length of any track in mm (default is 5 x voxelsize without ACT, 2 x voxelsize with ACT).
 

--- a/src/dwi/tractography/algorithms/fact.h
+++ b/src/dwi/tractography/algorithms/fact.h
@@ -52,7 +52,7 @@ namespace MR
           if (rk4)
             throw Exception ("4th-order Runge-Kutta integration not valid for FACT algorithm");
 
-          set_step_size (rk4 ? 0.5f : 0.1f, false);
+          set_step_size (0.1f, false);
           set_num_points();
           set_cutoff (TCKGEN_DEFAULT_CUTOFF_FIXEL);
 

--- a/src/dwi/tractography/algorithms/iFOD1.h
+++ b/src/dwi/tractography/algorithms/iFOD1.h
@@ -57,10 +57,10 @@ namespace MR
             throw Exception ("Algorithm iFOD1 expects as input a spherical harmonic (SH) image");
           }
 
-          set_step_size (rk4 ? 0.5f : 0.1f, rk4);
+          set_step_size (0.1f, rk4);
           // max_angle needs to be set because it influences the cone in which FOD amplitudes are sampled
           if (rk4) {
-            max_angle_1o = 0.5 * max_angle_ho;
+            max_angle_1o = 0.5f * max_angle_ho;
             cos_max_angle_1o = std::cos (max_angle_1o);
           }
           sin_max_angle_1o = std::sin (max_angle_1o);

--- a/src/dwi/tractography/algorithms/iFOD2.h
+++ b/src/dwi/tractography/algorithms/iFOD2.h
@@ -79,7 +79,7 @@ namespace MR
                   properties.set (lmax, "lmax");
                   properties.set (num_samples, "samples_per_step");
                   properties.set (max_trials, "max_trials");
-                  fod_power = 1.0/num_samples;
+                  fod_power = 1.0f/num_samples;
                   properties.set (fod_power, "fod_power");
                   bool precomputed = true;
                   properties.set (precomputed, "sh_precomputed");
@@ -88,9 +88,9 @@ namespace MR
 
                   // num_samples is number of samples excluding first point
                   --num_samples;
-                  INFO ("iFOD2 using " + str(num_samples) + " vertices per " + str(step_size) + "mm step");
                   set_step_size (0.5f, true);
                   sin_max_angle_ho = std::sin (max_angle_ho);
+                  INFO ("iFOD2 using " + str(num_samples) + " vertices per " + str(step_size) + "mm step");
 
                   // iFOD2 by default downsamples after track propagation back to the desired 'step size'
                   //   i.e. the sub-step detail is removed from the output

--- a/src/dwi/tractography/algorithms/sd_stream.h
+++ b/src/dwi/tractography/algorithms/sd_stream.h
@@ -48,7 +48,7 @@ class SDStream : public MethodBase { MEMALIGN(SDStream)
           if (is_act() && act().backtrack())
             throw Exception ("Backtracking not valid for deterministic algorithms");
 
-          set_step_size (rk4 ? 0.5f : 0.1f, rk4);
+          set_step_size (0.1f, rk4);
           dot_threshold = std::cos (max_angle_1o);
           set_num_points();
           set_cutoff (TCKGEN_DEFAULT_CUTOFF_FOD);

--- a/src/dwi/tractography/algorithms/tensor_det.h
+++ b/src/dwi/tractography/algorithms/tensor_det.h
@@ -55,7 +55,7 @@ namespace MR
           if (is_act() && act().backtrack())
             throw Exception ("Backtracking not valid for deterministic algorithms");
 
-          set_step_size (rk4 ? 0.5f : 0.1f, rk4);
+          set_step_size (0.1f, rk4);
           set_num_points();
           set_cutoff (TCKGEN_DEFAULT_CUTOFF_FA);
 

--- a/src/dwi/tractography/tracking/shared.cpp
+++ b/src/dwi/tractography/tracking/shared.cpp
@@ -179,9 +179,9 @@ namespace MR
 
 
 
-        void SharedBase::set_step_size (float stepsize, bool is_higher_order)
+        void SharedBase::set_step_size (float voxel_frac, bool is_higher_order)
         {
-          step_size = stepsize * vox();
+          step_size = voxel_frac * vox();
           properties.set (step_size, "step_size");
           INFO ("step size = " + str (step_size) + " mm");
 
@@ -197,32 +197,26 @@ namespace MR
           const std::string angle_msg = is_higher_order ?
                                         "maximum angular change in fibre orientation per step" :
                                         "maximum deviation angle per step";
-          if (properties.find ("max_angle") == properties.end()) {
-            min_radius = vox();
-            max_angle_1o = 2.0f * std::asin (step_size / (2.0f * min_radius));
-            cos_max_angle_1o = std::cos (max_angle_1o);
-            const float max_angle_deg = max_angle_1o * 180.0f / Math::pi;
-            properties["max_angle"] = str (max_angle_deg);
-            INFO (angle_msg + " = " + str (max_angle_deg) + " deg");
-          } else {
-            max_angle_1o = to<float> (properties["max_angle"]);
-            INFO (angle_msg + " = " + str (max_angle_1o) + " deg");
-            // User provides angle at command-line in degrees, not radians
-            max_angle_1o *= Math::pi / 180.0f;
-            cos_max_angle_1o = std::cos (max_angle_1o);
-            min_radius = step_size / (2.0f * std::sin (0.5f * max_angle_1o));
-          }
+
+          max_angle_1o = 90.0f * step_size / vox();
+          properties.set (max_angle_1o, "max_angle");
+          INFO (angle_msg + " = " + str (max_angle_1o) + " deg");
+          // Both automated calculation of angle, and user-specified angles,
+          //   are in degrees
+          max_angle_1o *= Math::pi / 180.0;
+          cos_max_angle_1o = std::cos (max_angle_1o);
+
+          min_radius = step_size / (2.0f * std::sin (0.5f * max_angle_1o));
+          INFO ("Minimum radius of curvature = " + str(min_radius) + "mm");
 
           if (is_higher_order) {
             max_angle_ho = max_angle_1o;
             cos_max_angle_ho = cos_max_angle_1o;
             // Clear these variables so that the next() function of the underlying method
             //   does not enforce curvature constraints; rely on e.g. RK4 to do it
-            max_angle_1o = Math::pi;
+            max_angle_1o = float(Math::pi);
             cos_max_angle_1o = 0.0f;
           }
-
-          INFO ("Minimum radius of curvature = " + str(min_radius) + "mm");
         }
 
 
@@ -230,7 +224,7 @@ namespace MR
         void SharedBase::set_num_points()
         {
           // Angle around the circle of minimum radius for the given step size
-          const float angle_minradius_preds = 2.0 * std::asin (step_size / (2.0 * min_radius));
+          const float angle_minradius_preds = 2.0f * std::asin (step_size / (2.0f * min_radius));
           // Maximum inter-vertex distance after streamline has been downsampled
           const float max_step_postds = downsampler.get_ratio() * step_size;
 
@@ -245,9 +239,9 @@ namespace MR
           // Maximal angle around this minimum radius traversed after downsampling
           const float angle_minradius_postds = downsampler.get_ratio() * angle_minradius_preds;
           // Minimum chord length after streamline has been downsampled
-          const float min_step_postds = (angle_minradius_postds > 2.0 * Math::pi) ?
-                                        0.0 :
-                                        (2.0 * min_radius * std::sin (0.5 * angle_minradius_postds));
+          const float min_step_postds = (angle_minradius_postds > float(2.0 * Math::pi)) ?
+                                        0.0f :
+                                        (2.0f * min_radius * std::sin (0.5f * angle_minradius_postds));
 
           // What we need:
           //   - Before downsampling:

--- a/src/dwi/tractography/tracking/tractography.cpp
+++ b/src/dwi/tractography/tracking/tractography.cpp
@@ -48,9 +48,7 @@ namespace MR
           + Argument ("size").type_float (0.0)
 
       + Option ("angle",
-            "set the maximum angle between successive steps: "
-            "default is chosen such that minimum radius of curvature is one voxel; "
-            "interpretation depends on order of integration (see Description).")
+            "set the maximum angle between successive steps (default is 90deg x stepsize / voxelsize)")
           + Argument ("theta").type_float (0.0)
 
       + Option ("minlength",


### PR DESCRIPTION
First component of #1729. This reverts changes that affected default maximum angles for various tracking algorithms made in #1507. A second PR will then investigate potential changes to these defaults in a more targeted fashion.

Main changes being reverted can be found in the diff of #1507 [here](https://github.com/MRtrix3/mrtrix3/pull/1507/files#diff-8664fcc974921f94a61f6dd2bdc73f5a).