### PR TITLE
population_template: remove relic str2filename conversion

### DIFF
--- a/bin/population_template
+++ b/bin/population_template
@@ -252,10 +252,6 @@ def get_common_prefix(file_list):
   return os.path.commonprefix(file_list)
 
 
-def str2filename(string, include_list=('.', '_')):
-  return "".join(c for c in string if c.isalnum() or c in include_list).rstrip()
-
-
 class Contrasts(object):
   """
       Class that parses arguments and holds information specific to each image contrast
@@ -495,7 +491,6 @@ def parse_input_files(in_files, mask_files, contrasts, f_agg_weight=None):
     mask_common_prefix = get_common_prefix([os.path.split(m)[1] for m in mask_files])
     for mfile in mask_files:
       mask_uids.append(os.path.split(mfile)[1].rstrip(re.escape(mask_common_postfix)).lstrip(re.escape(mask_common_prefix)))
-    mask_uids = [str2filename(uid) for uid in mask_uids]
     if len(mask_uids) != len(set(mask_uids)):
       non_unique = [uid for uid, count in collections.Counter(mask_uids).items() if count > 1]
       MRtrixError("mask identifiers not unique:\n" + '""\n'.join(non_unique))
@@ -507,8 +502,8 @@ def parse_input_files(in_files, mask_files, contrasts, f_agg_weight=None):
   common_prefix = [get_common_prefix(files) for files in in_files]
   # xcontrast_xsubject_pre_postfix: prefix and postfix of the common part across contrasts and subjects,
   # without image extensions and leading or trailing '_' or '-'
-  xcontrast_xsubject_pre_postfix = [str2filename(get_common_postfix(common_prefix)).lstrip('_-'),
-                                    str2filename(get_common_prefix([re.sub('.('+'|'.join(IMAGEEXT)+')(.gz)?$', '', pfix).rstrip('_-') for pfix in common_postfix]))]
+  xcontrast_xsubject_pre_postfix = [get_common_postfix(common_prefix).lstrip('_-'),
+                                    get_common_prefix([re.sub('.('+'|'.join(IMAGEEXT)+')(.gz)?$', '', pfix).rstrip('_-') for pfix in common_postfix])]
   if app.VERBOSITY > 1:
     app.console("common_postfix: " + str(common_postfix))
     app.console("common_prefix: " + str(common_prefix))
@@ -519,8 +514,8 @@ def parse_input_files(in_files, mask_files, contrasts, f_agg_weight=None):
 
   c_uids = []
   for cid, files in enumerate(in_files):
-    c_uids.append([str2filename(re.sub(re.escape(common_postfix[cid])+'$', '',
-                                       re.sub('^'+re.escape(common_prefix[cid]), '', fname))) for fname in files])
+    c_uids.append([re.sub(re.escape(common_postfix[cid])+'$', '',
+                          re.sub('^'+re.escape(common_prefix[cid]), '', fname)) for fname in files])
     if not all([len(_uid) for _uid in c_uids[-1]]):
       MRtrixError("No uniquely identifiable part of filename found in file :\n" + '""\n'.join(non_unique))
 
@@ -611,7 +606,7 @@ def execute(): #pylint: disable=unused-variable
     if not os.path.isdir(inargs[0]):
       raise MRtrixError('input directory %s not found' % inargs[0])
     app.ARGS.input_dir.append(relpath(inargs[0]))
-    app.ARGS.template.append(path.from_user(inargs[1], True))
+    app.ARGS.template.append(relpath(inargs[1]))
 
   cns = Contrasts()
   app.debug(str(cns))


### PR DESCRIPTION
addresses #1899

removed `str2filename` conversion, fix if template path contains characters to be escaped.