### PR TITLE
linear registration: change of transform file format

### DIFF
--- a/cmd/mrregister.cpp
+++ b/cmd/mrregister.cpp
@@ -893,13 +893,13 @@ void run () {
     }
 
     if (output_rigid_1tomid)
-      save_transform (rigid.get_centre(), rigid.get_transform_half(), rigid_1tomid_filename);
+      save_transform (rigid.get_transform_half(), rigid.get_centre(), rigid_1tomid_filename);
 
     if (output_rigid_2tomid)
-      save_transform (rigid.get_centre(), rigid.get_transform_half_inverse(), rigid_2tomid_filename);
+      save_transform (rigid.get_transform_half_inverse(), rigid.get_centre(), rigid_2tomid_filename);
 
     if (output_rigid)
-      save_transform (rigid.get_centre(), rigid.get_transform(), rigid_filename);
+      save_transform (rigid.get_transform(), rigid.get_centre(), rigid_filename);
   }
 
   // ****** RUN AFFINE REGISTRATION *******
@@ -961,13 +961,13 @@ void run () {
       } else throw Exception ("FIXME: metric selection");
     }
     if (output_affine_1tomid)
-      save_transform (affine.get_centre(), affine.get_transform_half(), affine_1tomid_filename);
+      save_transform (affine.get_transform_half(), affine.get_centre(), affine_1tomid_filename);
 
     if (output_affine_2tomid)
-      save_transform (affine.get_centre(), affine.get_transform_half_inverse(), affine_2tomid_filename);
+      save_transform (affine.get_transform_half_inverse(), affine.get_centre(), affine_2tomid_filename);
 
     if (output_affine)
-      save_transform (affine.get_centre(), affine.get_transform(), affine_filename);
+      save_transform (affine.get_transform(), affine.get_centre(), affine_filename);
   }
 
 

--- a/core/math/math.h
+++ b/core/math/math.h
@@ -247,13 +247,18 @@ namespace MR
         M(i,j) = V[i][j];
 
     if (centre.size() == 3) {
-      std::string key = " centre: ";
+      const std::string key = " centre: ";
+      const std::string key_legacy = "centre ";
       centre[0] = NaN;
       centre[1] = NaN;
       centre[2] = NaN;
+      vector<std::string> elements;
       for (auto & line : comments) {
-        if (strncmp(line.c_str(), key.c_str(), key.size()) == 0) {
-          const auto elements = split (strip (line.substr (key.size())), " ,;\t", true);
+        if (strncmp(line.c_str(), key.c_str(), key.size()) == 0)
+          elements = split (strip (line.substr (key.size())), " ,;\t", true);
+        else if (strncmp(line.c_str(), key_legacy.c_str(), key_legacy.size()) == 0)
+          elements = split (strip (line.substr (key_legacy.size())), " ,;\t", true);
+        if (elements.size()) {
           if (elements.size() != 3)
             throw Exception ("could not parse centre in transformation file " + filename + ": " + strip (line.substr (key.size())));
           try {

--- a/core/math/math.h
+++ b/core/math/math.h
@@ -247,7 +247,7 @@ namespace MR
         M(i,j) = V[i][j];
 
     if (centre.size() == 3) {
-      std::string key = "centre ";
+      std::string key = " centre: ";
       centre[0] = NaN;
       centre[1] = NaN;
       centre[2] = NaN;
@@ -292,15 +292,14 @@ namespace MR
   template <class Derived>
   inline void save_transform (const Eigen::MatrixBase<Derived>& centre, const transform_type& M, const std::string& filename)
   {
-    DEBUG ("saving transform to file \"" + filename + "\"...");
     if (centre.rows() != 3 or centre.cols() != 1)
       throw Exception ("save transform requires 3x1 vector as centre");
-    File::OFStream out (filename);
-    Eigen::IOFormat fmt(Eigen::FullPrecision, Eigen::DontAlignCols, " ", "\n", "", "", "", "");
-    Eigen::IOFormat centrefmt(Eigen::FullPrecision, Eigen::DontAlignCols, " ", "\n", "#centre ", "", "", "");
-    out << centre.transpose().format(centrefmt) << "\n";
-    out << M.matrix().format(fmt);
-    out << "\n0 0 0 1\n";
+    auto keyvals = KeyValues();
+    Eigen::IOFormat centrefmt(Eigen::FullPrecision, Eigen::DontAlignCols, " ", "\n", "", "", "", "\n");
+    std::ostringstream os;
+    os<<centre.transpose().format(centrefmt);
+    keyvals.insert(std::pair<std::string, std::string>("centre",  os.str()));
+    save_transform(M, filename, keyvals);
   }
 
   //! write the vector \a V to file

--- a/core/math/math.h
+++ b/core/math/math.h
@@ -261,7 +261,7 @@ namespace MR
             centre[1] = to<default_type> (elements[1]);
             centre[2] = to<default_type> (elements[2]);
           } catch (...) {
-            throw Exception ("File \"" + filename + "\" contains non-numerical data in centre" + ": " + strip (line.substr (key.size())));
+            throw Exception ("File \"" + filename + "\" contains non-numerical data in centre: " + strip (line.substr (key.size())));
           }
           break;
         }
@@ -290,16 +290,16 @@ namespace MR
   }
 
   template <class Derived>
-  inline void save_transform (const Eigen::MatrixBase<Derived>& centre, const transform_type& M, const std::string& filename)
+  inline void save_transform (const transform_type& M, const Eigen::MatrixBase<Derived>& centre, const std::string& filename, const KeyValues& keyvals = KeyValues(), const bool add_to_command_history = true)
   {
     if (centre.rows() != 3 or centre.cols() != 1)
-      throw Exception ("save transform requires 3x1 vector as centre");
-    auto keyvals = KeyValues();
+      throw Exception ("save_transform() requires 3x1 vector as centre");
+    KeyValues local_keyvals = keyvals;
     Eigen::IOFormat centrefmt(Eigen::FullPrecision, Eigen::DontAlignCols, " ", "\n", "", "", "", "\n");
     std::ostringstream os;
     os<<centre.transpose().format(centrefmt);
-    keyvals.insert(std::pair<std::string, std::string>("centre",  os.str()));
-    save_transform(M, filename, keyvals);
+    local_keyvals.insert(std::pair<std::string, std::string>("centre",  os.str()));
+    save_transform(M, filename, local_keyvals, add_to_command_history);
   }
 
   //! write the vector \a V to file
@@ -331,6 +331,3 @@ namespace MR
 }
 
 #endif
-
-
-


### PR DESCRIPTION
modified centre of images format in linear transformation format (`save_transform()` and `load_transform()`) to unify key-value data  #1878

The file format changed from
```
#centre -1 -4 -2
1 0 0 0
0 1 0 0
0 0 1 0
0 0 0 1
```

to 

```
# command_history: mrregister ...
# centre: -1 -4 -2
1 0 0 0
0 1 0 0
0 0 1 0
0 0 0 1
```

but the reading of the deprecated format is still supported.