### PR TITLE
tckgen: fix out-of-bounds access in downsampler

### DIFF
--- a/src/dwi/tractography/resampling/downsampler.cpp
+++ b/src/dwi/tractography/resampling/downsampler.cpp
@@ -26,8 +26,10 @@ namespace MR {
 
         bool Downsampler::operator() (Tracking::GeneratedTrack& tck) const
         {
-          if (ratio <= 1 || tck.size() < 2)
+          if (ratio <= 1)
             return false;
+          if (tck.size() <= 1)
+            return true;
           size_t index_old = ratio;
           if (tck.get_seed_index()) {
             index_old = (((tck.get_seed_index() - 1) % ratio) + 1);

--- a/src/dwi/tractography/resampling/downsampler.cpp
+++ b/src/dwi/tractography/resampling/downsampler.cpp
@@ -26,7 +26,7 @@ namespace MR {
 
         bool Downsampler::operator() (Tracking::GeneratedTrack& tck) const
         {
-          if (ratio <= 1 || tck.empty())
+          if (ratio <= 1 || tck.size() < 2)
             return false;
           size_t index_old = ratio;
           if (tck.get_seed_index()) {


### PR DESCRIPTION
This caused crashes in rare cases, due to downsampling tracks with a single vertex.

First raised by @bjeurissen due to consistent crashes in `dwigradcheck` on Catalina, eventually tracked down to the use of downsampling (so nothing to do with macOS or multi-threading), and the issue isolated with a massive overnight 'valgrind' job on Linux... :sweat_smile: 