### PR TITLE
tckgen: fix out-of-bounds access in downsampler

### DIFF
--- a/src/dwi/tractography/resampling/downsampler.cpp
+++ b/src/dwi/tractography/resampling/downsampler.cpp
@@ -25,8 +25,10 @@ namespace MR {
 
         bool Downsampler::operator() (Tracking::GeneratedTrack& tck) const
         {
-          if (ratio <= 1 || tck.empty())
+          if (ratio <= 1)
             return false;
+          if (tck.size() <= 1)
+            return true;
           size_t index_old = ratio;
           if (tck.get_seed_index()) {
             index_old = (((tck.get_seed_index() - 1) % ratio) + 1);


### PR DESCRIPTION
same as #1814, applied to master branch
