### PR TITLE
Change testing log filenames

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,8 +15,8 @@ build_script:
   - cmd: C:\msys64\msys2_shell.cmd -mingw64 -here -defterm -no-start -c "./build -nowarnings -nopaginate" || (appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%/build.log & EXIT 1)
 
 test_script:
-  - cmd: C:\msys64\msys2_shell.cmd -mingw64 -here -defterm -no-start -c "./run_tests units && mv testing.log testing_units.log" || (appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%/testing_units.log & EXIT 1)
-  - cmd: C:\msys64\msys2_shell.cmd -mingw64 -here -defterm -no-start -c "./run_tests binaries && mv testing.log testing_binaries.log" || (appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%/testing_binaries.log & EXIT 1)
+  - cmd: C:\msys64\msys2_shell.cmd -mingw64 -here -defterm -no-start -c "./run_tests units" || (appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%/testing_units.log & EXIT 1)
+  - cmd: C:\msys64\msys2_shell.cmd -mingw64 -here -defterm -no-start -c "./run_tests binaries" || (appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%/testing_binaries.log & EXIT 1)
 
 artifacts:
   - path: pacman.log

--- a/run_tests
+++ b/run_tests
@@ -15,8 +15,6 @@
 #
 # For more details, see http://www.mrtrix.org/.
 
-LOGFILE=testing.log
-
 if test "$#" -ne 1; then
   echo "Script must be provided with single input argument: \"binaries\", \"scripts\", \"units\", or the name of a specific test to be run."
   exit 1
@@ -73,6 +71,7 @@ case $1 in
 esac
 
 
+LOGFILE="testing_"$1".log"
 echo logging to \""$LOGFILE"\"
 cat > $LOGFILE <<EOD
 ------------------------------------------

--- a/travis.sh
+++ b/travis.sh
@@ -38,7 +38,7 @@ case  $test in
     $py ./configure -nooptim && $py ./build -nowarnings -persistent -nopaginate
     ;;
   "run")
-    $py ./configure -assert && $py ./build -nowarnings -persistent -nopaginate && ./run_tests units && mv testing.log testing_units.log && ./run_tests binaries && mv testing.log testing_binaries.log
+    $py ./configure -assert && $py ./build -nowarnings -persistent -nopaginate && ./run_tests units && ./run_tests binaries
     ;;
   *)
     echo "Envvar \"test\" not defined";


### PR DESCRIPTION
A little cleanup following #1614.

Currently, if certain aspects of CI fail, the relevant log files are not visible, because the requisite file move operation is not executed due to `run_tests` returning non-zero.