### PR TITLE
app.py: progress bar: cast to int

### DIFF
--- a/lib/mrtrix3/app.py
+++ b/lib/mrtrix3/app.py
@@ -870,7 +870,7 @@ class progressBar(object): #pylint: disable=unused-variable
       sys.stderr.write('\r' + self.scriptname + ': ' + colourExec + '[' + ('100%' if self.multiplier else 'done') + ']' + colourClear + ' ' + colourConsole + self.message + colourClear + clearLine + '\n')
     else:
       if self.newline:
-        sys.stderr.write(self.scriptname + ': ' + self.message + ' [' + ('=' * (self.value/2)) + ']\n')
+        sys.stderr.write(self.scriptname + ': ' + self.message + ' [' + ('=' * int(self.value/2)) + ']\n')
       else:
         sys.stderr.write('=' * (int(self.value/2) - int(self.old_value/2)) + ']\n')
     sys.stderr.flush()


### PR DESCRIPTION
Fix to a glitch in the progress bar `done` method as reported on the [forum](https://community.mrtrix.org/t/population-template-python-error/2931).