### PR TITLE
mrview: add config option to show ortho view in a row

### DIFF
--- a/src/gui/mrview/mode/ortho.cpp
+++ b/src/gui/mrview/mode/ortho.cpp
@@ -192,6 +192,7 @@ namespace MR
         void Ortho::set_show_as_row_slot (bool state)
         {
           show_as_row = state;
+          frame_VB.clear();
           updateGL();
         }
 

--- a/src/gui/mrview/mode/ortho.cpp
+++ b/src/gui/mrview/mode/ortho.cpp
@@ -188,7 +188,9 @@ namespace MR
           updateGL();
         }
 
-        void Ortho::set_show_as_row (bool state) {
+
+        void Ortho::set_show_as_row_slot (bool state)
+        {
           show_as_row = state;
           updateGL();
         }

--- a/src/gui/mrview/mode/ortho.cpp
+++ b/src/gui/mrview/mode/ortho.cpp
@@ -188,6 +188,11 @@ namespace MR
           updateGL();
         }
 
+        void Ortho::set_show_as_row (bool state) {
+          show_as_row = state;
+          TRACE;
+        }
+
 
       }
     }

--- a/src/gui/mrview/mode/ortho.cpp
+++ b/src/gui/mrview/mode/ortho.cpp
@@ -28,7 +28,21 @@ namespace MR
       namespace Mode
       {
 
+        bool Ortho::show_as_row = false;
 
+        //CONF option: MRViewOrthoAsRow
+        //CONF Display the 3 orthogonal views of the Ortho mode in a row,
+        //CONF rather than as a 2x2 montage
+        //CONF default: false
+
+        Ortho::Ortho () :
+          projections (3, projection),
+          current_plane (0) {
+            static bool conf_read = false;
+            if (!conf_read)
+              show_as_row = MR::File::Config::get_bool ("MRViewOrthoAsRow", false);
+            conf_read = true;
+          }
 
 
         void Ortho::paint (Projection& projection)
@@ -191,6 +205,7 @@ namespace MR
 
         void Ortho::set_show_as_row_slot (bool state)
         {
+          GL::Context::Grab context;
           show_as_row = state;
           frame_VB.clear();
           updateGL();

--- a/src/gui/mrview/mode/ortho.cpp
+++ b/src/gui/mrview/mode/ortho.cpp
@@ -190,7 +190,7 @@ namespace MR
 
         void Ortho::set_show_as_row (bool state) {
           show_as_row = state;
-          TRACE;
+          updateGL();
         }
 
 

--- a/src/gui/mrview/mode/ortho.h
+++ b/src/gui/mrview/mode/ortho.h
@@ -34,11 +34,7 @@ namespace MR
             Q_OBJECT
 
           public:
-              Ortho () :
-                projections (3, projection),
-                current_plane (0),
-                show_as_row (MR::File::Config::get_bool ("MRViewOrthoAsRow", false)) { }
-
+            Ortho ();
             virtual void paint (Projection& projection);
 
             virtual void mouse_press_event ();
@@ -48,13 +44,14 @@ namespace MR
             virtual void request_update_mode_gui (ModeGuiVisitor& visitor) const {
                  visitor.update_ortho_mode_gui(*this); }
 
+            static bool show_as_row;
+
           public slots:
             void set_show_as_row_slot (bool state);
 
           protected:
             vector<Projection> projections;
             int current_plane;
-            bool show_as_row;
             GL::VertexBuffer frame_VB;
             GL::VertexArrayObject frame_VAO;
             GL::Shader::Program frame_program;

--- a/src/gui/mrview/mode/ortho.h
+++ b/src/gui/mrview/mode/ortho.h
@@ -45,11 +45,17 @@ namespace MR
             virtual void slice_move_event (float x);
             virtual void panthrough_event ();
             virtual const Projection* get_current_projection () const;
+            virtual void request_update_mode_gui (ModeGuiVisitor& visitor) const {
+                 visitor.update_ortho_mode_gui(*this); }
+            virtual void set_show_as_row (bool state);
+
+          public slots:
+            void set_show_as_row_slot (bool state) { set_show_as_row (state); }
 
           protected:
             vector<Projection> projections;
             int current_plane;
-            const bool show_as_row;
+            bool show_as_row;
             GL::VertexBuffer frame_VB;
             GL::VertexArrayObject frame_VAO;
             GL::Shader::Program frame_program;

--- a/src/gui/mrview/mode/ortho.h
+++ b/src/gui/mrview/mode/ortho.h
@@ -34,9 +34,10 @@ namespace MR
             Q_OBJECT
 
           public:
-              Ortho () : 
+              Ortho () :
                 projections (3, projection),
-                current_plane (0) { }
+                current_plane (0),
+                show_as_row (MR::File::Config::get_int ("MRViewOrthoAsRow", 0)) { }
 
             virtual void paint (Projection& projection);
 
@@ -48,6 +49,7 @@ namespace MR
           protected:
             vector<Projection> projections;
             int current_plane;
+            const bool show_as_row;
             GL::VertexBuffer frame_VB;
             GL::VertexArrayObject frame_VAO;
             GL::Shader::Program frame_program;
@@ -59,7 +61,6 @@ namespace MR
 }
 
 #endif
-
 
 
 

--- a/src/gui/mrview/mode/ortho.h
+++ b/src/gui/mrview/mode/ortho.h
@@ -47,10 +47,9 @@ namespace MR
             virtual const Projection* get_current_projection () const;
             virtual void request_update_mode_gui (ModeGuiVisitor& visitor) const {
                  visitor.update_ortho_mode_gui(*this); }
-            virtual void set_show_as_row (bool state);
 
           public slots:
-            void set_show_as_row_slot (bool state) { set_show_as_row (state); }
+            void set_show_as_row_slot (bool state);
 
           protected:
             vector<Projection> projections;

--- a/src/gui/mrview/mode/ortho.h
+++ b/src/gui/mrview/mode/ortho.h
@@ -37,7 +37,7 @@ namespace MR
               Ortho () :
                 projections (3, projection),
                 current_plane (0),
-                show_as_row (MR::File::Config::get_int ("MRViewOrthoAsRow", 0)) { }
+                show_as_row (MR::File::Config::get_bool ("MRViewOrthoAsRow", false)) { }
 
             virtual void paint (Projection& projection);
 

--- a/src/gui/mrview/tool/view.cpp
+++ b/src/gui/mrview/tool/view.cpp
@@ -270,9 +270,24 @@ namespace MR
           connect (max_entry, SIGNAL (valueChanged()), this, SLOT (onSetScaling()));
           hlayout->addWidget (max_entry);
 
+          // ortho view options
+          ortho_box = new QGroupBox ("Ortho view options");
+          main_box->addWidget (ortho_box);
+          VBoxLayout* vlayout = new VBoxLayout;
+          ortho_box->setLayout (vlayout);
+
+          hlayout = new HBoxLayout;
+          vlayout->addLayout (hlayout);
+
+          ortho_view_in_row = new QCheckBox ("display images in a row");
+          ortho_view_in_row->setCheckable (true);
+          ortho_view_in_row->setChecked (MR::File::Config::get_int ("MRViewOrthoAsRow", 0));
+          hlayout->addWidget (ortho_view_in_row);
+
+          // volume render options
           transparency_box = new QGroupBox ("Transparency");
           main_box->addWidget (transparency_box);
-          VBoxLayout* vlayout = new VBoxLayout;
+          vlayout = new VBoxLayout;
           transparency_box->setLayout (vlayout);
 
           hlayout = new HBoxLayout;
@@ -675,6 +690,7 @@ namespace MR
           threshold_box->setVisible (mode->features & Mode::ShaderTransparency);
           clip_box->setVisible (mode->features & Mode::ShaderClipping);
           lightbox_box->setVisible (false);
+          ortho_box->setVisible (false);
           mode->request_update_mode_gui(*this);
         }
 
