### PR TITLE
connectome2tck: Skip non-valid exemplars

### DIFF
--- a/cmd/connectome2tck.cpp
+++ b/cmd/connectome2tck.cpp
@@ -228,7 +228,7 @@ void run ()
       if (volumes[index])
         COMs[index] = (transform.voxel2scanner * (COMs[index] * (1.0f / float(volumes[index]))).cast<default_type>()).cast<float>();
       else
-        COMs[index][0] = COMs[index][1] = COMs[index][2] = NAN;
+        COMs[index][0] = COMs[index][1] = COMs[index][2] = NaN;
     }
 
     // If user specifies a subset of nodes, only a subset of exemplars need to be calculated

--- a/src/dwi/tractography/connectome/exemplar.h
+++ b/src/dwi/tractography/connectome/exemplar.h
@@ -35,12 +35,13 @@ class Exemplar : private Tractography::Streamline<float>
 { MEMALIGN(Exemplar)
   public:
     using Tractography::Streamline<float>::point_type;
-    Exemplar (const size_t length, const NodePair& nodes, const std::pair<point_type, point_type>& COMs) :
+    Exemplar (const size_t exemplar_index, const size_t length, const NodePair& nodes, const std::pair<point_type, point_type>& COMs) :
         Tractography::Streamline<float> (length, { 0.0f, 0.0f, 0.0f }),
         nodes (nodes),
         node_COMs (COMs),
         is_finalized (false)
     {
+      index = exemplar_index;
       weight = 0.0f;
     }
 

--- a/src/dwi/tractography/connectome/extract.cpp
+++ b/src/dwi/tractography/connectome/extract.cpp
@@ -87,13 +87,14 @@ WriterExemplars::WriterExemplars (const Tractography::Properties& properties, co
   else
     length = std::round (to<float>(max_dist_it->second) / step_size) + 1;
 
+  size_t index = 0;
   if (exclusive) {
     for (size_t i = 0; i != nodes.size(); ++i) {
       const node_t one = nodes[i];
       for (size_t j = i; j != nodes.size(); ++j) {
         const node_t two = nodes[j];
         selectors.push_back (Selector (one, two));
-        exemplars.push_back (Exemplar (length, std::make_pair (one, two), std::make_pair (COMs[one], COMs[two])));
+        exemplars.push_back (Exemplar (index++, length, std::make_pair (one, two), std::make_pair (COMs[one], COMs[two])));
       }
     }
   } else {
@@ -103,7 +104,7 @@ WriterExemplars::WriterExemplars (const Tractography::Properties& properties, co
       for (node_t two = one; two != COMs.size(); ++two) {
         if (std::find (nodes.begin(), nodes.end(), one) != nodes.end() || std::find (nodes.begin(), nodes.end(), two) != nodes.end()) {
           selectors.push_back (Selector (one, two));
-          exemplars.push_back (Exemplar (length, std::make_pair (one, two), std::make_pair (COMs[one], COMs[two])));
+          exemplars.push_back (Exemplar (index++, length, std::make_pair (one, two), std::make_pair (COMs[one], COMs[two])));
         }
       }
     }


### PR DESCRIPTION
Fixes #1769.

Cannot modify `mrview` to properly read data generated by `connectome2tck` prior to this fix, since the NaNs present in the track file make accurate parsing of the data impossible. However upon fixing the output of `connectome2tck`, no modification of `mrview` code was required in order to properly display these exemplars without assertion failure despite the absent parcels:

![Screenshot from 2019-10-22 15-19-45](https://user-images.githubusercontent.com/5637955/67259701-05964b00-f4e3-11e9-90e8-c39100abdcc7.png)

Thanks @JeroenBlommaert for the report.