### PR TITLE
mrview: fixel --> vector field and ROI opacity

### DIFF
--- a/docs/reference/config_file_options.rst
+++ b/docs/reference/config_file_options.rst
@@ -357,6 +357,12 @@ List of MRtrix3 configuration file options
 
      The factor by which the ODF overlay is scaled.
 
+.. option:: MRViewRoiAlpha
+
+    *default: 0.5*
+
+     The default alpha of a ROI overlay.
+
 .. option:: MRViewRotateModifierKey
 
     *default: ctrl*

--- a/src/gui/mrview/displayable.h
+++ b/src/gui/mrview/displayable.h
@@ -41,10 +41,12 @@ namespace MR
       const uint32_t DiscardUpper = 0x40000000;
       const uint32_t Transparency = 0x80000000;
       const uint32_t Lighting = 0x01000000;
+      const uint32_t Directionality = 0x02000000;
       const uint32_t DiscardLowerEnabled = 0x00100000;
       const uint32_t DiscardUpperEnabled = 0x00200000;
       const uint32_t TransparencyEnabled = 0x00400000;
       const uint32_t LightingEnabled = 0x00800000;
+      const uint32_t UniDirectionalEnabled = 0x01000000;
 
       class Image;
       namespace Tool { class BaseFixel; }
@@ -128,12 +130,13 @@ namespace MR
 
           uint32_t flags () const { return flags_; }
 
-          void set_allowed_features (bool thresholding, bool transparency, bool lighting) {
+          void set_allowed_features (bool thresholding, bool transparency, bool lighting, bool unidirectionality=false) {
             uint32_t cmap = flags_;
             set_bit (cmap, DiscardLowerEnabled, thresholding);
             set_bit (cmap, DiscardUpperEnabled, thresholding);
             set_bit (cmap, TransparencyEnabled, transparency);
             set_bit (cmap, LightingEnabled, lighting);
+            set_bit (cmap, UniDirectionalEnabled, unidirectionality);
             flags_ = cmap;
           }
 
@@ -165,6 +168,11 @@ namespace MR
             set_bit (InvertScale, yesno);
           }
 
+          void set_uni_directional (bool yesno) {
+            if (!uni_directional_enabled()) return;
+            set_bit (Directionality, yesno);
+          }
+
           bool scale_inverted () const {
             return flags_ & InvertScale;
           }
@@ -185,6 +193,10 @@ namespace MR
             return flags_ & LightingEnabled;
           }
 
+          bool uni_directional_enabled () const {
+            return flags_ & UniDirectionalEnabled;
+          }
+
           bool use_discard_lower () const {
             return discard_lower_enabled() && ( flags_ & DiscardLower );
           }
@@ -199,6 +211,10 @@ namespace MR
 
           bool use_lighting () const {
             return lighting_enabled() && ( flags_ & Lighting );
+          }
+
+          bool use_uni_directional () const {
+            return uni_directional_enabled() && ( flags_ & Directionality );
           }
 
 

--- a/src/gui/mrview/tool/fixel/base_fixel.cpp
+++ b/src/gui/mrview/tool/fixel/base_fixel.cpp
@@ -15,7 +15,7 @@
  */
 
 #include "gui/mrview/tool/fixel/base_fixel.h"
-
+#include "file/config.h"
 
 namespace MR
 {
@@ -155,10 +155,18 @@ namespace MR
             default:
               break;
           }
-
-          source +=
+          //CONF option: MRViewFixelsAreVectors
+          //CONF default: false
+          //CONF Fixels are displayed as vector field with origin in voxel centre.
+          if (File::Config::get_bool ("MRViewFixelsAreVectors", false))
+            source +=
+               "    vec4 start = MVP * (gl_in[0].gl_Position);\n"
+               "    vec4 end = MVP * (gl_in[0].gl_Position + 2.0 * line_offset);\n";
+          else
+            source +=
                "    vec4 start = MVP * (gl_in[0].gl_Position - line_offset);\n"
-               "    vec4 end = MVP * (gl_in[0].gl_Position + line_offset);\n"
+               "    vec4 end = MVP * (gl_in[0].gl_Position + line_offset);\n";
+          source +=
                "    vec4 line = end - start;\n"
                "    vec4 normal =  normalize(vec4(-line.y, line.x, 0.0, 0.0));\n"
                "    vec4 thick_vec =  line_thickness * normal;\n"

--- a/src/gui/mrview/tool/fixel/base_fixel.cpp
+++ b/src/gui/mrview/tool/fixel/base_fixel.cpp
@@ -15,7 +15,6 @@
  */
 
 #include "gui/mrview/tool/fixel/base_fixel.h"
