### PR TITLE
run.command(): Fix mrconvert_keyval usage

### DIFF
--- a/bin/dwishellmath
+++ b/bin/dwishellmath
@@ -57,7 +57,7 @@ def execute(): #pylint: disable=unused-variable
     files.append(filename)
   # concatenate to output file
   run.command('mrcat -axis 3 ' + ' '.join(files) + ' out.mif')
-  run.command('mrconvert out.mif ' + path.from_user(app.ARGS.output), mrconvert_keyval=path.from_user(app.ARGS.input), force=app.FORCE_OVERWRITE)
+  run.command('mrconvert out.mif ' + path.from_user(app.ARGS.output), mrconvert_keyval=path.from_user(app.ARGS.input, False), force=app.FORCE_OVERWRITE)
 
 
 # Execute the script

--- a/bin/labelsgmfix
+++ b/bin/labelsgmfix
@@ -164,7 +164,7 @@ def execute(): #pylint: disable=unused-variable
   # Insert the new delineations of all SGM structures in a single call
   # Enforce unsigned integer datatype of output image
   run.command('mrcalc sgm_new_labels.mif 0.5 -gt sgm_new_labels.mif parc.mif -if result.mif -datatype uint32')
-  run.command('mrconvert result.mif ' + path.from_user(app.ARGS.output), mrconvert_keyval=path.from_user(app.ARGS.parc), force=app.FORCE_OVERWRITE)
+  run.command('mrconvert result.mif ' + path.from_user(app.ARGS.output), mrconvert_keyval=path.from_user(app.ARGS.parc, False), force=app.FORCE_OVERWRITE)
 
 
 

--- a/bin/population_template
+++ b/bin/population_template
@@ -739,7 +739,7 @@ def execute(): #pylint: disable=unused-variable
     progress = app.ProgressBar('Copying non-linear warps to output directory "' + warp_path + '"')
     for i in inputs:
       run.command('mrconvert ' + os.path.join('warps', '%s.mif' % i.prefix) + ' ' + os.path.join(warp_path, '%s.mif' % i.prefix), \
-                  mrconvert_keyval=path.from_user(os.path.join(input_dir, i.filename)), \
+                  mrconvert_keyval=path.from_user(os.path.join(input_dir, i.filename), False), \
                   force=app.FORCE_OVERWRITE)
       progress.increment()
     progress.done()
@@ -758,7 +758,7 @@ def execute(): #pylint: disable=unused-variable
     progress = app.ProgressBar('Copying transformed images to output directory "' + transformed_path + '"')
     for i in inputs:
       run.command('mrconvert ' + os.path.join('inputs_transformed', '%s.mif' % i.prefix) + ' ' + os.path.join(transformed_path, '%s.mif' % i.prefix), \
-                  mrconvert_keyval=path.from_user(os.path.join(input_dir, i.filename)), \
+                  mrconvert_keyval=path.from_user(os.path.join(input_dir, i.filename), False), \
                   force=app.FORCE_OVERWRITE)
       progress.increment()
     progress.done()

--- a/lib/mrtrix3/_5ttgen/freesurfer.py
+++ b/lib/mrtrix3/_5ttgen/freesurfer.py
@@ -79,4 +79,4 @@ def execute(): #pylint: disable=unused-variable
 
   run.command('mrcat cgm.mif sgm.mif wm.mif csf.mif path.mif - -axis 3 | mrconvert - result.mif -datatype float32')
 
-  run.command('mrconvert result.mif ' + path.from_user(app.ARGS.output), mrconvert_keyval=path.from_user(app.ARGS.input), force=app.FORCE_OVERWRITE)
+  run.command('mrconvert result.mif ' + path.from_user(app.ARGS.output), mrconvert_keyval=path.from_user(app.ARGS.input, False), force=app.FORCE_OVERWRITE)

--- a/lib/mrtrix3/_5ttgen/fsl.py
+++ b/lib/mrtrix3/_5ttgen/fsl.py
@@ -229,4 +229,4 @@ def execute(): #pylint: disable=unused-variable
   else:
     run.command('mrmath combined_precrop.mif sum - -axis 3 | mrthreshold - - -abs 0.5 | mrgrid combined_precrop.mif crop result.mif -mask -')
 
-  run.command('mrconvert result.mif ' + path.from_user(app.ARGS.output), mrconvert_keyval=path.from_user(app.ARGS.input), force=app.FORCE_OVERWRITE)
+  run.command('mrconvert result.mif ' + path.from_user(app.ARGS.output), mrconvert_keyval=path.from_user(app.ARGS.input, False), force=app.FORCE_OVERWRITE)