@@ -1049,7 +1065,13 @@ namespace MR
           light_box_volume_inc->setVisible (can_show_vol);
         }
 
-
+        // Called in respose to a request_update_mode_gui(ModeGuiVisitor& visitor) call
+        void View::update_ortho_mode_gui(const Mode::Ortho & mode)
+        {
+          ortho_box->setVisible(true);
+          TRACE;
+          // connect(ortho_view_in_row, SIGNAL (toggled(bool)), &mode, SLOT (set_show_as_row_slot(bool))); // TODO does not compile
+        }
 
 
         // Called in respose to a request_update_mode_gui(ModeGuiVisitor& visitor) call

--- a/src/gui/mrview/tool/view.cpp
+++ b/src/gui/mrview/tool/view.cpp
@@ -280,7 +280,7 @@ namespace MR
           // ortho view options
           ortho_view_in_row_check_box = new QCheckBox ("display images in a row");
           ortho_view_in_row_check_box->setCheckable (true);
-          ortho_view_in_row_check_box->setChecked (MR::File::Config::get_int ("MRViewOrthoAsRow", 0));
+          ortho_view_in_row_check_box->setChecked (MR::File::Config::get_bool ("MRViewOrthoAsRow", false));
           ortho_view_in_row_check_box->setToolTip (
               "Display the 3 orthogonal views in a row, rather than a 2x2 montage.\n\n"
               "To make this the default, set the \"MRViewOrthoAsRow\" option in your configuration file.");
