### PR TITLE
JSON: import simple array as a single header entry

### DIFF
--- a/bin/dwipreproc
+++ b/bin/dwipreproc
@@ -230,7 +230,7 @@ if eddy_mporder:
     slice_timing = dwi_header.keyval()['SliceTiming'][0]
     app.var(slice_timing)
     if len(slice_timing) != dwi_num_slices:
-      app.error('Cannot use slice timing information in image header for slice-to-volume correction: Number of entries (' + len(slice_timing) + ') does not match number of slices (' + dwi_header.size()[2] + ')')
+      app.error('Cannot use slice timing information in image header for slice-to-volume correction: Number of entries (' + str(len(slice_timing)) + ') does not match number of slices (' + str(dwi_header.size()[2]) + ')')
 
 # Use new features of dirstat to query the quality of the diffusion acquisition scheme
 # Need to know the mean b-value in each shell, and the asymmetry value of each shell

--- a/core/file/json_utils.cpp
+++ b/core/file/json_utils.cpp
@@ -54,24 +54,33 @@ namespace MR
             H.keyval().insert (std::make_pair (i.key(), str<int>(i.value())));
           } else if (i->is_number_float()) {
             H.keyval().insert (std::make_pair (i.key(), str<float>(i.value())));
+          } else if (i->is_string()) {
+            H.keyval().insert (std::make_pair (i.key(), str (i.value())));
           } else if (i->is_array()) {
-            vector<std::string> s;
-            for (auto j = i->cbegin(); j != i->cend(); ++j) {
-              if (j->is_array()) {
+            size_t num_array = 0;
+            for (const auto j : *i)
+              if (j.is_array())
+                ++num_array;
+
+            if (num_array == 0) {
+              vector<std::string> line;
+              for (const auto k : *i)
+                line.push_back (str(k));
+              H.keyval().insert (std::make_pair (i.key(), join (line, ",")));
+            }
+            else if (num_array == i->size()) {
+              vector<std::string> s;
+              for (const auto j : *i) {
                 vector<std::string> line;
-                for (auto k : *j)
+                for (const auto k : j)
                   line.push_back (str(k));
                 s.push_back (join(line, ","));
-              } else {
-                s.push_back (str(*j));
               }
+              H.keyval().insert (std::make_pair (i.key(), join(s, "\n")));
             }
-            H.keyval().insert (std::make_pair (i.key(), join(s, "\n")));
-          } else if (i->is_string()) {
-            const std::string s = i.value();
-            H.keyval().insert (std::make_pair (i.key(), s));
+            else
+              throw Exception ("JSON entry contains mixture of elements and arrays");
           }
-
         }
 
         if (!Header::do_not_realign_transform) {


### PR DESCRIPTION
Apparently converting data via `dcm2niix` and converting to `mif` with a JSON import results in the slice timings being represented as multiple separate header entries, rather than the single entry with a comma-separated list that a direct `mrconvert` call produces. This means a call to `dwipreproc` fails when used with slice to vol, with error message:
```
dwipreproc: No slice encoding direction information present; assuming third axis corresponds to slices
Traceback (most recent call last):
  File "/home/finn/Software/mrtrix3/bin/dwipreproc", line 233, in <module>
    app.error('Cannot use slice timing information in image header for slice-to-volume correction: Number of entries (' + len(slice_timing) + ') does not match number of slices (' + dwi_header.size()[2] + ')')
TypeError: cannot concatenate 'str' and 'int' objects
```
Note there's another fix here for that python error...

This pull request modifies the handling of the import of JSON arrays, so that:

- if the array contains **no** sub-arrays, it'll concatenate into a single comma-separated list and insert the information as a single header entry;
- if the array contains **only** sub-arrays, it'll concatenate each sub-array into a comma-separated list and insert the information as one header entry per sub-array
- if it contains a mixture of simple elements and arrays, it'll throw an Exception

That last behaviour might need to be revised depending on whether there are any instances where we would reasonably be expected to handle a mix of elements and arrays. Alternatives are:

- issue a warning and ignore
- issue a warning and insert as one entry per element or sub-array. 

But I'll admit I don't know enough about BIDS to make an informed decision here. I just expect that if we ever encounter a BIDS entry that consists of such a mix, we'll have trouble interpreting it correctly anyway... 