### PR TITLE
New MR::to<std::complex>() specialisation

### DIFF
--- a/cmd/mrcalc.cpp
+++ b/cmd/mrcalc.cpp
@@ -365,20 +365,23 @@ class StackEntry { NOMEMALIGN
           image.reset (new Image<complex_type> (header.get_image<complex_type>()));
           image_list.insert (std::make_pair (arg, LoadedImage (image, image_is_complex)));
         }
-        catch (Exception&) {
+        catch (Exception& e_image) {
           try {
             std::string a = lowercase (arg);
             if      (a == "pi")    { value = Math::pi; }
             else if (a == "e")     { value = Math::e; }
-            else if (a ==  "nan")  { value =  std::numeric_limits<real_type>::quiet_NaN(); }
-            else if (a == "-nan")  { value = -std::numeric_limits<real_type>::quiet_NaN(); }
-            else if (a ==  "inf")  { value =  std::numeric_limits<real_type>::infinity(); }
-            else if (a == "-inf")  { value = -std::numeric_limits<real_type>::infinity(); }
             else if (a == "rand")  { value = 0.0; rng.reset (new Math::RNG()); rng_gaussian = false; }
             else if (a == "randn") { value = 0.0; rng.reset (new Math::RNG()); rng_gaussian = true; }
             else                   { value =  to<complex_type> (arg); }
-          } catch (Exception&) {
-            throw Exception (std::string ("Could not interpret string \"") + arg + "\" as either an image path or a numerical value");
+          } catch (Exception& e_number) {
+            Exception e (std::string ("Could not interpret string \"") + arg + "\" as either an image path or a numerical value");
+            e.push_back ("As image: ");
+            for (size_t i = 0; i != e_image.num(); ++i)
+              e.push_back (e_image[i]);
+            e.push_back ("As numerical value: ");
+            for (size_t i = 0; i != e_number.num(); ++i)
+              e.push_back (e_number[i]);
+            throw e;
           }
         }
       }

--- a/core/file/json_utils.cpp
+++ b/core/file/json_utils.cpp
@@ -146,13 +146,9 @@ namespace MR
         bool attempt_scalar (const std::pair<std::string, std::string>& kv, nlohmann::json& json)
         {
           try {
-            std::stringstream stream (kv.second);
-            T temp;
-            stream >> temp;
-            if (stream && stream.eof()) {
-              json[kv.first] = temp;
-              return true;
-            }
+            const T temp = to<T> (kv.second);
+            json[kv.first] = temp;
+            return true;
           } catch (...) { }
           return false;
         }
@@ -219,7 +215,6 @@ namespace MR
         };
 
         for (const auto& kv : keyval) {
-
           if (attempt_scalar<int> (kv, json)) continue;
           if (attempt_scalar<default_type> (kv, json)) continue;
           if (attempt_scalar<bool> (kv, json)) continue;

--- a/core/mrtrix.h
+++ b/core/mrtrix.h
@@ -177,7 +177,7 @@ namespace MR
   }
 
 
