### PR TITLE
Mtnormalise tests

### DIFF
--- a/cmd/mtnormalise.cpp
+++ b/cmd/mtnormalise.cpp
@@ -277,6 +277,7 @@ void run_primitive () {
   auto opt = get_options ("mask");
 
   auto orig_mask = MaskType::open (opt[0][0]);
+  check_dimensions (header_3D, orig_mask);
   auto initial_mask = MaskType::scratch (orig_mask, "Initial processing mask");
   auto mask = MaskType::scratch (orig_mask, "Processing mask");
   auto prev_mask = MaskType::scratch (orig_mask, "Previous processing mask");

--- a/testing/tests/dwi2fod
+++ b/testing/tests/dwi2fod
@@ -1,5 +1,5 @@
 dwi2fod csd dwi.mif response.txt - | testing_diff_image - dwi2fod/out.mif -voxel 1e-5
 dwi2fod csd dwi.mif -mask mask.mif response.txt - | testing_diff_image - dwi2fod/out_mask.mif -voxel 1e-5
 dwi2fod csd dwi.mif response.txt -lmax 12 - | testing_diff_image - dwi2fod/out_lmax12.mif -voxel 1e-5
-dwi2fod msmt_csd dwi2fod/msmt/dwi.mif dwi2fod/msmt/wm.txt tmp_wm.mif dwi2fod/msmt/gm.txt tmp_gm.mif dwi2fod/msmt/csf.txt tmp_csf.mif && mrcat tmp_wm.mif tmp_gm.mif tmp_csf.mif - -axis 3 | testing_diff_image - dwi2fod/msmt/out.mif -voxel 1e-5
-dwi2fod msmt_csd dwi2fod/msmt/dwi.mif -mask dwi2fod/msmt/mask.mif dwi2fod/msmt/wm.txt tmp_wm_m.mif dwi2fod/msmt/gm.txt tmp_gm_m.mif dwi2fod/msmt/csf.txt tmp_csf_m.mif && mrcat tmp_wm_m.mif tmp_gm_m.mif tmp_csf_m.mif - -axis 3 | testing_diff_image - dwi2fod/msmt/out_masked.mif -voxel 1e-5
+dwi2fod msmt_csd dwi2fod/msmt/dwi.mif dwi2fod/msmt/wm.txt tmp_wm.mif dwi2fod/msmt/gm.txt tmp_gm.mif dwi2fod/msmt/csf.txt tmp_csf.mif && testing_diff_image tmp_wm.mif dwi2fod/msmt/wm.mif -abs 1e-5 && testing_diff_image tmp_gm.mif dwi2fod/msmt/gm.mif -abs 1e-5 && testing_diff_image tmp_csf.mif dwi2fod/msmt/csf.mif -abs 1e-5
+dwi2fod msmt_csd dwi2fod/msmt/dwi.mif -mask dwi2fod/msmt/mask.mif dwi2fod/msmt/wm.txt tmp_wm_m.mif dwi2fod/msmt/gm.txt tmp_gm_m.mif dwi2fod/msmt/csf.txt tmp_csf_m.mif && testing_diff_image tmp_wm_m.mif dwi2fod/msmt/wm_masked.mif -abs 1e-5 && testing_diff_image tmp_gm_m.mif dwi2fod/msmt/gm_masked.mif -abs 1e-5 && testing_diff_image tmp_csf_m.mif dwi2fod/msmt/csf_masked.mif -abs 1e-5 

--- a/testing/tests/mtnormalise
+++ b/testing/tests/mtnormalise
@@ -1,0 +1,2 @@
+mtnormalise -mask dwi2fod/msmt/mask.mif dwi2fod/msmt/wm.mif tmp_wm.mif dwi2fod/msmt/gm.mif tmp_gm.mif dwi2fod/msmt/csf.mif tmp_csf.mif -check_norm tmp_field.mif && testing_diff_image tmp_wm.mif mtnormalise/wm.mif -abs 1e-5 && testing_diff_image tmp_gm.mif mtnormalise/gm.mif -abs 1e-5 && testing_diff_image tmp_csf.mif mtnormalise/csf.mif -abs 1e-5 && testing_diff_image tmp_field.mif mtnormalise/field.mif -abs 1e-5 
+


### PR DESCRIPTION
Add a test for `mtnormalise`. Note that this involved modifying the existing tests for `dwi2fod msmt_csd` to preserve separate outputs for WM, GM & CSF. 