--- a/lib/mrtrix3/_5ttgen/gif.py
+++ b/lib/mrtrix3/_5ttgen/gif.py
@@ -65,4 +65,4 @@ def execute(): #pylint: disable=unused-variable
   else:
     run.command('mrmath 5tt.mif sum - -axis 3 | mrthreshold - - -abs 0.5 | mrgrid 5tt.mif crop result.mif -mask -')
 
-  run.command('mrconvert result.mif ' + path.from_user(app.ARGS.output), mrconvert_keyval=path.from_user(app.ARGS.input), force=app.FORCE_OVERWRITE)
+  run.command('mrconvert result.mif ' + path.from_user(app.ARGS.output), mrconvert_keyval=path.from_user(app.ARGS.input, False), force=app.FORCE_OVERWRITE)

--- a/lib/mrtrix3/dwi2response/dhollander.py
+++ b/lib/mrtrix3/dwi2response/dhollander.py
@@ -263,5 +263,5 @@ def execute(): #pylint: disable=unused-variable
   run.function(shutil.copyfile, 'response_gm.txt', path.from_user(app.ARGS.out_gm, False), show=False)
   run.function(shutil.copyfile, 'response_csf.txt', path.from_user(app.ARGS.out_csf, False), show=False)
   if app.ARGS.voxels:
-    run.command('mrconvert check_voxels.mif ' + path.from_user(app.ARGS.voxels), mrconvert_keyval=path.from_user(app.ARGS.input), force=app.FORCE_OVERWRITE, show=False)
+    run.command('mrconvert check_voxels.mif ' + path.from_user(app.ARGS.voxels), mrconvert_keyval=path.from_user(app.ARGS.input, False), force=app.FORCE_OVERWRITE, show=False)
   app.console('-------')

--- a/lib/mrtrix3/dwi2response/fa.py
+++ b/lib/mrtrix3/dwi2response/fa.py
@@ -71,4 +71,4 @@ def execute(): #pylint: disable=unused-variable
 
   run.function(shutil.copyfile, 'response.txt', path.from_user(app.ARGS.output, False))
   if app.ARGS.voxels:
-    run.command('mrconvert voxels.mif ' + path.from_user(app.ARGS.voxels), mrconvert_keyval=path.from_user(app.ARGS.input), force=app.FORCE_OVERWRITE)
+    run.command('mrconvert voxels.mif ' + path.from_user(app.ARGS.voxels), mrconvert_keyval=path.from_user(app.ARGS.input, False), force=app.FORCE_OVERWRITE)

--- a/lib/mrtrix3/dwi2response/manual.py
+++ b/lib/mrtrix3/dwi2response/manual.py
@@ -80,4 +80,4 @@ def execute(): #pylint: disable=unused-variable
 
   run.function(shutil.copyfile, 'response.txt', path.from_user(app.ARGS.output, False))
   if app.ARGS.voxels:
-    run.command('mrconvert in_voxels.mif ' + path.from_user(app.ARGS.voxels), mrconvert_keyval=path.from_user(app.ARGS.input), force=app.FORCE_OVERWRITE)
+    run.command('mrconvert in_voxels.mif ' + path.from_user(app.ARGS.voxels), mrconvert_keyval=path.from_user(app.ARGS.input, False), force=app.FORCE_OVERWRITE)

--- a/lib/mrtrix3/dwi2response/msmt_5tt.py
+++ b/lib/mrtrix3/dwi2response/msmt_5tt.py
@@ -142,4 +142,4 @@ def execute(): #pylint: disable=unused-variable
   # Generate output 4D binary image with voxel selections; RGB as in MSMT-CSD paper
   run.command('mrcat csf_mask.mif gm_mask.mif wm_sf_mask.mif voxels.mif -axis 3')
   if app.ARGS.voxels:
-    run.command('mrconvert voxels.mif ' + path.from_user(app.ARGS.voxels), mrconvert_keyval=path.from_user(app.ARGS.input), force=app.FORCE_OVERWRITE)
+    run.command('mrconvert voxels.mif ' + path.from_user(app.ARGS.voxels), mrconvert_keyval=path.from_user(app.ARGS.input, False), force=app.FORCE_OVERWRITE)

