### PR TITLE
mrtrix3.matrix: Precision changes

### DIFF
--- a/bin/dwifslpreproc
+++ b/bin/dwifslpreproc
@@ -442,7 +442,7 @@ def execute(): #pylint: disable=unused-variable
   # This may be required by -rpe_all for extracting b=0 volumes while retaining phase-encoding information
   import_dwi_pe_table_option = ''
   if dwi_manual_pe_scheme:
-    matrix.save_matrix('dwi_manual_pe_scheme.txt', dwi_manual_pe_scheme)
+    phaseencoding.save('dwi_manual_pe_scheme.txt', dwi_manual_pe_scheme)
     import_dwi_pe_table_option = ' -import_pe_table dwi_manual_pe_scheme.txt'
 
 
@@ -681,7 +681,7 @@ def execute(): #pylint: disable=unused-variable
   # This may be required when setting up the topup call
   se_epi_manual_pe_table_option = ''
   if se_epi_manual_pe_scheme:
-    matrix.save_matrix('se_epi_manual_pe_scheme.txt', se_epi_manual_pe_scheme)
+    phaseencoding.save('se_epi_manual_pe_scheme.txt', se_epi_manual_pe_scheme)
     se_epi_manual_pe_table_option = ' -import_pe_table se_epi_manual_pe_scheme.txt'
 
 

--- a/lib/mrtrix3/matrix.py
+++ b/lib/mrtrix3/matrix.py
@@ -160,7 +160,7 @@ def load_vector(filename, **kwargs): #pylint: disable=unused-variable
 
 # Save numeric data to a text file
 def save_numeric(filename, data, **kwargs):
-  fmt = kwargs.pop('fmt', '%6f')
+  fmt = kwargs.pop('fmt', '%.15g')
   delimiter = kwargs.pop('delimiter', ' ')
   newline = kwargs.pop('newline', '\n')
   add_to_command_history = bool(kwargs.pop('add_to_command_history', True))
@@ -237,6 +237,7 @@ def save_matrix(filename, data, **kwargs): #pylint: disable=unused-variable
   for line in data[1:]:
     if len(line) != columns:
       raise TypeError('Input to matrix.save_matrix() must be a 2D matrix')
+  kwargs['fmt'] = kwargs['fmt'] if 'fmt' in kwargs else '%18.15f'
   save_numeric(filename, data, **kwargs)
 
 
@@ -248,15 +249,14 @@ def save_transform(filename, data, **kwargs): #pylint: disable=unused-variable
   for line in data:
     if len(line) != 4:
       raise TypeError('Input to matrix.save_transform() must be a 3x4 or 4x4 matrix')
-  kwargs['fmt'] = kwargs['fmt'] if 'fmt' in kwargs else '%18.15f'
   if len(data) == 4:
     if any(a!=b for a, b in zip(data[3], _TRANSFORM_LAST_ROW)):
       raise TypeError('Input to matrix.save_transform() is not a valid affine matrix (fourth line contains values other than "0,0,0,1")')
-    save_numeric(filename, data, **kwargs)
+    save_matrix(filename, data, **kwargs)
   elif len(data) == 3:
     padded_data = data[:]
     padded_data.append(_TRANSFORM_LAST_ROW)
-    save_numeric(filename, data, **kwargs)
+    save_matrix(filename, data, **kwargs)
   else:
     raise TypeError('Input to matrix.save_matrix() must be a 3x4 or 4x4 matrix')
 

--- a/lib/mrtrix3/phaseencoding.py
+++ b/lib/mrtrix3/phaseencoding.py
@@ -17,7 +17,7 @@
 
 
 
-from mrtrix3 import MRtrixError
+from mrtrix3 import COMMAND_HISTORY_STRING, MRtrixError
 from mrtrix3.utils import STRING_TYPES
 
 
@@ -75,7 +75,7 @@ def get_scheme(arg): #pylint: disable=unused-variable
   from mrtrix3 import app, image #pylint: disable=import-outside-toplevel
   if not isinstance(arg, image.Header):
     if not isinstance(arg, STRING_TYPES):
