### PR TITLE
SIFT: Fix TDI SH image output

### DIFF
--- a/src/dwi/tractography/SIFT/output.h
+++ b/src/dwi/tractography/SIFT/output.h
@@ -167,7 +167,7 @@ namespace MR
         H_sh.stride (3) = 0;
         auto out = Image<float>::create (path, H_sh);
         VoxelAccessor v (accessor());
-        for (auto l = Loop (out) (out, v); l; ++l) {
+        for (auto l = Loop (v) (out, v); l; ++l) {
           if (v.value()) {
             Eigen::Matrix<default_type, Eigen::Dynamic, 1> sum = Eigen::Matrix<default_type, Eigen::Dynamic, 1>::Zero (N);
             for (typename Fixel_map<Fixel>::ConstIterator i = begin (v); i; ++i) {


### PR DESCRIPTION
Only applies if SH output images are [explicitly enabled by uncommenting code](https://github.com/MRtrix3/mrtrix3/blob/3.0_RC3/src/dwi/tractography/SIFT/model_base.h#L45); but a bug nevertheless.