### PR TITLE
mrdegibbs: fix check for number of entries supplied to -axes

### DIFF
--- a/cmd/mrdegibbs.cpp
+++ b/cmd/mrdegibbs.cpp
@@ -321,7 +321,7 @@ void run ()
     vector<int> axes = opt[0][0];
     if (axes.size() != 2)
       throw Exception ("slice axes must be specified as a comma-separated 2-vector");
-    if (std::max (axes[0], axes[1]) >= header.ndim())
+    if (size_t(std::max (axes[0], axes[1])) >= header.ndim())
       throw Exception ("slice axes must be within the dimensionality of the image");
     if (axes[0] == axes[1])
       throw Exception ("two independent slice axes must be specified");

--- a/cmd/mrdegibbs.cpp
+++ b/cmd/mrdegibbs.cpp
@@ -319,7 +319,7 @@ void run ()
   const bool axes_set_manually = opt.size();
   if (opt.size()) {
     vector<int> axes = opt[0][0];
-    if (slice_axes.size() != 2)
+    if (axes.size() != 2)
       throw Exception ("slice axes must be specified as a comma-separated 2-vector");
     slice_axes = { size_t(axes[0]), size_t(axes[1]) };
   }

--- a/cmd/mrdegibbs.cpp
+++ b/cmd/mrdegibbs.cpp
@@ -331,16 +331,16 @@ void run ()
   auto slice_encoding_it = header.keyval().find ("SliceEncodingDirection");
   if (slice_encoding_it != header.keyval().end()) {
     try {
-      const Eigen::Vector3 slice_endocing_axis_onehot = Axes::id2dir (slice_encoding_it->second);
+      const Eigen::Vector3 slice_encoding_axis_onehot = Axes::id2dir (slice_encoding_it->second);
       vector<size_t> auto_slice_axes = { 0, 0 };
-      if (slice_endocing_axis_onehot[0])
+      if (slice_encoding_axis_onehot[0])
         auto_slice_axes = { 1, 2 };
-      else if (slice_endocing_axis_onehot[1])
+      else if (slice_encoding_axis_onehot[1])
         auto_slice_axes = { 0, 2 };
-      else if (slice_endocing_axis_onehot[2])
+      else if (slice_encoding_axis_onehot[2])
         auto_slice_axes = { 0, 1 };
       else
-        throw Exception ("Fatal error: Invalid slice axis one-hot encoding [ " + str(slice_endocing_axis_onehot.transpose()) + " ]");
+        throw Exception ("Fatal error: Invalid slice axis one-hot encoding [ " + str(slice_encoding_axis_onehot.transpose()) + " ]");
       if (axes_set_manually) {
         if (slice_axes == auto_slice_axes) {
           INFO ("User's manual selection of within-slice axes consistent with \"SliceEncodingDirection\" field in image header");

--- a/cmd/mrdegibbs.cpp
+++ b/cmd/mrdegibbs.cpp
@@ -321,6 +321,10 @@ void run ()
     vector<int> axes = opt[0][0];
     if (axes.size() != 2)
       throw Exception ("slice axes must be specified as a comma-separated 2-vector");
+    if (std::max (axes[0], axes[1]) >= header.ndim())
+      throw Exception ("slice axes must be within the dimensionality of the image");
+    if (axes[0] == axes[1])
+      throw Exception ("two independent slice axes must be specified");
     slice_axes = { size_t(axes[0]), size_t(axes[1]) };
   }
 


### PR DESCRIPTION
Currently, running with `-axes 0,1,2` does not raise an error, but it should...