### PR TITLE
Add copyright notice to non-CPP files

### DIFF
--- a/bin/5ttgen
+++ b/bin/5ttgen
@@ -1,5 +1,20 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 # Script that generates a five-tissue-type (5TT) segmented image: the format appropriate for ACT
 #
 # In this script, major stages of processing can be performed in one of two ways:

--- a/bin/blend
+++ b/bin/blend
@@ -1,4 +1,20 @@
 #!/usr/bin/env python2
+
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 import os
 import sys
 

--- a/bin/convert_bruker
+++ b/bin/convert_bruker
@@ -1,5 +1,20 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 import sys, os.path
 
 if len (sys.argv) != 3:

--- a/bin/dwi2response
+++ b/bin/dwi2response
@@ -1,5 +1,20 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 # Script for estimating response functions for spherical deconvolution
 # A number of different approaches are available within this script for performing response function estimation.
 

--- a/bin/dwibiascorrect
+++ b/bin/dwibiascorrect
@@ -1,5 +1,20 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 # Script that performs B1 field inhomogeneity correction for a DWI volume series
 # Bias field is typically estimated using the mean b=0 image, and subsequently used to correct all volumes
 

--- a/bin/dwicat
+++ b/bin/dwicat
@@ -1,5 +1,20 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 
 
 import json

--- a/bin/dwifslpreproc
+++ b/bin/dwifslpreproc
@@ -1,5 +1,20 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 # Script for performing DWI pre-processing using FSL 5.0 (onwards) tools eddy / topup / applytopup
 
 

--- a/bin/dwigradcheck
+++ b/bin/dwigradcheck
@@ -1,6 +1,19 @@
 #!/usr/bin/env python
 
-
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
 
 import copy, numbers, os, shutil, sys
 

--- a/bin/dwinormalise
+++ b/bin/dwinormalise
@@ -1,5 +1,20 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 # Script that performs intensity normalisation of DWIs in various ways
 
 

--- a/bin/dwishellmath
+++ b/bin/dwishellmath
@@ -1,5 +1,20 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 
 SUPPORTED_OPS = ['mean', 'median', 'sum', 'product', 'rms', 'norm', 'var', 'std', 'min', 'max', 'absmax', 'magmax']
 

--- a/bin/foreach
+++ b/bin/foreach
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
 
 
 import os, re, sys, threading

--- a/bin/gen_scheme
+++ b/bin/gen_scheme
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 set -e
 
 if [ "$#" -eq 0 ]; then
@@ -12,7 +27,7 @@ SYNOPSIS
 
        numPE        the number of phase-encoding directions to be included in
                     the scheme (most scanners will only support a single PE
-                    direction per sequence, so this will typically be 1). 
+                    direction per sequence, so this will typically be 1).
 
        bvalue       the b-value of the shell
 
@@ -24,7 +39,7 @@ DESCRIPTION
     This script generates a diffusion gradient table according to the
     parameters specified. For most users, something like the following would be
     appropriate:
-    
+
         gen_scheme 1 0 5 750 20 3000 60
 
     which will geneate a multi-shell diffusion gradient table with a single
@@ -32,13 +47,13 @@ DESCRIPTION
     volumes.
 
     The gradient table is generated using the following procedure:
-    
+
     - The directions for each shell are optimally distributed using a bipolar
-      electrostatic repulsion model (using the command 'dirgen'). 
+      electrostatic repulsion model (using the command 'dirgen').
 
     - These are then split into numPE sets (if numPE != 1) using a brute-force
       random search for the most optimally-distributed subsets (using the command
-      'dirsplit'). 
+      'dirsplit').
 
     - Each of the resulting sets is then rearranged by inversion of individual
       directions through the origin (i.e. direction vector x => -x) using a
@@ -53,13 +68,13 @@ DESCRIPTION
       b-value and directional domains. In other words, the approach aims to
       ensure that if the acquisition is cut short, the set of volumes acquired
       nonetheless contains the same relative proportions of b-values as
-      specified, with directions that are near-uniformly distributed. 
+      specified, with directions that are near-uniformly distributed.
 
     The primary output of this command is a file called 'dw_scheme.txt',
     consisting of a 5-column table, with one line per volume. Each column
     consists of [ x y z b PE ], where [ x y z ] is the unit direction vector, b
-    is the b-value in unit of s/mm², and PE is a integer ID from 1 to numPE. 
-    
+    is the b-value in unit of s/mm², and PE is a integer ID from 1 to numPE.
+
     The command also retains all of the subsets generated along the way, which
     you can safely delete once the command has completed. Since this can
     consist of quite a few files, it is recommended to run this command within
@@ -107,16 +122,16 @@ else
       if [ $nPE -gt 2 ]; then
         dirsplit dirs-b$1-$2-1.txt dirs-b$1-$2-1{1..2}.txt -force $perm
         dirsplit dirs-b$1-$2-2.txt dirs-b$1-$2-2{1..2}.txt -force $perm
-	# TODO: the rest...
-	for n in dirs-b$1-$2-{1,2}{1,2}.txt; do
+        # TODO: the rest...
+        for n in dirs-b$1-$2-{1,2}{1,2}.txt; do
           dirflip $n ${n%.txt}-flip.txt -force $perm
-	  merge=$merge" "${n%.txt}-flip.txt
+          merge=$merge" "${n%.txt}-flip.txt
         done
-      else 
+      else
         for n in dirs-b$1-$2-{1,2}.txt; do
           dirflip $n ${n%.txt}-flip.txt -force $perm
           merge=$merge" "${n%.txt}-flip.txt
-	done
+        done
       fi
     else
       dirflip dirs-b$1-$2.txt dirs-b$1-$2-flip.txt -force $perm

--- a/bin/labelsgmfix
+++ b/bin/labelsgmfix
@@ -1,5 +1,20 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 # Script for 'repairing' a FreeSurfer parcellation image
 # FreeSurfer's sub-cortical structure segmentation has been observed to be highly variable
 #   under scan-rescan conditions. This introduces unwanted variability into the connectome,

--- a/bin/mrtrix3.py
+++ b/bin/mrtrix3.py
@@ -1,3 +1,19 @@
+
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 import imp, os, sys
 from distutils.spawn import find_executable
 

