### PR TITLE
dwi2mask: Fix for cleaning filter with cropped data

### DIFF
--- a/cmd/dwi2mask.cpp
+++ b/cmd/dwi2mask.cpp
@@ -81,7 +81,7 @@ void run () {
   PhaseEncoding::clear_scheme (H_out);
   auto output = Image<bool>::create (argument[1], H_out);
 
-  unsigned int scale = get_option_value ("clean_scale", DEFAULT_CLEAN_SCALE);
+  unsigned int scale = get_option_value<unsigned int> ("clean_scale", DEFAULT_CLEAN_SCALE);
 
   if (scale > 0) {
     try {
@@ -92,7 +92,7 @@ void run () {
         if (temp_mask.value()) {
           bool all_zero = true;
           for (auto vl = Loop (3) (input); vl; ++vl) {
-            if (std::isfinite (input.value()) && input.value()) {
+            if (std::isfinite (float(input.value())) && input.value()) {
               all_zero = false;
               break;
             }

--- a/cmd/dwi2mask.cpp
+++ b/cmd/dwi2mask.cpp
@@ -87,7 +87,21 @@ void run () {
     try {
       Filter::MaskClean clean_filter (temp_mask, std::string("applying mask cleaning filter"));
       clean_filter.set_scale (scale);
-      clean_filter (temp_mask, output);
+      clean_filter (temp_mask, temp_mask);
+      for (auto l = Loop (0,3) (input, temp_mask, output); l; ++l) {
+        if (temp_mask.value()) {
+          bool all_zero = true;
+          for (auto vl = Loop (3) (input); vl; ++vl) {
+            if (std::isfinite (input.value()) && input.value()) {
+              all_zero = false;
+              break;
+            }
+          }
+          output.value() = !all_zero;
+        } else {
+          output.value() = false;
+        }
+      }
     } catch (...) {
       WARN("Unable to run mask cleaning filter (image is not truly 3D); skipping");
       for (auto l = Loop (0,3) (temp_mask, output); l; ++l)


### PR DESCRIPTION
Description in 099b4fc.

While it's unlikely for this behaviour to have been consequential for any analyses being undertaken on `master`, and it's principally to make a specific processing technique in #1543 work as intended, it is nevertheless erroneous behaviour and should therefore be fixed on `master`.