### PR TITLE
mrconvert -json_import: Preserve existing key-values

### DIFF
--- a/core/file/json_utils.cpp
+++ b/core/file/json_utils.cpp
@@ -65,9 +65,9 @@ namespace MR
 
 
 
-      KeyValues read (const nlohmann::json& json)
+      KeyValues read (const nlohmann::json& json, const KeyValues& preexisting)
       {
-        KeyValues result;
+        KeyValues result (preexisting);
         for (auto i = json.cbegin(); i != json.cend(); ++i) {
 
           if (i->is_boolean()) {
@@ -101,7 +101,7 @@ namespace MR
 
       void read (const nlohmann::json& json, Header& header, const bool realign)
       {
-        header.keyval() = read (json);
+        header.keyval() = read (json, header.keyval());
         if (realign && !Header::do_not_realign_transform) {
 
           // The corresponding header may have been rotated on image load prior to the JSON

--- a/core/file/json_utils.h
+++ b/core/file/json_utils.h
@@ -32,7 +32,8 @@ namespace MR
       void load (Header&, const std::string&);
       void save (const Header&, const std::string&);
 
-      KeyValues read (const nlohmann::json& json);
+      KeyValues read (const nlohmann::json& json,
+                      const KeyValues& preexisting = KeyValues());
       void read (const nlohmann::json& json,
                  Header& header,
                  const bool realign);


### PR DESCRIPTION
This is necessary in order for the combination of `-fslgrad` and `-json_import` to work correctly: without this fix, the diffusion gradient table imported via `-fslgrad` is erased upon populating the header key-value member using the contents of the input JSON file.