### PR TITLE
mrview: fix initial size of view tool

### DIFF
--- a/src/gui/mrview/tool/base.cpp
+++ b/src/gui/mrview/tool/base.cpp
@@ -28,7 +28,7 @@ namespace MR
 
         void Dock::closeEvent (QCloseEvent*) { assert (tool); tool->close_event(); }
 
-        Base::Base (Dock* parent) : 
+        Base::Base (Dock* parent) :
           QFrame (parent) {
             QFont f = font();
             //CONF option: MRViewToolFontSize
@@ -36,21 +36,13 @@ namespace MR
             //CONF The point size for the font to use in MRView tools.
             f.setPointSize (MR::File::Config::get_int ("MRViewToolFontSize", f.pointSize()-2));
             setFont (f);
-            setFrameShadow (QFrame::Sunken); 
+            setFrameShadow (QFrame::Sunken);
             setFrameShape (QFrame::Panel);
             setAcceptDrops (true);
           }
 
-        void Base::adjustSize () 
-        {
-          layout()->update();
-          layout()->activate();
-          setMinimumSize (layout()->minimumSize());
-        }
 
-
-        QSize Base::sizeHint () const { return minimumSize(); }
-
+        QSize Base::sizeHint () const { return minimumSizeHint(); }
 
         void Base::draw (const Projection&, bool, int, int) { }
 

--- a/src/gui/mrview/tool/base.h
+++ b/src/gui/mrview/tool/base.h
@@ -48,8 +48,11 @@ namespace MR
         class Dock : public QDockWidget
         { NOMEMALIGN
           public:
-            Dock (const QString& name) :
-              QDockWidget (name, Window::main), tool (nullptr) { }
+            Dock (const QString& name, bool floating) :
+              QDockWidget (name, Window::main), tool (nullptr) {
+                Window::main->addDockWidget (Qt::RightDockWidgetArea, this);
+                setFloating (floating);
+              }
             ~Dock ();
 
             void closeEvent (QCloseEvent*) override;
@@ -130,7 +133,6 @@ namespace MR
                 }
             };
 
-            void adjustSize();
             virtual void draw (const Projection& transform, bool is_3D, int axis, int slice);
             virtual void draw_colourbars ();
             virtual size_t visible_number_colourbars () { return 0; }
@@ -191,12 +193,9 @@ namespace MR
         template <class T>
           Dock* create (const QString& text, bool floating)
           {
-            Dock* dock = new Dock (text);
-            Window::main->addDockWidget (Qt::RightDockWidgetArea, dock);
+            Dock* dock = new Dock (text, floating);
             dock->tool = new T (dock);
-            dock->tool->adjustSize();
             dock->setWidget (dock->tool);
-            dock->setFloating (floating);
             dock->show();
             return dock;
           }

--- a/src/gui/mrview/tool/connectome/connectome.cpp
+++ b/src/gui/mrview/tool/connectome/connectome.cpp
@@ -51,7 +51,7 @@ namespace MR
             mat2vec (nullptr),
             lighting (this),
             lighting_dock (nullptr),
-            node_list (new Tool::Dock ("Connectome node list")),
+            node_list (new Tool::Dock ("Connectome node list", Window::tools_floating)),
             is_3D (true),
             crop_to_slab (false),
             slab_thickness (0.0f),

--- a/src/gui/mrview/tool/view.cpp
+++ b/src/gui/mrview/tool/view.cpp
@@ -457,6 +457,11 @@ namespace MR
           init_lightbox_gui (main_box);
 
           main_box->addStretch ();
+
+          transparency_box->setVisible (false);
+          threshold_box->setVisible (false);
+          clip_box->setVisible (false);
+          lightbox_box->setVisible (false);
         }
 
 

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -53,6 +53,7 @@ namespace MR
 */
 
       Window* Window::main = nullptr;
+      bool Window::tools_floating = false;
 
       namespace {
 
@@ -263,6 +264,12 @@ namespace MR
           QToolButton* button;
 
           setTabPosition (Qt::AllDockWidgetAreas, QTabWidget::East);
+
+          //CONF option: MRViewDockFloating
+          //CONF default: 0 (false)
+          //CONF Whether MRView tools should start docked in the main window, or
+          //CONF floating (detached from the main window).
+          tools_floating = MR::File::Config::get_int ("MRViewDockFloating", 0);
 
           // Main toolbar:
 
@@ -991,16 +998,10 @@ namespace MR
         if (dynamic_cast<Tool::__Action__*>(action)->dock)
           return;
 
-        //CONF option: MRViewDockFloating
-        //CONF default: 0 (false)
-        //CONF Whether MRView tools should start docked in the main window, or
-        //CONF floating (detached from the main window).
-        bool floating = MR::File::Config::get_int ("MRViewDockFloating", 0);
-
-        Tool::Dock* tool = dynamic_cast<Tool::__Action__*>(action)->create (floating);
+        Tool::Dock* tool = dynamic_cast<Tool::__Action__*>(action)->create (tools_floating);
         connect (tool, SIGNAL (visibilityChanged (bool)), action, SLOT (setChecked (bool)));
 
-        if (!floating) {
+        if (!tools_floating) {
 
           for (int i = 0; i < tool_group->actions().size(); ++i) {
             Tool::Dock* other_tool = dynamic_cast<Tool::__Action__*>(tool_group->actions()[i])->dock;

--- a/src/gui/mrview/window.h
+++ b/src/gui/mrview/window.h
@@ -153,6 +153,7 @@ namespace MR
 
           static void add_commandline_options (MR::App::OptionList& options);
           static Window* main;
+          static bool tools_floating;
 
         signals:
           void focusChanged ();


### PR DESCRIPTION
Finally figured out how to make the initial size of the view tool behave... Helps prevent massive expansion of window when initially showing the view tool.