### PR TITLE
dwifslpreproc: Fix writing of matrix files for FSL

### DIFF
--- a/bin/dwifslpreproc
+++ b/bin/dwifslpreproc
@@ -823,7 +823,7 @@ def execute(): #pylint: disable=unused-variable
       app.debug('New: ' + str(new_slice_groups))
       slice_groups = new_slice_groups
 
-    matrix.save_numeric('slspec.txt', slice_groups, header='', fmt='%d')
+    matrix.save_numeric('slspec.txt', slice_groups, add_to_command_history=False, fmt='%d')
     eddy_manual_options.append('--slspec=slspec.txt')
 
 
@@ -989,8 +989,8 @@ def execute(): #pylint: disable=unused-variable
       bvals_combined.append(0.5 * (grad[pair[0]][3] + grad[pair[1]][3]))
 
     bvecs_combined = matrix.transpose(bvecs_combined_transpose)
-    matrix.save_matrix('bvecs_combined', bvecs_combined, header='')
-    matrix.save_vector('bvals_combined', bvals_combined, delimiter=' ', header='')
+    matrix.save_matrix('bvecs_combined', bvecs_combined, add_to_command_history=False)
+    matrix.save_vector('bvals_combined', bvals_combined, add_to_command_history=False)
 
     # Prior to 5.0.8, a bug resulted in the output field map image from topup having an identity transform,
     #   regardless of the transform of the input image


### PR DESCRIPTION
Discovered issues from #1603 in `dwifslpreproc` arising specifically from use of either slice-to-volume motion correction or explicit volume recombination.