### PR TITLE
connectomestats: Rename NBSE to TFNBS

### DIFF
--- a/cmd/connectomestats.cpp
+++ b/cmd/connectomestats.cpp
@@ -50,6 +50,18 @@ void usage ()
 
   SYNOPSIS = "Connectome group-wise statistics at the edge level using non-parametric permutation testing";
 
+  DESCRIPTION
+  + "For the TFNBS algorithm, default parameters for statistical enhancement "
+    "have been set based on the work in: \n"
+    "Vinokur, L.; Zalesky, A.; Raffelt, D.; Smith, R.E. & Connelly, A. A Novel Threshold-Free Network-Based Statistics Method: Demonstration using Simulated Pathology. OHBM, 2015, 4144; \n"
+    "and: \n"
+    "Vinokur, L.; Zalesky, A.; Raffelt, D.; Smith, R.E. & Connelly, A. A novel threshold-free network-based statistical method: Demonstration and parameter optimisation using in vivo simulated pathology. In Proc ISMRM, 2015, 2846. \n"
+    "Note however that not only was the optimisation of these parameters not "
+    "very precise, but the outcomes of statistical inference (for both this "
+    "algorithm and the NBS method) can vary markedly for even small changes to "
+    "enhancement parameters. Therefore the specificity of results obtained using "
+    "either of these methods should be interpreted with caution.";
+
 
   ARGUMENTS
   + Argument ("input", "a text file listing the file names of the input connectomes").type_file_in ()
@@ -84,10 +96,6 @@ void usage ()
              + "* If using the TFNBS algorithm: \n"
                "Baggio, H.C.; Abos, A.; Segura, B.; Campabadal, A.; Garcia-Diaz, A.; Uribe, C.; Compta, Y.; Marti, M.J.; Valldeoriola, F.; Junque, C. Statistical inference in brain graphs using threshold-free network-based statistics."
                "HBM, 2018, 39, 2289-2302"
-
-             + "* If using the TFNBS algorithm: \n"
-               "Vinokur, L.; Zalesky, A.; Raffelt, D.; Smith, R.E. & Connelly, A. A Novel Threshold-Free Network-Based Statistics Method: Demonstration using Simulated Pathology. \n"
-               "OHBM, 2015, 4144"
 
              + "* If using the -nonstationary option: \n"
                "Salimi-Khorshidi, G.; Smith, S.M. & Nichols, T.E. Adjusting the effect of nonstationarity in cluster-based and TFCE inference. \n"

--- a/cmd/connectomestats.cpp
+++ b/cmd/connectomestats.cpp
@@ -33,7 +33,7 @@ using namespace MR;
 using namespace App;
 
 
-const char* algorithms[] = { "nbs", "nbse", "none", nullptr };
+const char* algorithms[] = { "nbs", "tfnbs", "none", nullptr };
 
 
 
@@ -81,7 +81,11 @@ void usage ()
                "Zalesky, A.; Fornito, A. & Bullmore, E. T. Network-based statistic: Identifying differences in brain networks. \n"
                "NeuroImage, 2010, 53, 1197-1207"
 
-             + "* If using the NBSE algorithm: \n"
+             + "* If using the TFNBS algorithm: \n"
+               "Baggio, H.C.; Abos, A.; Segura, B.; Campabadal, A.; Garcia-Diaz, A.; Uribe, C.; Compta, Y.; Marti, M.J.; Valldeoriola, F.; Junque, C. Statistical inference in brain graphs using threshold-free network-based statistics."
+               "HBM, 2018, 39, 2289-2302"
+
+             + "* If using the TFNBS algorithm: \n"
                "Vinokur, L.; Zalesky, A.; Raffelt, D.; Smith, R.E. & Connelly, A. A Novel Threshold-Free Network-Based Statistics Method: Demonstration using Simulated Pathology. \n"
                "OHBM, 2015, 4144"
 

--- a/docs/reference/commands/connectomestats.rst
+++ b/docs/reference/commands/connectomestats.rst
@@ -16,7 +16,7 @@ Usage
     connectomestats [ options ]  input algorithm design contrast output
 
 -  *input*: a text file listing the file names of the input connectomes
