### PR TITLE
RNG: use std::random_device to initialise on all platforms

### DIFF
--- a/core/math/rng.h
+++ b/core/math/rng.h
@@ -79,15 +79,8 @@ namespace MR
           if (from_env)
             return to<std::mt19937::result_type> (from_env);
 
-#ifdef MRTRIX_WINDOWS
-          struct timeval tv;
-          gettimeofday (&tv, nullptr);
-          return tv.tv_sec ^ tv.tv_usec;
-#else
-          // TODO check whether this does in fact work on Windows...
           std::random_device rd;
           return rd();
-#endif
         }
 
 


### PR DESCRIPTION
A quick test shows that `std::random_device` now works as expected on Windows too (it used to produce the same seed every time). This now means the RNG initialisation uses the same code across all platforms. 

