### PR TITLE
run.command(): Keyword argument "env"

### DIFF
--- a/lib/mrtrix3/run.py
+++ b/lib/mrtrix3/run.py
@@ -213,6 +213,7 @@ def command(cmd, **kwargs): #pylint: disable=unused-variable
   show = kwargs.pop('show', True)
   mrconvert_keyval = kwargs.pop('mrconvert_keyval', None)
   force = kwargs.pop('force', False)
+  env = kwargs.pop('env', shared.env)
   if kwargs:
     raise TypeError('Unsupported keyword arguments passed to run.command(): ' + str(kwargs))
 
@@ -224,7 +225,7 @@ def command(cmd, **kwargs): #pylint: disable=unused-variable
     subprocess_kwargs['creationflags'] = subprocess.CREATE_NEW_PROCESS_GROUP
   if shell:
     subprocess_kwargs['shell'] = True
-  subprocess_kwargs['env'] = shared.env
+  subprocess_kwargs['env'] = env
 
   if isinstance(cmd, list):
     if shell:


### PR DESCRIPTION
Allows providing an environment variable dictionary to be propagated to the subprocess call(s) just for that `run.command()` invocation.

Was a bit surprised when I went to use this and it wasn't there...