### PR TITLE
tcksift: Sorter fix for rare usage

### DIFF
--- a/src/dwi/tractography/SIFT/gradient_sort.cpp
+++ b/src/dwi/tractography/SIFT/gradient_sort.cpp
@@ -33,7 +33,8 @@ namespace MR
 
 
 
-      MT_gradient_vector_sorter::MT_gradient_vector_sorter (MT_gradient_vector_sorter::VecType& in, const track_t block_size)
+      MT_gradient_vector_sorter::MT_gradient_vector_sorter (MT_gradient_vector_sorter::VecType& in, const track_t block_size) :
+          end (in.end())
       {
         BlockSender source (in.size(), block_size);
         Sorter      pipe   (in);
@@ -45,11 +46,14 @@ namespace MR
 
       MT_gradient_vector_sorter::VecItType MT_gradient_vector_sorter::get()
       {
+        if (candidates.empty())
+          return end;
         VecItType return_iterator (*candidates.begin());
         VecItType incremented (*candidates.begin());
         ++incremented;
         candidates.erase (candidates.begin());
-        candidates.insert (incremented);
+        if (incremented != end && initial_candidates.find(incremented) == initial_candidates.end())
+          candidates.insert (incremented);
         return return_iterator;
       }
 

--- a/src/dwi/tractography/SIFT/gradient_sort.h
+++ b/src/dwi/tractography/SIFT/gradient_sort.h
@@ -99,12 +99,14 @@ namespace MR
           bool operator() (const VecItType& in)
           {
             candidates.insert (in);
+            initial_candidates.insert (in);
             return true;
           }
 
 
         private:
-          SetType candidates;
+          SetType candidates, initial_candidates;
+          VecItType end;
 
 
           class BlockSender

--- a/src/dwi/tractography/SIFT/sifter.cpp
+++ b/src/dwi/tractography/SIFT/sifter.cpp
@@ -129,7 +129,7 @@ namespace MR
           // Trying a heuristic for now; go for a sort size of 1000 following initial sort, assuming half of all
           //   remaining streamlines have a negative gradient
 
-          const track_t sort_size = std::min (num_tracks() / double(Thread::number_of_threads()), std::round (2000.0 * double(num_tracks()) / double(tracks_remaining)));
+          const track_t sort_size = std::min (std::ceil(num_tracks() / double(Thread::number_of_threads())), std::round (2000.0 * double(num_tracks()) / double(tracks_remaining)));
           MT_gradient_vector_sorter sorter (gradient_vector, sort_size);
 
           // Remove candidate streamlines one at a time, and correspondingly modify the fixels to which they were attributed

--- a/src/dwi/tractography/SIFT/sifter.cpp
+++ b/src/dwi/tractography/SIFT/sifter.cpp
@@ -177,9 +177,14 @@ namespace MR
             } else { // Proceed as normal
 
               const vector<Cost_fn_gradient_sort>::iterator candidate = sorter.get();
+              if (candidate == gradient_vector.end()) {
+                recalculate = POS_GRADIENT;
+                if (!removed_this_iteration)
+                  another_iteration = false;
+                goto end_iteration;
+              }
 
               const track_t candidate_index = candidate->get_tck_index();
-
               if (candidate->get_cost_gradient() >= 0.0) {
                 recalculate = POS_GRADIENT;
                 if (!removed_this_iteration)


### PR DESCRIPTION
Necessary to fix a segfault in some demonstration data I'm working on. Basically for certain synthetic reconstructions, an entire multi-threaded search block gets removed, resulting in an iterator overflow.