### PR TITLE
tckgen: Change default step size for RK4

### DIFF
--- a/docs/reference/commands/tckgen.rst
+++ b/docs/reference/commands/tckgen.rst
@@ -53,7 +53,7 @@ Streamlines tractography options
 
 -  **-select number** set the desired number of streamlines to be selected by tckgen, after all selection criteria have been applied (i.e. inclusion/exclusion ROIs, min/max length, etc). tckgen will keep seeding streamlines until this number of streamlines have been selected, or the maximum allowed number of seeds has been exceeded (see -seeds option). By default, 5000 streamlines are to be selected. Set to zero to disable, which will result in streamlines being seeded until the number specified by -seeds has been reached.
 
--  **-step size** set the step size of the algorithm in mm (default is 0.1 x voxelsize; for iFOD2: 0.5 x voxelsize).
+-  **-step size** set the step size of the algorithm in mm (default is 0.1 x voxelsize; if using RK4, 0.25 x voxelsize; for iFOD2: 0.5 x voxelsize).
 
 -  **-angle theta** set the maximum angle between successive steps (default is 90deg x stepsize / voxelsize)
 

--- a/src/dwi/tractography/algorithms/iFOD1.h
+++ b/src/dwi/tractography/algorithms/iFOD1.h
@@ -57,7 +57,7 @@ namespace MR
             throw Exception ("Algorithm iFOD1 expects as input a spherical harmonic (SH) image");
           }
 
-          set_step_size (0.1f, rk4);
+          set_step_size (rk4 ? 0.25f : 0.1f, rk4);
           // max_angle needs to be set because it influences the cone in which FOD amplitudes are sampled
           if (rk4) {
             max_angle_1o = 0.5f * max_angle_ho;

--- a/src/dwi/tractography/algorithms/nulldist.h
+++ b/src/dwi/tractography/algorithms/nulldist.h
@@ -43,7 +43,7 @@ namespace MR
         Shared (const std::string& diff_path, DWI::Tractography::Properties& property_set) :
           SharedBase (diff_path, property_set)
         {
-          set_step_size (rk4 ? 0.5f : 0.1f, rk4);
+          set_step_size (rk4 ? 0.25f : 0.1f, rk4);
           set_num_points();
           set_cutoff (0.0f);
           sin_max_angle_1o = std::sin (max_angle_1o);

--- a/src/dwi/tractography/algorithms/sd_stream.h
+++ b/src/dwi/tractography/algorithms/sd_stream.h
@@ -48,7 +48,7 @@ class SDStream : public MethodBase { MEMALIGN(SDStream)
           if (is_act() && act().backtrack())
             throw Exception ("Backtracking not valid for deterministic algorithms");
 
-          set_step_size (0.1f, rk4);
+          set_step_size (rk4 ? 0.25f : 0.1f, rk4);
           dot_threshold = std::cos (max_angle_1o);
           set_num_points();
           set_cutoff (TCKGEN_DEFAULT_CUTOFF_FOD);

--- a/src/dwi/tractography/algorithms/tensor_det.h
+++ b/src/dwi/tractography/algorithms/tensor_det.h
@@ -55,7 +55,7 @@ namespace MR
           if (is_act() && act().backtrack())
             throw Exception ("Backtracking not valid for deterministic algorithms");
 
-          set_step_size (0.1f, rk4);
+          set_step_size (rk4 ? 0.25f : 0.1f, rk4);
           set_num_points();
           set_cutoff (TCKGEN_DEFAULT_CUTOFF_FA);
 

--- a/src/dwi/tractography/tracking/tractography.cpp
+++ b/src/dwi/tractography/tracking/tractography.cpp
@@ -44,7 +44,7 @@ namespace MR
           + Argument ("number").type_integer (0)
 
       + Option ("step",
-            "set the step size of the algorithm in mm (default is 0.1 x voxelsize; for iFOD2: 0.5 x voxelsize).")
+            "set the step size of the algorithm in mm (default is 0.1 x voxelsize; if using RK4, 0.25 x voxelsize; for iFOD2: 0.5 x voxelsize).")
           + Argument ("size").type_float (0.0)
 
       + Option ("angle",


### PR DESCRIPTION
First proposed change to default tracking parameters aspart of #1729.

First-order algorithms use a very small default step size in order to mitigate curvature overshoot. An alternative solution to curvature overshoot is to use the 4th-order Runge-Kutta method. Therefore, when the latter is activated using the `-rk4` option in `tckgen`, there is no longer a good justification to keep the default step size very small. However in the current code, the same default step size of 1/10th of a voxel is used regardless of the use of RK4.

Initially I was going to make the default step size with RK4 1/2 of a voxel, mimicking the default for iFOD2. However I then considered that for default iFOD2 parameters, there are in fact 3 vertices per 1/2-voxel "step" that are used for sampling 5TT image / ROIs more densely. If the default step size for these first-order algorithms with RK4 were to be 1/2 the size of a diffusion image voxel, there may be a risk of "jumping" features that are defined at a smaller spatial scale. I therefore went for a compromise of 1/4 of a voxel size.

This brings run times with RK4 closer to that without. The fraction of streamlines retained vs. rejected is generally comparable between no RK4 / RK4 with 1/10th voxel step / RK4 with 1/4 voxel step. As far as results are concerned it's difficult to judge the tractograms as being any different.

(`iFOD1` and `sd_stream` outputs are looking particularly woeful however; the latter is probably related to #1630, may need to look into the former).

If this change is accepted it may alter the considerations within #1630.

There is also a further question in here with respect to the interaction between RK4 and the maximum angle. [Internally](https://github.com/MRtrix3/mrtrix3/blob/3.0_RC3/src/dwi/tractography/tracking/exec.h#L486-L520) RK4 involves taking two fibre orientation estimates at half a step size away from the current vertex. Currently, no maximum angle constraint is applied at those two points (with the exception of `ifod1`, which needs its rejection sampling constrained); the maximum angle constraint is only applied based on the fibre orientation estimate at the new vertex. Question is: Should a restriction of half / all of the maximum angle constraint be applied to those two interior calculation points? 