@@ -1077,7 +1077,7 @@ namespace MR
         void View::update_ortho_mode_gui (const Mode::Ortho & mode)
         {
           ortho_view_in_row_check_box->setVisible (true);
-          connect (ortho_view_in_row_check_box, SIGNAL (toggled(bool)), &mode, SLOT (set_show_as_row_slot(bool))); // TODO does not compile
+          connect (ortho_view_in_row_check_box, SIGNAL (toggled(bool)), &mode, SLOT (set_show_as_row_slot(bool)));
         }
 
 

--- a/src/gui/mrview/tool/view.cpp
+++ b/src/gui/mrview/tool/view.cpp
@@ -271,10 +271,19 @@ namespace MR
           connect (max_entry, SIGNAL (valueChanged()), this, SLOT (onSetScaling()));
           hlayout->addWidget (max_entry);
 
+
+          //CONF option: MRViewOrthoAsRow
+          //CONF Display the 3 orthogonal views of the Ortho mode in a row,
+          //CONF rather than as a 2x2 montage
+          //CONF default: false
+
           // ortho view options
           ortho_view_in_row_check_box = new QCheckBox ("display images in a row");
           ortho_view_in_row_check_box->setCheckable (true);
           ortho_view_in_row_check_box->setChecked (MR::File::Config::get_int ("MRViewOrthoAsRow", 0));
+          ortho_view_in_row_check_box->setToolTip (
+              "Display the 3 orthogonal views in a row, rather than a 2x2 montage.\n\n"
+              "To make this the default, set the \"MRViewOrthoAsRow\" option in your configuration file.");
           main_box->addWidget (ortho_view_in_row_check_box);
 
           // volume render options

--- a/src/gui/mrview/tool/view.cpp
+++ b/src/gui/mrview/tool/view.cpp
@@ -475,6 +475,7 @@ namespace MR
 
           main_box->addStretch ();
 
+          ortho_view_in_row_check_box->setVisible (false);
           transparency_box->setVisible (false);
           threshold_box->setVisible (false);
           clip_box->setVisible (false);

--- a/src/gui/mrview/tool/view.cpp
+++ b/src/gui/mrview/tool/view.cpp
@@ -272,15 +272,10 @@ namespace MR
           hlayout->addWidget (max_entry);
 
 
-          //CONF option: MRViewOrthoAsRow
-          //CONF Display the 3 orthogonal views of the Ortho mode in a row,
-          //CONF rather than as a 2x2 montage
-          //CONF default: false
-
           // ortho view options
           ortho_view_in_row_check_box = new QCheckBox ("display images in a row");
           ortho_view_in_row_check_box->setCheckable (true);
-          ortho_view_in_row_check_box->setChecked (MR::File::Config::get_bool ("MRViewOrthoAsRow", false));
+          ortho_view_in_row_check_box->setChecked (false);
           ortho_view_in_row_check_box->setToolTip (
               "Display the 3 orthogonal views in a row, rather than a 2x2 montage.\n\n"
               "To make this the default, set the \"MRViewOrthoAsRow\" option in your configuration file.");
@@ -1077,6 +1072,7 @@ namespace MR
         void View::update_ortho_mode_gui (const Mode::Ortho & mode)
         {
           ortho_view_in_row_check_box->setVisible (true);
+          ortho_view_in_row_check_box->setChecked (Mode::Ortho::show_as_row);
           connect (ortho_view_in_row_check_box, SIGNAL (toggled(bool)), &mode, SLOT (set_show_as_row_slot(bool)));
         }
 

--- a/src/gui/mrview/tool/view.cpp
+++ b/src/gui/mrview/tool/view.cpp
@@ -21,6 +21,7 @@
 #include "gui/mrview/window.h"
 #include "gui/mrview/mode/volume.h"
 #include "gui/mrview/mode/lightbox_gui.h"
+#include "gui/mrview/mode/ortho.h"
 #include "gui/mrview/mode/lightbox.h"
 #include "gui/mrview/adjust_button.h"
 
@@ -271,23 +272,15 @@ namespace MR
           hlayout->addWidget (max_entry);
 
           // ortho view options
