### PR TITLE
Partially addressing Issue #1654

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ testing/bin/
 testing/src/project_version.cpp
 testing/src/project_version.h
 .__tmp.log
+.check_syntax.tmp
+.check_syntax2.tmp

--- a/build
+++ b/build
@@ -1334,7 +1334,7 @@ def update_user_docs ():
 ###########################################################################
 
 with open (os.path.join(mrtrix_dir[-1], script_dir, '_version.py'),'w') as vfile:
-  vfile.write('__version__ = "'+ mrtrix_version() +'"\n')
+  vfile.write('__version__ = "'+ mrtrix_version() +'" #pylint: disable=unused-variable\n')
 
 
 ###########################################################################

--- a/check_syntax
+++ b/check_syntax
@@ -120,6 +120,8 @@ for f in $(find cmd core src -type f -name '*.h' -o -name '*.cpp' | $grep -v '_m
     $grep -Po '\w*print(?!.*?print).*?$'
   )
 
+# delete intermediate files
+rm -f .check_syntax.tmp .check_syntax2.tmp
 
 # if anything is left after that, show it:
   if [[ ! -z $res ]]; then

--- a/src/dwi/sdeconv/msmt_csd.h
+++ b/src/dwi/sdeconv/msmt_csd.h
@@ -29,6 +29,7 @@
 #include "dwi/gradient.h"
 #include "dwi/shells.h"
 
+#define DEFAULT_MSMTCSD_LMAX 8
 #define DEFAULT_MSMTCSD_NORM_LAMBDA 1.0e-10
 #define DEFAULT_MSMTCSD_NEG_LAMBDA 1.0e-10
 
@@ -101,7 +102,7 @@ namespace MR
                 if (lmax.empty()) {
                   lmax = lmax_response;
                   for (size_t t = 0; t != num_tissues(); ++t) {
-                    lmax[t] = std::min (8, lmax[t]);
+                    lmax[t] = std::min (DEFAULT_MSMTCSD_LMAX, lmax[t]);
                   }
                 } else {
                   if (lmax.size() != num_tissues())


### PR DESCRIPTION
- Address temporary files generated by "`check_syntax`" script.
- Prevent `pylint` failures for file "`lib/mrtrix3/_version.py`" when run outside of CI.

Couldn't immediately reproduce the erroneous script algorithm docs issue. I did encounter an issue when both branch swapping and using different versions of Python, but that was an outright Exception. 