### PR TITLE
JSON handling on dev

### DIFF
--- a/cmd/mrconvert.cpp
+++ b/cmd/mrconvert.cpp
@@ -548,6 +548,6 @@ void run ()
 
   opt = get_options ("json_export");
   if (opt.size())
-    File::JSON::save (header_out, opt[0][0]);
+    File::JSON::save (header_out, opt[0][0], argument[1]);
 }
 

--- a/cmd/mrinfo.cpp
+++ b/cmd/mrinfo.cpp
@@ -218,7 +218,7 @@ void header2json (const Header& header, nlohmann::json& json)
                         { T(2,0), T(2,1), T(2,2), T(2,3) },
                         {    0.0,    0.0,    0.0,    1.0 } };
   // Load key-value entries into a nested keyval.* member
-  File::JSON::write (header, json["keyval"], false);
+  File::JSON::write (header, json["keyval"], header.name());
 }
 
 
@@ -245,7 +245,7 @@ void run ()
     throw Exception ("Cannot use -json_all option with multiple input images");
 
   if (get_options ("norealign").size())
-    Header::do_not_realign_transform = true;
+    Header::do_realign_transform = false;
 
   const bool name          = get_options("name")          .size();
   const bool format        = get_options("format")        .size();
@@ -297,7 +297,7 @@ void run ()
     PhaseEncoding::export_commandline (header);
 
     if (json_keyval)
-      File::JSON::write (header, *json_keyval, false);
+      File::JSON::write (header, *json_keyval, (argument.size() > 1 ? std::string("") : std::string(argument[0])));
 
     if (json_all)
       header2json (header, *json_all);

--- a/cmd/mrinfo.cpp
+++ b/cmd/mrinfo.cpp
@@ -218,7 +218,7 @@ void header2json (const Header& header, nlohmann::json& json)
                         { T(2,0), T(2,1), T(2,2), T(2,3) },
                         {    0.0,    0.0,    0.0,    1.0 } };
   // Load key-value entries into a nested keyval.* member
-  File::JSON::write (header, json["keyval"]);
+  File::JSON::write (header, json["keyval"], false);
 }
 
 
@@ -297,7 +297,7 @@ void run ()
     PhaseEncoding::export_commandline (header);
 
     if (json_keyval)
-      File::JSON::write (header, *json_keyval);
+      File::JSON::write (header, *json_keyval, false);
 
     if (json_all)
       header2json (header, *json_all);

--- a/cmd/mrinfo.cpp
+++ b/cmd/mrinfo.cpp
@@ -85,8 +85,6 @@ void usage ()
     +   Option ("multiplier", "image intensity multiplier")
     +   Option ("transform", "the transformation from image coordinates [mm] to scanner / real world coordinates [mm]")
 
-    + NoRealignOption
-
     + FieldExportOptions
 
     + GradImportOptions

--- a/cmd/mrinfo.cpp
+++ b/cmd/mrinfo.cpp
@@ -218,7 +218,7 @@ void header2json (const Header& header, nlohmann::json& json)
                         { T(2,0), T(2,1), T(2,2), T(2,3) },
                         {    0.0,    0.0,    0.0,    1.0 } };
   // Load key-value entries into a nested keyval.* member
-  File::JSON::write (header, json["keyval"], false);
+  File::JSON::write (header, json["keyval"]);
 }
 
 
@@ -297,7 +297,7 @@ void run ()
     PhaseEncoding::export_commandline (header);
 
     if (json_keyval)
-      File::JSON::write (header, *json_keyval, false);
+      File::JSON::write (header, *json_keyval);
 
     if (json_all)
       header2json (header, *json_all);

--- a/core/axes.cpp
+++ b/core/axes.cpp
@@ -68,7 +68,7 @@ namespace MR
 
 
 
-    void get_permutation_to_make_axial (const transform_type& T, size_t perm[3], bool flip[3])
+    void get_permutation_to_make_axial (const transform_type& T, std::array<size_t, 3>& perm, std::array<bool, 3>& flip)
     {
       // Find which row of the transform is closest to each scanner axis
       decltype(T.matrix().topLeftCorner<3,3>())::Index index;

--- a/core/axes.h
+++ b/core/axes.h
@@ -43,7 +43,7 @@ namespace MR
 
     //! determine the axis permutations and flips necessary to make an image
     //!   appear approximately axial
-    void get_permutation_to_make_axial (const transform_type& T, size_t perm[3], bool flip[3]);
+    void get_permutation_to_make_axial (const transform_type& T, std::array<size_t, 3>& perm, std::array<bool, 3>& flip);
 
 
 

--- a/core/file/config.cpp
+++ b/core/file/config.cpp
@@ -16,6 +16,7 @@
 
 #include "app.h"
 #include "debug.h"
+#include "header.h"
 
 #include "file/path.h"
 #include "file/config.h"
@@ -76,6 +77,12 @@ namespace MR
       auto opt = App::get_options ("config");
       for (const auto& keyval : opt)
         config[std::string(keyval[0])] = std::string(keyval[1]);
+
+      //CONF option: RealignTransform
+      //CONF default: 1 (true)
+      //CONF A boolean value to indicate whether all images should be realigned
+      //CONF to an approximately axial orientation at load.
+      Header::do_realign_transform = get_bool("RealignTransform", true);
     }
 
 

--- a/core/file/json_utils.cpp
+++ b/core/file/json_utils.cpp
@@ -58,7 +58,7 @@ namespace MR
       void save (const Header& H, const std::string& path)
       {
         nlohmann::json json;
-        write (H, json);
+        write (H, json, true);
         File::OFStream out (path);
         out << json.dump(4);
       }
@@ -267,10 +267,10 @@ namespace MR
 
 
 
