### PR TITLE
tractography: fix ROI construction when passed a 4D mask

### DIFF
--- a/src/dwi/tractography/roi.cpp
+++ b/src/dwi/tractography/roi.cpp
@@ -74,7 +74,7 @@ namespace MR {
       Image<bool> Mask::__get_mask (const std::string& name)
       {
         auto data = Image<bool>::open (name);
-        vector<size_t> bottom (data.ndim(), 0), top (data.ndim(), 0);
+        vector<size_t> bottom (3, 0), top (3, 0);
         std::fill_n (bottom.begin(), 3, std::numeric_limits<size_t>::max());
 
         size_t sum = 0;


### PR DESCRIPTION
Bug exposed by change in ebaba50, and triggered by passing single-volume 4D mask as ROI to `tckgen`, resulting in:

    tckgen: [ERROR] FIXME: sizes requested for Subset adapter must be positive

This is on `master`, so needs to be fixed ASAP.