--- a/bin/notfound
+++ b/bin/notfound
@@ -1,13 +1,28 @@
 #!/bin/bash
 
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 if [ $# -eq 0 ]; then
   cat << 'HELP_PAGE'
-USAGE: 
+USAGE:
   $ notfound base_directory search_string
 
-  This is a simple script designed to help identify subjects that do not yet have a specific file generated. For example when adding new patients to a study. It is designed to be used when each patient has a folder containing their images. 
+  This is a simple script designed to help identify subjects that do not yet have a specific file generated. For example when adding new patients to a study. It is designed to be used when each patient has a folder containing their images.
 
-  For example: 
+  For example:
     $ notfound study_folder fod.mif
   will identify all subject folders (e.g. study_folder/subject001, study_folder/subject002, ...) that do NOT contain a file fod.mif
 
@@ -16,7 +31,7 @@ USAGE:
 HELP_PAGE
 
 exit 1
-  
+
 fi
 
 find ${1} -mindepth 1 -maxdepth 1 \( -type l -o -type d \) '!' -exec test -e "{}/${2}" ';' -print

--- a/bin/population_template
+++ b/bin/population_template
@@ -1,5 +1,20 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 # Generates an unbiased group-average template via image registration of images to a midway space.
 
 

--- a/bin/responsemean
+++ b/bin/responsemean
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
 
 
 import math, os, sys

--- a/build
+++ b/build
@@ -1,5 +1,20 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 # pylint: disable=redefined-outer-name,invalid-name
 
 usage_string = '''

--- a/check_syntax
+++ b/check_syntax
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 LOG=syntax.log
 echo -n "Checking syntax and memory alignment for Eigen 3.3 compatibility... "
 echo "Checking syntax and memory alignment for Eigen 3.3 compatibility..." > $LOG

--- a/configure
+++ b/configure
@@ -1,5 +1,20 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 # pylint: disable=invalid-name
 
 usage_string = '''

--- a/docs/format_config_options
+++ b/docs/format_config_options
@@ -1,5 +1,20 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 import sys
 
 optionlist =  [ ]

--- a/docs/format_environment_variables
+++ b/docs/format_environment_variables
@@ -1,5 +1,20 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 import sys
 
 varlist =  [ ]

--- a/docs/generate_user_docs.sh
+++ b/docs/generate_user_docs.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 #
 # Generate .rst documentation for commands/scripts listing
 # Based off of the update_doc script originally used to update the MRtrix wiki

--- a/generate_bash_completion.py
+++ b/generate_bash_completion.py
@@ -1,4 +1,20 @@
 #!/usr/bin/env python
+
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 #
 # Generates bash completion file for MRtrix commands
 # MRtrix needs to be built prior to running this
@@ -12,42 +28,42 @@ import getopt, sys, os, re, subprocess, locale
 
 def usage():
   print ('''
-Usage:	%s -m [dir_path] -c [file_path]\n
-	-m, --mrtrix_commands_dir [dir path]: The directory where the mrtrix executable commands reside.
-	-c, --completion_path [file path]: The generated bash completion file path.
+Usage:  %s -m [dir_path] -c [file_path]\n
+        -m, --mrtrix_commands_dir [dir path]: The directory where the mrtrix executable commands reside.
+        -c, --completion_path [file path]: The generated bash completion file path.
 ''' % (sys.argv[0]))
 
 
 def main(argv):
-	try:
-		opts, args = getopt.getopt(argv, "m:c:", ["mrtrix_commands_dir=", "completion_path="])
-		if not opts or len(opts) != 2:
-			raise getopt.GetoptError('Incorrect number of arguments') 
-	except getopt.GetoptError:
-		usage()
-		sys.exit(2)
-	
-	commands_dir = ""
-	completion_path = ""
-	commands = []
+  try:
+    opts, args = getopt.getopt(argv, "m:c:", ["mrtrix_commands_dir=", "completion_path="])
+    if not opts or len(opts) != 2:
+      raise getopt.GetoptError('Incorrect number of arguments')
+  except getopt.GetoptError:
+    usage()
+    sys.exit(2)
 
-	for opt, arg in opts:
-		if opt in ("-m", "--mrtrix_commands_dir"):
-			commands_dir = arg
-		elif opt in ("-c", "--completion_path"):
-			completion_path = arg
-	
-	if not commands_dir or not os.path.isdir (commands_dir) or not completion_path:
-		usage()
-		sys.exit (2)
-	
-	# Filter out any non executable files or debug commands
-	commands = [comm for comm in os.listdir (commands_dir) if os.access ( os.path.join( commands_dir, comm ), os.X_OK) and not re.match (r'^\w+__debug', comm)]
+  commands_dir = ""
+  completion_path = ""
+  commands = []
 
-	if not commands:
-		sys.exit (0)
-	
-	parse_commands (commands_dir, completion_path, commands)
+  for opt, arg in opts:
+    if opt in ("-m", "--mrtrix_commands_dir"):
+      commands_dir = arg
+    elif opt in ("-c", "--completion_path"):
+      completion_path = arg
+
+  if not commands_dir or not os.path.isdir (commands_dir) or not completion_path:
+    usage()
+    sys.exit (2)
+
+  # Filter out any non executable files or debug commands
+  commands = [comm for comm in os.listdir (commands_dir) if os.access ( os.path.join( commands_dir, comm ), os.X_OK) and not re.match (r'^\w+__debug', comm)]
+
+  if not commands:
+    sys.exit (0)
+
+  parse_commands (commands_dir, completion_path, commands)
 
 
 
@@ -58,208 +74,208 @@ def main(argv):
 
 
 def parse_commands (commands_dir, completion_path, commands):
-		
-	completion_file = open (completion_path, 'w+')
-		
+
+  completion_file = open (completion_path, 'w+')
+
 ###########################################################################
 #                         INNER PARSE FUNCTIONS
 ###########################################################################
 
-	def flush_option_num_args ():
-		if not current_option:
-			print ('\t_%s_max_num_args() { echo %s; }\n' % (command, current_num_of_option_args), file = completion_file)
-		else:					
-			print ('\t_%s_%s_max_num_args() { echo %s; }\n' % (command, current_option, current_num_of_option_args), file = completion_file)
-	
-	def flush_option_arg ():
-		if not current_option:		
-			print ('\t_%s_arg_%s()' % (command, current_num_of_option_args), file = completion_file)
-		else:
-			print ('\t_%s_%s_arg_%s()' % (command, current_option, current_num_of_option_args), file = completion_file)
+  def flush_option_num_args ():
+    if not current_option:
+      print ('\t_%s_max_num_args() { echo %s; }\n' % (command, current_num_of_option_args), file = completion_file)
+    else:
+      print ('\t_%s_%s_max_num_args() { echo %s; }\n' % (command, current_option, current_num_of_option_args), file = completion_file)
 
-		print ('\t{ echo "%s"; }\n' % (current_arg_choices) , file = completion_file)
+  def flush_option_arg ():
+    if not current_option:
+      print ('\t_%s_arg_%s()' % (command, current_num_of_option_args), file = completion_file)
+    else:
+      print ('\t_%s_%s_arg_%s()' % (command, current_option, current_num_of_option_args), file = completion_file)
 
-	def	flush_option_arg_allows_multiple ():
-		if not current_option:	
-			print ('\t_%s_arg_%s_allows_multiple()' %  (command, current_num_of_option_args), file = completion_file)
-		else:
-			print ('\t_%s_%s_arg_%s_allows_multiple()' % (command, current_option, current_num_of_option_args), file = completion_file)
-		
-		print ('\t{ echo %s; }\n' % (current_arg_allows_multiple), file = completion_file)
-	
-	def parse_option_arg_choices (arg_type, choices = []):
-		arg_choices = ""
+    print ('\t{ echo "%s"; }\n' % (current_arg_choices) , file = completion_file)
 
-		if arg_type == 'CHOICE':
-			for choice in choices:
-				choice = choice.rstrip ()
-				# End of choice lists are generally delimited by -1
-				# however tckgen choices are delimited by 2 (?)
-				if choice in ['-1', '2']:
-					break;
-				else:
-					arg_choices +=  " " + choice
-		elif arg_type == 'IMAGEIN':
-			arg_choices ='`eval ls $1*.{mih,mif,nii,dcm,msf,hdr,mgh,nii.gz,mif.gz} 2> /dev/null | tr "\n" " "``eval ls -d $1*/ 2> /dev/null | tr "\n" " "`'
-		elif arg_type == 'FILEIN':
-			arg_choices ='`eval ls "$1*" 2> /dev/null | grep -E "$1*\.[^[:space:]]+"``eval ls -d $1*/ 2> /dev/null | tr "\n" " "`'
-		elif arg_type == 'TRACKSIN':
-			arg_choices ='`eval ls $1*.tck 2> /dev/null | tr "\n" " "``eval ls -d $1*/ 2> /dev/null | tr "\n" " "`'
-		#elif arg_type in ['FLOAT', 'INT']:
-		else:
-			arg_choices = "__empty__"
-		
+  def flush_option_arg_allows_multiple ():
+    if not current_option:
+      print ('\t_%s_arg_%s_allows_multiple()' %  (command, current_num_of_option_args), file = completion_file)
+    else:
+      print ('\t_%s_%s_arg_%s_allows_multiple()' % (command, current_option, current_num_of_option_args), file = completion_file)
 
-		return arg_choices
+    print ('\t{ echo %s; }\n' % (current_arg_allows_multiple), file = completion_file)
+
+  def parse_option_arg_choices (arg_type, choices = []):
+    arg_choices = ""
+
+    if arg_type == 'CHOICE':
+      for choice in choices:
+        choice = choice.rstrip ()
+        # End of choice lists are generally delimited by -1
+        # however tckgen choices are delimited by 2 (?)
+        if choice in ['-1', '2']:
+          break;
+        else:
+          arg_choices +=  " " + choice
+    elif arg_type == 'IMAGEIN':
+      arg_choices ='`eval ls $1*.{mih,mif,nii,dcm,msf,hdr,mgh,nii.gz,mif.gz} 2> /dev/null | tr "\n" " "``eval ls -d $1*/ 2> /dev/null | tr "\n" " "`'
+    elif arg_type == 'FILEIN':
+      arg_choices ='`eval ls "$1*" 2> /dev/null | grep -E "$1*\.[^[:space:]]+"``eval ls -d $1*/ 2> /dev/null | tr "\n" " "`'
+    elif arg_type == 'TRACKSIN':
+      arg_choices ='`eval ls $1*.tck 2> /dev/null | tr "\n" " "``eval ls -d $1*/ 2> /dev/null | tr "\n" " "`'
+    #elif arg_type in ['FLOAT', 'INT']:
+    else:
+      arg_choices = "__empty__"
+
+
+    return arg_choices
 
 
 ###########################################################################
 #                          IS_SCRIPT FUNCTION
 ###########################################################################
-	def is_script (command):
-		textchars = bytearray({7,8,9,10,12,13,27} | set(range(0x20, 0x100)) - {0x7f})
-		with open(os.path.join(commands_dir, command), "rb") as f:
-			bytes = f.read(1024)
-		return not bytes.translate(None, textchars)
+  def is_script (command):
+    textchars = bytearray({7,8,9,10,12,13,27} | set(range(0x20, 0x100)) - {0x7f})
+    with open(os.path.join(commands_dir, command), "rb") as f:
+      bytes = f.read(1024)
+    return not bytes.translate(None, textchars)
 
-	
+
 ###########################################################################
 #                         END INTERNAL FUNCTIONS
 ###########################################################################
 
-	encoding = locale.getdefaultlocale()[1]
+  encoding = locale.getdefaultlocale()[1]
 
-	for command in sorted(commands):
+  for command in sorted(commands):
 
-		if is_script(command):
-			continue
+    if is_script(command):
+      continue
 
-		single_dash_options = ""
-		double_dash_options = ""
-		current_option = ""
-		current_num_of_option_args = 0
-		current_arg = ""
-		current_arg_optional = -1
-		current_arg_allows_multiple = -1
-		current_arg_type = ""
-		current_arg_choices = ""			
+    single_dash_options = ""
+    double_dash_options = ""
+    current_option = ""
+    current_num_of_option_args = 0
+    current_arg = ""
+    current_arg_optional = -1
+    current_arg_allows_multiple = -1
+    current_arg_type = ""
+    current_arg_choices = ""
 
-		try:
-			process = subprocess.Popen ([ os.path.join( commands_dir, command ), '__print_full_usage__'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    try:
+      process = subprocess.Popen ([ os.path.join( commands_dir, command ), '__print_full_usage__'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
-			print ('''
+      print ('''
 _%s()
-{ 
+{
 ''' % (command), file = completion_file)
 
-			for line in process.stdout:
-				words = line.decode(encoding).split (' ')
-				
-				if not words:
-					continue				
-				
-				if words[0] == 'OPTION':
-					flush_option_num_args ()
-					current_arg = ""
-					current_arg_type = ""
-					current_option = words[1]
-					single_dash_options += ' -' + current_option
-					double_dash_options += ' --' + current_option
-					current_num_of_option_args = 0
-				elif words[0] == 'ARGUMENT':
-					current_arg = words[1]
-					current_arg_optional = words[2] 
-					current_arg_allows_multiple = words[3]
-					current_arg_type = words[4].rstrip ()
-					current_arg_choices = parse_option_arg_choices (current_arg_type, words[5:])
-					flush_option_arg_allows_multiple ()
-					flush_option_arg ()
-					current_num_of_option_args += 1
+      for line in process.stdout:
+        words = line.decode(encoding).split (' ')
 
-			flush_option_num_args ()
+        if not words:
+          continue
 
-			print ('''
-	current_option=""
-	current_max_args=0
-	current_arg_index=0;
-	consumed_option_tokens=0;
-	current_num_consumed_option_args=0;
-	first_option_consumed=0;
+        if words[0] == 'OPTION':
+          flush_option_num_args ()
+          current_arg = ""
+          current_arg_type = ""
+          current_option = words[1]
+          single_dash_options += ' -' + current_option
+          double_dash_options += ' --' + current_option
+          current_num_of_option_args = 0
+        elif words[0] == 'ARGUMENT':
+          current_arg = words[1]
+          current_arg_optional = words[2]
+          current_arg_allows_multiple = words[3]
+          current_arg_type = words[4].rstrip ()
+          current_arg_choices = parse_option_arg_choices (current_arg_type, words[5:])
+          flush_option_arg_allows_multiple ()
+          flush_option_arg ()
+          current_num_of_option_args += 1
 
-	COMPREPLY=();
-	cur="${COMP_WORDS[COMP_CWORD]}";
-	cur_filtered=`echo "${COMP_WORDS[COMP_CWORD]}" | sed 's/\..*$//g'`;
+      flush_option_num_args ()
 
-	if [[ "$cur" == --* ]]; then
-		COMPREPLY=( $( compgen -W "%s" -- "$cur" ) );
-	elif [[ "$cur" == -* ]]; then
-		COMPREPLY=( $( compgen -W "%s" -- "$cur" ) );
-	else
-		current_option=""
-		word=""	
-		array=""	
+      print ('''
+  current_option=""
+  current_max_args=0
+  current_arg_index=0;
+  consumed_option_tokens=0;
+  current_num_consumed_option_args=0;
+  first_option_consumed=0;
 
-		for ((i=${#COMP_WORDS[@]}-2; i>=0; i--)); do
-  			word="${COMP_WORDS[$i]}"
-			if [[ "$word" == -* ]]; then
-				option=$(echo $word | sed -E "s/-//g");
-				if [[ ${#option} == 0 ]]; then
-					continue; 
-				fi
-				arg_index=$(( $COMP_CWORD - $i - 1));
-				max_args=$(_%s_${option}_max_num_args);
-				
-				current_num_consumed_option_args=$((current_num_consumed_option_args > max_args ? max_args : current_num_consumed_option_args))
-				consumed_option_tokens=$(($current_consumed_option_tokens + $current_num_consumed_option_args + 1))
-				current_num_consumed_option_args=0;
-				
-				if (( first_option_consumed == 0 )); then
-					current_option="$option";
-					current_arg_index=$arg_index;
-					current_max_args=$max_args;
-					first_option_consumed=1;
-				fi
-				
-			else
-				current_num_consumed_option_args=$(($current_num_option_args + 1));
-			fi
-		done
+  COMPREPLY=();
+  cur="${COMP_WORDS[COMP_CWORD]}";
+  cur_filtered=`echo "${COMP_WORDS[COMP_CWORD]}" | sed 's/\..*$//g'`;
 
-		if [[ "$current_option" != "" ]] && (( $current_arg_index >= 0 && $current_arg_index < $current_max_args )); then
-			array=`_%s_${current_option}_arg_${current_arg_index} $cur_filtered`
-		else
-			current_arg_index=$(($COMP_CWORD - $consumed_option_tokens - 1));		
-			current_max_args=$(_%s_max_num_args);
+  if [[ "$cur" == --* ]]; then
+    COMPREPLY=( $( compgen -W "%s" -- "$cur" ) );
+  elif [[ "$cur" == -* ]]; then
+    COMPREPLY=( $( compgen -W "%s" -- "$cur" ) );
+  else
+    current_option=""
+    word=""
+    array=""
 
-			# Check whether any of our arguments accepts multiple inputs
-			# If so, adjust the argument index to be the min. of these
-			for ((i=${current_max_args} - 1; i>=0; i--)); do
-				if (( $(_%s_arg_${i}_allows_multiple) == 1 )); then
-					current_arg_index=$((current_arg_index > i ? i : current_arg_index))
-				fi
-			done
+    for ((i=${#COMP_WORDS[@]}-2; i>=0; i--)); do
+        word="${COMP_WORDS[$i]}"
+      if [[ "$word" == -* ]]; then
+        option=$(echo $word | sed -E "s/-//g");
+        if [[ ${#option} == 0 ]]; then
+          continue;
+        fi
+        arg_index=$(( $COMP_CWORD - $i - 1));
+        max_args=$(_%s_${option}_max_num_args);
 
-			if (( $current_arg_index >= 0 && $current_arg_index < $current_max_args )); then
-				array=`_%s_arg_${current_arg_index} $cur_filtered`;
-			fi
-		fi
+        current_num_consumed_option_args=$((current_num_consumed_option_args > max_args ? max_args : current_num_consumed_option_args))
+        consumed_option_tokens=$(($current_consumed_option_tokens + $current_num_consumed_option_args + 1))
+        current_num_consumed_option_args=0;
 
-		if [[ "$array" == "__empty__" ]]; then
-			COMPREPLY=()
-			compopt +o default %s;
-		else
-			mapfile -t COMPREPLY < <( compgen -W "$array" -- "$cur" )
-			compopt -o default %s;
-		fi
-	fi
+        if (( first_option_consumed == 0 )); then
+          current_option="$option";
+          current_arg_index=$arg_index;
+          current_max_args=$max_args;
+          first_option_consumed=1;
+        fi
+
+      else
+        current_num_consumed_option_args=$(($current_num_option_args + 1));
+      fi
+    done
+
+    if [[ "$current_option" != "" ]] && (( $current_arg_index >= 0 && $current_arg_index < $current_max_args )); then
+      array=`_%s_${current_option}_arg_${current_arg_index} $cur_filtered`
+    else
+      current_arg_index=$(($COMP_CWORD - $consumed_option_tokens - 1));
+      current_max_args=$(_%s_max_num_args);
+
+      # Check whether any of our arguments accepts multiple inputs
+      # If so, adjust the argument index to be the min. of these
+      for ((i=${current_max_args} - 1; i>=0; i--)); do
+        if (( $(_%s_arg_${i}_allows_multiple) == 1 )); then
+          current_arg_index=$((current_arg_index > i ? i : current_arg_index))
+        fi
+      done
+
+      if (( $current_arg_index >= 0 && $current_arg_index < $current_max_args )); then
+        array=`_%s_arg_${current_arg_index} $cur_filtered`;
+      fi
+    fi
+
+    if [[ "$array" == "__empty__" ]]; then
+      COMPREPLY=()
+      compopt +o default %s;
+    else
+      mapfile -t COMPREPLY < <( compgen -W "$array" -- "$cur" )
+      compopt -o default %s;
+    fi
+  fi
 }
 complete -F _%s %s \n''' % (double_dash_options, single_dash_options, command, command, command, command, command, command, command, command, command), file = completion_file)
 
-		except:
-			pass
+    except:
+      pass
 
-	completion_file.close ()
+  completion_file.close ()
 
 
 if __name__ == "__main__":
-	main(sys.argv[1:])
+  main(sys.argv[1:])

--- a/install_mime_types.sh
+++ b/install_mime_types.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 for s in 16 32 48 64 128; do
   for t in mrtrix mrtrix-gz nifti nifti-gz mgh mgz analyze; do #TODO add mrtrix-tracks
     xdg-icon-resource install --context apps --size $s icons/desktop/${s}x${s}/mrtrix.png application-x-${t}

--- a/lib/mrtrix3/_5ttgen/freesurfer.py
+++ b/lib/mrtrix3/_5ttgen/freesurfer.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 import os.path, shutil
 from mrtrix3 import MRtrixError
 from mrtrix3 import app, path, run

--- a/lib/mrtrix3/_5ttgen/fsl.py
+++ b/lib/mrtrix3/_5ttgen/fsl.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 import math, os
 from distutils.spawn import find_executable
 from mrtrix3 import MRtrixError

--- a/lib/mrtrix3/_5ttgen/gif.py
+++ b/lib/mrtrix3/_5ttgen/gif.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 import os
 from mrtrix3 import MRtrixError
 from mrtrix3 import app, image, path, run

--- a/lib/mrtrix3/__init__.py
+++ b/lib/mrtrix3/__init__.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 import inspect, os, sys
 from collections import namedtuple
 try:

--- a/lib/mrtrix3/algorithm.py
+++ b/lib/mrtrix3/algorithm.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 # Set of functionalities for when a single script has many 'algorithms' that may be invoked,
 #   i.e. the script deals with generating a particular output, but there are a number of
 #   processes to select from, each of which is capable of generating that output.

--- a/lib/mrtrix3/app.py
+++ b/lib/mrtrix3/app.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 import argparse, inspect, math, os, random, shlex, shutil, signal, string, subprocess, sys, textwrap
 import mrtrix3
 from mrtrix3 import ANSI, CONFIG, MRtrixError, setup_ansi

--- a/lib/mrtrix3/dwi2response/dhollander.py
+++ b/lib/mrtrix3/dwi2response/dhollander.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 import math, shutil
 from mrtrix3 import CONFIG, MRtrixError
 from mrtrix3 import app, image, path, run

--- a/lib/mrtrix3/dwi2response/fa.py
+++ b/lib/mrtrix3/dwi2response/fa.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 import shutil
 from mrtrix3 import MRtrixError
 from mrtrix3 import app, image, path, run

--- a/lib/mrtrix3/dwi2response/manual.py
+++ b/lib/mrtrix3/dwi2response/manual.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 import os, shutil
 from mrtrix3 import MRtrixError
 from mrtrix3 import app, image, path, run

--- a/lib/mrtrix3/dwi2response/msmt_5tt.py
+++ b/lib/mrtrix3/dwi2response/msmt_5tt.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 import os, shutil
 from mrtrix3 import MRtrixError
 from mrtrix3 import app, image, path, run

--- a/lib/mrtrix3/dwi2response/tax.py
+++ b/lib/mrtrix3/dwi2response/tax.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 import math, os, shutil
 from mrtrix3 import MRtrixError
 from mrtrix3 import app, image, matrix, path, run

--- a/lib/mrtrix3/dwi2response/tournier.py
+++ b/lib/mrtrix3/dwi2response/tournier.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 import os, shutil
 from mrtrix3 import MRtrixError
 from mrtrix3 import app, image, matrix, path, run

--- a/lib/mrtrix3/dwibiascorrect/ants.py
+++ b/lib/mrtrix3/dwibiascorrect/ants.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 from distutils.spawn import find_executable
 from mrtrix3 import MRtrixError
 from mrtrix3 import app, path, run

--- a/lib/mrtrix3/dwibiascorrect/fsl.py
+++ b/lib/mrtrix3/dwibiascorrect/fsl.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 import os
 from mrtrix3 import MRtrixError
 from mrtrix3 import app, fsl, path, run, utils

--- a/lib/mrtrix3/dwinormalise/group.py
+++ b/lib/mrtrix3/dwinormalise/group.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 import os
 from mrtrix3 import MRtrixError
 from mrtrix3 import app, image, path, run

--- a/lib/mrtrix3/dwinormalise/individual.py
+++ b/lib/mrtrix3/dwinormalise/individual.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 from mrtrix3 import app, path, run
 
 

--- a/lib/mrtrix3/fsl.py
+++ b/lib/mrtrix3/fsl.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 import os
 from distutils.spawn import find_executable
 from mrtrix3 import MRtrixError

--- a/lib/mrtrix3/image.py
+++ b/lib/mrtrix3/image.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 # A collection of functions for extracting information from images. Mostly these involve
 #   calling the relevant MRtrix3 binaries in order to parse image headers / process image
 #   data, rather than trying to duplicate support for all possible image formats natively

--- a/lib/mrtrix3/matrix.py
+++ b/lib/mrtrix3/matrix.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 # Various utility functions related to vector and matrix data
 
 

--- a/lib/mrtrix3/path.py
+++ b/lib/mrtrix3/path.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 # Collection of convenience functions for manipulating filesystem paths
 
 

--- a/lib/mrtrix3/phaseencoding.py
+++ b/lib/mrtrix3/phaseencoding.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 # Functions relating to handling phase encoding information
 
 

--- a/lib/mrtrix3/run.py
+++ b/lib/mrtrix3/run.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 import collections, itertools, os, shlex, signal, string, subprocess, sys, tempfile, threading
 from distutils.spawn import find_executable
 from mrtrix3 import ANSI, BIN_PATH, COMMAND_HISTORY_STRING, EXE_LIST, MRtrixBaseError, MRtrixError

--- a/lib/mrtrix3/utils.py
+++ b/lib/mrtrix3/utils.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 # Various utility functions / classes that don't sensibly slot into any other module
 
 

--- a/matlab/read_mrtrix.m
+++ b/matlab/read_mrtrix.m
@@ -1,8 +1,23 @@
+% Copyright (c) 2008-2019 the MRtrix3 contributors.
+%
+% This Source Code Form is subject to the terms of the Mozilla Public
+% License, v. 2.0. If a copy of the MPL was not distributed with this
+% file, You can obtain one at http://mozilla.org/MPL/2.0/.
+%
+% Covered Software is provided under this License on an "as is"
+% basis, without warranty of any kind, either expressed, implied, or
+% statutory, including, without limitation, warranties that the
+% Covered Software is free of defects, merchantable, fit for a
+% particular purpose or non-infringing.
+% See the Mozilla Public License v. 2.0 for more details.
+%
+% For more details, see http://www.mrtrix.org/.
+
 function image = read_mrtrix (filename)
 
 % function: image = read_mrtrix (filename)
 %
-% returns a structure containing the header information and data for the MRtrix 
+% returns a structure containing the header information and data for the MRtrix
 % format image 'filename' (i.e. files with the extension '.mif' or '.mih').
 
 f = fopen (filename, 'r');
@@ -41,7 +56,7 @@ while 1
       file = value;
     elseif strcmp(key, 'dw_scheme')
       dw_scheme(end+1,:) = str2num(char(split_strings (value, ',')))';
-    else 
+    else
       image = add_field (image, key, value);
     end
   end
@@ -80,12 +95,12 @@ if strcmp(byteorder, 'le')
 elseif strcmp(byteorder, 'be')
   f = fopen (file, 'r', 'b');
   datatype = datatype(1:end-2);
-else 
+else
   if strcmp(datatype, 'bit')
     datatype = 'bit1';
-    f = fopen(file, 'r', 'b'); 
+    f = fopen(file, 'r', 'b');
   else
-    f = fopen(file, 'r'); 
+    f = fopen(file, 'r');
   end
 end
 

--- a/matlab/read_mrtrix_tracks.m
+++ b/matlab/read_mrtrix_tracks.m
@@ -1,9 +1,24 @@
+% Copyright (c) 2008-2019 the MRtrix3 contributors.
+%
+% This Source Code Form is subject to the terms of the Mozilla Public
+% License, v. 2.0. If a copy of the MPL was not distributed with this
+% file, You can obtain one at http://mozilla.org/MPL/2.0/.
+%
+% Covered Software is provided under this License on an "as is"
+% basis, without warranty of any kind, either expressed, implied, or
+% statutory, including, without limitation, warranties that the
+% Covered Software is free of defects, merchantable, fit for a
+% particular purpose or non-infringing.
+% See the Mozilla Public License v. 2.0 for more details.
+%
+% For more details, see http://www.mrtrix.org/.
+
 function tracks = read_mrtrix_tracks (filename)
 
 % function: tracks = read_mrtrix_tracks (filename)
 %
-% returns a structure containing the header information and data for the MRtrix 
-% format track file 'filename' (i.e. files with the extension '.tck'). 
+% returns a structure containing the header information and data for the MRtrix
+% format track file 'filename' (i.e. files with the extension '.tck').
 % The track data will be stored as a cell array in the 'data' field of the
 % return variable.
 
@@ -32,7 +47,7 @@ while 1
       file = value;
     elseif strcmp(key, 'datatype')
       tracks.datatype = value;
-    else 
+    else
       tracks = add_field (tracks, key, value);
     end
   end

--- a/matlab/read_mrtrix_tsf.m
+++ b/matlab/read_mrtrix_tsf.m
@@ -1,12 +1,27 @@
+% Copyright (c) 2008-2019 the MRtrix3 contributors.
+%
+% This Source Code Form is subject to the terms of the Mozilla Public
+% License, v. 2.0. If a copy of the MPL was not distributed with this
+% file, You can obtain one at http://mozilla.org/MPL/2.0/.
+%
+% Covered Software is provided under this License on an "as is"
+% basis, without warranty of any kind, either expressed, implied, or
+% statutory, including, without limitation, warranties that the
+% Covered Software is free of defects, merchantable, fit for a
+% particular purpose or non-infringing.
+% See the Mozilla Public License v. 2.0 for more details.
+%
+% For more details, see http://www.mrtrix.org/.
+
 function tsf = read_mrtrix_tsf (filename)
 
-% function: tracks = read_mrtrix_tsf (filename)
+% function: tsf = read_mrtrix_tsf (filename)
 %
-% returns a structure containing the header information and data for the MRtrix 
+% returns a structure containing the header information and data for the MRtrix
 % format tsf 'filename' (i.e. files with the extension '.tsf').
 
 f = fopen (filename, 'r');
-if (f<1) 
+if (f<1)
   disp (['error opening ' filename ]);
   return
 end
@@ -34,7 +49,7 @@ while 1
       file = value;
     elseif strcmp(key, 'datatype')
       tsf.datatype = value;
-    else 
+    else
       tsf = setfield (tsf, key, value);
     end
   end
@@ -72,7 +87,7 @@ else
   return;
 end
 
-if (f<1) 
+if (f<1)
   disp (['error opening ' filename ]);
   return
 end
@@ -89,5 +104,5 @@ for n = 1:(prod(size(k)))
   tsf.data{end+1} = data(pk:(k(n)-1),:);
   pk = k(n)+1;
 end
-  
+
 

--- a/matlab/write_mrtrix.m
+++ b/matlab/write_mrtrix.m
@@ -1,8 +1,23 @@
+% Copyright (c) 2008-2019 the MRtrix3 contributors.
+%
+% This Source Code Form is subject to the terms of the Mozilla Public
+% License, v. 2.0. If a copy of the MPL was not distributed with this
+% file, You can obtain one at http://mozilla.org/MPL/2.0/.
+%
+% Covered Software is provided under this License on an "as is"
+% basis, without warranty of any kind, either expressed, implied, or
+% statutory, including, without limitation, warranties that the
+% Covered Software is free of defects, merchantable, fit for a
+% particular purpose or non-infringing.
+% See the Mozilla Public License v. 2.0 for more details.
+%
+% For more details, see http://www.mrtrix.org/.
+
 function write_mrtrix (image, filename)
 
 % function: write_mrtrix (image, filename)
 %
-% write the data contained in the structure 'image' in the MRtrix 
+% write the data contained in the structure 'image' in the MRtrix
 % format image 'filename' (i.e. files with the extension '.mif' or '.mih').
 %
 % 'image' is either a N-dimensional array (N <= 16), or a structure containing
@@ -27,7 +42,7 @@ end
 
 while prod(size(dim)) < 3
   dim(end+1) = 1;
-end 
+end
 
 fprintf (fid, '%d', dim(1));
 fprintf (fid, ',%d', dim(2:end));
@@ -35,7 +50,7 @@ fprintf (fid, ',%d', dim(2:end));
 fprintf (fid, '\nvox: ');
 if isstruct (image) && isfield (image, 'vox')
   fprintf (fid, '%.3f', image.vox(1));
-  fprintf (fid, ',%.3f', image.vox(2:end)); 
+  fprintf (fid, ',%.3f', image.vox(2:end));
 else
   fprintf(fid, '2');
   fprintf(fid, ',%d', 2*ones(1,size(dim,2)-1));
@@ -55,7 +70,7 @@ if isstruct (image) && isfield (image, 'datatype')
   elseif strcmp(byteorder, 'be')
     precision = datatype(1:end-2);
     byteorder = 'b';
-  else 
+  else
     if strcmp(datatype, 'bit')
       precision = 'bit1';
       byteorder = 'n';
@@ -66,15 +81,15 @@ if isstruct (image) && isfield (image, 'datatype')
         datatype(end+1:end+3) = 'le';
       else
         datatype(end+1:end+3) = 'be';
-      end 
+      end
     end
   end
 else
   if endian == 'L'
     datatype = 'float32le';
-  else 
+  else
     datatype = 'float32be';
-  end 
+  end
   precision = 'float32';
   byteorder = 'n';
 end
@@ -109,7 +124,7 @@ if isstruct (image)
   f(strcmp(f,'transform')) = [];
   f(strcmp(f,'dw_scheme')) = [];
   f(strcmp(f,'data')) = [];
-  
+
   % write out contents of the remainging fields:
   for n = 1:numel(f)
     val = getfield (image, f{n});
@@ -122,7 +137,7 @@ if isstruct (image)
     end
   end
 end
- 
+
 
 if strcmp(filename(end-3:end), '.mif')
   datafile = filename;

--- a/matlab/write_mrtrix_tracks.m
+++ b/matlab/write_mrtrix_tracks.m
@@ -1,3 +1,18 @@
+% Copyright (c) 2008-2019 the MRtrix3 contributors.
+%
+% This Source Code Form is subject to the terms of the Mozilla Public
+% License, v. 2.0. If a copy of the MPL was not distributed with this
+% file, You can obtain one at http://mozilla.org/MPL/2.0/.
+%
+% Covered Software is provided under this License on an "as is"
+% basis, without warranty of any kind, either expressed, implied, or
+% statutory, including, without limitation, warranties that the
+% Covered Software is free of defects, merchantable, fit for a
+% particular purpose or non-infringing.
+% See the Mozilla Public License v. 2.0 for more details.
+%
+% For more details, see http://www.mrtrix.org/.
+
 function write_mrtrix_tracks (tracks, filename)
 
 % function: write_mrtrix_tracks (tracks, filename)

--- a/matlab/write_mrtrix_tsf.m
+++ b/matlab/write_mrtrix_tsf.m
@@ -1,3 +1,18 @@
+% Copyright (c) 2008-2019 the MRtrix3 contributors.
+%
+% This Source Code Form is subject to the terms of the Mozilla Public
+% License, v. 2.0. If a copy of the MPL was not distributed with this
+% file, You can obtain one at http://mozilla.org/MPL/2.0/.
+%
+% Covered Software is provided under this License on an "as is"
+% basis, without warranty of any kind, either expressed, implied, or
+% statutory, including, without limitation, warranties that the
+% Covered Software is free of defects, merchantable, fit for a
+% particular purpose or non-infringing.
+% See the Mozilla Public License v. 2.0 for more details.
+%
+% For more details, see http://www.mrtrix.org/.
+
 function write_mrtrix_tsf (tsf, filename)
 
 % function: write_mrtrix_tsf (tracks, filename)

--- a/package_mrtrix
+++ b/package_mrtrix
@@ -1,4 +1,20 @@
 #!/bin/bash
+
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 cat <<EOF
 This script collates all the executables and runtime dependencies needed for
 MRtrix3, and creates a GZ compressed archive suitable for deployment on other
@@ -30,8 +46,8 @@ read
   set -e
   mkdir -p _package/mrtrix3/
   cp -r bin/ _package/mrtrix3/
-  cp -r lib/ _package/mrtrix3/ 
-  cp -r share/ _package/mrtrix3/ 
+  cp -r lib/ _package/mrtrix3/
+  cp -r share/ _package/mrtrix3/
 
   [ ${1:-"x"} == "-standalone" ] && (
     cat > _package/mrtrix3/launcher <<"EOF"
@@ -45,7 +61,7 @@ EOF
     (
       cd _package/mrtrix3/bin
       for n in *; do
-      file $n | grep -q script || ( 
+      file $n | grep -q script || (
         mv $n ../exe
         ln -s ../launcher $n
       )

--- a/run_pylint
+++ b/run_pylint
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 LOGFILE=pylint.log
 echo logging to \""$LOGFILE"\"
 

--- a/run_tests
+++ b/run_tests
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 LOGFILE=testing.log
 echo logging to \""$LOGFILE"\"
 

--- a/set_path
+++ b/set_path
@@ -1,5 +1,20 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 # automatically set the PATH environment variable to include the MRtrix3
 # executables and scripts. This script must be run after a successful build,
 # from the MRtrix3 toplevel folder:

--- a/share/mrtrix3/_5ttgen/FreeSurfer2ACT.txt
+++ b/share/mrtrix3/_5ttgen/FreeSurfer2ACT.txt
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 # Config file to convert FreeSurfer volumetric segmentation outputs
 #   into a format that can be used in Anatomically-Constrained Tractography
 
@@ -835,7 +850,7 @@
 3   wm_lh_S_temporal_inf
 3   wm_lh_S_temporal_sup
 3   wm_lh_S_temporal_transverse
- 
+
 3   wm_rh_Unknown
 3   wm_rh_G_and_S_frontomargin
 3   wm_rh_G_and_S_occipital_inf

--- a/share/mrtrix3/_5ttgen/FreeSurfer2ACT_sgm_amyg_hipp.txt
+++ b/share/mrtrix3/_5ttgen/FreeSurfer2ACT_sgm_amyg_hipp.txt
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 # Config file to convert FreeSurfer volumetric segmentation outputs
 #   into a format that can be used in Anatomically-Constrained Tractography
 
@@ -818,7 +833,7 @@
 3   wm_lh_S_temporal_inf
 3   wm_lh_S_temporal_sup
 3   wm_lh_S_temporal_transverse
- 
+
 3   wm_rh_Unknown
 3   wm_rh_G_and_S_frontomargin
 3   wm_rh_G_and_S_occipital_inf

--- a/share/mrtrix3/labelconvert/aal.txt
+++ b/share/mrtrix3/labelconvert/aal.txt
@@ -1,3 +1,17 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
 
 0    ???         Unknown                 0   0   0   0
 

--- a/share/mrtrix3/labelconvert/aal2.txt
+++ b/share/mrtrix3/labelconvert/aal2.txt
@@ -1,3 +1,17 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
 
 0    ???         Unknown                0   0   0   0
 

--- a/share/mrtrix3/labelconvert/fs2lobes_cinginc_convert.txt
+++ b/share/mrtrix3/labelconvert/fs2lobes_cinginc_convert.txt
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 # Lookup table for MRtrix command labelconvert
 # Extracts the relevant grey matter parcellations from the default FreeSurfer segmentation (desikan_killiany), but segmentations are summarised into lobes and subcortical areas
 # Cingulate nodes are included in the (approximately) relevant lobes
@@ -87,12 +102,12 @@
 11    ctx-rh-precuneus
 12    ctx-rh-rostralanteriorcingulate
 12    ctx-rh-rostralmiddlefrontal
-12    ctx-rh-superiorfrontal     
-11    ctx-rh-superiorparietal    
-9     ctx-rh-superiortemporal    
-11    ctx-rh-supramarginal       
-12    ctx-rh-frontalpole         
-9     ctx-rh-temporalpole        
-9     ctx-rh-transversetemporal  
+12    ctx-rh-superiorfrontal
+11    ctx-rh-superiorparietal
+9     ctx-rh-superiortemporal
+11    ctx-rh-supramarginal
+12    ctx-rh-frontalpole
+9     ctx-rh-temporalpole
+9     ctx-rh-transversetemporal
 #x    ctx-rh-insula
 

--- a/share/mrtrix3/labelconvert/fs2lobes_cinginc_labels.txt
+++ b/share/mrtrix3/labelconvert/fs2lobes_cinginc_labels.txt
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 # Lookup table file to accompany conversion file fs2lobes_cinginc_convert.txt
 # Following conversion of a label image to the targets as defined in the file fs2lobes_cinginc_convert.txt, this file provides the labels for the resulting image.
 

--- a/share/mrtrix3/labelconvert/fs2lobes_cingsep_convert.txt
+++ b/share/mrtrix3/labelconvert/fs2lobes_cingsep_convert.txt
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 # Lookup table for MRtrix command labelconvert
 # Extracts the relevant grey matter parcellations from the default FreeSurfer segmentation (desikan_killiany), but segmentations are summarised into lobes and subcortical areas
 # Cingulate regions are combined to produce their own separate 'cingulate lobe' nodes
@@ -87,12 +102,12 @@
 13    ctx-rh-precuneus
 10    ctx-rh-rostralanteriorcingulate
 14    ctx-rh-rostralmiddlefrontal
-14    ctx-rh-superiorfrontal     
-13    ctx-rh-superiorparietal    
-11    ctx-rh-superiortemporal    
-13    ctx-rh-supramarginal       
-14    ctx-rh-frontalpole         
-11    ctx-rh-temporalpole        
-11    ctx-rh-transversetemporal  
+14    ctx-rh-superiorfrontal
+13    ctx-rh-superiorparietal
+11    ctx-rh-superiortemporal
+13    ctx-rh-supramarginal
+14    ctx-rh-frontalpole
+11    ctx-rh-temporalpole
+11    ctx-rh-transversetemporal
 #x    ctx-rh-insula
 

--- a/share/mrtrix3/labelconvert/fs2lobes_cingsep_labels.txt
+++ b/share/mrtrix3/labelconvert/fs2lobes_cingsep_labels.txt
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 # Lookup table file to accompany conversion file fs2lobes_cingsep_convert.txt
 # Following conversion of a label image to the targets as defined in the file fs2lobes_cingsep_convert.txt, this file provides the labels for the resulting image.
 

--- a/share/mrtrix3/labelconvert/fs_a2009s.txt
+++ b/share/mrtrix3/labelconvert/fs_a2009s.txt
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 # Lookup table for extracting the relevant grey matter parcellations from the a2009s FreeSurfer segmentation
 
 0      Unknown                          0   0   0   0

--- a/share/mrtrix3/labelconvert/fs_default.txt
+++ b/share/mrtrix3/labelconvert/fs_default.txt
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 # Lookup table for extracting the relevant grey matter parcellations from the default FreeSurfer segmentation (desikan_killiany)
 
 0     ???     Unknown                         0   0   0   0

--- a/share/mrtrix3/labelconvert/hcpmmp1_ordered.txt
+++ b/share/mrtrix3/labelconvert/hcpmmp1_ordered.txt
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 # Lookup table for defining the Glasser parcellation as values incrementing from 1
 # Thanks to Marlene Tahedl (https://github.com/martahedl)
 # ID Labelname       R   G   B   A

--- a/share/mrtrix3/labelconvert/hcpmmp1_original.txt
+++ b/share/mrtrix3/labelconvert/hcpmmp1_original.txt
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 # Lookup table for grey matter parcellations as provided by the Glasser atlas
 # This tableprovides parcel names and colours as they are provded from e.g. the following command:
 #   mri_aparc2aseg --old-ribbon --annotation glasser --s hmsc001-01 --o glasser.mgz

--- a/share/mrtrix3/labelconvert/lpba40.txt
+++ b/share/mrtrix3/labelconvert/lpba40.txt
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 # Lookup table for converting LPBA40 parcellation into a numerical scheme appropriate for connectome construction
 
 #Index  Name                          Red   Green    Blue   Alpha

--- a/share/mrtrix3/labelsgmfix/FreeSurferSGM.txt
+++ b/share/mrtrix3/labelsgmfix/FreeSurferSGM.txt
@@ -1,3 +1,18 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 # This file is used to extract sub-cortical structures from FreeSurfer segmentations
 
 # Previously, the labelsgmfix command was compatible with both FreeSurfer LUT files and connectome config files, as the first two columns were identical. Now, this command ideally needs to be compatible with LUT files in any format.

--- a/travis.sh
+++ b/travis.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 set -ev
 
 # Script expects environment variables ${py} and ${test} to be set

--- a/update_dev_doc
+++ b/update_dev_doc
@@ -1,12 +1,27 @@
 #!/bin/bash
 
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
 set -e
 ./doxygen
 
-[ -d mrtrix3-dev-doc ] || git clone git@github.com:MRtrix3/mrtrix3-dev-doc.git 
+[ -d mrtrix3-dev-doc ] || git clone git@github.com:MRtrix3/mrtrix3-dev-doc.git
 
 (
-  cd mrtrix3-dev-doc 
+  cd mrtrix3-dev-doc
   git pull
   git rm -rf *
   cp -r ../devdoc/* .
@@ -14,5 +29,5 @@ set -e
   git commit -a -m "automatic update of dev doc"
   git push
 )
-  
+
 


### PR DESCRIPTION
Don't recall exactly where this was raised, but we should have the same copyright notice across all source files in the repository regardless of language.