### PR TITLE
image.statistics(): Return namedtuple

### DIFF
--- a/bin/dwi2response
+++ b/bin/dwi2response
@@ -111,7 +111,7 @@ def execute(): #pylint: disable=unused-variable
     app.console('Computing brain mask (dwi2mask)...')
     run.command('dwi2mask dwi.mif mask.mif', show=False)
 
-  if not image.statistic('mask.mif', 'count', '-mask mask.mif'):
+  if not image.statistics('mask.mif', mask='mask.mif').count:
     raise MRtrixError(('Provided' if app.ARGS.mask else 'Generated') + ' mask image does not contain any voxels')
 
   # From here, the script splits depending on what estimation algorithm is being used

--- a/bin/labelsgmfix
+++ b/bin/labelsgmfix
@@ -154,7 +154,7 @@ def execute(): #pylint: disable=unused-variable
   progress = app.ProgressBar('Replacing SGM parcellations', len(structure_map))
   for struct in structure_map:
     image_path = struct + '_mask.mif'
-    index = int(image.statistic('sgm_new_labels.mif', 'median', '-mask ' + image_path))
+    index = int(image.statistics('sgm_new_labels.mif', mask=image_path).median)
     run.command('mrcalc parc.mif ' + str(index) + ' -eq 0 parc.mif -if parc_removed.mif')
     run.function(os.remove, 'parc.mif')
     run.function(os.rename, 'parc_removed.mif', 'parc.mif')

--- a/lib/mrtrix3/dwi2response/msmt_5tt.py
+++ b/lib/mrtrix3/dwi2response/msmt_5tt.py
@@ -112,9 +112,9 @@ def execute(): #pylint: disable=unused-variable
     run.command('dwi2response fa dwi.mif wm_ss_response.txt -mask wm_mask.mif -threshold ' + str(app.ARGS.sfwm_fa_threshold) + ' -voxels wm_sf_mask.mif -scratch ' + path.quote(app.SCRATCH_DIR) + recursive_cleanup_option)
 
   # Check for empty masks
-  wm_voxels  = image.statistic('wm_sf_mask.mif', 'count', '-mask wm_sf_mask.mif')
-  gm_voxels  = image.statistic('gm_mask.mif',    'count', '-mask gm_mask.mif')
-  csf_voxels = image.statistic('csf_mask.mif',   'count', '-mask csf_mask.mif')
+  wm_voxels  = image.statistics('wm_sf_mask.mif', mask='wm_sf_mask.mif').count
+  gm_voxels  = image.statistics('gm_mask.mif',    mask='gm_mask.mif').count
+  csf_voxels = image.statistics('csf_mask.mif',   mask='csf_mask.mif').count
   empty_masks = [ ]
   if not wm_voxels:
     empty_masks.append('WM')

--- a/lib/mrtrix3/dwi2response/tax.py
+++ b/lib/mrtrix3/dwi2response/tax.py
@@ -73,8 +73,9 @@ def execute(): #pylint: disable=unused-variable
 
       # Grab the mean and standard deviation across all volumes in a single mrstats call
       # Also scale them to reflect the fact that we're moving to the SH basis
-      mean = image.statistic('dwi.mif', 'mean', '-mask mask.mif -allvolumes') * math.sqrt(4.0 * math.pi)
-      std = image.statistic('dwi.mif', 'std', '-mask mask.mif -allvolumes') * math.sqrt(4.0 * math.pi)
+      image_stats = image.statistics('dwi.mif', mask='mask.mif', allvolumes=True)
+      mean = image_stats.mean * math.sqrt(4.0 * math.pi)
+      std = image_stats.std * math.sqrt(4.0 * math.pi)
 
       # Now produce the initial response function
       # Let's only do it to lmax 4
@@ -105,7 +106,7 @@ def execute(): #pylint: disable=unused-variable
     run.command('mrcalc ' + prefix + 'peak_ratio.mif ' + str(app.ARGS.peak_ratio) + ' -lt ' + mask_in_path + ' -mult ' + prefix + 'SF.mif -datatype bit')
     app.cleanup(prefix + 'peak_ratio.mif')
     # Make sure image isn't empty
-    sf_voxel_count = image.statistic(prefix + 'SF.mif', 'count', '-mask ' + prefix + 'SF.mif')
+    sf_voxel_count = image.statistics(prefix + 'SF.mif', mask=prefix+'SF.mif').count
     if not sf_voxel_count:
       raise MRtrixError('Aborting: All voxels have been excluded from single-fibre selection')
     # Generate a new response function

--- a/lib/mrtrix3/dwi2response/tournier.py
+++ b/lib/mrtrix3/dwi2response/tournier.py
@@ -102,7 +102,7 @@ def execute(): #pylint: disable=unused-variable
     run.command('mrcalc ' + prefix + 'first_peaks.mif -sqrt 1 ' + prefix + 'second_peaks.mif ' + prefix + 'first_peaks.mif -div -sub 2 -pow -mult '+ prefix + 'CF.mif')
     app.cleanup(prefix + 'first_peaks.mif')
     app.cleanup(prefix + 'second_peaks.mif')
-    voxel_count = int(image.statistic(prefix + 'CF.mif', 'count'))
+    voxel_count = image.statistics(prefix + 'CF.mif').count
     # Select the top-ranked voxels
     run.command('mrthreshold ' + prefix + 'CF.mif -top ' + str(min([app.ARGS.number, voxel_count])) + ' ' + prefix + 'SF.mif')
     # Generate a new response function based on this selection
