### PR TITLE
Use thread local on macos

### DIFF
--- a/src/dwi/tractography/algorithms/iFOD1.h
+++ b/src/dwi/tractography/algorithms/iFOD1.h
@@ -200,7 +200,7 @@ namespace MR
                 max_truncation = val/max_val;
             }
 
-            if (uniform(*rng) < val/max_val) {
+            if (uniform(rng) < val/max_val) {
               dir = new_dir;
               dir.normalize();
               pos += S.step_size * dir;

--- a/src/dwi/tractography/algorithms/iFOD2.h
+++ b/src/dwi/tractography/algorithms/iFOD2.h
@@ -271,7 +271,7 @@ end_init:
                     max_truncation = val/max_val;
                 }
 
-                if (uniform(*rng) < val/max_val) {
+                if (uniform(rng) < val/max_val) {
                   mean_sample_num += n;
                   half_log_prob0 = last_half_log_probN;
                   pos = positions[0];

--- a/src/dwi/tractography/algorithms/nulldist.h
+++ b/src/dwi/tractography/algorithms/nulldist.h
@@ -74,7 +74,7 @@ namespace MR
         return CONTINUE;
       }
 
-      float get_metric() override { return uniform(*rng); }
+      float get_metric() override { return uniform(rng); }
 
 
       protected:
@@ -154,7 +154,7 @@ namespace MR
         sample_idx = S.num_samples;
       }
 
-      float get_metric() override { return uniform(*rng); }
+      float get_metric() override { return uniform(rng); }
 
 
       protected:

--- a/src/dwi/tractography/algorithms/tensor_prob.h
+++ b/src/dwi/tractography/algorithms/tensor_prob.h
@@ -105,7 +105,7 @@ namespace MR
 
                   for (ssize_t i = 0; i < residuals.size(); ++i) {
                     residuals[i] = residuals[i] ? (data[i] - std::exp (-residuals[i])) : float(0.0);
-                    data[i] += uniform_int (*rng) ? residuals[i] : -residuals[i];
+                    data[i] += uniform_int (rng) ? residuals[i] : -residuals[i];
                   }
                 }
 

--- a/src/dwi/tractography/rng.cpp
+++ b/src/dwi/tractography/rng.cpp
@@ -23,11 +23,7 @@ namespace MR
     namespace Tractography
     {
 
-#ifdef MRTRIX_MACOSX
-      __thread Math::RNG* rng = nullptr;
-#else
       thread_local Math::RNG* rng = nullptr;
-#endif 
 
     }
   }

--- a/src/dwi/tractography/rng.cpp
+++ b/src/dwi/tractography/rng.cpp
@@ -23,7 +23,7 @@ namespace MR
     namespace Tractography
     {
 
-      thread_local Math::RNG* rng = nullptr;
+      thread_local Math::RNG rng;
 
     }
   }

--- a/src/dwi/tractography/rng.h
+++ b/src/dwi/tractography/rng.h
@@ -27,7 +27,7 @@ namespace MR
     {
 
       //! thread-local, but globally accessible RNG to vastly simplify multi-threading
-      extern thread_local Math::RNG* rng;
+      extern thread_local Math::RNG rng;
 
     }
   }

--- a/src/dwi/tractography/rng.h
+++ b/src/dwi/tractography/rng.h
@@ -27,11 +27,7 @@ namespace MR
     {
 
       //! thread-local, but globally accessible RNG to vastly simplify multi-threading
-#ifdef MRTRIX_MACOSX
-      extern __thread Math::RNG* rng;
-#else
       extern thread_local Math::RNG* rng;
-#endif 
 
     }
   }

