### PR TITLE
Python: No empty "command_history" outputs

### DIFF
--- a/lib/mrtrix3/__init__.py
+++ b/lib/mrtrix3/__init__.py
@@ -32,10 +32,12 @@ class MRtrixError(MRtrixBaseError): #pylint: disable=unused-variable
 
 
 # Contains the command currently being executed, appended with the version of the MRtrix3 Python library
-COMMAND_HISTORY_STRING = sys.argv[0]
-for arg in sys.argv[1:]:
-  COMMAND_HISTORY_STRING += ' ' + quote(arg) # Use quotation marks only if required
-COMMAND_HISTORY_STRING += '  (version=' + __version__ + ')"'
+COMMAND_HISTORY_STRING = None
+if sys.argv:
+  COMMAND_HISTORY_STRING = sys.argv[0]
+  for arg in sys.argv[1:]:
+    COMMAND_HISTORY_STRING += ' ' + quote(arg) # Use quotation marks only if required
+  COMMAND_HISTORY_STRING += '  (version=' + __version__ + ')'
 
 
 # Location of binaries that belong to the same MRtrix3 installation as the Python library being invoked

--- a/lib/mrtrix3/matrix.py
+++ b/lib/mrtrix3/matrix.py
@@ -187,7 +187,7 @@ def save_numeric(filename, data, **kwargs):
   else:
     header = { }
 
-  if add_to_command_history:
+  if add_to_command_history and COMMAND_HISTORY_STRING:
     if 'command_history' in header:
       header['command_history'] += '\n' + COMMAND_HISTORY_STRING
     else:

--- a/lib/mrtrix3/phaseencoding.py
+++ b/lib/mrtrix3/phaseencoding.py
@@ -120,7 +120,7 @@ def save(filename, scheme, **kwargs): #pylint: disable=unused-variable
   else:
     header = { }
 
-  if add_to_command_history:
+  if add_to_command_history and COMMAND_HISTORY_STRING:
     if 'command_history' in header:
       header['command_history'] += '\n' + COMMAND_HISTORY_STRING
     else:

--- a/lib/mrtrix3/run.py
+++ b/lib/mrtrix3/run.py
@@ -317,7 +317,9 @@ def command(cmd, **kwargs): #pylint: disable=unused-variable
       if cmdstack[-1][0] != 'mrconvert':
         raise TypeError('Argument "mrconvert_keyval=" can only be used if the mrconvert command is being invoked')
       assert not (mrconvert_keyval[0] in [ '\'', '"' ] or mrconvert_keyval[-1] in [ '\'', '"' ])
-      cmdstack[-1].extend([ '-copy_properties', mrconvert_keyval, '-append_property', 'command_history', COMMAND_HISTORY_STRING ])
+      cmdstack[-1].extend([ '-copy_properties', mrconvert_keyval ])
+      if COMMAND_HISTORY_STRING:
+        cmdstack[-1].extend([ '-append_property', 'command_history', COMMAND_HISTORY_STRING ])
 
     for line in cmdstack:
       is_mrtrix_exe = line[0] in EXE_LIST


### PR DESCRIPTION
If the *MRtrix3* Python modules are being used in interactive mode, do not attempt to extend the `command_history` key-value of any outputs.

Note: Will require a manual change to resolve with #1903. **Edit**: Done (153349e).