--  *algorithm*: the algorithm to use in network-based clustering/enhancement. Options are: nbs, nbse, none
+-  *algorithm*: the algorithm to use in network-based clustering/enhancement. Options are: nbs, tfnbs, none
 -  *design*: the design matrix. Note that a column of 1's will need to be added for correlations.
 -  *contrast*: the contrast vector, specified as a single row of weights
 -  *output*: the filename prefix for all output.
@@ -77,7 +77,9 @@ References
 
 * If using the NBS algorithm: Zalesky, A.; Fornito, A. & Bullmore, E. T. Network-based statistic: Identifying differences in brain networks. NeuroImage, 2010, 53, 1197-1207
 
-* If using the NBSE algorithm: Vinokur, L.; Zalesky, A.; Raffelt, D.; Smith, R.E. & Connelly, A. A Novel Threshold-Free Network-Based Statistics Method: Demonstration using Simulated Pathology. OHBM, 2015, 4144
+* If using the TFNBS algorithm: Baggio, H.C.; Abos, A.; Segura, B.; Campabadal, A.; Garcia-Diaz, A.; Uribe, C.; Compta, Y.; Marti, M.J.; Valldeoriola, F.; Junque, C. Statistical inference in brain graphs using threshold-free network-based statistics.HBM, 2018, 39, 2289-2302
+
+* If using the TFNBS algorithm: Vinokur, L.; Zalesky, A.; Raffelt, D.; Smith, R.E. & Connelly, A. A Novel Threshold-Free Network-Based Statistics Method: Demonstration using Simulated Pathology. OHBM, 2015, 4144
 
 * If using the -nonstationary option: Salimi-Khorshidi, G.; Smith, S.M. & Nichols, T.E. Adjusting the effect of nonstationarity in cluster-based and TFCE inference. Neuroimage, 2011, 54(3), 2006-19
 

--- a/docs/reference/commands/connectomestats.rst
+++ b/docs/reference/commands/connectomestats.rst
@@ -21,6 +21,11 @@ Usage
 -  *contrast*: the contrast vector, specified as a single row of weights
 -  *output*: the filename prefix for all output.
 
+Description
+-----------
+
+For the TFNBS algorithm, default parameters for statistical enhancement have been set based on the work in: Vinokur, L.; Zalesky, A.; Raffelt, D.; Smith, R.E. & Connelly, A. A Novel Threshold-Free Network-Based Statistics Method: Demonstration using Simulated Pathology. OHBM, 2015, 4144; and: Vinokur, L.; Zalesky, A.; Raffelt, D.; Smith, R.E. & Connelly, A. A novel threshold-free network-based statistical method: Demonstration and parameter optimisation using in vivo simulated pathology. In Proc ISMRM, 2015, 2846. Note however that not only was the optimisation of these parameters not very precise, but the outcomes of statistical inference (for both this algorithm and the NBS method) can vary markedly for even small changes to enhancement parameters. Therefore the specificity of results obtained using either of these methods should be interpreted with caution.
+
 Options
 -------
 
@@ -78,8 +83,6 @@ References
 * If using the NBS algorithm: Zalesky, A.; Fornito, A. & Bullmore, E. T. Network-based statistic: Identifying differences in brain networks. NeuroImage, 2010, 53, 1197-1207
 
 * If using the TFNBS algorithm: Baggio, H.C.; Abos, A.; Segura, B.; Campabadal, A.; Garcia-Diaz, A.; Uribe, C.; Compta, Y.; Marti, M.J.; Valldeoriola, F.; Junque, C. Statistical inference in brain graphs using threshold-free network-based statistics.HBM, 2018, 39, 2289-2302
-
-* If using the TFNBS algorithm: Vinokur, L.; Zalesky, A.; Raffelt, D.; Smith, R.E. & Connelly, A. A Novel Threshold-Free Network-Based Statistics Method: Demonstration using Simulated Pathology. OHBM, 2015, 4144
 
 * If using the -nonstationary option: Salimi-Khorshidi, G.; Smith, S.M. & Nichols, T.E. Adjusting the effect of nonstationarity in cluster-based and TFCE inference. Neuroimage, 2011, 54(3), 2006-19
 


### PR DESCRIPTION
As raised on the [forum](https://community.mrtrix.org/t/group-connectivity-analysis/2333/3). We no longer have the authority to attempt to change the name of a published method, given the duration of time since its publication, our generally pessimistic outlook on its performance, and the subtlety of our criticism of the existing name; so we'll be sticking to this name from now on.