-      void write (const Header& header, nlohmann::json& json)
+      void write (const Header& header, nlohmann::json& json, const bool realign)
       {
-        const bool realign = Formats::is_nifti (header);
-        if (!realign) {
+        const bool do_realign = realign && Formats::is_nifti (header);
+        if (!do_realign) {
           write (header.keyval(), json);
           return;
         }

--- a/core/file/json_utils.cpp
+++ b/core/file/json_utils.cpp
@@ -163,7 +163,7 @@ namespace MR
               Eigen::VectorXd new_line = pe_scheme.row (row);
               for (ssize_t axis = 0; axis != 3; ++axis) {
                 new_line[axis] = pe_scheme(row, perm[axis]);
-                if (new_line[axis] && flip[axis])
+                if (new_line[axis] && flip[perm[axis]])
                   new_line[axis] = -new_line[axis];
               }
               pe_scheme.row (row) = new_line;
@@ -181,7 +181,7 @@ namespace MR
             const Eigen::Vector3 orig_dir (Axes::id2dir (slice_encoding_it->second));
             Eigen::Vector3 new_dir;
             for (size_t axis = 0; axis != 3; ++axis)
-              new_dir[axis] = flip[axis] ? -orig_dir[perm[axis]] : orig_dir[perm[axis]];
+              new_dir[axis] = flip[perm[axis]] ? -orig_dir[perm[axis]] : orig_dir[perm[axis]];
             slice_encoding_it->second = Axes::dir2id (new_dir);
             INFO ("Slice encoding direction read from JSON file modified to conform to prior MRtrix3 internal transform realignment of input image");
           } else {

--- a/core/file/json_utils.cpp
+++ b/core/file/json_utils.cpp
@@ -20,6 +20,8 @@
 #include "file/json_utils.h"
 #include "file/nifti_utils.h"
 
+#include "formats/nifti_utils.h"
+
 #include "axes.h"
 #include "exception.h"
 #include "header.h"
@@ -56,7 +58,7 @@ namespace MR
       void save (const Header& H, const std::string& path)
       {
         nlohmann::json json;
-        write (H, json, true);
+        write (H, json);
         File::OFStream out (path);
         out << json.dump(4);
       }
@@ -71,7 +73,7 @@ namespace MR
         for (auto i = json.cbegin(); i != json.cend(); ++i) {
 
           if (i->is_boolean()) {
-            result.insert (std::make_pair (i.key(), i.value() ? "1" : "0"));
+            result.insert (std::make_pair (i.key(), i.value() ? "true" : "false"));
           } else if (i->is_number_integer()) {
             result.insert (std::make_pair (i.key(), str<int>(i.value())));
           } else if (i->is_number_float()) {
@@ -82,15 +84,15 @@ namespace MR
               if (j->is_array()) {
                 vector<std::string> line;
                 for (auto k : *j)
-                  line.push_back (str(k));
+                  line.push_back (unquote(str(k)));
                 s.push_back (join(line, ","));
               } else {
-                s.push_back (str(*j));
+                s.push_back (unquote(str(*j)));
               }
             }
             result.insert (std::make_pair (i.key(), join(s, "\n")));
           } else if (i->is_string()) {
-            const std::string s = i.value();
+            const std::string s = unquote(i.value());
             result.insert (std::make_pair (i.key(), s));
           }
         }
@@ -102,41 +104,47 @@ namespace MR
       void read (const nlohmann::json& json, Header& header, const bool realign)
       {
         header.keyval() = read (json, header.keyval());
-        if (realign && !Header::do_not_realign_transform) {
+        const bool do_realign = realign && !Header::do_not_realign_transform;
 
-          // The corresponding header may have been rotated on image load prior to the JSON
-          //   being loaded. If this is the case, any fields that indicate an image axis
-          //   number / direction need to be correspondingly modified.
+        // The corresponding header may have been rotated on image load prior to the JSON
+        //   being loaded. If this is the case, any fields that indicate an image axis
+        //   number / direction need to be correspondingly modified.
+        std::array<size_t, 3> perm;
+        std::array<bool, 3> flip;
+        header.realignment (perm, flip);
+        if (perm[0] == 0 && perm[1] == 1 && perm[2] == 2 && !flip[0] && !flip[1] && !flip[2])
+          return;
 
-          size_t perm[3];
-          bool flip[3];
-          Axes::get_permutation_to_make_axial (header.transform(), perm, flip);
-          if (perm[0] != 0 || perm[1] != 1 || perm[2] != 2 || flip[0] || flip[1] || flip[2]) {
-
-            auto pe_scheme = PhaseEncoding::get_scheme (header);
-            if (pe_scheme.rows()) {
-              for (ssize_t row = 0; row != pe_scheme.rows(); ++row) {
-                Eigen::VectorXd new_line = pe_scheme.row (row);
-                for (ssize_t axis = 0; axis != 3; ++axis)
-                  new_line[perm[axis]] = flip[perm[axis]] ? pe_scheme(row,axis) : -pe_scheme(row,axis);
-                pe_scheme.row (row) = new_line;
-              }
-              PhaseEncoding::set_scheme (header, pe_scheme);
-              INFO ("Phase encoding information read from JSON file modified according to expected input image header transform realignment");
+        auto pe_scheme = PhaseEncoding::get_scheme (header);
+        if (pe_scheme.rows()) {
+          if (do_realign) {
+            for (ssize_t row = 0; row != pe_scheme.rows(); ++row) {
+              Eigen::VectorXd new_line = pe_scheme.row (row);
+              for (ssize_t axis = 0; axis != 3; ++axis)
+                new_line[perm[axis]] = flip[perm[axis]] ? -pe_scheme(row,axis) : pe_scheme(row,axis);
+              pe_scheme.row (row) = new_line;
             }
-
-            auto slice_encoding_it = header.keyval().find ("SliceEncodingDirection");
-            if (slice_encoding_it != header.keyval().end()) {
-              const Eigen::Vector3 orig_dir (Axes::id2dir (slice_encoding_it->second));
-              Eigen::Vector3 new_dir;
-              for (size_t axis = 0; axis != 3; ++axis)
-                new_dir[perm[axis]] = flip[perm[axis]] > 0 ? orig_dir[axis] : -orig_dir[axis];
-              slice_encoding_it->second = Axes::dir2id (new_dir);
-              INFO ("Slice encoding direction read from JSON file modified according to expected input image header transform realignment");
-            }
-
+            PhaseEncoding::set_scheme (header, pe_scheme);
+            INFO ("Phase encoding information read from JSON file modified according to prior input image header transform realignment");
+          } else {
+            INFO ("Phase encoding information read from JSON file not modified");
           }
         }
+
+        auto slice_encoding_it = header.keyval().find ("SliceEncodingDirection");
+        if (slice_encoding_it != header.keyval().end()) {
+          if (do_realign) {
+            const Eigen::Vector3 orig_dir (Axes::id2dir (slice_encoding_it->second));
+            Eigen::Vector3 new_dir;
+            for (size_t axis = 0; axis != 3; ++axis)
+              new_dir[perm[axis]] = flip[perm[axis]] ? -orig_dir[axis] : orig_dir[axis];
+            slice_encoding_it->second = Axes::dir2id (new_dir);
+            INFO ("Slice encoding direction read from JSON file modified according to prior input image header transform realignment");
+          } else {
+            INFO ("Slice encoding information read from JSON file not modified");
+          }
+        }
+
       }
 
 
@@ -232,44 +240,46 @@ namespace MR
 
 
 
-      void write (const Header& header, nlohmann::json& json, const bool realign)
+      void write (const Header& header, nlohmann::json& json)
       {
-        if (realign && !Header::do_not_realign_transform) {
-          auto pe_scheme = PhaseEncoding::get_scheme (header);
-          vector<size_t> order;
-          File::NIfTI::adjust_transform (header, order);
-          Header H_adj (header);
-          const bool axes_adjusted = (order[0] != 0 || order[1] != 1 || order[2] != 2 || header.stride(0) < 0 || header.stride(1) < 0 || header.stride(2) < 0);
-          if (pe_scheme.rows() && axes_adjusted) {
-            // Assume that image being written to disk is going to have its transform adjusted,
-            //   so modify the phase encoding scheme appropriately before writing to JSON
-            for (ssize_t row = 0; row != pe_scheme.rows(); ++row) {
-              Eigen::VectorXd new_line = pe_scheme.row (row);
-              for (ssize_t axis = 0; axis != 3; ++axis)
-                new_line[axis] = header.stride (order[axis]) > 0 ? pe_scheme(row, order[axis]) : -pe_scheme(row, order[axis]);
-              pe_scheme.row (row) = new_line;
-            }
-            PhaseEncoding::set_scheme (H_adj, pe_scheme);
-            INFO ("Phase encoding information written to JSON file modified according to expected output NIfTI header transform realignment");
-          }
-          auto slice_encoding_it = H_adj.keyval().find ("SliceEncodingDirection");
-          if (slice_encoding_it != H_adj.keyval().end() && axes_adjusted) {
-            const Eigen::Vector3 orig_dir (Axes::id2dir (slice_encoding_it->second));
-            Eigen::Vector3 new_dir;
-            for (size_t axis = 0; axis != 3; ++axis)
-              new_dir[order[axis]] = header.stride (order[axis]) > 0 ? orig_dir[order[axis]] : -orig_dir[order[axis]];
-            slice_encoding_it->second = Axes::dir2id (new_dir);
-            INFO ("Slice encoding direction written to JSON file modified according to expected output NIfTI header transform realignment");
-          }
-          write (H_adj.keyval(), json);
-        } else {
+        const bool realign = Formats::is_nifti (header);
+        if (!realign) {
           write (header.keyval(), json);
+          return;
         }
+
+        vector<size_t> order;
+        File::NIfTI::adjust_transform (header, order);
+        if (!(order[0] != 0 || order[1] != 1 || order[2] != 2 || header.stride(0) < 0 || header.stride(1) < 0 || header.stride(2) < 0)) {
+          write (header.keyval(), json);
+          return;
+        }
+
+        Header H_adj (header);
+        auto pe_scheme = PhaseEncoding::get_scheme (header);
+        if (pe_scheme.rows()) {
+          // Assume that image being written to disk is going to have its transform adjusted,
+          //   so modify the phase encoding scheme appropriately before writing to JSON
+          for (ssize_t row = 0; row != pe_scheme.rows(); ++row) {
+            Eigen::VectorXd new_line = pe_scheme.row (row);
+            for (ssize_t axis = 0; axis != 3; ++axis)
+              new_line[axis] = header.stride (order[axis]) > 0 ? pe_scheme(row, order[axis]) : -pe_scheme(row, order[axis]);
+            pe_scheme.row (row) = new_line;
+          }
+          PhaseEncoding::set_scheme (H_adj, pe_scheme);
+          INFO ("Phase encoding information written to JSON file modified according to expected output NIfTI header transform realignment");
+        }
+        auto slice_encoding_it = H_adj.keyval().find ("SliceEncodingDirection");
+        if (slice_encoding_it != H_adj.keyval().end()) {
+          const Eigen::Vector3 orig_dir (Axes::id2dir (slice_encoding_it->second));
+          Eigen::Vector3 new_dir;
+          for (size_t axis = 0; axis != 3; ++axis)
+            new_dir[order[axis]] = header.stride (order[axis]) > 0 ? orig_dir[order[axis]] : -orig_dir[order[axis]];
+          slice_encoding_it->second = Axes::dir2id (new_dir);
+          INFO ("Slice encoding direction written to JSON file modified according to expected output NIfTI header transform realignment");
+        }
+        write (H_adj.keyval(), json);
       }
-
-
-
-
 
 
 

--- a/core/file/json_utils.cpp
+++ b/core/file/json_utils.cpp
@@ -90,7 +90,7 @@ namespace MR
               vector<std::string> line;
               for (const auto k : *i)
                 line.push_back (str(k));
-              H.keyval().insert (std::make_pair (i.key(), join (line, ",")));
+              result.insert (std::make_pair (i.key(), join (line, ",")));
             }
             else if (num_array == i->size()) {
               vector<std::string> s;
@@ -100,11 +100,10 @@ namespace MR
                   line.push_back (unquote(str(k)));
                 s.push_back (join(line, ","));
               }
-              H.keyval().insert (std::make_pair (i.key(), join(s, "\n")));
+              result.insert (std::make_pair (i.key(), join(s, "\n")));
             }
             else
               throw Exception ("JSON entry contains mixture of elements and arrays");
-            result.insert (std::make_pair (i.key(), join(s, "\n")));
           } else if (i->is_string()) {
             const std::string s = unquote(i.value());
             result.insert (std::make_pair (i.key(), s));

--- a/core/file/json_utils.cpp
+++ b/core/file/json_utils.cpp
@@ -309,7 +309,7 @@ namespace MR
           for (ssize_t row = 0; row != pe_scheme.rows(); ++row) {
             Eigen::VectorXd new_line = pe_scheme.row (row);
             for (ssize_t axis = 0; axis != 3; ++axis)
-              new_line[order[axis]] = header.stride (order[axis]) > 0 ? pe_scheme(row, axis) : -pe_scheme(row, axis);
+              new_line[axis] = header.stride (order[axis]) > 0 ? pe_scheme(row, order[axis]) : -pe_scheme(row, order[axis]);
             pe_scheme.row (row) = new_line;
           }
           PhaseEncoding::set_scheme (H_adj, pe_scheme);
@@ -320,10 +320,11 @@ namespace MR
           const Eigen::Vector3 orig_dir (Axes::id2dir (slice_encoding_it->second));
           Eigen::Vector3 new_dir;
           for (size_t axis = 0; axis != 3; ++axis)
-            new_dir[order[axis]] = header.stride (order[axis]) > 0 ? orig_dir[axis] : -orig_dir[axis];
+            new_dir[axis] = header.stride (order[axis]) > 0 ? orig_dir[order[axis]] : -orig_dir[order[axis]];
           slice_encoding_it->second = Axes::dir2id (new_dir);
           INFO ("Slice encoding direction written to JSON file modified according to expected output NIfTI header transform realignment");
         }
+
         write (H_adj.keyval(), json);
       }
 

--- a/core/file/json_utils.h
+++ b/core/file/json_utils.h
@@ -30,7 +30,7 @@ namespace MR
     {
 
       void load (Header&, const std::string&);
-      void save (const Header&, const std::string&);
+      void save (const Header&, const std::string&, const std::string&);
 
       KeyValues read (const nlohmann::json& json,
                       const KeyValues& preexisting = KeyValues());
@@ -41,7 +41,7 @@ namespace MR
       void write (const KeyValues& keyval, nlohmann::json& json);
       void write (const Header& header,
                   nlohmann::json& json,
-                  const bool realign);
+                  const std::string& image_path);
 
     }
   }