--- a/src/dwi/tractography/seeding/basic.cpp
+++ b/src/dwi/tractography/seeding/basic.cpp
@@ -33,7 +33,7 @@ namespace MR
         {
           std::uniform_real_distribution<float> uniform;
           do {
-            p = { 2.0f*uniform(*rng)-1.0f, 2.0f*uniform(*rng)-1.0f, 2.0f*uniform(*rng)-1.0f };
+            p = { 2.0f*uniform(rng)-1.0f, 2.0f*uniform(rng)-1.0f, 2.0f*uniform(rng)-1.0f };
           } while (p.squaredNorm() > 1.0f);
           p = pos + rad*p;
           return true;
@@ -45,14 +45,14 @@ namespace MR
 
         bool SeedMask::get_seed (Eigen::Vector3f& p) const
         {
-          auto seed = mask;
+         auto seed = mask;
           do {
-            seed.index(0) = std::uniform_int_distribution<int>(0, mask.size(0)-1)(*rng);
-            seed.index(1) = std::uniform_int_distribution<int>(0, mask.size(1)-1)(*rng);
-            seed.index(2) = std::uniform_int_distribution<int>(0, mask.size(2)-1)(*rng);
+            seed.index(0) = std::uniform_int_distribution<int>(0, mask.size(0)-1)(rng);
+            seed.index(1) = std::uniform_int_distribution<int>(0, mask.size(1)-1)(rng);
+            seed.index(2) = std::uniform_int_distribution<int>(0, mask.size(2)-1)(rng);
           } while (!seed.value());
           std::uniform_real_distribution<float> uniform;
-          p = { seed.index(0)+uniform(*rng)-0.5f, seed.index(1)+uniform(*rng)-0.5f, seed.index(2)+uniform(*rng)-0.5f };
+          p = { seed.index(0)+uniform(rng)-0.5f, seed.index(1)+uniform(rng)-0.5f, seed.index(2)+uniform(rng)-0.5f };
           p = (*mask.voxel2scanner) * p;
           return true;
         }
@@ -90,7 +90,7 @@ namespace MR
           }
 
           std::uniform_real_distribution<float> uniform;
-          p = { mask.index(0)+uniform(*rng)-0.5f, mask.index(1)+uniform(*rng)-0.5f, mask.index(2)+uniform(*rng)-0.5f };
+          p = { mask.index(0)+uniform(rng)-0.5f, mask.index(1)+uniform(rng)-0.5f, mask.index(2)+uniform(rng)-0.5f };
           p = (*mask.voxel2scanner) * p;
           return true;
         }