-          ortho_box = new QGroupBox ("Ortho view options");
-          main_box->addWidget (ortho_box);
-          VBoxLayout* vlayout = new VBoxLayout;
-          ortho_box->setLayout (vlayout);
-
-          hlayout = new HBoxLayout;
-          vlayout->addLayout (hlayout);
-
-          ortho_view_in_row = new QCheckBox ("display images in a row");
-          ortho_view_in_row->setCheckable (true);
-          ortho_view_in_row->setChecked (MR::File::Config::get_int ("MRViewOrthoAsRow", 0));
-          hlayout->addWidget (ortho_view_in_row);
+          ortho_view_in_row_check_box = new QCheckBox ("display images in a row");
+          ortho_view_in_row_check_box->setCheckable (true);
+          ortho_view_in_row_check_box->setChecked (MR::File::Config::get_int ("MRViewOrthoAsRow", 0));
+          main_box->addWidget (ortho_view_in_row_check_box);
 
           // volume render options
           transparency_box = new QGroupBox ("Transparency");
           main_box->addWidget (transparency_box);
-          vlayout = new VBoxLayout;
+          VBoxLayout* vlayout = new VBoxLayout;
           transparency_box->setLayout (vlayout);
 
           hlayout = new HBoxLayout;
@@ -690,7 +683,7 @@ namespace MR
           threshold_box->setVisible (mode->features & Mode::ShaderTransparency);
           clip_box->setVisible (mode->features & Mode::ShaderClipping);
           lightbox_box->setVisible (false);
-          ortho_box->setVisible (false);
+          ortho_view_in_row_check_box->setVisible (false);
           mode->request_update_mode_gui(*this);
         }
 
@@ -1065,30 +1058,29 @@ namespace MR
           light_box_volume_inc->setVisible (can_show_vol);
         }
 
-        // Called in respose to a request_update_mode_gui(ModeGuiVisitor& visitor) call
-        void View::update_ortho_mode_gui(const Mode::Ortho & mode)
+        // Called in response to a request_update_mode_gui(ModeGuiVisitor& visitor) call
+        void View::update_ortho_mode_gui (const Mode::Ortho & mode)
         {
-          ortho_box->setVisible(true);
-          TRACE;
-          // connect(ortho_view_in_row, SIGNAL (toggled(bool)), &mode, SLOT (set_show_as_row_slot(bool))); // TODO does not compile
+          ortho_view_in_row_check_box->setVisible (true);
+          connect (ortho_view_in_row_check_box, SIGNAL (toggled(bool)), &mode, SLOT (set_show_as_row_slot(bool))); // TODO does not compile
         }
 
 
         // Called in respose to a request_update_mode_gui(ModeGuiVisitor& visitor) call
-        void View::update_lightbox_mode_gui(const Mode::LightBox &mode)
+        void View::update_lightbox_mode_gui (const Mode::LightBox &mode)
         {
           lightbox_box->setVisible(true);
 
           connect(&mode, SIGNAL (slice_increment_reset()), this, SLOT (light_box_slice_inc_reset_slot()));
 
-          connect(light_box_rows, SIGNAL (valueChanged(int)), &mode, SLOT (nrows_slot(int)));
-          connect(light_box_cols, SIGNAL (valueChanged(int)), &mode, SLOT (ncolumns_slot(int)));
-          connect(light_box_slice_inc, SIGNAL (valueChanged(float)), &mode, SLOT (slice_inc_slot(float)));
-          connect(light_box_volume_inc, SIGNAL (valueChanged(int)), &mode, SLOT (volume_inc_slot(int)));
-          connect(light_box_show_grid, SIGNAL (toggled(bool)), &mode, SLOT (show_grid_slot(bool)));
-          connect(light_box_show_4d, SIGNAL (toggled(bool)), &mode, SLOT (show_volumes_slot(bool)));
-          connect(light_box_show_4d, SIGNAL (toggled(bool)), this, SLOT (light_box_toggle_volumes_slot(bool)));
-          connect(&window(), SIGNAL (volumeChanged()), &mode, SLOT (image_volume_changed_slot()));
+          connect (light_box_rows, SIGNAL (valueChanged(int)), &mode, SLOT (nrows_slot(int)));
+          connect (light_box_cols, SIGNAL (valueChanged(int)), &mode, SLOT (ncolumns_slot(int)));
+          connect (light_box_slice_inc, SIGNAL (valueChanged(float)), &mode, SLOT (slice_inc_slot(float)));
+          connect (light_box_volume_inc, SIGNAL (valueChanged(int)), &mode, SLOT (volume_inc_slot(int)));
+          connect (light_box_show_grid, SIGNAL (toggled(bool)), &mode, SLOT (show_grid_slot(bool)));
+          connect (light_box_show_4d, SIGNAL (toggled(bool)), &mode, SLOT (show_volumes_slot(bool)));
+          connect (light_box_show_4d, SIGNAL (toggled(bool)), this, SLOT (light_box_toggle_volumes_slot(bool)));
+          connect (&window(), SIGNAL (volumeChanged()), &mode, SLOT (image_volume_changed_slot()));
 
           reset_light_box_gui_controls();
         }

