### PR TITLE
dwifslpreproc: Fix strides of images input to applytopup

### DIFF
--- a/bin/dwifslpreproc
+++ b/bin/dwifslpreproc
@@ -769,7 +769,7 @@ def execute(): #pylint: disable=unused-variable
       json_path = prefix + '.json'
       temp_path = prefix + '_applytopup.nii'
       output_path = prefix + '_applytopup.mif'
-      run.command('dwiextract ' + dwi_path + import_dwi_pe_table_option + ' -pe ' + ','.join(str(value) for value in line) + ' - | mrconvert - ' + input_path + ' -json_export ' + json_path)
+      run.command('dwiextract ' + dwi_path + import_dwi_pe_table_option + ' -pe ' + ','.join(str(value) for value in line) + ' - | mrconvert - ' + input_path + ' -strides -1,+2,+3,+4 -json_export ' + json_path)
       run.command(applytopup_cmd + ' --imain=' + input_path + ' --datain=applytopup_config.txt --inindex=' + str(index) + ' --topup=field --out=' + temp_path + ' --method=jac')
       app.cleanup(input_path)
       temp_path = fsl.find_image(temp_path)


### PR DESCRIPTION
Bug discovered after report on the [forum](https://community.mrtrix.org/t/dwifslpreproc-eddy-mask-nii-looks-faulty/3164).

Issue was introduced in `3.0_RC1`. Due to the generalisation of `dwipreproc` features, `applytopup` was no longer run on the NIfTI images provided as input to `topup`, instead being run on volumes extracted from the imported DWI series based on phase encoding information. That image possesses the same strides as the input image.