### PR TITLE
New config file option "BValueEpsilon"

### DIFF
--- a/docs/reference/config_file_options.rst
+++ b/docs/reference/config_file_options.rst
@@ -18,6 +18,13 @@ List of MRtrix3 configuration file options
      should be assumed to be in LAS orientation (default) or RAS
      (when this is option is turned on).
 
+.. option:: BValueEpsilon
+
+    *default: 80.0*
+
+     Specifies the difference between b-values necessary for image
+     volumes to be classified as belonging to different shells.
+
 .. option:: BValueScaling
 
     *default: 1 (true)*

--- a/src/dwi/shells.cpp
+++ b/src/dwi/shells.cpp
@@ -42,7 +42,7 @@ namespace MR
 
 
     FORCE_INLINE default_type bvalue_epsilon () {
-      static const default_type value = File::Config::get_float ("BValueEpsilon", DWI_SHELLS_BZERO_THREHSOLD);
+      static const default_type value = File::Config::get_float ("BValueEpsilon", DWI_SHELLS_EPSILON);
       return value;
     }
 

--- a/src/dwi/shells.cpp
+++ b/src/dwi/shells.cpp
@@ -41,6 +41,13 @@ namespace MR
 
 
 
+    FORCE_INLINE default_type bvalue_epsilon () {
+      static const default_type value = File::Config::get_float ("BValueEpsilon", DWI_SHELLS_BZERO_THREHSOLD);
+      return value;
+    }
+
+
+
 
 
     Shell::Shell (const Eigen::MatrixXd& grad, const vector<size_t>& indices) :
@@ -384,7 +391,7 @@ namespace MR
     void Shells::regionQuery (const BValueList& bvals, const default_type b, vector<size_t>& idx) const
     {
       for (ssize_t i = 0; i < bvals.size(); i++) {
-        if (abs (b - bvals[i]) < DWI_SHELLS_EPSILON)
+        if (abs (b - bvals[i]) < bvalue_epsilon())
           idx.push_back (i);
       }
     }

--- a/src/dwi/shells.h
+++ b/src/dwi/shells.h
@@ -32,12 +32,14 @@
 //   method should be robust to all incoming data
 
 // Maximum absolute difference in b-value for two volumes to be considered to be in the same shell
-#define DWI_SHELLS_EPSILON 100
+#define DWI_SHELLS_EPSILON 80
 // Minimum number of volumes within DWI_SHELL_EPSILON necessary to continue expansion of the cluster selection
 #define DWI_SHELLS_MIN_LINKAGE 3
 // Default number of volumes necessary for a shell to be retained
 //   (note: only applies if function reject_small_shells() is called explicitly)
 #define DWI_SHELLS_MIN_DIRECTIONS 6
+// Default b-value threshold for a shell to be classified as "b=0"
+#define DWI_SHELLS_BZERO_THREHSOLD 10.0
 
 
 
@@ -45,6 +47,11 @@
 //CONF default: 10.0
 //CONF Specifies the b-value threshold for determining those image
 //CONF volumes that correspond to b=0.
+
+//CONF option: BValueEpsilon
+//CONF default: 80.0
+//CONF Specifies the difference between b-values necessary for image
+//CONF volumes to be classified as belonging to different shells.
 
 
 
@@ -59,7 +66,7 @@ namespace MR
     extern const App::OptionGroup ShellsOption;
 
     FORCE_INLINE default_type bzero_threshold () {
-      static const default_type value = File::Config::get_float ("BZeroThreshold", 10.0);
+      static const default_type value = File::Config::get_float ("BZeroThreshold", DWI_SHELLS_BZERO_THREHSOLD);
       return value;
     }
 


### PR DESCRIPTION
This option controls the difference in b-value necessary for DWI volumes to be classified as belonging to different shells.

In addition, the default epsilon has been changed from 100 to 80.

Closes #1634.