### PR TITLE
DICOM: allow simple selection of series from environment variables

### DIFF
--- a/core/file/dicom/tree.cpp
+++ b/core/file/dicom/tree.cpp
@@ -117,6 +117,7 @@ namespace MR {
 
       void Tree::read (const std::string& filename)
       {
+        description = filename;
         ProgressBar progress ("scanning DICOM folder \"" + shorten (filename) + "\"", 0);
         if (Path::is_dir (filename))
           read_dir (filename, progress);

--- a/core/mrtrix.cpp
+++ b/core/mrtrix.cpp
@@ -154,4 +154,49 @@ namespace MR
 
 
 
+
+
+  namespace {
+
+    // from https://www.geeksforgeeks.org/wildcard-character-matching/
+
+    inline bool __match (const char* first, const char* second)
+    {
+      // If we reach at the end of both strings, we are done
+      if (*first == '\0' && *second == '\0')
+        return true;
+
+      // Make sure that the characters after '*' are present
+      // in second string. This function assumes that the first
+      // string will not contain two consecutive '*'
+      if (*first == '*' && *(first+1) != '\0' && *second == '\0')
+        return false;
+
+      // If the first string contains '?', or current characters
+      // of both strings match
+      if (*first == '?' || *first == *second)
+        return match(first+1, second+1);
+
+      // If there is *, then there are two possibilities
+      // a) We consider current character of second string
+      // b) We ignore current character of second string.
+      if (*first == '*')
+        return match(first+1, second) || match(first, second+1);
+
+      return false;
+    }
+  }
+
+
+
+  bool match (const std::string& pattern, const std::string& text, bool ignore_case)
+  {
+    if (ignore_case)
+      return __match (lowercase(pattern).c_str(), lowercase (text).c_str());
+    else
+      return __match (pattern.c_str(), text.c_str());
+  }
+
+
+
 }

--- a/core/mrtrix.h
+++ b/core/mrtrix.h
@@ -195,6 +195,7 @@ namespace MR
 */
 
 
+  bool match (const std::string& pattern, const std::string& text, bool ignore_case = false);
 
 
 

--- a/docs/reference/environment_variables.rst
+++ b/docs/reference/environment_variables.rst
@@ -4,6 +4,26 @@
 List of MRtrix3 environment variables
 ##########################################
 
+.. envvar:: DICOM_ID
+
+     when reading DICOM data, match the PatientID entry against
+     the string provided
+
+.. envvar:: DICOM_PATIENT
+
+     when reading DICOM data, match the PatientName entry against
+     the string provided
+
+.. envvar:: DICOM_SERIES
+
+     when reading DICOM data, match the SeriesName entry against
+     the string provided
+
+.. envvar:: DICOM_STUDY
+
+     when reading DICOM data, match the StudyName entry against
+     the string provided
+
 .. envvar:: MRTRIX_CONFIGFILE
 
      This can be used to set the location of the system-wide


### PR DESCRIPTION
Another branch that was lying around gathering dust...

This allows the use of simple wildcard pattern matching with patterns supplied via the environment variables:
- DICOM_PATIENT to match PatientName
- DICOM_ID      to match PatientID
- DICOM_STUDY   to match StudyName
- DICOM_SERIES  to match SeriesName

Example usage:
```
DICOM_SERIES='diff*iPat2' DICOM_PATIENT='*donald*' mrinfo dicom/
```