--- a/lib/mrtrix3/dwi2response/tax.py
+++ b/lib/mrtrix3/dwi2response/tax.py
@@ -148,4 +148,4 @@ def execute(): #pylint: disable=unused-variable
 
   run.function(shutil.copyfile, 'response.txt', path.from_user(app.ARGS.output, False))
   if app.ARGS.voxels:
-    run.command('mrconvert voxels.mif ' + path.from_user(app.ARGS.voxels), mrconvert_keyval=path.from_user(app.ARGS.input), force=app.FORCE_OVERWRITE)
+    run.command('mrconvert voxels.mif ' + path.from_user(app.ARGS.voxels), mrconvert_keyval=path.from_user(app.ARGS.input, False), force=app.FORCE_OVERWRITE)

--- a/lib/mrtrix3/dwi2response/tournier.py
+++ b/lib/mrtrix3/dwi2response/tournier.py
@@ -137,4 +137,4 @@ def execute(): #pylint: disable=unused-variable
 
   run.function(shutil.copyfile, 'response.txt', path.from_user(app.ARGS.output, False))
   if app.ARGS.voxels:
-    run.command('mrconvert voxels.mif ' + path.from_user(app.ARGS.voxels), mrconvert_keyval=path.from_user(app.ARGS.input), force=app.FORCE_OVERWRITE)
+    run.command('mrconvert voxels.mif ' + path.from_user(app.ARGS.voxels), mrconvert_keyval=path.from_user(app.ARGS.input, False), force=app.FORCE_OVERWRITE)

--- a/lib/mrtrix3/dwibiascorrect/ants.py
+++ b/lib/mrtrix3/dwibiascorrect/ants.py
@@ -81,6 +81,6 @@ def execute(): #pylint: disable=unused-variable
 
   # Common final steps for all algorithms
   run.command('mrcalc in.mif bias.mif -div result.mif')
-  run.command('mrconvert result.mif ' + path.from_user(app.ARGS.output), mrconvert_keyval=path.from_user(app.ARGS.input), force=app.FORCE_OVERWRITE)
+  run.command('mrconvert result.mif ' + path.from_user(app.ARGS.output), mrconvert_keyval=path.from_user(app.ARGS.input, False), force=app.FORCE_OVERWRITE)
   if app.ARGS.bias:
-    run.command('mrconvert bias.mif ' + path.from_user(app.ARGS.bias), mrconvert_keyval=path.from_user(app.ARGS.input), force=app.FORCE_OVERWRITE)
+    run.command('mrconvert bias.mif ' + path.from_user(app.ARGS.bias), mrconvert_keyval=path.from_user(app.ARGS.input, False), force=app.FORCE_OVERWRITE)

--- a/lib/mrtrix3/dwibiascorrect/fsl.py
+++ b/lib/mrtrix3/dwibiascorrect/fsl.py
@@ -65,6 +65,6 @@ def execute(): #pylint: disable=unused-variable
   # Rather than using a bias field estimate of 1.0 outside the brain mask, zero-fill the
   #   output image outside of this mask
   run.command('mrcalc in.mif ' + bias_path + ' -div mask.mif -mult result.mif')
-  run.command('mrconvert result.mif ' + path.from_user(app.ARGS.output), mrconvert_keyval=path.from_user(app.ARGS.input), force=app.FORCE_OVERWRITE)
+  run.command('mrconvert result.mif ' + path.from_user(app.ARGS.output), mrconvert_keyval=path.from_user(app.ARGS.input, False), force=app.FORCE_OVERWRITE)
   if app.ARGS.bias:
-    run.command('mrconvert ' + bias_path + ' ' + path.from_user(app.ARGS.bias), mrconvert_keyval=path.from_user(app.ARGS.input), force=app.FORCE_OVERWRITE)
+    run.command('mrconvert ' + bias_path + ' ' + path.from_user(app.ARGS.bias), mrconvert_keyval=path.from_user(app.ARGS.input, False), force=app.FORCE_OVERWRITE)

--- a/lib/mrtrix3/dwinormalise/group.py
+++ b/lib/mrtrix3/dwinormalise/group.py
@@ -102,7 +102,7 @@ def execute(): #pylint: disable=unused-variable
   for i in input_list:
     run.command('mrtransform template_wm_mask.mif -interp nearest -warp_full ' + os.path.join('population_template', 'warps', i.prefix + '.mif') + ' ' + os.path.join('wm_mask_warped', i.prefix + '.mif') + ' -from 2 -template ' + os.path.join('fa', i.prefix + '.mif'))
     run.command('dwinormalise individual ' + path.quote(os.path.join(input_dir, i.filename)) + ' ' + os.path.join('wm_mask_warped', i.prefix + '.mif') + ' temp.mif')
