### PR TITLE
population_template: Progress bars

### DIFF
--- a/bin/population_template
+++ b/bin/population_template
@@ -204,25 +204,18 @@ def aggregate(inputs, output, contrast_idx, mode, force=True):
     raise MRtrixError("aggregation mode %s not understood" % mode)
 
 
-def inplace_nan_mask(images, masks, progress=True):
-  from mrtrix3 import app, run  # pylint: disable=no-name-in-module, import-outside-toplevel
+def inplace_nan_mask(images, masks):
+  from mrtrix3 import run  # pylint: disable=no-name-in-module, import-outside-toplevel
   assert len(images) == len(masks), (len(images), len(masks))
-  if progress:
-    pbar = app.ProgressBar('NaN masking', len(images))
   for image, mask in zip(images, masks):
     target_dir = os.path.split(image)[0]
     masked = os.path.join(target_dir, '__' + os.path.split(image)[1])
     run.command("mrcalc " + mask + " " + image + " nan -if " + masked, force=True)
     run.function(shutil.move, masked, image)
-    if progress:
-      pbar.increment()
-  if progress:
-    pbar.done()
 
 
 def calculate_isfinite(inputs, contrasts):
-  from mrtrix3 import app, run, path  # pylint: disable=no-name-in-module, import-outside-toplevel
-  progress = app.ProgressBar('Preparations for leave one out registration', len(inputs) * contrasts.n_contrasts + 1)
+  from mrtrix3 import run, path  # pylint: disable=no-name-in-module, import-outside-toplevel
   agg_weights = [float(inp.aggregation_weight) for inp in inputs if inp.aggregation_weight is not None]
   for cid in range(contrasts.n_contrasts):
     for inp in inputs:
@@ -234,14 +227,12 @@ def calculate_isfinite(inputs, contrasts):
         cmd += ' %s -mult ' % inp.aggregation_weight
       cmd += ' isfinite%s/%s.mif' % (contrasts.suff[cid], inp.uid)
       run.command(cmd, force=True)
-      progress.increment()
   for cid in range(contrasts.n_contrasts):
     cmd = ['mrmath', path.all_in_dir('isfinite%s' % contrasts.suff[cid]), 'sum']
     if agg_weights:
       agg_weight_norm = str(float(len(agg_weights)) / sum(agg_weights))
       cmd += ['-', '|', 'mrcalc', '-', agg_weight_norm, '-mult']
     run.command(cmd + [contrasts.isfinite_count[cid]], force=True)
-  progress.done()
 
 
 def get_common_postfix(file_list):
@@ -1257,7 +1248,7 @@ def execute(): #pylint: disable=unused-variable
 
       if nanmask_input:
         inplace_nan_mask([inp.ims_transformed[cid] for inp in ins for cid in range(n_contrasts)],
-                         [inp.msk_transformed for inp in ins for cid in range(n_contrasts)], progress=False)
+                         [inp.msk_transformed for inp in ins for cid in range(n_contrasts)])
 
       if leave_one_out:
         calculate_isfinite(ins, cns)
@@ -1360,7 +1351,7 @@ def execute(): #pylint: disable=unused-variable
 
       if nanmask_input:
         inplace_nan_mask([_inp.ims_transformed[cid] for _inp in ins for cid in range(n_contrasts)],
-                         [_inp.msk_transformed for _inp in ins for cid in range(n_contrasts)], progress=True)
+                         [_inp.msk_transformed for _inp in ins for cid in range(n_contrasts)])
 
       if leave_one_out:
         calculate_isfinite(ins, cns)

--- a/bin/population_template
+++ b/bin/population_template
@@ -1400,7 +1400,7 @@ def execute(): #pylint: disable=unused-variable
     if os.path.exists(warp_path):
       run.function(shutil.rmtree, warp_path)
     os.makedirs(warp_path)