@@ -208,9 +208,9 @@ namespace MR
           Eigen::Vector3f pos;
           do {
             pos = {
-              uniform (*rng) * (interp.size(0)-1), 
-              uniform (*rng) * (interp.size(1)-1), 
-              uniform (*rng) * (interp.size(2)-1) 
+              uniform (rng) * (interp.size(0)-1),
+              uniform (rng) * (interp.size(1)-1),
+              uniform (rng) * (interp.size(2)-1)
             };
             seed.voxel (pos);
             selector = rng->Uniform() * max;
@@ -220,12 +220,12 @@ namespace MR
           auto seed = image;
           float selector;
           do {
-            seed.index(0) = std::uniform_int_distribution<int> (0, image.size(0)-1) (*rng);
-            seed.index(1) = std::uniform_int_distribution<int> (0, image.size(1)-1) (*rng);
-            seed.index(2) = std::uniform_int_distribution<int> (0, image.size(2)-1) (*rng);
-            selector = uniform (*rng) * max;
+            seed.index(0) = std::uniform_int_distribution<int> (0, image.size(0)-1) (rng);
+            seed.index(1) = std::uniform_int_distribution<int> (0, image.size(1)-1) (rng);
+            seed.index(2) = std::uniform_int_distribution<int> (0, image.size(2)-1) (rng);
+            selector = uniform (rng) * max;
           } while (seed.value() < selector);
-          p = { seed.index(0)+uniform(*rng)-0.5f, seed.index(1)+uniform(*rng)-0.5f, seed.index(2)+uniform(*rng)-0.5f };
+          p = { seed.index(0)+uniform(rng)-0.5f, seed.index(1)+uniform(rng)-0.5f, seed.index(2)+uniform(rng)-0.5f };
           p = voxel2scanner * p;
 #endif
           return true;

--- a/src/dwi/tractography/seeding/dynamic.cpp
+++ b/src/dwi/tractography/seeding/dynamic.cpp
@@ -168,7 +168,7 @@ namespace MR
 
       bool Dynamic::get_seed (Eigen::Vector3f&) const { return false; }
 
-      bool Dynamic::get_seed (Eigen::Vector3f& p, Eigen::Vector3f& d) 
+      bool Dynamic::get_seed (Eigen::Vector3f& p, Eigen::Vector3f& d)
       {
 
         uint64_t this_attempts = 0;
@@ -178,7 +178,7 @@ namespace MR
         while (1) {
 
           ++this_attempts;
-          const size_t fixel_index = 1 + uniform_int (*rng);
+          const size_t fixel_index = 1 + uniform_int (rng);
           Fixel& fixel = fixels[fixel_index];
           float seed_prob;
           if (fixel.can_update()) {
@@ -214,10 +214,10 @@ namespace MR
             seed_prob = fixel.get_old_prob();
           }
 
-          if (seed_prob > uniform_float (*rng)) {
+          if (seed_prob > uniform_float (rng)) {
 
             const Eigen::Vector3i& v (fixel.get_voxel());
-            const Eigen::Vector3f vp (v[0]+uniform_float(*rng)-0.5, v[1]+uniform_float(*rng)-0.5, v[2]+uniform_float(*rng)-0.5);
+            const Eigen::Vector3f vp (v[0]+uniform_float(rng)-0.5, v[1]+uniform_float(rng)-0.5, v[2]+uniform_float(rng)-0.5);
             p = transform.voxel2scanner.cast<float>() * vp;
 
             bool good_seed = !act;

--- a/src/dwi/tractography/seeding/gmwmi.cpp
+++ b/src/dwi/tractography/seeding/gmwmi.cpp
@@ -67,7 +67,7 @@ namespace MR
           plane_one = (normal.cross (Eigen::Vector3f (0.0f,1.0f,0.0f))).normalized();
         const Eigen::Vector3f plane_two ((normal.cross (plane_one)).normalized());
         std::uniform_real_distribution<float> uniform;
-        p += ((uniform(*rng)-0.5f) * perturb_max_step * plane_one) + ((uniform(*rng)-0.5f) * perturb_max_step * plane_two);
+        p += ((uniform(rng)-0.5f) * perturb_max_step * plane_one) + ((uniform(rng)-0.5f) * perturb_max_step * plane_two);
         return find_interface (p, interp);
       }
 

--- a/src/dwi/tractography/seeding/list.cpp
+++ b/src/dwi/tractography/seeding/list.cpp
@@ -35,8 +35,8 @@ namespace MR
           if (seeders.size() && !(in->is_finite() == is_finite()))
             throw Exception ("Cannot use a combination of seed types where some are number-limited and some are not!");
 
-          if (!App::get_options ("max_seed_attempts").size()) 
-            for (auto& i : seeders) 
+          if (!App::get_options ("max_seed_attempts").size())
+            for (auto& i : seeders)
               if (i->get_max_attempts() != in->get_max_attempts())
                 throw Exception ("Cannot use a combination of seed types where the default maximum number "
                     "of sampling attempts per seed is unequal, unless you use the -max_seed_attempts option.");
@@ -77,7 +77,7 @@ namespace MR
 
             do {
               float incrementer = 0.0;
-              const float sample = uniform (*rng) * total_volume;
+              const float sample = uniform (rng) * total_volume;
               for (auto& i : seeders)
                 if ((incrementer += i->vol()) > sample)
                   return i->get_seed (p, d);

--- a/src/dwi/tractography/tracking/exec.h
+++ b/src/dwi/tractography/tracking/exec.h
@@ -117,7 +117,6 @@ namespace MR
 
 
             bool operator() (GeneratedTrack& item) {
-              rng = &thread_local_RNG;
               if (!seed_track (item))
                 return false;
               if (track_excluded) {
@@ -142,7 +141,6 @@ namespace MR
           private:
 
             const typename Method::Shared& S;
-            Math::RNG thread_local_RNG;
             Method method;
             bool track_excluded;
             vector<bool> track_included;

--- a/src/dwi/tractography/tracking/method.cpp
+++ b/src/dwi/tractography/tracking/method.cpp
@@ -73,9 +73,9 @@ namespace MR
         {
           Eigen::Vector3f d;
           do {
-            d[0] = 2.0 * uniform(*rng) - 1.0;
-            d[1] = 2.0 * uniform(*rng) - 1.0;
-            d[2] = 2.0 * uniform(*rng) - 1.0;
+            d[0] = 2.0 * uniform(rng) - 1.0;
+            d[1] = 2.0 * uniform(rng) - 1.0;
+            d[2] = 2.0 * uniform(rng) - 1.0;
           } while (d.squaredNorm() > 1.0);
           d.normalize();
           return d;
@@ -85,11 +85,11 @@ namespace MR
 
         Eigen::Vector3f MethodBase::random_direction (const float max_angle, const float sin_max_angle)
         {
-          float phi = 2.0 * Math::pi * uniform(*rng);
+          float phi = 2.0 * Math::pi * uniform(rng);
           float theta;
           do {
-            theta = max_angle * uniform(*rng);
-          } while (sin_max_angle * uniform(*rng) > sin (theta));
+            theta = max_angle * uniform(rng);
+          } while (sin_max_angle * uniform(rng) > sin (theta));
           return Eigen::Vector3f (sin(theta)*cos(phi), sin(theta)*sin(phi), cos(theta));
         }
 


### PR DESCRIPTION
It looks like XCode finally supports this as of version 8:
https://stackoverflow.com/a/29929949/3244166

This unifies the handling of the RNG instance used in the tractography code between macOS and the other platforms, and avoid having to handle it using a clunky pointer.