-    run.command('mrconvert temp.mif ' + path.from_user(os.path.join(app.ARGS.output_dir, i.filename)), mrconvert_keyval=path.from_user(os.path.join(input_dir, i.filename)), force=app.FORCE_OVERWRITE)
+    run.command('mrconvert temp.mif ' + path.from_user(os.path.join(app.ARGS.output_dir, i.filename)), mrconvert_keyval=path.from_user(os.path.join(input_dir, i.filename), False), force=app.FORCE_OVERWRITE)
     os.remove('temp.mif')
     progress.increment()
   progress.done()

--- a/lib/mrtrix3/dwinormalise/individual.py
+++ b/lib/mrtrix3/dwinormalise/individual.py
@@ -70,5 +70,5 @@ def execute(): #pylint: disable=unused-variable
 
   run.command('mrcalc ' + path.from_user(app.ARGS.input_dwi) + ' ' + str(multiplier) + ' -mult - | ' + \
               'mrconvert - ' + path.from_user(app.ARGS.output_dwi) + grad_option, \
-              mrconvert_keyval=path.from_user(app.ARGS.input_dwi), \
+              mrconvert_keyval=path.from_user(app.ARGS.input_dwi, False), \
               force=app.FORCE_OVERWRITE)

--- a/lib/mrtrix3/run.py
+++ b/lib/mrtrix3/run.py
@@ -312,6 +312,7 @@ def command(cmd, **kwargs): #pylint: disable=unused-variable
     if mrconvert_keyval:
       if cmdstack[-1][0] != 'mrconvert':
         raise TypeError('Argument "mrconvert_keyval=" can only be used if the mrconvert command is being invoked')
+      assert not (mrconvert_keyval[0] in [ '\'', '"' ] or mrconvert_keyval[-1] in [ '\'', '"' ])
       cmdstack[-1].extend([ '-copy_properties', mrconvert_keyval, '-append_property', 'command_history', COMMAND_HISTORY_STRING ])
 
     for line in cmdstack:

--- a/lib/mrtrix3/run.py
+++ b/lib/mrtrix3/run.py
@@ -312,7 +312,7 @@ def command(cmd, **kwargs): #pylint: disable=unused-variable
     if mrconvert_keyval:
       if cmdstack[-1][0] != 'mrconvert':
         raise TypeError('Argument "mrconvert_keyval=" can only be used if the mrconvert command is being invoked')
-      cmdstack[-1].extend([ '-copy_properties', mrconvert_keyval.strip('"'), '-append_property', 'command_history', COMMAND_HISTORY_STRING ])
+      cmdstack[-1].extend([ '-copy_properties', mrconvert_keyval, '-append_property', 'command_history', COMMAND_HISTORY_STRING ])
 
     for line in cmdstack:
       is_mrtrix_exe = line[0] in EXE_LIST


### PR DESCRIPTION
Passing a user-specified path to `run.command()`'s keyword argument `mrconvert_keyval` must not be escaped, as the string is inserted directly as a list element and is not parsed as part of a command string.

Cherry-picked first commit from #1689.

Comments:

- This arose because I failed to appropriately modify usage during the evolution of #1449. In an earlier iteration I was inserting these entries into the `mrconvert` command string, which required path escaping, and then trying to subseequently erase them from the command string printed to the terminal; eventually I realised I could just separate the actual command `argv` from the terminal printout at an earlier point in the function, and have this parameter only influence the former. I simply failed to update the calls to specify `escape=False` to match.

- I'm still struggling to see why this is being portrayed as such a severe issue (#1845). In some contexts, filesystem paths need to be escaped, in others they need to not be; that's why `path.from_user()` has the `escape` parameter. Only possible change in light of this issue would be to revert that parameter to not have a default value, and force it to always be specified. But the challenge of filesystem path handling is no more an existential crisis now than it was before observing this specific mis-use.

- I also still don't see why the question of running `quote()` twice on one string is being elevated. In the commit message of c7f91da it seems to get raised out of nowhere; there's no indication that this is actually happening anywhere, or that it is a legitimate concern for any hypothetical case that would not itself be a mis-use of the API. If you want a warning comment above the `path.from_user()` function indicating to not run it on a string that may have itself already been quote-escaped, that's fine; it just seems to me that this is a non-issue right now.