### PR TITLE
Python: Better identification of string data

### DIFF
--- a/lib/mrtrix3/app.py
+++ b/lib/mrtrix3/app.py
@@ -469,7 +469,7 @@ class ProgressBar(object): #pylint: disable=unused-variable
   def __init__(self, msg, target=0):
     from mrtrix3 import run #pylint: disable=import-outside-toplevel
     global EXEC_NAME, VERBOSITY
-    if not (isinstance(msg, str) or callable(msg)):
+    if not (isinstance(msg, utils.STRING_TYPES) or callable(msg)):
       raise TypeError('app.ProgressBar must be constructed using either a string or a function')
     self.counter = 0
     self.isatty = sys.stderr.isatty()
@@ -627,7 +627,7 @@ class Parser(argparse.ArgumentParser):
 
   # Mutually exclusive options need to be added before the command-line input is parsed
   def flag_mutually_exclusive_options(self, options, required=False): #pylint: disable=unused-variable
-    if not isinstance(options, list) or not isinstance(options[0], str):
+    if not isinstance(options, list) or not isinstance(options[0], utils.STRING_TYPES):
       raise Exception('Parser.flagMutuallyExclusiveOptions() only accepts a list of strings')
     self._mutually_exclusive_option_groups.append( (options, required) )
 

--- a/lib/mrtrix3/image.py
+++ b/lib/mrtrix3/image.py
@@ -21,6 +21,7 @@
 
 import json, math, os, shlex, subprocess
 from mrtrix3 import MRtrixError
+from mrtrix3.utils import STRING_TYPES
 
 
 
@@ -126,7 +127,7 @@ def axis2dir(string): #pylint: disable=unused-variable
 def check_3d_nonunity(image_in): #pylint: disable=unused-variable
   from mrtrix3 import app #pylint: disable=import-outside-toplevel
   if not isinstance(image_in, Header):
-    if not isinstance(image_in, str):
+    if not isinstance(image_in, STRING_TYPES):
       raise MRtrixError('Error trying to test \'' + str(image_in) + '\': Not an image header or file path')
     image_in = Header(image_in)
   if len(image_in.size()) < 3:
@@ -167,11 +168,11 @@ def match(image_one, image_two, **kwargs): #pylint: disable=unused-variable, too
   if kwargs:
     raise TypeError('Unsupported keyword arguments passed to image.match(): ' + str(kwargs))
   if not isinstance(image_one, Header):
-    if not isinstance(image_one, str):
+    if not isinstance(image_one, STRING_TYPES):
       raise MRtrixError('Error trying to test \'' + str(image_one) + '\': Not an image header or file path')
     image_one = Header(image_one)
   if not isinstance(image_two, Header):
-    if not isinstance(image_two, str):
+    if not isinstance(image_two, STRING_TYPES):
       raise MRtrixError('Error trying to test \'' + str(image_two) + '\': Not an image header or file path')
     image_two = Header(image_two)
   debug_prefix = '\'' + image_one.name() + '\' \'' + image_two.name() + '\''

--- a/lib/mrtrix3/matrix.py
+++ b/lib/mrtrix3/matrix.py
@@ -19,7 +19,7 @@
 
 import itertools, re
 from mrtrix3 import COMMAND_HISTORY_STRING, MRtrixError
-
+from mrtrix3.utils import STRING_TYPES
 
 
 _TRANSFORM_LAST_ROW = [ 0.0, 0.0, 0.0, 1.0 ]
@@ -176,7 +176,7 @@ def save_numeric(filename, data, **kwargs):
     encode_args['encoding'] = encoding
 
   if header:
-    if isinstance(header, str):
+    if isinstance(header, STRING_TYPES):
       header = { 'comments' : header }
     elif isinstance(header, list):
       header = { 'comments' : '\n'.join(str(entry) for entry in header) }
@@ -192,7 +192,7 @@ def save_numeric(filename, data, **kwargs):
       header['command_history'] = COMMAND_HISTORY_STRING
 
   if footer:
-    if isinstance(footer, str):
+    if isinstance(footer, STRING_TYPES):
       footer = { 'comments' : footer }
     elif isinstance(footer, list):
       footer = { 'comments' : '\n'.join(str(entry) for entry in footer) }

--- a/lib/mrtrix3/path.py
+++ b/lib/mrtrix3/path.py
@@ -26,6 +26,7 @@ try:
 except ImportError:
   from pipes import quote
 from mrtrix3 import CONFIG
+from mrtrix3.utils import STRING_TYPES
 
 
 
@@ -229,12 +230,12 @@ def wait_for(paths): #pylint: disable=unused-variable
 
   # Make sure the data we're dealing with is a list of strings;
   #   or make it a list of strings if it's just a single entry
-  if isinstance(paths, str):
+  if isinstance(paths, STRING_TYPES):
     paths = [ paths ]
   else:
     assert isinstance(paths, list)
     for entry in paths:
-      assert isinstance(entry, str)
+      assert isinstance(entry, STRING_TYPES)
 
   app.debug(str(paths))
 

