### PR TITLE
Remove all references to "output_step_size"

### DIFF
--- a/cmd/tckedit.cpp
+++ b/cmd/tckedit.cpp
@@ -216,9 +216,6 @@ void run ()
 
   Loader loader (input_file_list);
   Worker worker (properties, inverse, ends_only);
-  // This needs to be run AFTER creation of the Worker class
-  // (worker needs to be able to set max & min number of points based on step size in input file,
-  //  receiver needs "output_step_size" field to have been updated before file creation)
   Receiver receiver (output_path, properties, number, skip);
 
   Thread::run_queue (

--- a/cmd/tckresample.cpp
+++ b/cmd/tckresample.cpp
@@ -125,26 +125,6 @@ void run ()
 
   const std::unique_ptr<Resampling::Base> resampler (Resampling::get_resampler());
 
-  const float old_step_size = properties.get_stepsize();
-  if (!std::isfinite (old_step_size)) {
-    INFO ("Do not have step size information from input track file");
-  }
-
-  float new_step_size = NaN;
-  if (dynamic_cast<Resampling::FixedStepSize*>(resampler.get())) {
-    new_step_size = dynamic_cast<Resampling::FixedStepSize*> (resampler.get())->get_step_size();
-  } else if (std::isfinite (old_step_size)) {
-    if (dynamic_cast<Resampling::Downsampler*>(resampler.get()))
-      new_step_size = old_step_size * dynamic_cast<Resampling::Downsampler*> (resampler.get())->get_ratio();
-    if (dynamic_cast<Resampling::Upsampler*>(resampler.get()))
-      new_step_size = old_step_size / dynamic_cast<Resampling::Upsampler*> (resampler.get())->get_ratio();
-  }
-  properties["output_step_size"] = std::isfinite (new_step_size) ? str(new_step_size) : "variable";
-
-  auto downsample = properties.find ("downsample_factor");
-  if (downsample != properties.end())
-    properties.erase (downsample);
-
   Worker worker (resampler);
   Receiver receiver (argument[1], properties);
   Thread::run_queue (read,

--- a/src/dwi/tractography/algorithms/iFOD2.h
+++ b/src/dwi/tractography/algorithms/iFOD2.h
@@ -90,10 +90,9 @@ namespace MR
 
                   // iFOD2 by default downsamples after track propagation back to the desired 'step size'
                   //   i.e. the sub-step detail is removed from the output
-                  size_t downsample_ratio = num_samples;
-                  properties.set (downsample_ratio, "downsample_factor");
-                  downsampler.set_ratio (downsample_ratio);
-                  properties["output_step_size"] = str (step_size * downsample_ratio / float(num_samples));
+                  size_t downsample_factor = num_samples;
+                  properties.set (downsample_factor, "downsample_factor");
+                  downsampler.set_ratio (downsample_factor);
 
                   // For iFOD2, "step_size" represents the length of the chord represented
                   //   using "num_samples" vertices rather than just one; the following two
@@ -102,7 +101,7 @@ namespace MR
                   //     (prior to downsampling)
                   const float angle_minradius_preds = 2.0 * std::asin (step_size / (2.0 * min_radius)) / float(num_samples);
                   //   - The maximal possible distance between vertices after downsampling
-                  const float max_step_postds = downsampler.get_ratio() * step_size / float(num_samples);
+                  const float max_step_postds = downsample_factor * step_size / float(num_samples);
                   set_num_points (angle_minradius_preds, max_step_postds);
                 }
 

--- a/src/dwi/tractography/properties.cpp
+++ b/src/dwi/tractography/properties.cpp
@@ -102,14 +102,11 @@ namespace MR
 
       float Properties::get_stepsize() const
       {
-        for (size_t index = 0; index != 2; ++index) {
-          const std::string key (index ? "step_size" : "output_step_size");
-          auto it = KeyValues::find (key);
-          if (it != KeyValues::end()) {
-            try {
-              return to<float> (it->second);
-            } catch (...) { }
-          }
+        auto it = KeyValues::find ("step_size");
+        if (it != KeyValues::end()) {
+          try {
+            return to<float> (it->second);
+          } catch (...) { }
         }
         return NaN;
       }

--- a/src/dwi/tractography/tracking/shared.cpp
+++ b/src/dwi/tractography/tracking/shared.cpp
@@ -185,9 +185,6 @@ namespace MR
           properties.set (step_size, "step_size");
           INFO ("step size = " + str (step_size) + " mm");
 
-          if (downsampler.get_ratio() > 1)
-            properties["output_step_size"] = str (step_size * downsampler.get_ratio());
-
           max_dist = Defaults::maxlength_voxels * vox();
           properties.set (max_dist, "max_dist");
 

--- a/src/gui/mrview/tool/tractography/tractogram.cpp
+++ b/src/gui/mrview/tool/tractography/tractogram.cpp
@@ -577,6 +577,8 @@ namespace MR
 
         inline void Tractogram::update_stride ()
         {
+          // Note: If streamlines have been resampled at all,
+          //   strides will be incorrect
           const float step_size = properties.get_stepsize();
           GLint new_stride = 1;
 


### PR DESCRIPTION
This field was intended to inform decisions regarding length calculations, but is not adequately robust to serve that purpose. For instance, use of upsampling / downsampling results in a non-constant step size. Until some more robust technique is used, this parameter perhaps gives a false sense of certainty. It does however mean that if the distance between vertices in the track file differs substantially from the tracking step size, some calculations may be inaccurate; though those are typically not calculations where precision is essential.

Closes #1813.