--- a/core/file/json_utils.h
+++ b/core/file/json_utils.h
@@ -40,7 +40,8 @@ namespace MR
 
       void write (const KeyValues& keyval, nlohmann::json& json);
       void write (const Header& header,
-                  nlohmann::json& json);
+                  nlohmann::json& json,
+                  const bool realign);
 
     }
   }

--- a/core/file/json_utils.h
+++ b/core/file/json_utils.h
@@ -40,8 +40,7 @@ namespace MR
 
       void write (const KeyValues& keyval, nlohmann::json& json);
       void write (const Header& header,
-                  nlohmann::json& json,
-                  const bool realign);
+                  nlohmann::json& json);
 
     }
   }

--- a/core/file/nifti1_utils.cpp
+++ b/core/file/nifti1_utils.cpp
@@ -462,7 +462,7 @@ namespace MR
           else
             assert (0);
           json_path += ".json";
-          File::JSON::save (H, json_path);
+          File::JSON::save (H, json_path, H.name());
         }
       }
 

--- a/core/file/nifti2_utils.cpp
+++ b/core/file/nifti2_utils.cpp
@@ -410,7 +410,7 @@ namespace MR
           else
             assert (0);
           json_path += ".json";
-          File::JSON::save (H, json_path);
+          File::JSON::save (H, json_path, H.name());
         }
       }
 

