### PR TITLE
dirorder: Exhaustive search

### DIFF
--- a/cmd/dirflip.cpp
+++ b/cmd/dirflip.cpp
@@ -45,7 +45,7 @@ void usage ()
 
 
   OPTIONS
-    + Option ("permutations", "number of permutations to try.")
+    + Option ("permutations", "number of permutations to try (default: " + str(DEFAULT_PERMUTATIONS) + ")")
     +   Argument ("num").type_integer (1)
 
     + Option ("cartesian", "Output the directions in Cartesian coordinates [x y z] instead of [az el].");

--- a/cmd/dirorder.cpp
+++ b/cmd/dirorder.cpp
@@ -56,7 +56,7 @@ vector<size_t> optimise (const Eigen::MatrixXd& directions, const size_t first_v
 {
   vector<size_t> indices (1, first_volume);
   vector<size_t> remaining;
-  for (ssize_t n = 0; n < directions.rows(); ++n)
+  for (size_t n = 0; n < size_t(directions.rows()); ++n)
     if (n != indices[0])
       remaining.push_back (n);
 
@@ -95,7 +95,7 @@ value_type calc_cost (const Eigen::MatrixXd& directions, const vector<size_t>& o
   Eigen::MatrixXd subset (start, 3);
   for (size_t i = 0; i != start; ++i)
     subset.row(i) = directions.row(order[i]);
-  for (size_t N = start+1; N < directions.rows(); ++N) {
+  for (size_t N = start+1; N < size_t(directions.rows()); ++N) {
     // Don't include condition numbers where precisely the number of coefficients
     //   for that spherical harmonic degree are included, as these tend to
     //   be outliers
@@ -118,7 +118,7 @@ void run ()
   value_type min_cost = std::numeric_limits<value_type>::infinity();
   vector<size_t> best_order;
   ProgressBar progress ("Determining best reordering", directions.rows());
-  for (size_t first_volume = 0; first_volume != directions.rows(); ++first_volume) {
+  for (size_t first_volume = 0; first_volume != size_t(directions.rows()); ++first_volume) {
     const vector<size_t> order = optimise (directions, first_volume);
     const value_type cost = calc_cost (directions, order);
     if (cost < min_cost) {

--- a/cmd/dirorder.cpp
+++ b/cmd/dirorder.cpp
@@ -18,6 +18,7 @@
 #include "progressbar.h"
 #include "math/rng.h"
 #include "math/SH.h"
+#include "dwi/gradient.h"
 #include "dwi/directions/file.h"
 
 #include <random>
@@ -46,26 +47,15 @@ void usage ()
 }
 
 
+
 using value_type = double;
 
 
-  template <typename value_type>
-inline std::function<value_type()> get_rng_uniform (value_type from, value_type to)
+
+vector<size_t> optimise (const Eigen::MatrixXd& directions, const size_t first_volume)
 {
-  std::random_device rd;
-  std::mt19937 gen (rd());
-  std::uniform_int_distribution<value_type> dis (from, to);
-  return std::bind (dis, gen);
-}
-
-
-void run ()
-{
-  auto directions = DWI::Directions::load_cartesian (argument[0]);
-  auto rng = get_rng_uniform<size_t> (0, directions.rows()-1);
-
-  vector<ssize_t> indices (1, rng());
-  vector<ssize_t> remaining;
+  vector<size_t> indices (1, first_volume);
+  vector<size_t> remaining;
   for (ssize_t n = 0; n < directions.rows(); ++n)
     if (n != indices[0])
       remaining.push_back (n);
@@ -92,10 +82,55 @@ void run ()
     remaining.erase (remaining.begin()+best);
   }
 
+  return indices;
+}
+
+
+
+
+value_type calc_cost (const Eigen::MatrixXd& directions, const vector<size_t>& order)
+{
+  value_type cost = value_type(0);
+  const size_t start = Math::SH::NforL (2);
+  Eigen::MatrixXd subset (start, 3);
+  for (size_t i = 0; i != start; ++i)
+    subset.row(i) = directions.row(order[i]);
+  for (size_t N = start+1; N < directions.rows(); ++N) {
+    // Don't include condition numbers where precisely the number of coefficients
+    //   for that spherical harmonic degree are included, as these tend to
+    //   be outliers
+    const size_t lmax = Math::SH::LforN (N-1);
+    subset.conservativeResize (N, 3);
+    subset.row(N-1) = directions.row(order[N-1]);
+    const value_type cond = DWI::condition_number_for_lmax (subset, lmax);
+    cost += cond;
+  }
+  return cost;
+}
+
+
+
+
+void run ()
+{
+  auto directions = DWI::Directions::load_cartesian (argument[0]);
+
+  value_type min_cost = std::numeric_limits<value_type>::infinity();
+  vector<size_t> best_order;
+  ProgressBar progress ("Determining best reordering", directions.rows());
+  for (size_t first_volume = 0; first_volume != directions.rows(); ++first_volume) {
+    const vector<size_t> order = optimise (directions, first_volume);
+    const value_type cost = calc_cost (directions, order);
+    if (cost < min_cost) {
+      min_cost = cost;
+      best_order = order;
+    }
+    ++progress;
+  }
 
   decltype(directions) output (directions.rows(), 3);
   for (ssize_t n = 0; n < directions.rows(); ++n)
-    output.row(n) = directions.row (indices[n]);
+    output.row(n) = directions.row (best_order[n]);
 
   DWI::Directions::save (output, argument[1], get_options("cartesian").size());
 }

--- a/cmd/dirsplit.cpp
+++ b/cmd/dirsplit.cpp
@@ -39,7 +39,7 @@ ARGUMENTS
 
 
 OPTIONS
-  + Option ("permutations", "number of permutations to try")
+  + Option ("permutations", "number of permutations to try (default: " + str(DEFAULT_PERMUTATIONS) + ")")
   +   Argument ("num").type_integer (1)
 
   + Option ("cartesian", "Output the directions in Cartesian coordinates [x y z] instead of [az el].");

--- a/docs/reference/commands/dirflip.rst
+++ b/docs/reference/commands/dirflip.rst
@@ -26,7 +26,7 @@ The orientations themselves are not affected, only their polarity; this is neces
 Options
 -------
 
--  **-permutations num** number of permutations to try.
+-  **-permutations num** number of permutations to try (default: 100000000)
 
 -  **-cartesian** Output the directions in Cartesian coordinates [x y z] instead of [az el].
 

--- a/docs/reference/commands/dirsplit.rst
+++ b/docs/reference/commands/dirsplit.rst
@@ -21,7 +21,7 @@ Usage
 Options
 -------
 
--  **-permutations num** number of permutations to try
+-  **-permutations num** number of permutations to try (default: 100000000)
 
 -  **-cartesian** Output the directions in Cartesian coordinates [x y z] instead of [az el].
 


### PR DESCRIPTION
Encountered this internal limitation while writing a script for generating acquisition schemes. Details in 3593415.

Execution is still way faster than other related commands, so that's no issue.

Also considered altering the optimisation of order by calculating the SH condition numbers for prospective addition of individual remaining directions; but undecided as to whether or not it's worth the effort yet.