### PR TITLE
mrview: fix -overlay.intensity

### DIFF
--- a/src/gui/mrview/adjust_button.h
+++ b/src/gui/mrview/adjust_button.h
@@ -35,8 +35,8 @@ namespace MR
         public:
           AdjustButton (QWidget* parent, float change_rate = 1.0);
 
-          float value () const { 
-            if (text().isEmpty()) 
+          float value () const {
+            if (text().isEmpty())
               return NAN;
             try {
               return to<float> (text().toStdString());
@@ -66,6 +66,8 @@ namespace MR
               clear();
               is_min = is_max = false;
             }
+            emit valueChanged();
+            emit valueChanged(value());
           }
 
 


### PR DESCRIPTION
As discussed in #1462. Would appreciate others giving this a shot. 
Note this fixes the `-overlay.intensity` issue, but is unlikely to fix the `-overlay.colourmap` one discussed in [this forum thread](https://community.mrtrix.org/t/overlay-colourmap-and-intensity-are-not-applied-in-mrview-via-command-line/3115?u=jdtournier). I'll keep digging on that one...