### PR TITLE
Track files: Support multi-line key-values

### DIFF
--- a/cmd/tckinfo.cpp
+++ b/cmd/tckinfo.cpp
@@ -55,7 +55,10 @@ void run ()
     for (Tractography::Properties::iterator i = properties.begin(); i != properties.end(); ++i) {
       std::string S (i->first + ':');
       S.resize (22, ' ');
-      std::cout << "    " << S << i->second << "\n";
+      const auto lines = split_lines (i->second);
+      std::cout << "    " << S << lines[0] << "\n";
+      for (size_t i = 1; i != lines.size(); ++i)
+        std::cout << "                          " << lines[i] << "\n";
     }
 
     if (properties.comments.size()) {

--- a/src/dwi/tractography/file_base.cpp
+++ b/src/dwi/tractography/file_base.cpp
@@ -45,7 +45,7 @@ namespace MR {
           else if (key == "comment") properties.comments.push_back (kv.value());
           else if (key == "file") data_file = kv.value();
           else if (key == "datatype") dtype = DataType::parse (kv.value());
-          else properties[kv.key()] = kv.value();
+          else add_line (properties[kv.key()], kv.value());
         }
 
         if (dtype == DataType::Undefined)

--- a/src/dwi/tractography/file_base.h
+++ b/src/dwi/tractography/file_base.h
@@ -91,8 +91,10 @@ namespace MR
               out << "mrtrix " + type + "\nEND\n";
 
               for (const auto& i : properties) {
-                if ((i.first != "count") && (i.first != "total_count"))
-                  out << i.first << ": " << i.second << "\n";
+                if ((i.first != "count") && (i.first != "total_count")) {
+                  for (const auto line : split_lines (i.second))
+                    out << i.first << ": " << i.second << "\n";
+                }
               }
 
               for (const auto& i : properties.comments)

--- a/src/dwi/tractography/file_base.h
+++ b/src/dwi/tractography/file_base.h
@@ -93,7 +93,7 @@ namespace MR
               for (const auto& i : properties) {
                 if ((i.first != "count") && (i.first != "total_count")) {
                   for (const auto line : split_lines (i.second))
-                    out << i.first << ": " << i.second << "\n";
+                    out << i.first << ": " << line << "\n";
                 }
               }
 
@@ -158,4 +158,3 @@ namespace MR
 
 
 #endif
-


### PR DESCRIPTION
Issue arose due to potential for multi-line "`command_history`" field following #1603.

Closes #1925.
