### PR TITLE
Testing: Change fod2fixel temp data paths

### DIFF
--- a/run_tests
+++ b/run_tests
@@ -160,6 +160,7 @@ EOD
   echo -n 'running "'${testitem}'"... '
   rm -f $datadir/tmp*.*
   rm -rf $datadir/tmp-*/
+  rm -rf $datadir/tmp_*/
   rm -rf $datadir/*-tmp-*/
   ((ntests=0))
   ((success=0))

--- a/testing/binaries/tests/fod2fixel
+++ b/testing/binaries/tests/fod2fixel
@@ -1,3 +1,3 @@
-fod2fixel -nthread 1 fod.mif tmp_fod2fixel1 -afd afd.mif -peak peak.mif -disp disp.mif -force && testing_diff_fixel -frac 10e-5 fod2fixel/out1 tmp_fod2fixel1
-fod2fixel -nthread 1 fod.mif -mask mask.mif tmp_fod2fixel2 -afd afd.mif -peak peak.mif -disp disp.mif -force && testing_diff_fixel -frac 10e-5 fod2fixel/out2 tmp_fod2fixel2
-fod2fixel -nthread 1 -fmls_no_thresholds fod.mif tmp_fod2fixel3 -afd afd.mif -peak peak.mif -disp disp.mif -force && testing_diff_fixel -frac 10e-5 fod2fixel/out3 tmp_fod2fixel3
+fod2fixel -nthread 1 fod.mif tmp-fod2fixel1 -afd afd.mif -peak peak.mif -disp disp.mif -force && testing_diff_fixel -frac 10e-5 fod2fixel/out1 tmp-fod2fixel1
+fod2fixel -nthread 1 fod.mif -mask mask.mif tmp-fod2fixel2 -afd afd.mif -peak peak.mif -disp disp.mif -force && testing_diff_fixel -frac 10e-5 fod2fixel/out2 tmp-fod2fixel2
+fod2fixel -nthread 1 -fmls_no_thresholds fod.mif tmp-fod2fixel3 -afd afd.mif -peak peak.mif -disp disp.mif -force && testing_diff_fixel -frac 10e-5 fod2fixel/out3 tmp-fod2fixel3


### PR DESCRIPTION
Minor fix to CI testing so that repeated executions of `run_tests` does not yield failures in `fod2fixel` tests due to pre-existing (i.e. not properly deleted) directories.