### PR TITLE
MRView: report 3D texture size

### DIFF
--- a/src/gui/dialog/opengl.cpp
+++ b/src/gui/dialog/opengl.cpp
@@ -61,8 +61,8 @@ namespace MR
         root->appendChild (new TreeItem ("VSync", format.swapInterval() ? "on" : "off", root));
         root->appendChild (new TreeItem ("Multisample anti-aliasing", format.samples() ? str(format.samples()).c_str() : "off", root));
 
-        gl::GetIntegerv (gl::MAX_TEXTURE_SIZE, &i);
-        root->appendChild (new TreeItem ("Maximum texture size", str (i), root));
+        gl::GetIntegerv (gl::MAX_3D_TEXTURE_SIZE, &i);
+        root->appendChild (new TreeItem ("Maximum 3D texture size", str (i), root));
 
         QTreeView* view = new QTreeView;
         view->setModel (model);

--- a/src/gui/dialog/opengl.cpp
+++ b/src/gui/dialog/opengl.cpp
@@ -61,6 +61,9 @@ namespace MR
         root->appendChild (new TreeItem ("VSync", format.swapInterval() ? "on" : "off", root));
         root->appendChild (new TreeItem ("Multisample anti-aliasing", format.samples() ? str(format.samples()).c_str() : "off", root));
 
+        gl::GetIntegerv (gl::MAX_TEXTURE_SIZE, &i);
+        root->appendChild (new TreeItem ("Maximum 2D texture size", str (i), root));
+
         gl::GetIntegerv (gl::MAX_3D_TEXTURE_SIZE, &i);
         root->appendChild (new TreeItem ("Maximum 3D texture size", str (i), root));
 


### PR DESCRIPTION
Turns out the max texture size isn't the same for 2D and 3D textures... We basically only use 3D textures in `mrview`, so that's what should be reported in the OpenGL dialog. Could have saved me a lot of time debugging a non-issue...