### PR TITLE
math/math.h: Remove unneeded <locale> header

### DIFF
--- a/core/math/math.h
+++ b/core/math/math.h
@@ -19,7 +19,6 @@
 
 #include <cmath>
 #include <cstdlib>
-#include <locale>
 
 #include "app.h"
 #include "exception.h"


### PR DESCRIPTION
Raised in #1549.