--- a/core/formats/nifti_utils.h
+++ b/core/formats/nifti_utils.h
@@ -1,0 +1,44 @@
+/* Copyright (c) 2008-2019 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Covered Software is provided under this License on an "as is"
+ * basis, without warranty of any kind, either expressed, implied, or
+ * statutory, including, without limitation, warranties that the
+ * Covered Software is free of defects, merchantable, fit for a
+ * particular purpose or non-infringing.
+ * See the Mozilla Public License v. 2.0 for more details.
+ *
+ * For more details, see http://www.mrtrix.org/.
+ */
+
+
+#include <string>
+
+#include "header.h"
+
+
+namespace MR
+{
+  namespace Formats
+  {
+
+
+
+    inline bool is_nifti (const Header& H)
+    {
+      const std::string format = H.format();
+      return (format == "NIfTI-1.1" ||
+              format == "NIfTI-2" ||
+              format == "NIfTI-1.1 (GZip compressed)" ||
+              format == "NIfTI-2 (GZip compressed)" ||
+              format == "AnalyseAVW / NIfTI");
+    }
+
+
+
+  }
+}
+

--- a/core/formats/nifti_utils.h
+++ b/core/formats/nifti_utils.h
@@ -17,7 +17,7 @@
 
 #include <string>
 