--- a/src/gui/mrview/tool/view.h
+++ b/src/gui/mrview/tool/view.h
@@ -57,6 +57,7 @@ namespace MR
             bool get_clipintersectionmodestate () const;
 
             void update_lightbox_mode_gui(const Mode::LightBox &mode) override;
+            void update_ortho_mode_gui(const Mode::Ortho &mode) override;
 
           protected:
             virtual void showEvent (QShowEvent* event) override;
@@ -112,9 +113,9 @@ namespace MR
             AdjustButton *max_entry, *min_entry, *fov;
             AdjustButton *transparent_intensity, *opaque_intensity;
             AdjustButton *lower_threshold, *upper_threshold;
-            QCheckBox *lower_threshold_check_box, *upper_threshold_check_box, *clip_highlight_check_box, *clip_intersectionmode_check_box;
+            QCheckBox *lower_threshold_check_box, *upper_threshold_check_box, *clip_highlight_check_box, *clip_intersectionmode_check_box, *ortho_view_in_row;
             QComboBox *plane_combobox;
-            QGroupBox *volume_box, *transparency_box, *threshold_box, *clip_box, *lightbox_box;
+            QGroupBox *volume_box, *transparency_box, *threshold_box, *clip_box, *lightbox_box, *ortho_box;
             QSlider *opacity;
             QMenu *clip_planes_option_menu, *clip_planes_reset_submenu;
             QAction *clip_planes_new_axial_action, *clip_planes_new_sagittal_action, *clip_planes_new_coronal_action;

--- a/src/gui/mrview/tool/view.h
+++ b/src/gui/mrview/tool/view.h
@@ -56,8 +56,8 @@ namespace MR
             bool get_cliphighlightstate () const;
             bool get_clipintersectionmodestate () const;
 
-            void update_lightbox_mode_gui(const Mode::LightBox &mode) override;
-            void update_ortho_mode_gui(const Mode::Ortho &mode) override;
+            void update_lightbox_mode_gui (const Mode::LightBox &mode) override;
+            void update_ortho_mode_gui (const Mode::Ortho &mode) override;
 
           protected:
             virtual void showEvent (QShowEvent* event) override;
@@ -113,9 +113,9 @@ namespace MR
             AdjustButton *max_entry, *min_entry, *fov;
             AdjustButton *transparent_intensity, *opaque_intensity;
             AdjustButton *lower_threshold, *upper_threshold;
-            QCheckBox *lower_threshold_check_box, *upper_threshold_check_box, *clip_highlight_check_box, *clip_intersectionmode_check_box, *ortho_view_in_row;
+            QCheckBox *lower_threshold_check_box, *upper_threshold_check_box, *clip_highlight_check_box, *clip_intersectionmode_check_box, *ortho_view_in_row_check_box;
             QComboBox *plane_combobox;
-            QGroupBox *volume_box, *transparency_box, *threshold_box, *clip_box, *lightbox_box, *ortho_box;
+            QGroupBox *volume_box, *transparency_box, *threshold_box, *clip_box, *lightbox_box;
             QSlider *opacity;
             QMenu *clip_planes_option_menu, *clip_planes_reset_submenu;
             QAction *clip_planes_new_axial_action, *clip_planes_new_sagittal_action, *clip_planes_new_coronal_action;

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -269,7 +269,7 @@ namespace MR
           //CONF default: 0 (false)
           //CONF Whether MRView tools should start docked in the main window, or
           //CONF floating (detached from the main window).
-          tools_floating = MR::File::Config::get_int ("MRViewDockFloating", 0);
+          tools_floating = MR::File::Config::get_bool ("MRViewDockFloating", false);
 
           // Main toolbar:
 


### PR DESCRIPTION
Adds a config file option `MRViewOrthoAsRow` to show the 3 orthoview panes in a row, e.g.:
![Screenshot from 2020-01-23 14-08-27](https://user-images.githubusercontent.com/3221000/72991419-e234b200-3de9-11ea-954c-e12f0838ffd7.png)

Any use...? 
