### PR TITLE
GitHub: Fix for Windows workflows

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -120,7 +120,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: fetch and install MSYS2
-      run: bash -c 'curl -sL https://github.com/MRtrix3/MinGW/releases/download/1.0/msys2.tar.{1..5} | tar xf -'
+      run: bash -c 'curl -sL https://github.com/MRtrix3/MinGW/releases/download/1.0/msys2.tar.{0..4} | tar xf -'
 
     - name: run qtbinpatcher
       shell: cmd

--- a/.github/workflows/package-windows-msys2.yml
+++ b/.github/workflows/package-windows-msys2.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
 
     - name: fetch and install MSYS2
-      run: bash -c 'curl -sL https://github.com/MRtrix3/MinGW/releases/download/1.0/msys2.tar.{1..5} | tar xf -'
+      run: bash -c 'curl -sL https://github.com/MRtrix3/MinGW/releases/download/1.0/msys2.tar.{0..4} | tar xf -'
 
     - name: run qtbinpatcher
       shell: cmd


### PR DESCRIPTION
I think this is what's borking Windows tests. Couldn't rename the files in the release to match the fetch calls.