### PR TITLE
mrview: fix view tool

### DIFF
--- a/src/gui/mrview/adjust_button.h
+++ b/src/gui/mrview/adjust_button.h
@@ -66,8 +66,6 @@ namespace MR
               clear();
               is_min = is_max = false;
             }
-            emit valueChanged();
-            emit valueChanged(value());
           }
 
 

--- a/src/gui/mrview/tool/overlay.cpp
+++ b/src/gui/mrview/tool/overlay.cpp
@@ -772,9 +772,9 @@ namespace MR
               if (values.size() != 2)
                 throw Exception ("must provide exactly two comma-separated values to the -overlay.intensity option");
               min_value->blockSignals (true);
-              min_value->setValue (values[0]);
+              min_value->setMin (values[0]);
               min_value->blockSignals (false);
-              max_value->setValue (values[1]);
+              max_value->setMax (values[1]);
             }
             catch (Exception& e) { e.display(); }
             return true;

--- a/src/gui/mrview/tool/overlay.cpp
+++ b/src/gui/mrview/tool/overlay.cpp
@@ -771,10 +771,9 @@ namespace MR
               auto values = parse_floats (opt[0]);
               if (values.size() != 2)
                 throw Exception ("must provide exactly two comma-separated values to the -overlay.intensity option");
-              min_value->blockSignals (true);
-              min_value->setMin (values[0]);
-              min_value->blockSignals (false);
-              max_value->setMax (values[1]);
+              min_value->setValue (values[0]);
+              max_value->setValue (values[1]);
+              values_changed();
             }
             catch (Exception& e) { e.display(); }
             return true;


### PR DESCRIPTION
Suggested fix to bug introduced in d411e6c5d7928ca (#1850), reported [here](https://community.mrtrix.org/t/mrview-view-options-segmentation-fault/3170). It seems to work but I am not 100% sure if this is a full fix as I've reverted `setValue` back to not trigger the `valueChanged` signals, `setMin` and `setMax` do.