### PR TITLE
mrview: add support for QFileOpenEvent (macOS)

### DIFF
--- a/cmd/mrview.cpp
+++ b/cmd/mrview.cpp
@@ -20,6 +20,7 @@
 #include "memory.h"
 #include "gui/mrview/icons.h"
 #include "gui/mrview/window.h"
+#include "gui/mrview/file_open.h"
 #include "gui/mrview/mode/list.h"
 #include "gui/mrview/tool/list.h"
 

--- a/cmd/shview.cpp
+++ b/cmd/shview.cpp
@@ -21,6 +21,7 @@
 #include "math/SH.h"
 #include "gui/shview/icons.h"
 #include "gui/shview/render_window.h"
+#include "gui/shview/file_open.h"
 
 
 using namespace MR;

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -17,6 +17,8 @@
 #ifndef __gui_app_h__
 #define __gui_app_h__
 
+#include <QApplication>
+
 #include "app.h"
 #include "file/config.h"
 #include "gui/opengl/gl.h"
@@ -27,15 +29,14 @@ namespace MR
   {
 
 
-    class App : public QObject { NOMEMALIGN
-      Q_OBJECT
+    class App : public QApplication { NOMEMALIGN
 
       public:
         App (int& cmdline_argc, char** cmdline_argv);
 
-        ~App () {
-          delete qApp;
-        }
+        // this needs to be defined on a per-application basis:
+        virtual bool event (QEvent *event) override;
+
 
         static void set_main_window (QWidget* window, GL::Area* glarea) {
           main_window = window;

--- a/src/gui/mrview/file_open.cpp
+++ b/src/gui/mrview/file_open.cpp
@@ -14,42 +14,31 @@
  * For more details, see http://www.mrtrix.org/.
  */
 
-#include <locale>
-#include <clocale>
-#include "gui/gui.h"
-#include "gui/opengl/gl.h"
+#include "gui/mrview/file_open.h"
+#include "gui/mrview/window.h"
 
 namespace MR
 {
   namespace GUI
   {
 
-
-
-    QWidget* App::main_window = nullptr;
-    App* App::application = nullptr;
-
-
-
-    App::App (int& cmdline_argc, char** cmdline_argv) :
-      QApplication (cmdline_argc, cmdline_argv)
+    bool App::event (QEvent *event)
     {
-      application = this;
-      ::MR::File::Config::init ();
-      ::MR::GUI::GL::set_default_context ();
-
-      QLocale::setDefault(QLocale::c());
-      std::locale::global (std::locale::classic());
-      std::setlocale (LC_ALL, "C");
-
-      setAttribute (Qt::AA_DontCreateNativeWidgetSiblings);
+      if (event->type() == QEvent::FileOpen) {
+        QFileOpenEvent *openEvent = static_cast<QFileOpenEvent *>(event);
+        vector<std::unique_ptr<MR::Header>> list;
+        try {
+          list.push_back (make_unique<MR::Header> (MR::Header::open (openEvent->file().toUtf8().data())));
+        }
+        catch (Exception& E) {
+          E.display();
+        }
+        reinterpret_cast<MRView::Window*> (main_window)->add_images (list);
+      }
+      return QApplication::event(event);
     }
-
 
 
   }
 }
-
-
-
 

--- a/src/gui/mrview/file_open.h
+++ b/src/gui/mrview/file_open.h
@@ -14,42 +14,10 @@
  * For more details, see http://www.mrtrix.org/.
  */
 
-#include <locale>
-#include <clocale>
+#ifndef __gui_mrview_file_open_h__
+#define __gui_mrview_file_open_h__
+
 #include "gui/gui.h"
-#include "gui/opengl/gl.h"
 
-namespace MR
-{
-  namespace GUI
-  {
-
-
-
-    QWidget* App::main_window = nullptr;
-    App* App::application = nullptr;
-
-
-
-    App::App (int& cmdline_argc, char** cmdline_argv) :
-      QApplication (cmdline_argc, cmdline_argv)
-    {
-      application = this;
-      ::MR::File::Config::init ();
-      ::MR::GUI::GL::set_default_context ();
-
-      QLocale::setDefault(QLocale::c());
-      std::locale::global (std::locale::classic());
-      std::setlocale (LC_ALL, "C");
-
-      setAttribute (Qt::AA_DontCreateNativeWidgetSiblings);
-    }
-
-
-
-  }
-}
-
-
-
+#endif
 

--- a/src/gui/opengl/gl.cpp
+++ b/src/gui/opengl/gl.cpp
@@ -14,7 +14,6 @@
  * For more details, see http://www.mrtrix.org/.
  */
 
-#include "gui/gui.h"
 #include "gui/opengl/gl.h"
 #include "file/config.h"
 

--- a/src/gui/shview/file_open.cpp
+++ b/src/gui/shview/file_open.cpp
@@ -1,0 +1,32 @@
+/* Copyright (c) 2008-2019 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Covered Software is provided under this License on an "as is"
+ * basis, without warranty of any kind, either expressed, implied, or
+ * statutory, including, without limitation, warranties that the
+ * Covered Software is free of defects, merchantable, fit for a
+ * particular purpose or non-infringing.
+ * See the Mozilla Public License v. 2.0 for more details.
+ *
+ * For more details, see http://www.mrtrix.org/.
+ */
+
+#include "gui/shview/file_open.h"
+
+namespace MR
+{
+  namespace GUI
+  {
+
+    bool App::event (QEvent *event)
+    {
+      return QApplication::event(event);
+    }
+
+
+  }
+}
+

--- a/src/gui/shview/file_open.h
+++ b/src/gui/shview/file_open.h
@@ -1,0 +1,23 @@
+/* Copyright (c) 2008-2019 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Covered Software is provided under this License on an "as is"
+ * basis, without warranty of any kind, either expressed, implied, or
+ * statutory, including, without limitation, warranties that the
+ * Covered Software is free of defects, merchantable, fit for a
+ * particular purpose or non-infringing.
+ * See the Mozilla Public License v. 2.0 for more details.
+ *
+ * For more details, see http://www.mrtrix.org/.
+ */
+
+#ifndef __gui_mrview_file_open_h__
+#define __gui_mrview_file_open_h__
+
+#include "gui/gui.h"
+
+#endif
+


### PR DESCRIPTION
This adds support for opening images by dragging onto the dash, and by double-clicking in the Finder.