### PR TITLE
run_pylint macOS head fix

### DIFF
--- a/run_pylint
+++ b/run_pylint
@@ -33,7 +33,7 @@ if [ $# == 0 ]; then
     fi
   done
   for bin_path in bin/*; do
-    if [ -f ${bin_path} ] && $(head ${bin_path} -n1 | grep -q "#!/usr/bin/env python"); then
+    if [ -f ${bin_path} ] && $(head -n1 ${bin_path} | grep -q "#!/usr/bin/env python"); then
       tests="$tests $bin_path"
     fi
   done


### PR DESCRIPTION
fixes issue with BSD `head` (`head: cannot open '–n1' for reading: No such file or directory`)