### PR TITLE
build: Don't remove bin/mrtrix3.pyc

### DIFF
--- a/build
+++ b/build
@@ -266,7 +266,9 @@ def get_real_name (path):
 
 
 def _get_expected_bin_filenames (exe_suffix, cmd_directory=cmd_dir):
-  binary_apps = { 'mrtrix.dll' } if exe_suffix else set()
+  binary_apps = { 'mrtrix3.pyc' }
+  if exe_suffix:
+    binary_apps.add('mrtrix.dll')
   for entry in os.listdir(cmd_directory):
     if entry.endswith(cpp_suffix):
       binary_apps.add (entry[:-len(cpp_suffix)] + exe_suffix)


### PR DESCRIPTION
Resolve conflict between #1550 and #1613, which resulted in compiled Python file "`bin/mrtrix3.pyc`" being moved to `bin/purged_files/`.