-#include "header.h"
+#include "types.h"
 
 
 namespace MR
@@ -27,14 +27,16 @@ namespace MR
 
 
 
-    inline bool is_nifti (const Header& H)
+    /*! basic convenience function to determine whether an image path
+     *  corresponds to a NIfTI-format image. */
+    inline bool is_nifti (const std::string& path)
     {
-      const std::string format = H.format();
-      return (format == "NIfTI-1.1" ||
-              format == "NIfTI-2" ||
-              format == "NIfTI-1.1 (GZip compressed)" ||
-              format == "NIfTI-2 (GZip compressed)" ||
-              format == "AnalyseAVW / NIfTI");
+      static const vector<std::string> exts { ".nii", ".nii.gz", ".img" };
+      for (const auto& ext : exts) {
+        if (path.substr (path.size() - ext.size()) == ext)
+          return true;
+      }
+      return false;
     }
 
 

--- a/core/header.cpp
+++ b/core/header.cpp
@@ -666,7 +666,7 @@ namespace MR
         Eigen::VectorXd new_line (pe_scheme.row (row));
         for (ssize_t axis = 0; axis != 3; ++axis) {
           new_line[axis] = pe_scheme(row, realign_perm_[axis]);
-          if (new_line[axis] && realign_flip_[axis])
+          if (new_line[axis] && realign_flip_[realign_perm_[axis]])
             new_line[axis] = -new_line[axis];
         }
         pe_scheme.row (row) = new_line;
@@ -682,7 +682,7 @@ namespace MR
       const Eigen::Vector3 orig_dir (Axes::id2dir (slice_encoding_it->second));
       Eigen::Vector3 new_dir;
       for (size_t axis = 0; axis != 3; ++axis)
-        new_dir[axis] = orig_dir[realign_perm_[axis]] * (realign_flip_[axis] ? -1.0 : 1.0);
+        new_dir[axis] = orig_dir[realign_perm_[axis]] * (realign_flip_[realign_perm_[axis]] ? -1.0 : 1.0);
       slice_encoding_it->second = Axes::dir2id (new_dir);
       INFO ("Slice encoding direction has been modified to conform to MRtrix3 internal header transform realignment");
     }

--- a/core/header.cpp
+++ b/core/header.cpp
@@ -43,7 +43,8 @@ namespace MR
                  "and/or header contents as they are actually stored in the header, "
                  "rather than as MRtrix interprets them.");
 
-  bool Header::do_not_realign_transform = false;
+
+  bool Header::do_realign_transform = true;
 
 
 
@@ -238,7 +239,7 @@ namespace MR
       } // End branching for [] notation
 
       H.sanitise();
-      if (!do_not_realign_transform)
+      if (do_realign_transform)
         H.realign_transform();
     }
     catch (Exception& E) {
@@ -671,7 +672,7 @@ namespace MR
         pe_scheme.row (row) = new_line;
       }
       PhaseEncoding::set_scheme (*this, pe_scheme);
-      INFO ("Phase encoding scheme has been modified according to internal header transform realignment");
+      INFO ("Phase encoding scheme modified to conform to MRtrix3 internal header transform realignment");
     }
 
     // If there's any slice encoding direction information present in the
@@ -683,7 +684,7 @@ namespace MR
       for (size_t axis = 0; axis != 3; ++axis)
         new_dir[axis] = orig_dir[realign_perm_[axis]] * (realign_flip_[axis] ? -1.0 : 1.0);
       slice_encoding_it->second = Axes::dir2id (new_dir);
-      INFO ("Slice encoding direction has been modified according to internal header transform realignment");
+      INFO ("Slice encoding direction has been modified to conform to MRtrix3 internal header transform realignment");
     }
 
   }

