### PR TITLE
run.command(): Use same Python interpreter

### DIFF
--- a/lib/mrtrix3/run.py
+++ b/lib/mrtrix3/run.py
@@ -548,7 +548,6 @@ def version_match(item):
 # If the target executable is not a binary, but is actually a script, use the
 #   shebang at the start of the file to alter the subprocess call
 def _shebang(item):
-  from mrtrix3 import MRtrixError
   from mrtrix3 import app, utils #pylint: disable=import-outside-toplevel
   # If a complete path has been provided rather than just a file name, don't perform any additional file search
   if os.sep in item:

--- a/lib/mrtrix3/run.py
+++ b/lib/mrtrix3/run.py
@@ -587,7 +587,7 @@ def _shebang(item):
             return []
           shebang = [ sys.executable ] + shebang[2:]
           app.debug('File \"' + item + '\": Using current Python interpreter')
-        if utils.is_windows():
+        elif utils.is_windows():
           shebang = [ os.path.abspath(find_executable(exe_name(shebang[1]))) ] + shebang[2:]
       elif utils.is_windows():
         shebang = [ os.path.abspath(find_executable(exe_name(os.path.basename(shebang[0])))) ] + shebang[1:]

--- a/lib/mrtrix3/run.py
+++ b/lib/mrtrix3/run.py
@@ -548,6 +548,7 @@ def version_match(item):
 # If the target executable is not a binary, but is actually a script, use the
 #   shebang at the start of the file to alter the subprocess call
 def _shebang(item):
+  from mrtrix3 import MRtrixError
   from mrtrix3 import app, utils #pylint: disable=import-outside-toplevel
   # If a complete path has been provided rather than just a file name, don't perform any additional file search
   if os.sep in item:
@@ -574,19 +575,23 @@ def _shebang(item):
     if len(line) > 2 and line[0:2] == '#!':
       # Need to strip first in case there's a gap between the shebang symbol and the interpreter path
       shebang = line[2:].strip().split(' ')
-      if utils.is_windows():
-        # On Windows, /usr/bin/env can't be easily found, and any direct interpreter path will have a similar issue.
-        #   Instead, manually find the right interpreter to call using distutils
-        if os.path.basename(shebang[0]) == 'env':
-          new_shebang = [ os.path.abspath(find_executable(exe_name(shebang[1]))) ]
-          new_shebang.extend(shebang[2:])
-          shebang = new_shebang
-        else:
-          new_shebang = [ os.path.abspath(find_executable(exe_name(os.path.basename(shebang[0])))) ]
-          new_shebang.extend(shebang[1:])
-          shebang = new_shebang
-        if not shebang or not shebang[0]:
-          raise MRtrixError('malformed shebang in file \"' + item + '\": \"' + line + '\"')
+      # On Windows, /usr/bin/env can't be easily found, and any direct interpreter path will have a similar issue.
+      #   Instead, manually find the right interpreter to call using distutils
+      # Also if script is written in Python, try to execute it using the same interpreter as that currently running
+      if os.path.basename(shebang[0]) == 'env':
+        if len(shebang) < 2:
+          app.warn('Invalid shebang in script file \"' + item + '\" (missing interpreter after \"env\")')
+          return []
+        if shebang[1] == 'python':
+          if not sys.executable:
+            app.warn('Unable to self-identify Python interpreter; file \"' + item + '\" not guaranteed to execute on same version')
+            return []
+          shebang = [ sys.executable ] + shebang[2:]
+          app.debug('File \"' + item + '\": Using current Python interpreter')
+        if utils.is_windows():
+          shebang = [ os.path.abspath(find_executable(exe_name(shebang[1]))) ] + shebang[2:]
+      elif utils.is_windows():
+        shebang = [ os.path.abspath(find_executable(exe_name(os.path.basename(shebang[0])))) ] + shebang[1:]
       app.debug('File \"' + item + '\": string \"' + line + '\": ' + str(shebang))
       return shebang
   app.debug('File \"' + item + '\": No shebang found')


### PR DESCRIPTION
Works on Linux; requires test on Windows.

Closes #1825.