### PR TITLE
Fix dicom handling with stricter string conversion

### DIFF
--- a/core/file/dicom/csa_entry.h
+++ b/core/file/dicom/csa_entry.h
@@ -97,7 +97,7 @@ namespace MR {
               for (uint32_t m = 0; m < nitems; m++) {
                 uint32_t length = Raw::fetch_LE<uint32_t> (p);
                 if (length)
-                  return to<int> (std::string (reinterpret_cast<const char*> (p)+16, 4*((length+3)/4)));
+                  return to<int> (strip (std::string (reinterpret_cast<const char*> (p)+16, 4*((length+3)/4))));
                 p += 16 + 4*((length+3)/4);
               }
               return 0;
@@ -108,7 +108,7 @@ namespace MR {
               for (uint32_t m = 0; m < nitems; m++) {
                 uint32_t length = Raw::fetch_LE<uint32_t> (p);
                 if (length)
-                  return to<default_type> (std::string (reinterpret_cast<const char*> (p)+16, 4*((length+3)/4)));
+                  return to<default_type> (strip (std::string (reinterpret_cast<const char*> (p)+16, 4*((length+3)/4))));
                 p += 16 + 4*((length+3)/4);
               }
               return NaN;
@@ -121,7 +121,7 @@ namespace MR {
                   DEBUG ("CSA entry contains fewer items than expected - trailing entries will be set to NaN");
                 for (uint32_t m = 0; m < std::min<size_t> (nitems, v.size()); m++) {
                   uint32_t length = Raw::fetch_LE<uint32_t> (p);
-                  v[m] = length ? to<default_type> (std::string (reinterpret_cast<const char*> (p)+16, 4*((length+3)/4))) : NaN;
+                  v[m] = length ? to<default_type> (strip (std::string (reinterpret_cast<const char*> (p)+16, 4*((length+3)/4)))) : NaN;
                   p += 16 + 4*((length+3)/4);
                 }
                 for (uint32_t m = nitems; m < v.size(); ++m)

--- a/core/file/dicom/element.cpp
+++ b/core/file/dicom/element.cpp
@@ -318,7 +318,7 @@ namespace MR {
           auto strings = split (std::string (reinterpret_cast<const char*> (data), size), "\\", false);
           V.resize (strings.size());
           for (size_t n = 0; n < V.size(); n++)
-            V[n] = to<int32_t> (strings[n]);
+            V[n] = to<int32_t> (strip (strings[n]));
         }
         else
           report_unknown_tag_with_implicit_syntax();
@@ -342,7 +342,7 @@ namespace MR {
           auto strings = split (std::string (reinterpret_cast<const char*> (data), size), "\\", false);
           V.resize (strings.size());
           for (size_t n = 0; n < V.size(); n++)
-            V[n] = to<uint32_t> (strings[n]);
+            V[n] = to<uint32_t> (strip (strings[n]));
         }
         else
           report_unknown_tag_with_implicit_syntax();
@@ -364,7 +364,7 @@ namespace MR {
           auto strings = split (std::string (reinterpret_cast<const char*> (data), size), "\\", false);
           V.resize (strings.size());
           for (size_t n = 0; n < V.size(); n++)
-            V[n] = to<default_type> (strings[n]);
+            V[n] = to<default_type> (strip (strings[n]));
         }
         else
           report_unknown_tag_with_implicit_syntax();
@@ -377,7 +377,7 @@ namespace MR {
       Date Element::get_date () const
       {
         assert (type() == DATE);
-        return Date (std::string (reinterpret_cast<const char*> (data), size));
+        return Date (strip (std::string (reinterpret_cast<const char*> (data), size)));
       }
 
 
@@ -386,7 +386,7 @@ namespace MR {
       Time Element::get_time () const
       {
         assert (type() == TIME);
-        return Time (std::string (reinterpret_cast<const char*> (data), size));
+        return Time (strip (std::string (reinterpret_cast<const char*> (data), size)));
       }
 
 

--- a/testing/cmd/testing_to.cpp
+++ b/testing/cmd/testing_to.cpp
@@ -61,6 +61,9 @@ void run ()
     "0",
     "1",
     "2",
+    "0 ",
+    " 1",
+    "0 0",
     "0a",
     "a0",
     "true",
@@ -71,6 +74,7 @@ void run ()
     "FALSE",
     "fals",
     "falsee",
+    "true ",
     "yes",
     "YES",
     "yeah",
@@ -104,12 +108,16 @@ void run ()
     "a1+i",
     "1+1+i",
     "-1-i",
-    "inf+infi" };
+    "inf+infi",
+    " -inf+-nani " };
 
   const vector<bool> bool_tests = {
     true,  // "0"
     true,  // "1"
     true,  // "2"
+    true,  // "0 "
+    true,  // " 1"
+    false, // "0 0"
     false, // "0a"
     false, // "a0"
     true,  // "true"
@@ -120,6 +128,7 @@ void run ()
     true,  // "FALSE"
     false, // "fals"
     false, // "falsee"
+    true,  // "true "
     true,  // "yes"
     true,  // "YES"
     false, // "yeah"
@@ -153,13 +162,17 @@ void run ()
     false, // "a1+i"
     false, // "1+1+i"
     false, // "-1-i"
-    false  // "inf+infi"
+    false, // "inf+infi"
+    false  // " -inf+-nani "
   };
 
   const vector<bool> int_tests = {
       true,  // "0"
       true,  // "1"
       true,  // "2"
+      true,  // "0 "
+      true,  // " 1"
+      false, // "0 0"
       false, // "0a"
       false, // "a0"
       false, // "true"
@@ -170,6 +183,7 @@ void run ()
       false, // "FALSE"
       false, // "fals"
       false, // "falsee"
+      false, // "true "
       false, // "yes"
       false, // "YES"
       false, // "yeah"
@@ -203,13 +217,17 @@ void run ()
       false, // "a1+i"
       false, // "1+1+i"
       false, // "-1-i"
-      false  // "inf+infi"
+      false, // "inf+infi"
+      false  // " -inf+-nani "
   };
 
   const vector<bool> float_tests = {
       true,  // "0"
       true,  // "1"
       true,  // "2"
+      true,  // "0 "
+      true,  // " 1"
+      false, // "0 0"
       false, // "0a"
       false, // "a0"
       false, // "true"
@@ -220,6 +238,7 @@ void run ()
       false, // "FALSE"
       false, // "fals"
       false, // "falsee"
+      false, // "true "
       false, // "yes"
       false, // "YES"
       false, // "yeah"
@@ -253,13 +272,17 @@ void run ()
       false, // "a1+i"
       false, // "1+1+i"
       false, // "-1-i"
-      false  // "inf+infi"
+      false, // "inf+infi"
+      false  // " -inf+-nani "
   };
 
   const vector<bool> complex_tests = {
       true,  // "0"
       true,  // "1"
       true,  // "2"
+      true,  // "0 "
+      true,  // " 1"
+      false, // "0 0"
       false, // "0a"
       false, // "a0"
       false, // "true"
@@ -270,6 +293,7 @@ void run ()
       false, // "FALSE"
       false, // "fals"
       false, // "falsee"
+      false, // "true "
       false, // "yes"
       false, // "YES"
       false, // "yeah"
@@ -303,7 +327,8 @@ void run ()
       false, // "a1+i"
       false, // "1+1+i"
       true,  // "-1-i"
-      true   // "inf+infi"
+      true,  // "inf+infi"
+      true   //" -inf+-nani "
   };
 
   test<bool> (data, bool_tests);


### PR DESCRIPTION
Fix errors while reading DICOMs following #1794. 

This strips the strings prior to parsing with `to<type>()`, and fixes the issue as far as DICOM handling is concerned. 

But there is an argument for stripping all strings within the `to<type>()` call. This obviously fixes this issue, but also provides more lenient handling of string parsing in general. There's a good argument for considering strings with trailing whitespace as valid... 