### PR TITLE
TravisCI: Explicit brew update call

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ install:
   ##################################################
   - |
     if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
+        brew update
         brew install qt5
         brew link --force qt5
     fi


### PR DESCRIPTION
Necessary to fix TravisCI testing on `master` for various PRs.

Echoes #1535, which applied the same fix on `dev`.