-      raise MRtrixError('Error trying to derive phase-encoding scheme from \'' + str(arg) + '\': Not an image header or file path')
+      raise TypeError('Error trying to derive phase-encoding scheme from \'' + str(arg) + '\': Not an image header or file path')
     arg = image.Header(arg)
   if 'pe_scheme' in arg.keyval():
     app.debug(str(arg.keyval()['pe_scheme']))
@@ -89,3 +89,47 @@ def get_scheme(arg): #pylint: disable=unused-variable
   num_volumes = 1 if len(arg.size()) < 4 else arg.size()[3]
   app.debug(str(line) + ' x ' + str(num_volumes) + ' rows')
   return [ line ] * num_volumes
+
+
+
+# Save a phase-encoding scheme to file
+def save(filename, scheme, **kwargs):
+  from mrtrix3 import matrix
+  from mrtrix3.utils import STRING_TYPES
+  add_to_command_history = bool(kwargs.pop('add_to_command_history', True))
+  header = kwargs.pop('header', { })
+  if kwargs:
+    raise TypeError('Unsupported keyword arguments passed to phaseencoding.save(): ' + str(kwargs))
+
+  if not scheme:
+    raise MRtrixError('phaseencoding.save() cannot be run on an empty scheme')
+  if not matrix.is_2d_matrix(scheme):
+    raise TypeError('Input to phaseencoding.save() must be a 2D matrix')
+  if len(scheme[0]) != 4:
+    raise MRtrixError('Input to phaseencoding.save() not a valid scheme '
+                      '(contains ' + str(len(scheme[0])) + ' columns rather than 4)')
+
+  if header:
+    if isinstance(header, STRING_TYPES):
+      header = { 'comments' : header }
+    elif isinstance(header, list):
+      header = { 'comments' : '\n'.join(str(entry) for entry in header) }
+    elif isinstance(header, dict):
+      header = dict((key, str(value)) for key, value in header.items())
+    else:
+      raise TypeError('Unrecognised input to matrix.save_numeric() using "header=" option')
+  else:
+    header = { }
+
+  if add_to_command_history:
+    if 'command_history' in header:
+      header['command_history'] += '\n' + COMMAND_HISTORY_STRING
+    else:
+      header['command_history'] = COMMAND_HISTORY_STRING
+
+  with open(filename, 'w') as outfile:
+    for key, value in sorted(header.items()):
+      for line in value.splitlines():
+        outfile.write('# ' + key + ': ' + line + '\n')
+    for line in scheme:
+      outfile.write('{:d} {:d} {:d} {:.15g}\n'.format(*line))

--- a/lib/mrtrix3/phaseencoding.py
+++ b/lib/mrtrix3/phaseencoding.py
@@ -131,4 +131,4 @@ def save(filename, scheme, **kwargs): #pylint: disable=unused-variable
       for line in value.splitlines():
         outfile.write('# ' + key + ': ' + line + '\n')
     for line in scheme:
-      outfile.write('{:d} {:d} {:d} {:.15g}\n'.format(*line))
+      outfile.write('{:.0f} {:.0f} {:.0f} {:.15g}\n'.format(*line))

--- a/lib/mrtrix3/phaseencoding.py
+++ b/lib/mrtrix3/phaseencoding.py
@@ -93,9 +93,8 @@ def get_scheme(arg): #pylint: disable=unused-variable
 
 
 # Save a phase-encoding scheme to file
-def save(filename, scheme, **kwargs):
+def save(filename, scheme, **kwargs): #pylint: disable=unused-variable
   from mrtrix3 import matrix
-  from mrtrix3.utils import STRING_TYPES
   add_to_command_history = bool(kwargs.pop('add_to_command_history', True))
   header = kwargs.pop('header', { })
   if kwargs:


### PR DESCRIPTION
- When saving numerical data, default to full double-precision floating-point width (erasing trailing zeros); and for matrix / transform data, print with aligned columns; these are to be consistent with C++ API and not accidentally lose precision. Alters what was done in adda703a (#1775), and makes a09ee51c (#1792) redundant.

- New function `phaseencoding.save()`, which will properly write the phase encoding direction values as integers but the readout time as a float.

Twice in a row ended up with numerical data of lower precision than what I wanted. So decided it's better to go full-precision, and in specific cases where a lower precision is wanted to reduce file size, developer can request such. Also discovered the "`g`" specifier for `format()`, which removes trailing zeros from data that don't need it.