--- a/lib/mrtrix3/phaseencoding.py
+++ b/lib/mrtrix3/phaseencoding.py
@@ -18,6 +18,7 @@
 
 
 from mrtrix3 import MRtrixError
+from mrtrix3.utils import STRING_TYPES
 
 
 
@@ -73,7 +74,7 @@ def direction(string): #pylint: disable=unused-variable
 def get_scheme(arg): #pylint: disable=unused-variable
   from mrtrix3 import app, image #pylint: disable=import-outside-toplevel
   if not isinstance(arg, image.Header):
-    if not isinstance(arg, str):
+    if not isinstance(arg, STRING_TYPES):
       raise MRtrixError('Error trying to derive phase-encoding scheme from \'' + str(arg) + '\': Not an image header or file path')
     arg = image.Header(arg)
   if 'pe_scheme' in arg.keyval():

--- a/lib/mrtrix3/run.py
+++ b/lib/mrtrix3/run.py
@@ -250,13 +250,15 @@ def command(cmd, **kwargs): #pylint: disable=unused-variable
         cmdsplit.extend(entry)
       else:
         raise TypeError('When run.command() is provided with a list as input, entries in the list must be either strings or lists of strings')
-  else:
+  elif isinstance(cmd, STRING_TYPES):
     cmdstring = cmd
     # Split the command string by spaces, preserving anything encased within quotation marks
     if os.sep == '/': # Cheap POSIX compliance check
       cmdsplit = shlex.split(cmd)
     else: # Native Windows Python
       cmdsplit = [ entry.strip('\"') for entry in shlex.split(cmd, posix=False) ]
+  else:
+    raise TypeError('run.command() function only operates on strings, or lists of strings')
 
   if shared.get_continue():
     if shared.trigger_continue(cmdsplit):

--- a/lib/mrtrix3/run.py
+++ b/lib/mrtrix3/run.py
@@ -16,6 +16,7 @@
 import collections, itertools, os, shlex, signal, string, subprocess, sys, tempfile, threading
 from distutils.spawn import find_executable
 from mrtrix3 import ANSI, BIN_PATH, COMMAND_HISTORY_STRING, EXE_LIST, MRtrixBaseError, MRtrixError
+from mrtrix3.utils import STRING_TYPES
 
 IOStream = collections.namedtuple('IOStream', 'handle filename')
 
@@ -232,11 +233,11 @@ def command(cmd, **kwargs): #pylint: disable=unused-variable
     cmdstring = ''
     cmdsplit = []
     for entry in cmd:
-      if isinstance(entry, str):
+      if isinstance(entry, STRING_TYPES):
         cmdstring += (' ' if cmdstring else '') + entry
         cmdsplit.append(entry)
       elif isinstance(entry, list):
-        assert all([ isinstance(item, str) for item in entry ])
+        assert all([ isinstance(item, STRING_TYPES) for item in entry ])
         if len(entry) > 1:
           common_prefix = os.path.commonprefix(entry)
           common_suffix = os.path.commonprefix([i[::-1] for i in entry])[::-1]
@@ -465,7 +466,7 @@ def function(fn_to_execute, *args, **kwargs): #pylint: disable=unused-variable
   show = kwargs.pop('show', True)
 
   fnstring = fn_to_execute.__module__ + '.' + fn_to_execute.__name__ + \
-             '(' + ', '.join(['\'' + str(a) + '\'' if isinstance(a, str) else str(a) for a in args]) + \
+             '(' + ', '.join(['\'' + str(a) + '\'' if isinstance(a, STRING_TYPES) else str(a) for a in args]) + \
              (', ' if (args and kwargs) else '') + \
              ', '.join([key+'='+str(value) for key, value in kwargs.items()]) + ')'
 

--- a/lib/mrtrix3/utils.py
+++ b/lib/mrtrix3/utils.py
@@ -17,7 +17,18 @@
 
 
 
-import platform, re
+import platform, re, sys
+
+
+
+
+# For identifying function input arguments as strings on
+#   both Python 2 and 3
+if sys.version_info[0] == 2:
+  STRING_TYPES = (basestring,) #pylint: disable=undefined-variable
+else:
+  STRING_TYPES = (str,)
+
 
 
 
@@ -38,7 +49,7 @@ class RunList(object): #pylint: disable=unused-variable
       self.counter = 0
       self.valid = True
     elif isinstance(value, list):
-      assert all(isinstance(entry, str) for entry in value)
+      assert all(isinstance(entry, STRING_TYPES) for entry in value)
       self.progress = app.ProgressBar(message, len(value))
       for entry in value:
         run.command(entry)


### PR DESCRIPTION
I can't remember exactly what it was that caused me to start changing these, but I did eventually recall #1616 where we had an issue with Python2 passing unicode data to `run.command()`: the basic construct removed there for being problematic (testing whether a variable is of string type) is actually present in a number of other locations within the API.

This is the same technique as is used in the Python `six` module; but given that is not a built-in, I didn't want to introduce that dependency.