### PR TITLE
dwifslpreproc: eddy "slspec" export fix

### DIFF
--- a/bin/dwifslpreproc
+++ b/bin/dwifslpreproc
@@ -821,7 +821,7 @@ def execute(): #pylint: disable=unused-variable
       app.debug('New: ' + str(new_slice_groups))
       slice_groups = new_slice_groups
 
-    matrix.save_numeric('slspec.txt', slice_groups, header='')
+    matrix.save_numeric('slspec.txt', slice_groups, header='', fmt='%d')
     eddy_manual_options.append('--slspec=slspec.txt')
 
 

--- a/lib/mrtrix3/matrix.py
+++ b/lib/mrtrix3/matrix.py
@@ -156,7 +156,7 @@ def load_vector(filename, **kwargs): #pylint: disable=unused-variable
 
 # Save numeric data to a text file
 def save_numeric(filename, data, **kwargs):
-  fmt = kwargs.pop('fmt', '%.14e')
+  fmt = kwargs.pop('fmt', '%6f')
   delimiter = kwargs.pop('delimiter', ' ')
   newline = kwargs.pop('newline', '\n')
   add_to_command_history = bool(kwargs.pop('add_to_command_history', True))


### PR DESCRIPTION
Export of slice specification data for `eddy`'s slice-to-volume correction were not appropriately formatted as integers at point of text file generation.

Fixes #1773.