### PR TITLE
dwifslpreproc: Use DWI shell clustering algorithm

### DIFF
--- a/bin/dwifslpreproc
+++ b/bin/dwifslpreproc
@@ -276,25 +276,33 @@ def execute(): #pylint: disable=unused-variable
   app.debug('Manual readout time: ' + str(manual_trt))
 
 
-  do_topup = (not pe_design == 'None')
+  # Utilise the b-value clustering algorithm in src/dwi/shells.*
+  shell_indices = [ [ int(i) for i in entry.split(',') ] for entry in image.mrinfo('dwi.mif', 'shell_indices').split(' ') ]
+  # For each volume index, store the index of the shell to which it is attributed
+  #   (this will make it much faster to determine whether or not two volumes belong to the same shell)
+  vol2shell = [ -1 ] * dwi_num_volumes
+  for index, volumes in enumerate(shell_indices):
+    for volume in volumes:
+      vol2shell[volume] = index
+  assert all(index >= 0 for index in vol2shell)
 
 
   def grads_match(one, two):
+    # Are the two volumes assigned to the same b-value shell?
+    if vol2shell[one] != vol2shell[two]:
+      return False
     # Dot product between gradient directions
     # First, need to check for zero-norm vectors:
     # - If both are zero, skip this check
     # - If one is zero and the other is not, volumes don't match
     # - If neither is zero, test the dot product
-    if any(one[0:3]):
-      if not any(two[0:3]):
+    if any(grad[one][0:3]):
+      if not any(grad[two][0:3]):
         return False
-      dot_product = one[0]*two[0] + one[1]*two[1] + one[2]*two[2]
+      dot_product = grad[one][0]*grad[two][0] + grad[one][1]*grad[two][1] + grad[one][2]*grad[two][2]
       if abs(dot_product) < 0.999:
         return False
-    elif any(two[0:3]):
-      return False
-    # b-value
-    if abs(one[3]-two[3]) > 10.0:
+    elif any(grad[two][0:3]):
       return False
     return True
 
@@ -356,7 +364,7 @@ def execute(): #pylint: disable=unused-variable
         if grads_matched[index1] == dwi_num_volumes: # As yet unpaired
           for index2 in range(int(dwi_num_volumes/2), dwi_num_volumes):
             if grads_matched[index2] == dwi_num_volumes: # Also as yet unpaired
-              if grads_match(grad[index1], grad[index2]):
+              if grads_match(index1, index2):
                 grads_matched[index1] = index2
                 grads_matched[index2] = index1
                 grad_pairs.append([index1, index2])
@@ -452,6 +460,7 @@ def execute(): #pylint: disable=unused-variable
 
 
   # Deal with the phase-encoding of the images to be fed to topup (if applicable)
+  do_topup = (not pe_design == 'None')
   overwrite_se_epi_pe_scheme = False
   se_epi_path = 'se_epi.mif'
   dwi_permvols_preeddy_option = ''
@@ -823,7 +832,7 @@ def execute(): #pylint: disable=unused-variable
       app.debug('New: ' + str(new_slice_groups))
       slice_groups = new_slice_groups
 
-    matrix.save_numeric('slspec.txt', slice_groups, header='', fmt='%d')
+    matrix.save_numeric('slspec.txt', slice_groups, add_to_command_history=False, fmt='%d')
     eddy_manual_options.append('--slspec=slspec.txt')
 
 
@@ -929,7 +938,7 @@ def execute(): #pylint: disable=unused-variable
       for index2 in range(index1+1, dwi_num_volumes):
         if volume_matchings[index2] == dwi_num_volumes: # Also as yet unpaired
           # Here, need to check both gradient matching and reversed phase-encode direction
-          if not any(dwi_pe_scheme[index1][i] + dwi_pe_scheme[index2][i] for i in range(0,3)) and grads_match(grad[index1], grad[index2]):
+          if not any(dwi_pe_scheme[index1][i] + dwi_pe_scheme[index2][i] for i in range(0,3)) and grads_match(index1, index2):
             volume_matchings[index1] = index2
             volume_matchings[index2] = index1
             volume_pairs.append([index1, index2])
@@ -989,8 +998,8 @@ def execute(): #pylint: disable=unused-variable
       bvals_combined.append(0.5 * (grad[pair[0]][3] + grad[pair[1]][3]))
 
     bvecs_combined = matrix.transpose(bvecs_combined_transpose)
-    matrix.save_matrix('bvecs_combined', bvecs_combined, header='')
-    matrix.save_vector('bvals_combined', bvals_combined, delimiter=' ', header='')
+    matrix.save_matrix('bvecs_combined', bvecs_combined, add_to_command_history=False)
+    matrix.save_vector('bvals_combined', bvals_combined, add_to_command_history=False)
 
     # Prior to 5.0.8, a bug resulted in the output field map image from topup having an identity transform,
     #   regardless of the transform of the input image

--- a/docs/reference/commands/mrinfo.rst
+++ b/docs/reference/commands/mrinfo.rst
@@ -84,6 +84,8 @@ DW gradient table export options
 
 -  **-shell_sizes** list the number of volumes in each shell
 
+-  **-shell_indices** list the image volumes attributed to each b-value shell
+
 Options for exporting phase-encode tables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
- In `dwifslpreproc`, when determining whether or not explicit volume recombination should be performed (as well as which pairs of volumes should be combined), rather than using a hard-coded b-value difference threshold, instead obtain the outcomes of applying the C++ shell clustering algorithm to those data, and ensure that paired volumes are attributed to the same shell.

- `mrinfo` has a new option `-shell_indices` to facilitate this.

Closes #1848.

Passes script testing.