-#include "file/config.h"
 
 namespace MR
 {
@@ -41,7 +40,7 @@ namespace MR
           user_line_length_multiplier (1.f),
           line_thickness (0.0015f)
         {
-          set_allowed_features (true, true, false);
+          set_allowed_features (true, true, false, true);
           colourmap = 1;
           alpha = 1.0f;
           set_use_transparency (true);
@@ -155,17 +154,16 @@ namespace MR
             default:
               break;
           }
-          //CONF option: MRViewFixelsAreVectors
-          //CONF default: false
-          //CONF Fixels are displayed as vector field with origin in voxel centre.
-          if (File::Config::get_bool ("MRViewFixelsAreVectors", false))
+
+          if (fixel.use_uni_directional()) {
             source +=
                "    vec4 start = MVP * (gl_in[0].gl_Position);\n"
                "    vec4 end = MVP * (gl_in[0].gl_Position + 2.0 * line_offset);\n";
-          else
+          } else {
             source +=
                "    vec4 start = MVP * (gl_in[0].gl_Position - line_offset);\n"
                "    vec4 end = MVP * (gl_in[0].gl_Position + line_offset);\n";
+          }
           source +=
                "    vec4 line = end - start;\n"
                "    vec4 normal =  normalize(vec4(-line.y, line.x, 0.0, 0.0));\n"

--- a/src/gui/mrview/tool/fixel/fixel.cpp
+++ b/src/gui/mrview/tool/fixel/fixel.cpp
@@ -216,8 +216,8 @@ namespace MR
             main_box->addLayout (hlayout);
             hlayout->addWidget (new QLabel ("length multiplier"));
             length_multiplier = new AdjustButton (this, 0.01);
-            length_multiplier->setMin (0.1);
-            length_multiplier->setValue (1.0);
+            length_multiplier->setMin (0.001);
+            length_multiplier->setValue (10.0);
             connect (length_multiplier, SIGNAL (valueChanged()), this, SLOT (length_multiplier_slot()));
             hlayout->addWidget (length_multiplier);
 

--- a/src/gui/mrview/tool/fixel/fixel.h
+++ b/src/gui/mrview/tool/fixel/fixel.h
@@ -58,7 +58,7 @@ namespace MR
             void reset_colourmap (const ColourMapButton&) override;
 
             QPushButton* hide_all_button;
-            bool do_lock_to_grid, do_crop_to_slice;
+            bool do_lock_to_grid, do_crop_to_slice, is_bidirectional;
             bool not_3D;
             float line_opacity;
             Model* fixel_list_model;
@@ -72,6 +72,7 @@ namespace MR
             void hide_all_slot ();
             void on_lock_to_grid_slot (bool is_checked);
             void on_crop_to_slice_slot (bool is_checked);
+            void on_directional_slot (bool is_checked);
             void opacity_slot (int opacity);
             void line_thickness_slot (int thickness);
             void length_multiplier_slot ();
@@ -103,7 +104,7 @@ namespace MR
             QSlider *line_thickness_slider;
             QSlider *opacity_slider;
 
-            QGroupBox *lock_to_grid, *crop_to_slice;
+            QGroupBox *lock_to_grid, *crop_to_slice, *bidirectional;
 
             void add_images (vector<std::string>& list);
             void dropEvent (QDropEvent* event) override;
@@ -113,6 +114,7 @@ namespace MR
             void update_gui_scaling_controls (bool reload_scaling_types = true);
             void update_gui_colour_controls (bool reload_colour_types = true);
             void update_gui_threshold_controls (bool reload_threshold_types = true);
+            void update_directionality (bool reload_directionality = true);
         };
       }
     }

--- a/src/gui/mrview/tool/roi_editor/item.cpp
+++ b/src/gui/mrview/tool/roi_editor/item.cpp
@@ -62,7 +62,10 @@ namespace MR
           value_min = 0.0f; value_max = 1.0f;
           set_windowing (0.0f, 1.0f);
           min_max_set();
-          alpha = 1.0f;
+          //CONF option: MRViewRoiAlpha
+          //CONF default: 0.5
+          //CONF The default alpha of a ROI overlay.
+          alpha =  MR::File::Config::get_float ("MRViewRoiAlpha", 0.5f);
           colour = preset_colours[current_preset_colour++];
           if (current_preset_colour >= 6)
             current_preset_colour = 0;


### PR DESCRIPTION
extracting some mrview-related changes from the `mrreg` branch that I found sensible:

- added config option to change _fixels_ into _vector_ field (origin at voxel centre), allow greated dynamic range of fixel length
- ROI alpha defaults to 0.5 instead of 1. config file option added to change the default. 