### PR TITLE
dwi2response msmt_5tt: Update for 5ttcheck changes

### DIFF
--- a/lib/mrtrix3/dwi2response/msmt_5tt.py
+++ b/lib/mrtrix3/dwi2response/msmt_5tt.py
@@ -66,10 +66,14 @@ def execute(): #pylint: disable=unused-variable
   # May need to commit 5ttregrid...
 
   # Verify input 5tt image
-  stderr_5ttcheck = run.command('5ttcheck 5tt.mif').stderr
-  if '[WARNING]' in stderr_5ttcheck:
-    app.warn('Command 5ttcheck indicates minor problems with provided input 5TT image \'' + app.ARGS.in_5tt + '\':')
-    for line in stderr_5ttcheck.splitlines():
+  verification_text = ''
+  try:
+    verification_text = run.command('5ttcheck 5tt.mif').stderr
+  except run.MRtrixCmdError as except_5ttcheck:
+    verification_text = except_5ttcheck.stderr
+  if 'WARNING' in verification_text or 'ERROR' in verification_text:
+    app.warn('Command 5ttcheck indicates problems with provided input 5TT image \'' + app.ARGS.in_5tt + '\':')
+    for line in verification_text.splitlines():
       app.warn(line)
     app.warn('These may or may not interfere with the dwi2response msmt_5tt script')
 


### PR DESCRIPTION
Due to #1909 and #1915, 5ttcheck will not throw an Exception if there are image values that do not lie within the [0.0, 1.0] range. This includes the current version of test data. Rather than correspondingly causing `dwi2response msmt_5tt` to fail, instead catch the `run.MRtrixCmdError`, and print the message to the terminal at warning level as previously.