-  inline std::string strip (const std::string& string, const std::string& ws = {" \0\t\n", 4}, bool left = true, bool right = true)
+  inline std::string strip (const std::string& string, const std::string& ws = {" \0\t\r\n", 5}, bool left = true, bool right = true)
   {
     std::string::size_type start = (left ? string.find_first_not_of (ws) : 0);
     if (start == std::string::npos)

--- a/core/mrtrix.h
+++ b/core/mrtrix.h
@@ -294,7 +294,7 @@ namespace MR
       if (i == -1) {
         first = "0";
         second = string;
-      } else if (i == string.size()) {
+      } else if (i == ssize_t(string.size())) {
         first = string;
         second = "0i";
       } else {
@@ -355,7 +355,7 @@ namespace MR
       if (i == -1) {
         first = "0";
         second = string;
-      } else if (i == string.size()) {
+      } else if (i == ssize_t(string.size())) {
         first = string;
         second = "0i";
       } else {

--- a/src/connectome/lut.cpp
+++ b/src/connectome/lut.cpp
@@ -130,6 +130,7 @@ LUT::file_format LUT::guess_file_format (const std::string& path)
   size_t line_counter = 0;
   while (std::getline (in_lut, line)) {
     ++line_counter;
+    line = strip (line);
     if (line.size() > 1 && line[0] != '#') {
       // Before splitting by whitespace, need to capture any strings that are
       //   encased within quotation marks

--- a/testing/cmd/testing_diff_matrix.cpp
+++ b/testing/cmd/testing_diff_matrix.cpp
@@ -17,6 +17,7 @@
 #include <fstream>
 
 #include "command.h"
+#include "types.h"
 
 #include <Eigen/Dense>
 #include "math/math.h"
@@ -42,42 +43,77 @@ void usage ()
 }
 
 
+
+
+
+
 void run ()
 {
 
-  const Eigen::MatrixXf in1 = load_matrix<float> (argument[0]);
-  const Eigen::MatrixXf in2 = load_matrix<float> (argument[1]);
+  const default_type tolerance_frac = get_option_value ("frac", 0.0);
+  const default_type tolerance_abs = get_option_value ("abs", 0.0);
+
+  Eigen::MatrixXd in1, in2;
+
+  try {
+    in1 = load_matrix<double> (argument[0]);
+    in2 = load_matrix<double> (argument[1]);
+  } catch (Exception&) {
+
+    const auto in1c = load_matrix<cdouble> (argument[0]);
+    const auto in2c = load_matrix<cdouble> (argument[1]);
+
+    if (in1c.rows() != in2c.rows() || in1c.cols() != in2c.cols())
+      throw Exception ("matrices \"" + Path::basename (argument[0]) + "\" and \"" + Path::basename (argument[1]) + "\" do not have matching sizes"
+                       " (" + str(in1.rows()) + "x" + str(in1c.cols()) + " vs " + str(in2c.rows()) + "x" + str(in2c.cols()) + ")");
+
+    if (bool(tolerance_frac)) {
+      for (size_t col = 0; col != in1c.cols(); ++col) {
+        for (size_t row = 0; row != in1c.rows(); ++row) {
+          if ((abs (in1c(row, col).real() - in2c(row, col).real()) / (0.5 * (in1c(row, col).real() + in2c(row, col).real())) > tolerance_frac)
+              || (abs (in1c(row, col).imag() - in2c(row, col).imag()) / (0.5 * (in1c(row, col).imag() + in2c(row, col).imag())) > tolerance_frac))
+            throw Exception ("matrices \"" + Path::basename (argument[0]) + "\" and \"" + Path::basename (argument[1]) + " do not match within fractional precision of " + str(tolerance_frac)
+                             + " ((" + str(row) + ", " + str(col) + "): " + str(in1c(row, col)) + " vs " + str(in2c(row, col)) + ")");
+        }
+      }
+    }
+
+    if (bool(tolerance_abs) || !bool(tolerance_frac)) {
+      for (size_t col = 0; col != in1c.cols(); ++col) {
+        for (size_t row = 0; row != in1c.rows(); ++row) {
+          if ((abs (in1c(row, col).real() - in2c(row, col).real()) > tolerance_abs)
+              || (abs (in1c(row, col).imag() - in2c(row, col).imag()) > tolerance_abs))
+            throw Exception ("matrices \"" + Path::basename (argument[0]) + "\" and \"" + Path::basename (argument[1]) + " do not match within absolute precision of " + str(tolerance_abs)
+                             + " ((" + str(row) + ", " + str(col) + "): " + str(in1c(row, col)) + " vs " + str(in2c(row, col)) + ")");
+        }
+      }
+    }
+
+    return;
+  }
 
   if (in1.rows() != in2.rows() || in1.cols() != in2.cols())
     throw Exception ("matrices \"" + Path::basename (argument[0]) + "\" and \"" + Path::basename (argument[1]) + "\" do not have matching sizes"
                      " (" + str(in1.rows()) + "x" + str(in1.cols()) + " vs " + str(in2.rows()) + "x" + str(in2.cols()) + ")");
 
-  const size_t numel = in1.size();
-
-  auto opt = get_options ("frac");
-  if (opt.size()) {
-
-    const double tol = opt[0][0];
-
-    for (size_t i = 0; i != numel; ++i) {
-      if (abs ((*(in1.data()+i) - *(in2.data()+i)) / (0.5 * (*(in1.data()+i) + *(in2.data()+i)))) > tol)
-        throw Exception ("matrices \"" + Path::basename (argument[0]) + "\" and \"" + Path::basename (argument[1]) + " do not match within fractional precision of " + str(tol)
-                         + " (" + str(*(in1.data()+i)) + " vs " + str(*(in2.data()+i)) + ")");
+  if (bool(tolerance_frac)) {
+    for (size_t col = 0; col != in1.cols(); ++col) {
+      for (size_t row = 0; row != in1.rows(); ++row) {
+        if (abs (in1(row, col) - in2(row, col)) / (0.5 * (in1(row, col) + in2(row, col))) > tolerance_frac)
+          throw Exception ("matrices \"" + Path::basename (argument[0]) + "\" and \"" + Path::basename (argument[1]) + " do not match within fractional precision of " + str(tolerance_abs)
+                           + " ((" + str(row) + ", " + str(col) + "): " + str(in1(row, col)) + " vs " + str(in2(row, col)) + ")");
+      }
     }
+  }
 
-  } else {
-
-    double tol = 0.0;
-    opt = get_options ("abs");
-    if (opt.size())
-      tol = opt[0][0];
-
-    for (size_t i = 0; i != numel; ++i) {
-      if (abs (*(in1.data()+i) - *(in2.data()+i)) > tol)
-        throw Exception ("matrices \"" + Path::basename (argument[0]) + "\" and \"" + Path::basename (argument[1]) + " do not match within absolute precision of " + str(tol)
-                         + " (" + str(*(in1.data()+i)) + " vs " + str(*(in2.data()+i)) + ")");
+  if (bool(tolerance_abs) || !bool(tolerance_frac)) {
+    for (size_t col = 0; col != in1.cols(); ++col) {
+      for (size_t row = 0; row != in1.rows(); ++row) {
+        if (abs (in1(row, col) - in2(row, col)) > tolerance_abs)
+          throw Exception ("matrices \"" + Path::basename (argument[0]) + "\" and \"" + Path::basename (argument[1]) + " do not match within absolute precision of " + str(tolerance_abs)
+                           + " ((" + str(row) + ", " + str(col) + "): " + str(in1(row, col)) + " vs " + str(in2(row, col)) + ")");
+      }
     }
-
   }
 
   CONSOLE ("data checked OK");

--- a/testing/cmd/testing_to.cpp
+++ b/testing/cmd/testing_to.cpp
@@ -1,0 +1,324 @@
+/* Copyright (c) 2008-2019 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Covered Software is provided under this License on an "as is"
+ * basis, without warranty of any kind, either expressed, implied, or
+ * statutory, including, without limitation, warranties that the
+ * Covered Software is free of defects, merchantable, fit for a
+ * particular purpose or non-infringing.
+ * See the Mozilla Public License v. 2.0 for more details.
+ *
+ * For more details, see http://www.mrtrix.org/.
+ */
+
+#include <complex>
+
+#include "command.h"
+#include "mrtrix.h"
+#include "types.h"
+
+
+using namespace MR;
+using namespace App;
+
+
+void usage ()
+{
+  AUTHOR = "Robert E. Smith (robert.smith@florey.edu.au)";
+
+  SYNOPSIS = "Test the to<>(std::string) function";
+
+  REQUIRES_AT_LEAST_ONE_ARGUMENT = false;
+}
+
+
+vector<std::string> failures;
+
+
+template <class T>
+void test (const vector<std::string>& strings, const vector<bool>& results)
+{
+  for (size_t i = 0; i != strings.size(); ++i) {
+    try {
+      to<T> (strings[i]);
+      if (!results[i])
+        failures.push_back (strings[i] + " to " + typeid(T).name() + " succeeded");
+    } catch (Exception& e) {
+      if (results[i])
+        failures.push_back (strings[i] + " to " + typeid(T).name() + " failed: " + e[0]);
+    }
+  }
+}
+
+
+
+void run ()
+{
+  const vector<std::string> data = {
+    "0",
+    "1",
+    "2",
+    "0a",
+    "a0",
+    "true",
+    "TRUE",
+    "tru",
+    "truee",
+    "false",
+    "FALSE",
+    "fals",
+    "falsee",
+    "yes",
+    "YES",
+    "yeah",
+    "yess",
+    "no",
+    "NO",
+    "nope",
+    "na",
+    "0.0",
+    "1e",
+    "1e-1",
+    "1e-1a",
+    "inf",
+    "INF",
+    "infinity",
+    "-inf",
+    "-infinity",
+    "nan",
+    "NAN",
+    "nana",
+    "-nan",
+    "i",
+    "I",
+    "j",
+    "J",
+    "-i",
+    "1i",
+    "1i0",
+    "1+i",
+    "1+ii",
+    "a1+i",
+    "1+1+i",
+    "-1-i",
+    "inf+infi" };
+
+  const vector<bool> bool_tests = {
+    true,  // "0"
+    true,  // "1"
+    true,  // "2"
+    false, // "0a"
+    false, // "a0"
+    true,  // "true"
+    true,  // "TRUE"
+    false, // "tru"
+    false, // "truee"
+    true,  // "false"
+    true,  // "FALSE"
+    false, // "fals"
+    false, // "falsee"
+    true,  // "yes"
+    true,  // "YES"
+    false, // "yeah"
+    false, // "yess"
+    true,  // "no"
+    true,  // "NO"
+    false, // "nope"
+    false, // "na"
+    false, // "0.0"
+    false, // "1e"
+    false, // "1e-1"
+    false, // "1e-1a"
+    false, // "inf"
+    false, // "INF"
+    false, // "infinity"
+    false, // "-inf"
+    false, // "-infinity"
+    false, // "nan"
+    false, // "NAN"
+    false, // "nana"
+    false, // "-nan"
+    false, // "i"
+    false, // "I"
+    false, // "j"
+    false, // "J"
+    false, // "-i"
+    false, // "1i"
+    false, // "1i0"
+    false, // "1+i"
+    false, // "1+ii"
+    false, // "a1+i"
+    false, // "1+1+i"
+    false, // "-1-i"
+    false  // "inf+infi"
+  };
+
+  const vector<bool> int_tests = {
+      true,  // "0"
+      true,  // "1"
+      true,  // "2"
+      false, // "0a"
+      false, // "a0"
+      false, // "true"
+      false, // "TRUE"
+      false, // "tru"
+      false, // "truee"
+      false, // "false"
+      false, // "FALSE"
+      false, // "fals"
+      false, // "falsee"
+      false, // "yes"
+      false, // "YES"
+      false, // "yeah"
+      false, // "yess"
+      false, // "no"
+      false, // "NO"
+      false, // "nope"
+      false, // "na"
+      false, // "0.0"
+      false, // "1e"
+      false, // "1e-1"
+      false, // "1e-1a"
+      false, // "inf"
+      false, // "INF"
+      false, // "infinity"
+      false, // "-inf"
+      false, // "-infinity"
+      false, // "nan"
+      false, // "NAN"
+      false, // "nana"
+      false, // "-nan"
+      false, // "i"
+      false, // "I"
+      false, // "j"
+      false, // "J"
+      false, // "-i"
+      false, // "1i"
+      false, // "1i0"
+      false, // "1+i"
+      false, // "1+ii"
+      false, // "a1+i"
+      false, // "1+1+i"
+      false, // "-1-i"
+      false  // "inf+infi"
+  };
+
+  const vector<bool> float_tests = {
+      true,  // "0"
+      true,  // "1"
+      true,  // "2"
+      false, // "0a"
+      false, // "a0"
+      false, // "true"
+      false, // "TRUE"
+      false, // "tru"
+      false, // "truee"
+      false, // "false"
+      false, // "FALSE"
+      false, // "fals"
+      false, // "falsee"
+      false, // "yes"
+      false, // "YES"
+      false, // "yeah"
+      false, // "yess"
+      false, // "no"
+      false, // "NO"
+      false, // "nope"
+      false, // "na"
+      true,  // "0.0"
+      false, // "1e"
+      true,  // "1e-1"
+      false, // "1e-1a"
+      true,  // "inf"
+      true,  // "INF"
+      false, // "infinity"
+      true,  // "-inf"
+      false, // "-infinity"
+      true,  // "nan"
+      true,  // "NAN"
+      false, // "nana"
+      true,  // "-nan"
+      false, // "i"
+      false, // "I"
+      false, // "j"
+      false, // "J"
+      false, // "-i"
+      false, // "1i"
+      false, // "1i0"
+      false, // "1+i"
+      false, // "1+ii"
+      false, // "a1+i"
+      false, // "1+1+i"
+      false, // "-1-i"
+      false  // "inf+infi"
+  };
+
+  const vector<bool> complex_tests = {
+      true,  // "0"
+      true,  // "1"
+      true,  // "2"
+      false, // "0a"
+      false, // "a0"
+      false, // "true"
+      false, // "TRUE"
+      false, // "tru"
+      false, // "truee"
+      false, // "false"
+      false, // "FALSE"
+      false, // "fals"
+      false, // "falsee"
+      false, // "yes"
+      false, // "YES"
+      false, // "yeah"
+      false, // "yess"
+      false, // "no"
+      false, // "NO"
+      false, // "nope"
+      false, // "na"
+      true,  // "0.0"
+      false, // "1e"
+      true,  // "1e-1"
+      false, // "1e-1a"
+      true,  // "inf"
+      true,  // "INF"
+      false, // "infinity"
+      true,  // "-inf"
+      false, // "-infinity"
+      true,  // "nan"
+      true,  // "NAN"
+      false, // "nana"
+      true,  // "-nan"
+      true,  // "i"
+      false, // "I"
+      true,  // "j"
+      false, // "J"
+      true,  // "-i"
+      true,  // "1i"
+      false, // "1i0"
+      true,  // "1+i"
+      false, // "1+ii"
+      false, // "a1+i"
+      false, // "1+1+i"
+      true,  // "-1-i"
+      true   // "inf+infi"
+  };
+
+  test<bool> (data, bool_tests);
+  test<int>  (data, int_tests);
+  test<float> (data, float_tests);
+  test<std::complex<float>> (data, complex_tests);
+
+  if (failures.size()) {
+    Exception e (str(failures.size()) + " of " + str(4*data.size()) + " tests failed:");
+    for (const auto& s : failures)
+      e.push_back (s);
+    throw e;
+  }
+
+  CONSOLE ("All tests passed OK");
+
+}
+

--- a/testing/tests/to
+++ b/testing/tests/to
@@ -1,0 +1,1 @@
+testing_to


### PR DESCRIPTION
Closes #1780.

This one dragged out for longer than was predicted. In the end I had to completely overhaul the string-to-complex conversion, because it's a custom format (a+bi) that the standard stream operator doesn't handle, and it's called by `mrcalc` which means it needs to be robust.

Of the 188 tests in `testing/cmd/testing_to.cpp`, 56 currently fail on `master` / `dev`.

Anyone feel free to add extra tests if you think you can make it misbehave.