### PR TITLE
Build: Detect outdated configuration

### DIFF
--- a/build
+++ b/build
@@ -547,6 +547,13 @@ please run "./configure" prior to invoking this script
 
 ''')
 
+# renamed internal string substitutions
+if 'LDFLAGS' in ld or 'LDLIB_FLAGS' in ld_lib:
+  fail ('''configuration file is out of date!
+please run "./configure" prior to invoking this script
+
+''')
+
 if separate_project:
   cpp_flags += [ '-DMRTRIX_PROJECT' ]
 

--- a/build
+++ b/build
@@ -533,10 +533,10 @@ activate_build (active_config_core, mrtrix_dir)
 if config_file is None:
   config_file = os.path.normpath (os.path.join (mrtrix_dir[-1], 'config'))
 
-# prevent pylint from generating a huge number of undefined variable / non-iterable warnings
-PATH = obj_suffix = exe_suffix = lib_prefix = lib_suffix = \
-cpp = ld = runpath = ld_enabled = ld_lib = moc = rcc = nogui = None
-cpp_flags = ld_flags = ld_lib_flags = eigen_cflags = qt_cflags = qt_ldflags = [ ]
+# prevent pylint from generating undefined variable / non-iterable / membership test warnings
+PATH = obj_suffix = exe_suffix = lib_prefix = lib_suffix = None
+runpath = ld_enabled = moc = rcc = nogui = None
+cpp = cpp_flags = ld = ld_flags = ld_lib = ld_lib_flags = eigen_cflags = qt_cflags = qt_ldflags = [ ]
 
 try:
   log ('reading configuration from "' + config_file + '"...' + os.linesep)


### PR DESCRIPTION
Fix for changes in #1824 to detect mismatch between current configuration and `build` code due to changed internal string substitution names.