--- a/core/header.cpp
+++ b/core/header.cpp
@@ -36,13 +36,6 @@
 namespace MR
 {
 
-  const App::Option NoRealignOption
-  = App::Option ("norealign",
-                 "do not realign transform to near-default RAS coordinate system (the "
-                 "default behaviour on image load). This is useful to inspect the image "
-                 "and/or header contents as they are actually stored in the header, "
-                 "rather than as MRtrix interprets them.");
-
 
   bool Header::do_realign_transform = true;
 

--- a/core/header.h
+++ b/core/header.h
@@ -352,7 +352,7 @@ namespace MR
 
       /*! use to prevent automatic realignment of transform matrix into
        * near-standard (RAS) coordinate system. */
-      static bool do_not_realign_transform;
+      static bool do_realign_transform;
 
       //! return a string with the full description of the header
       std::string description (bool print_all = false) const;

--- a/core/header.h
+++ b/core/header.h
@@ -34,8 +34,6 @@
 namespace MR
 {
 
-  extern const App::Option NoRealignOption;
-
   /*! \defgroup ImageAPI Image access
    * \brief Classes and functions providing access to image data.
    *

--- a/core/mrtrix.h
+++ b/core/mrtrix.h
@@ -138,6 +138,20 @@ namespace MR
   }
 
 
+  //! Remove quotation marks only if surrounding entire string
+  inline std::string unquote (const std::string& string)
+  {
+    if (string.size() <= 2)
+      return string;
+    if (!(string.front() == '\"' && string.back() == '\"'))
+      return string;
+    const std::string substring = string.substr(1, string.size()-2);
+    if (std::none_of (substring.begin(), substring.end(), [] (const char& c) { return c == '\"'; }))
+      return substring;
+    return string;
+  }
+
+
 
   inline void replace (std::string& string, char orig, char final)
   {

--- a/docs/reference/commands/mrinfo.rst
+++ b/docs/reference/commands/mrinfo.rst
@@ -51,8 +51,6 @@ Options
 
 -  **-transform** the transformation from image coordinates [mm] to scanner / real world coordinates [mm]
 
--  **-norealign** do not realign transform to near-default RAS coordinate system (the default behaviour on image load). This is useful to inspect the image and/or header contents as they are actually stored in the header, rather than as MRtrix interprets them.
-
 Options for exporting image header fields
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/reference/commands/mrview.rst
+++ b/docs/reference/commands/mrview.rst
@@ -94,11 +94,6 @@ Debugging options
 
 -  **-fps** Display frames per second, averaged over the last 10 frames. The maximum over the last 3 seconds is also displayed.
 
-Other options
-^^^^^^^^^^^^^
-
--  **-norealign** do not realign transform to near-default RAS coordinate system (the default behaviour on image load). This is useful to inspect the image and/or header contents as they are actually stored in the header, rather than as MRtrix interprets them.
-
 Overlay tool options
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/reference/config_file_options.rst
+++ b/docs/reference/config_file_options.rst
@@ -501,6 +501,13 @@ List of MRtrix3 configuration file options
      The default colour to use for objects (i.e. SH glyphs) when not
      colouring by direction.
 
+.. option:: RealignTransform
+
+    *default: 1 (true)*
+
+     A boolean value to indicate whether all images should be realigned
+     to an approximately axial orientation at load.
+
 .. option:: RegAnalyseDescent
 
     *default: 0 (false)*

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -2195,11 +2195,7 @@ namespace MR
           + OptionGroup ("Debugging options")
 
           + Option ("fps", "Display frames per second, averaged over the last 10 frames. "
-              "The maximum over the last 3 seconds is also displayed.")
-
-          + OptionGroup ("Other options")
-
-          + NoRealignOption;
+              "The maximum over the last 3 seconds is also displayed.");
 
       }
 

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -735,7 +735,7 @@ namespace MR
       void Window::parse_arguments ()
       {
         if (MR::App::get_options ("norealign").size())
-          Header::do_not_realign_transform = true;
+          Header::do_realign_transform = false;
 
         if (MR::App::argument.size()) {
           if (MR::App::option.size())  {


### PR DESCRIPTION
In trying to resolve the various issues with JSON handling (#1735, #1738, #1771), it looks like there was quite a bit wrong with the relevant code. Given the breadth and magnitude of issues, I'd like to try to get JSON handling working as well as possible on `dev` (essentially expanding #1738), and then once we're happy with the behaviour here, determine what does or does not require immediate rectification on `master`.

-----

The complexity of the problem is as follows. 

1. Input orientation information could be either:

   1. Stored in the image header, in which case such data *may* be reoriented in the header key-value data during the `Header::realign_transform()` function (depending on `-norealign` or `Header::do_not_realign_transform`);

   2. Imported via `-json_import`, which occurs *after* `Header::realign_transform()` has already been completed.

2. Output orientation could be either:

   1. Stored in the header along with the image data;

   2. Exported to JSON to live alongside a non-NIfTI image;

   3. Exported to JSON to live alongside a NIfTI image.

So what I *think* may be two ongoing issues in parallel are:

1. `JSON::read()` was calling `Axes::get_permutation_to_make_axial()`, but doing so on an image header that has already had such permutation applied. So this change stores the permutations & flips applied to a `Header` as class member variables for later reference by `JSON::read()`.

2. On JSON export, realignment of header key-value information based on a predicted transformation of the corresponding output image data I think needs to be predicated on whether or not that output image *is or is not a NIfTI format*. The current function does so based on `Header::do_not_realign_transform` or a manual boolean input parameter. Unfortunately I couldn't find a very clean way of detecting the image format, so it's currently a string comparison against `Header::format()`.

   There's also the issue here of how `mrinfo` should work, as opposed to `mrconvert`, since the former doesn't actually have an output image...

In additon to these:

1. It seems that for JSON import the flipping of phase and slice encoding directions was erroneous, due to the minus signs being in [the](https://github.com/MRtrix3/mrtrix3/blob/3.0_RC3/core/file/json_utils.cpp#L93) wrong [place](https://github.com/MRtrix3/mrtrix3/blob/3.0_RC3/core/file/json_utils.cpp#L105)... I think @bjeurissen reported something akin to this at some point? Or was it @dchristiaens?

2. I think that changing from comma-separated to space-separated slice timing on `master` in #1735 may have been a band-aid placed at the wrong location... Other vector data in `.mif` headers are stored as comma-separated. So it might have fixed the export of such data on `master`, but using the wrong approach.

3. Strings imported from JSON retain double quotation marks around them, whereas e.g. DICOM converted data don't contain such.

So there's a fair bit in this changeset, and it also includes a cherry-pick from #1735, as the intention is to get JSON working "as best as possible". 

-----

Printing some test data results here; could potentially incorporate something into CI, but it won't be trivial. These are mainly for the format of the slice timing vector; the issue of phase and slice encoding directions is probably going to require further interrogation.

<details><summary>Test JSON file:</summary>
<p>

`cat testing/binaries/data/dwi.json`

```json
{
    "EchoTime": 0.028,
    "FlipAngle": 90,
    "MultibandAccelerationFactor": 1,
    "PhaseEncodingDirection": "j-",
    "RepetitionTime": 3.93,
    "SliceEncodingDirection": "k",
    "SliceTiming": [
        1.96500003,
        0.0,
        2.03250003,
        0.0675000027,
        2.09750009,
        0.132499993,
        2.1624999,
        0.197500005,
        2.22749996
    ],
    "TotalReadoutTime": 0.0447,
    "comments": [
        "ORIENTATION TEST (2016_10_05) [MR] ep2d_se AXIAL A-P",
        "study: BRI_PROTOCOLS VE11A Post 08-03-2016 SB.2002.060RS EPI - ROB - 20 [ ORIGINAL PRIMARY M ND NORM ]",
        "DOB: 01/01/1975",
        "DOS: 06/10/2016 14:09:38"
    ]
}
```

</p>
</details>


## `master`

<details><summary>mrinfo output: Slice timing as separate entries, quotation marks around comments</summary>
<p>

`mrconvert dwi.mif -clear_property dw_scheme -clear_property comments - | mrconvert - -json_import dwi.json - | mrinfo -`

```text
************************************************
Image:               "/tmp/mrtrix-tmp-usH348.mif"
************************************************
  Dimensions:        6 x 8 x 9 x 68
  Voxel size:        2.5 x 2.5 x 2.5 x ?
  Data strides:      [ -1 -2 3 4 ]
  Format:            Internal pipe
  Data type:         unsigned 16 bit integer (little endian)
  Intensity scaling: offset = 0, multiplier = 1
  Transform:               0.9987   4.153e-08     0.05091       33.12
                         0.003015      0.9982    -0.05915       43.34
                         -0.05082     0.05923       0.997        26.9
  EchoTime:          0.0280000009
  FlipAngle:         90
  MultibandAccelerationFactor: 1
  PhaseEncodingDirection: j-
  RepetitionTime:    3.93000007
  SliceEncodingDirection: k
  SliceTiming:       1.96500003
  [9 entries]        0.0
                     ...
                     0.197500005
                     2.22749996
  TotalReadoutTime:  0.0447000004
  command_history:   /home/rob/src/master/bin/mrconvert "dwi.mif" "-clear_property" "dw_scheme" "-clear_property" "comments" "-"  (version=3.0_RC3_latest-66-g323bc8ac)
                     /home/rob/src/master/bin/mrconvert "-" "-json_import" "dwi.json" "-"  (version=3.0_RC3_latest-66-g323bc8ac)
  comments:          "ORIENTATION TEST (2016_10_05) [MR] ep2d_se AXIAL A-P"
                     "study: BRI_PROTOCOLS VE11A Post 08-03-2016 SB.2002.060RS EPI - ROB - 20 [ ORIGINAL PRIMARY M ND NORM ]"
                     "DOB: 01/01/1975"
                     "DOS: 06/10/2016 14:09:38"
  mrtrix_version:    3.0_RC3_latest-66-g323bc8ac
```

</p>
</details>

<details><summary>JSON export: Key-values are all strings (#1738 was to `dev`), slice timing is list of lists, "comments" not split</summary>
<p>

`mrconvert dwi.mif -clear_property dw_scheme -clear_property comments - | mrconvert - -json_import dwi.json - | mrinfo - -json_keyval test.json; cat test.json`

```json
{
    "EchoTime": "0.0280000009",
    "FlipAngle": "90",
    "MultibandAccelerationFactor": "1",
    "PhaseEncodingDirection": "j-",
    "RepetitionTime": "3.93000007",
    "SliceEncodingDirection": "k",
    "SliceTiming": [
        [
            1.96500003
        ],
        [
            0.0
        ],
        [
            2.03250003
        ],
        [
            0.0675000027
        ],
        [
            2.09750009
        ],
        [
            0.132499993
        ],
        [
            2.1624999
        ],
        [
            0.197500005
        ],
        [
            2.22749996
        ]
    ],
    "TotalReadoutTime": "0.0447000004",
    "command_history": "/home/rob/src/master/bin/mrconvert \"dwi.mif\" \"-clear_property\" \"dw_scheme\" \"-clear_property\" \"comments\" \"-\"  (version=3.0_RC3_latest-66-g323bc8ac)\n/home/rob/src/master/bin/mrconvert \"-\" \"-json_import\" \"dwi.json\" \"-\"  (version=3.0_RC3_latest-66-g323bc8ac)",
    "comments": "\"ORIENTATION TEST (2016_10_05) [MR] ep2d_se AXIAL A-P\"\n\"study: BRI_PROTOCOLS VE11A Post 08-03-2016 SB.2002.060RS EPI - ROB - 20 [ ORIGINAL PRIMARY M ND NORM ]\"\n\"DOB: 01/01/1975\"\n\"DOS: 06/10/2016 14:09:38\"",
    "mrtrix_version": "3.0_RC3_latest-66-g323bc8ac"
}
```

</p>
</details>

## `dev`

<details><summary>mrinfo output: Slice timing is separate entries, comments have quotation marks</summary>
<p>

`mrconvert dwi.mif -clear_property dw_scheme -clear_property comments - | mrconvert - -json_import dwi.json - | mrinfo -`

```text
************************************************
Image name:          "/tmp/mrtrix-tmp-VO1cxD.mif"
************************************************
  Dimensions:        6 x 8 x 9 x 68
  Voxel size:        2.5 x 2.5 x 2.5 x ?
  Data strides:      [ -1 -2 3 4 ]
  Format:            Internal pipe
  Data type:         unsigned 16 bit integer (little endian)
  Intensity scaling: offset = 0, multiplier = 1
  Transform:               0.9987   4.153e-08     0.05091       33.12
                         0.003015      0.9982    -0.05915       43.34
                         -0.05082     0.05923       0.997        26.9
  EchoTime:          0.0280000009
  FlipAngle:         90
  MultibandAccelerationFactor: 1
  PhaseEncodingDirection: j-
  RepetitionTime:    3.93000007
  SliceEncodingDirection: k
  SliceTiming:       1.96500003
  [9 entries]        0.0
                     ...
                     0.197500005
                     2.22749996
  TotalReadoutTime:  0.0447000004
  command_history:   mrconvert dwi.mif -clear_property dw_scheme -clear_property comments -  (version=3.0_RC4-33-g0bd38e16-dirty)
                     mrconvert - -json_import dwi.json -  (version=3.0_RC4-33-g0bd38e16-dirty)
  comments:          "ORIENTATION TEST (2016_10_05) [MR] ep2d_se AXIAL A-P"
                     "study: BRI_PROTOCOLS VE11A Post 08-03-2016 SB.2002.060RS EPI - ROB - 20 [ ORIGINAL PRIMARY M ND NORM ]"
                     "DOB: 01/01/1975"
                     "DOS: 06/10/2016 14:09:38"
  mrtrix_version:    3.0_RC4-33-g0bd38e16-dirty
```

</p>
</details>

<details><summary>JSON export: comments have quotation marks</summary>
<p>

`mrconvert dwi.mif -clear_property dw_scheme -clear_property comments - | mrconvert - -json_import dwi.json - | mrinfo - -json_keyval test.json; cat test.json`

```json
{
    "EchoTime": 0.0280000009,
    "FlipAngle": 90,
    "MultibandAccelerationFactor": 1,
    "PhaseEncodingDirection": "j-",
    "RepetitionTime": 3.93000007,
    "SliceEncodingDirection": "k",
    "SliceTiming": [
        1.96500003,
        0.0,
        2.03250003,
        0.0675000027,
        2.09750009,
        0.132499993,
        2.1624999,
        0.197500005,
        2.22749996
    ],
    "TotalReadoutTime": 0.0447000004,
    "command_history": [
        "mrconvert dwi.mif -clear_property dw_scheme -clear_property comments -  (version=3.0_RC4-33-g0bd38e16-dirty)",
        "mrconvert - -json_import dwi.json -  (version=3.0_RC4-33-g0bd38e16-dirty)"
    ],
    "comments": [
        "\"ORIENTATION TEST (2016_10_05) [MR] ep2d_se AXIAL A-P\"",
        "\"study: BRI_PROTOCOLS VE11A Post 08-03-2016 SB.2002.060RS EPI - ROB - 20 [ ORIGINAL PRIMARY M ND NORM ]\"",
        "\"DOB: 01/01/1975\"",
        "\"DOS: 06/10/2016 14:09:38\""
    ],
    "mrtrix_version": "3.0_RC4-33-g0bd38e16-dirty"
}
```

</p>
</details>

## PR code

<details><summary>mrinfo output:</summary>
<p>

`mrconvert dwi.mif -clear_property dw_scheme -clear_property comments - | mrconvert - -json_import dwi.json - | mrinfo -`

```text
************************************************
Image name:          "/tmp/mrtrix-tmp-1RlY1W.mif"
************************************************
  Dimensions:        6 x 8 x 9 x 68
  Voxel size:        2.5 x 2.5 x 2.5 x ?
  Data strides:      [ -1 -2 3 4 ]
  Format:            Internal pipe
  Data type:         unsigned 16 bit integer (little endian)
  Intensity scaling: offset = 0, multiplier = 1
  Transform:               0.9987   4.153e-08     0.05091       33.12
                         0.003015      0.9982    -0.05915       43.34
                         -0.05082     0.05923       0.997        26.9
  EchoTime:          0.0280000009
  FlipAngle:         90
  MultibandAccelerationFactor: 1
  PhaseEncodingDirection: j-
  RepetitionTime:    3.93000007
  SliceEncodingDirection: k
  SliceTiming:       1.96500003,0.0,2.03250003,0.0675000027,2.09750009,0.132499993,2.1624999,0.197500005,2.22749996
  TotalReadoutTime:  0.0447000004
  command_history:   mrconvert dwi.mif -clear_property dw_scheme -clear_property comments -  (version=3.0_RC4-37-g14f760e1-dirty)
                     mrconvert - -json_import dwi.json -  (version=3.0_RC4-37-g14f760e1-dirty)
  comments:          ORIENTATION TEST (2016_10_05) [MR] ep2d_se AXIAL A-P
                     study: BRI_PROTOCOLS VE11A Post 08-03-2016 SB.2002.060RS EPI - ROB - 20 [ ORIGINAL PRIMARY M ND NORM ]
                     DOB: 01/01/1975
                     DOS: 06/10/2016 14:09:38
  mrtrix_version:    3.0_RC4-37-g14f760e1-dirty
```

</p>
</details>

<details><summary>JSON export:</summary>
<p>

`mrconvert dwi.mif -clear_property dw_scheme -clear_property comments - | mrconvert - -json_import dwi.json - | mrinfo - -json_keyval test.json; cat test.json`

```json
{
    "EchoTime": 0.0280000009,
    "FlipAngle": 90,
    "MultibandAccelerationFactor": 1,
    "PhaseEncodingDirection": "j-",
    "RepetitionTime": 3.93000007,
    "SliceEncodingDirection": "k",
    "SliceTiming": [
        1.96500003,
        0.0,
        2.03250003,
        0.0675000027,
        2.09750009,
        0.132499993,
        2.1624999,
        0.197500005,
        2.22749996
    ],
    "TotalReadoutTime": 0.0447000004,
    "command_history": [
        "mrconvert dwi.mif -clear_property dw_scheme -clear_property comments -  (version=3.0_RC4-37-g14f760e1-dirty)",
        "mrconvert - -json_import dwi.json -  (version=3.0_RC4-37-g14f760e1-dirty)"
    ],
    "comments": [
        "ORIENTATION TEST (2016_10_05) [MR] ep2d_se AXIAL A-P",
        "study: BRI_PROTOCOLS VE11A Post 08-03-2016 SB.2002.060RS EPI - ROB - 20 [ ORIGINAL PRIMARY M ND NORM ]",
        "DOB: 01/01/1975",
        "DOS: 06/10/2016 14:09:38"
    ],
    "mrtrix_version": "3.0_RC4-37-g14f760e1-dirty"
}
```

</p>
</details>