-    progress = app.ProgressBar('Copying non-linear warps to output directory "' + warp_path + '"')
+    progress = app.ProgressBar('Copying non-linear warps to output directory "' + warp_path + '"', len(ins))
     for inp in ins:
       run.command('mrconvert ' + os.path.join('warps', inp.uid + '.mif') + ' ' +
                   path.quote(os.path.join(warp_path, xcontrast_xsubject_pre_postfix[0] +
@@ -1425,7 +1425,7 @@ def execute(): #pylint: disable=unused-variable
       if os.path.exists(transformed_path):
         run.function(shutil.rmtree, transformed_path)
       os.makedirs(transformed_path)
-      progress = app.ProgressBar('Copying transformed images to output directory "' + transformed_path + '"')
+      progress = app.ProgressBar('Copying transformed images to output directory "' + transformed_path + '"', len(ins))
       for inp in ins:
         run.command(['mrconvert', inp.ims_transformed[cid], os.path.join(transformed_path, inp.ims_filenames[cid])],
                     mrconvert_keyval=inp.get_ims_path(False)[cid], force=app.FORCE_OVERWRITE)

--- a/bin/population_template
+++ b/bin/population_template
@@ -1142,9 +1142,12 @@ def execute(): #pylint: disable=unused-variable
       run.function(copy, os.path.join('linear_transforms_initial', inp.uid+'.txt'),
                    os.path.join('linear_transforms', inp.uid+'.txt'))
   else:
+    level = 0
+    regtype = linear_type[0]
+    def linear_msg():
+      return 'Optimising template with linear registration (stage {0} of {1}; {2})'.format(level, len(linear_scales), regtype)
+    progress = app.ProgressBar(linear_msg, (3 if use_masks else 2) * len(linear_scales) * len(ins))
     for level, (regtype, scale, niter, lmax) in enumerate(zip(linear_type, linear_scales, linear_niter, linear_lmax)):
-      msg = 'Optimising template with {2} registration (linear stage {0} of {1})'.format(level + 1, len(linear_scales), linear_type[level])
-      progress = app.ProgressBar(msg, len(ins) * n_contrasts)
       for inp in ins:
         initialise_option = ''
         if use_masks:
@@ -1215,7 +1218,7 @@ def execute(): #pylint: disable=unused-variable
           for im_temp in tmpl:
             run.function(os.remove, im_temp)
         progress.increment()
-      progress.done()
+
       # Here we ensure the template doesn't drift or scale
       # TODO matrix avarage might produce a large FOV for large rotations  # pylint: disable=fixme
       run.command('transformcalc ' + ' '.join(path.all_in_dir('linear_transforms_%02i' % level)) +
@@ -1230,7 +1233,6 @@ def execute(): #pylint: disable=unused-variable
           transform = matrix.dot(matrix.load_transform(os.path.join('linear_transforms_%02i' % level, inp.uid + '.txt')), average_inv)
           matrix.save_transform(os.path.join('linear_transforms_%02i' % level, inp.uid + '.txt'), transform)
 
-      progress = app.ProgressBar('Transforming all subjects to revised template', len(ins) * n_contrasts)
       for cid in range(n_contrasts):
         for inp in ins:
           run.command('mrtransform ' + c_mrtransform_reorientation[cid] + inp.ims_path[cid] +
@@ -1241,10 +1243,8 @@ def execute(): #pylint: disable=unused-variable
                       datatype_option,
                       force=True)
           progress.increment()
-      progress.done()
 
       if use_masks:
-        progress = app.ProgressBar('Transforming all masks to revised template', len(ins) * n_contrasts)
         for cid in range(n_contrasts):
           for inp in ins:
             run.command('mrtransform ' + inp.msk_path +
@@ -1254,7 +1254,6 @@ def execute(): #pylint: disable=unused-variable
                         ' ' + inp.msk_transformed,
                         force=True)
             progress.increment()
-        progress.done()
 
       if nanmask_input:
         inplace_nan_mask([inp.ims_transformed[cid] for inp in ins for cid in range(n_contrasts)],
@@ -1273,6 +1272,7 @@ def execute(): #pylint: disable=unused-variable
 
     for entry in os.listdir('linear_transforms_%02i' % level):
       run.function(copy, os.path.join('linear_transforms_%02i' % level, entry), os.path.join('linear_transforms', entry))
+    progress.done()
 
   # Create a template mask for nl registration by taking the intersection of all transformed input masks and dilating
   if use_masks and (dononlinear or app.ARGS.template_mask):
@@ -1281,11 +1281,12 @@ def execute(): #pylint: disable=unused-variable
     current_template_mask = 'init_nl_template_mask.mif'
 
   if dononlinear:
-    app.console('Optimising template with non-linear registration')
     path.make_dir('warps')
+    level = 0
+    def nonlinear_msg():
+      return 'Optimising template with non-linear registration (stage {0} of {1})'.format(level + 1, len(nl_scales))
+    progress = app.ProgressBar(nonlinear_msg, len(nl_scales) * len(ins))
     for level, (scale, niter, lmax) in enumerate(zip(nl_scales, nl_niter, nl_lmax)):
-      msg = 'Optimising template with non-linear registration (stage {0} of {1})'.format(level + 1, len(nl_scales))
-      progress = app.ProgressBar(msg, len(ins))
       for inp in ins:
         if level > 0:
           initialise_option = ' -nl_init ' + os.path.join('warps_%02i' % (level - 1), inp.uid + '.mif')
@@ -1355,8 +1356,7 @@ def execute(): #pylint: disable=unused-variable
         if level > 0:
           run.function(os.remove, os.path.join('warps_%02i' % (level - 1), inp.uid + '.mif'))
 
-        progress.increment()
-      progress.done()
+        progress.increment(nonlinear_msg())
 
       if nanmask_input:
         inplace_nan_mask([_inp.ims_transformed[cid] for _inp in ins for cid in range(n_contrasts)],
@@ -1389,6 +1389,7 @@ def execute(): #pylint: disable=unused-variable
       else:
         for inp in ins:
           run.function(shutil.move, os.path.join('warps_%02i' % level, inp.uid + '.mif'), 'warps')
+    progress.done()
 
   for cid in range(n_contrasts):
     run.command('mrconvert ' + cns.templates[cid] + ' ' + cns.templates_out[cid],

--- a/lib/mrtrix3/app.py
+++ b/lib/mrtrix3/app.py
@@ -491,11 +491,11 @@ class ProgressBar(object): #pylint: disable=unused-variable
       sys.stderr.write(EXEC_NAME + ': ' + self._get_message() + '... [' + self.newline)
     sys.stderr.flush()
 
-  def increment(self, msg=''):
+  def increment(self, msg=None):
     assert not self.iscomplete
     self.counter += 1
     force_update = False
-    if msg:
+    if msg is not None:
       self.message = msg
       force_update = True
     if self.multiplier:
@@ -514,10 +514,12 @@ class ProgressBar(object): #pylint: disable=unused-variable
         self.next_time = current_time + ProgressBar.INTERVAL
         self._update()
 
-  def done(self):
+  def done(self, msg=None):
     from mrtrix3 import run #pylint: disable=import-outside-toplevel
     global EXEC_NAME, VERBOSITY
     self.iscomplete = True
+    if msg is not None:
+      self.message = msg
     if self.multiplier:
       self.value = 100
     if self.isatty:


### PR DESCRIPTION
The terminal output from `population_template` is still pretty in-your-face despite the Progress Bars and the use of list inputs to `run.command()`.

With this proposal, linear and non-linear components each get their own single progress bar. I'm not convinced that being able to see the commands in between stages is actually informative under typical use; if a stream of command strings in the terminal is preferred by the user, `-info` can be provided.