@@ -116,7 +116,7 @@ def execute(): #pylint: disable=unused-variable
     if iteration > 0:
       run.command('mrcalc ' + prefix + 'SF.mif iter' + str(iteration-1) + '_SF.mif -sub ' + prefix + 'SF_diff.mif')
       app.cleanup('iter' + str(iteration-1) + '_SF.mif')
-      max_diff = image.statistic(prefix + 'SF_diff.mif', 'max')
+      max_diff = image.statistics(prefix + 'SF_diff.mif').max
       app.cleanup(prefix + 'SF_diff.mif')
       if not max_diff:
         app.cleanup(prefix + 'CF.mif')

--- a/lib/mrtrix3/image.py
+++ b/lib/mrtrix3/image.py
@@ -19,7 +19,8 @@
 #   in Python.
 
 
-import json, math, os, shlex, subprocess
+import json, math, os, subprocess
+from collections import namedtuple
 from mrtrix3 import MRtrixError
 from mrtrix3.utils import STRING_TYPES
 
@@ -86,6 +87,7 @@ class Header(object):
     return self._transform
   def keyval(self):
     return self._keyval
+
   def is_sh(self):
     """ is 4D image, with more than one volume, matching the number of coefficients of SH series """
     from mrtrix3 import sh  #pylint: disable=import-outside-toplevel
@@ -213,28 +215,39 @@ def match(image_one, image_two, **kwargs): #pylint: disable=unused-variable, too
 
 
 # Computes image statistics using mrstats.
-# Return values will be:
-# - A list if there is more than one volume and -allvolumes is not provided as an option;
-#     a single scalar value otherwise
-# - Integer(s) if statistic is 'count';
-#     floating-point otherwise
-def statistic(image_path, stat, options=''): #pylint: disable=unused-variable
+# Return will be a list of ImageStatistics instances if there is more than one volume
+#   and allvolumes=True is not set; a single ImageStatistics instance otherwise
+ImageStatistics = namedtuple('ImageStatistics', 'mean median std std_rv min max count')
+IMAGE_STATISTICS = [ 'mean', 'median', 'std', 'std_rv', 'min', 'max', 'count' ]
+
+def statistics(image_path, **kwargs): #pylint: disable=unused-variable
   from mrtrix3 import app, run #pylint: disable=import-outside-toplevel
-  command = [ run.exe_name(run.version_match('mrstats')), image_path, '-output', stat ]
-  if options:
-    command.extend(shlex.split(options))
+  mask = kwargs.pop('mask', None)
+  allvolumes = kwargs.pop('allvolumes', False)
+  ignorezero = kwargs.pop('ignorezero', False)
+  if kwargs:
+    raise TypeError('Unsupported keyword arguments passed to image.statistics(): ' + str(kwargs))
+
+  command = [ run.exe_name(run.version_match('mrstats')), image_path ]
+  for stat in IMAGE_STATISTICS:
+    command.extend([ '-output', stat ])
+  if mask:
+    command.extend([ '-mask', mask ])
+  if allvolumes:
+    command.append('-allvolumes')
+  if ignorezero:
+    command.append('-ignorezero')
   if app.VERBOSITY > 1:
     app.console('Command: \'' + ' '.join(command) + '\' (piping data to local storage)')
+
   proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=None)
-  result = [ line.strip() for line in proc.communicate()[0].decode('cp437').splitlines() ]
-  if stat == 'count':
-    result = [ int(i) for i in result ]
-  else:
-    result = [ float(f) for f in result ]
+  result = proc.communicate()[0]
+  if proc.returncode:
+    raise MRtrixError('Error trying to calculate statistic \'' + stat + '\' from image \'' + image_path + '\'')
+  result = [ line.strip() for line in result.decode('cp437').splitlines() ]
+  result = [ ImageStatistics(*[float(value) for value in line.split()[:6]], int(line.split()[6])) for line in result ]
   if len(result) == 1:
     result = result[0]
   if app.VERBOSITY > 1:
     app.console('Result: ' + str(result))
-  if proc.returncode:
-    raise MRtrixError('Error trying to calculate statistic \'' + stat + '\' from image \'' + image_path + '\'')
   return result

--- a/lib/mrtrix3/image.py
+++ b/lib/mrtrix3/image.py
@@ -241,11 +241,15 @@ def statistics(image_path, **kwargs): #pylint: disable=unused-variable
     app.console('Command: \'' + ' '.join(command) + '\' (piping data to local storage)')
 
   proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=None)
-  result = proc.communicate()[0]
+  stdout = proc.communicate()[0]
   if proc.returncode:
-    raise MRtrixError('Error trying to calculate statistic \'' + stat + '\' from image \'' + image_path + '\'')
-  result = [ line.strip() for line in result.decode('cp437').splitlines() ]
-  result = [ ImageStatistics(*[float(value) for value in line.split()[:6]], int(line.split()[6])) for line in result ]
+    raise MRtrixError('Error trying to calculate statistics from image \'' + image_path + '\'')
+  stdout_lines = [ line.strip() for line in stdout.decode('cp437').splitlines() ]
+  result = [ ]
+  for line in stdout_lines:
+    line = line.split()
+    assert len(line) == len(IMAGE_STATISTICS)
+    result.append(ImageStatistics(float(line[0]), float(line[1]), float(line[2]), float(line[3]), float(line[4]), float(line[5]), int(line[6])))
   if len(result) == 1:
     result = result[0]
   if app.VERBOSITY > 1:


### PR DESCRIPTION
Bashed this out because I'd rather make API changes before tag. This is far more Pythonic, precludes certain mis-uses, prevents having to call `mrstats` on the same image twice in a row in some instances, and really should have been done in #1737.

Closes #1921.