### PR TITLE
support foreach */ again to loop over directories

### DIFF
--- a/bin/foreach
+++ b/bin/foreach
@@ -161,7 +161,7 @@ def execute(): #pylint: disable=unused-variable
     def __init__(self, input_text):
       self.input_text = input_text
       self.sub_in = input_text
-      self.sub_name = os.path.basename(input_text)
+      self.sub_name = os.path.basename(input_text.rstrip('/'))
       self.sub_pre = os.path.splitext(self.sub_name.rstrip('.gz'))[0]
       if common_suffix:
         self.sub_uni = input_text[len(common_prefix):-len(common_suffix)]


### PR DESCRIPTION
foreach used to support looping over just folders, by adding a trailing '/'
Currently this is broken because basename('foldername/') is empty, causing NAME to be empty.
This should fix this.