### PR TITLE
Formats::is_nifti(): Fix for images with short names

### DIFF
--- a/core/formats/nifti_utils.h
+++ b/core/formats/nifti_utils.h
@@ -33,7 +33,8 @@ namespace MR
     {
       static const vector<std::string> exts { ".nii", ".nii.gz", ".img" };
       for (const auto& ext : exts) {
-        if (path.substr (path.size() - ext.size()) == ext)
+        if (path.size() >= ext.size() &&
+            path.substr (path.size() - ext.size()) == ext)
           return true;
       }
       return false;
@@ -43,4 +44,3 @@ namespace MR
 
   }
 }
-


### PR DESCRIPTION
Bug in #1843, which results in integer overflow if an image file name is shorter than "`.nii.gz`" (which arises in `./run_tests scripts`).