### PR TITLE
fod2fixel: Revise options / help / code RE: "peaks"

### DIFF
--- a/cmd/fod2fixel.cpp
+++ b/cmd/fod2fixel.cpp
@@ -50,7 +50,7 @@ const OptionGroup OutputOptions = OptionGroup ("Metric values for fixel-based sp
     + Argument ("image").type_image_out()
 
   + Option ("peak_amp",
-            "output the amplitude of the maximal FOD peak per fixel")
+            "output the amplitude of the FOD at the maximal peak per fixel")
     + Argument ("image").type_image_out()
 
   + Option ("disp",
@@ -128,9 +128,9 @@ class Segmented_FOD_receiver { MEMALIGN(Segmented_FOD_receiver)
     struct Primitive_FOD_lobe { MEMALIGN (Primitive_FOD_lobe)
       Eigen::Vector3f dir;
       float integral;
-      float peak_value;
-      Primitive_FOD_lobe (Eigen::Vector3f dir, float integral, float peak_value) :
-          dir (dir), integral (integral), peak_value (peak_value) {}
+      float max_peak_amp;
+      Primitive_FOD_lobe (Eigen::Vector3f dir, float integral, float max_peak_amp) :
+          dir (dir), integral (integral), max_peak_amp (max_peak_amp) {}
     };
 
 
@@ -267,14 +267,14 @@ void Segmented_FOD_receiver::commit ()
     if (peak_amp_image) {
       for (size_t i = 0; i < n_vox_fixels; ++i) {
         peak_amp_image->index(0) = offset + i;
-        peak_amp_image->value() = vox_fixels[i].peak_value;
+        peak_amp_image->value() = vox_fixels[i].max_peak_amp;
       }
     }
 
     if (disp_image) {
       for (size_t i = 0; i < n_vox_fixels; ++i) {
         disp_image->index(0) = offset + i;
-        disp_image->value() = vox_fixels[i].integral / vox_fixels[i].peak_value;
+        disp_image->value() = vox_fixels[i].integral / vox_fixels[i].max_peak_amp;
       }
     }
 

--- a/docs/reference/commands/fod2fixel.rst
+++ b/docs/reference/commands/fod2fixel.rst
@@ -26,20 +26,20 @@ Metric values for fixel-based sparse output images
 
 -  **-afd image** output the total Apparent Fibre Density per fixel (integral of FOD lobe)
 
--  **-peak image** output the peak FOD amplitude per fixel
+-  **-maximum image** output the maximum FOD amplitude per fixel
 
--  **-disp image** output a measure of dispersion per fixel as the ratio between FOD lobe integral and peak amplitude
+-  **-disp image** output a measure of dispersion per fixel as the ratio between FOD lobe integral and maximum amplitude
 
 FOD FMLS segmenter options
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 -  **-fmls_integral value** threshold absolute numerical integral of positive FOD lobes. Any lobe for which the integral is smaller than this threshold will be discarded. Default: 0.
 
--  **-fmls_peak_value value** threshold the raw peak amplitude of positive FOD lobes. Any lobe for which the peak amplitude is smaller than this threshold will be discarded. Default: 0.1.
+-  **-fmls_max_value value** threshold the raw maximal amplitude of positive FOD lobes. Any lobe for which the maximal amplitude is smaller than this threshold will be discarded. Default: 0.1.
 
 -  **-fmls_no_thresholds** disable all FOD lobe thresholding; every lobe with a positive FOD amplitude will be retained.
 
--  **-fmls_peak_ratio_to_merge value** specify the amplitude ratio between a sample and the smallest peak amplitude of the adjoining lobes, above which the lobes will be merged. This is the relative amplitude between the smallest of two adjoining lobes, and the 'bridge' between the two lobes. A value of 1.0 will never merge two peaks into a single lobe; a value of 0.0 will always merge lobes unless they are bisected by a zero crossing. Default: 1.
+-  **-fmls_max_ratio_to_merge value** Specify the ratio between a given FOD amplitude sample between two lobes, and the smallest maximal amplitude of the adjacent lobes, above which those lobes will be merged. This is the relative amplitude between the smallest of two adjoining lobes, and the 'bridge' between the two lobes. A value of 1.0 will never merge two lobes into one; a value of 0.0 will always merge lobes unless they are bisected by a zero-valued crossing. Default: 1.
 
 Other options for fod2fixel
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -50,7 +50,7 @@ Other options for fod2fixel
 
 -  **-nii** output the directions and index file in nii format (instead of the default mif)
 
--  **-dirpeak** define the fixel direction as the peak lobe direction as opposed to the lobe mean
+-  **-dirpeak** define the fixel direction as that of the lobe's maximal peak as opposed to its weighted mean direction (the default)
 
 Standard options
 ^^^^^^^^^^^^^^^^

--- a/docs/reference/commands/fod2fixel.rst
+++ b/docs/reference/commands/fod2fixel.rst
@@ -26,7 +26,7 @@ Metric values for fixel-based sparse output images
 
 -  **-afd image** output the total Apparent Fibre Density per fixel (integral of FOD lobe)
 
--  **-peak_amp image** output the amplitude of the maximal FOD peak per fixel
+-  **-peak_amp image** output the amplitude of the FOD at the maximal peak per fixel
 
 -  **-disp image** output a measure of dispersion per fixel as the ratio between FOD lobe integral and maximal peak amplitude
 

--- a/docs/reference/commands/fod2fixel.rst
+++ b/docs/reference/commands/fod2fixel.rst
@@ -26,20 +26,20 @@ Metric values for fixel-based sparse output images
 
 -  **-afd image** output the total Apparent Fibre Density per fixel (integral of FOD lobe)
 
--  **-maximum image** output the maximum FOD amplitude per fixel
+-  **-peak_amp image** output the amplitude of the maximal FOD peak per fixel
 
--  **-disp image** output a measure of dispersion per fixel as the ratio between FOD lobe integral and maximum amplitude
+-  **-disp image** output a measure of dispersion per fixel as the ratio between FOD lobe integral and maximal peak amplitude
 
 FOD FMLS segmenter options
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 -  **-fmls_integral value** threshold absolute numerical integral of positive FOD lobes. Any lobe for which the integral is smaller than this threshold will be discarded. Default: 0.
 
--  **-fmls_max_value value** threshold the raw maximal amplitude of positive FOD lobes. Any lobe for which the maximal amplitude is smaller than this threshold will be discarded. Default: 0.1.
+-  **-fmls_peak_value value** threshold peak amplitude of positive FOD lobes. Any lobe for which the maximal peak amplitude is smaller than this threshold will be discarded. Default: 0.1.
 
--  **-fmls_no_thresholds** disable all FOD lobe thresholding; every lobe with a positive FOD amplitude will be retained.
+-  **-fmls_no_thresholds** disable all FOD lobe thresholding; every lobe where the FOD is positive will be retained.
 
--  **-fmls_max_ratio_to_merge value** Specify the ratio between a given FOD amplitude sample between two lobes, and the smallest maximal amplitude of the adjacent lobes, above which those lobes will be merged. This is the relative amplitude between the smallest of two adjoining lobes, and the 'bridge' between the two lobes. A value of 1.0 will never merge two lobes into one; a value of 0.0 will always merge lobes unless they are bisected by a zero-valued crossing. Default: 1.
+-  **-fmls_lobe_merge_ratio value** Specify the ratio between a given FOD amplitude sample between two lobes, and the smallest peak amplitude of the adjacent lobes, above which those lobes will be merged. This is the amplitude of the FOD at the 'bridge' point between the two lobes, divided by the peak amplitude of the smaller of the two adjoining lobes. A value of 1.0 will never merge two lobes into one; a value of 0.0 will always merge lobes unless they are bisected by a zero-valued crossing. Default: 1.
 
 Other options for fod2fixel
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/dwi/fmls.cpp
+++ b/src/dwi/fmls.cpp
@@ -34,20 +34,20 @@ namespace MR {
             "Default: " + str(FMLS_INTEGRAL_THRESHOLD_DEFAULT, 2) + ".")
         + App::Argument ("value").type_float (0.0)
 
-        + App::Option ("fmls_peak_value",
-            "threshold the raw peak amplitude of positive FOD lobes. "
-            "Any lobe for which the peak amplitude is smaller than this threshold will be discarded. "
-            "Default: " + str(FMLS_PEAK_VALUE_THRESHOLD_DEFAULT, 2) + ".")
+        + App::Option ("fmls_max_value",
+            "threshold the raw maximal amplitude of positive FOD lobes. "
+            "Any lobe for which the maximal amplitude is smaller than this threshold will be discarded. "
+            "Default: " + str(FMLS_MAX_VALUE_THRESHOLD_DEFAULT, 2) + ".")
         + App::Argument ("value").type_float (0.0)
 
         + App::Option ("fmls_no_thresholds",
             "disable all FOD lobe thresholding; every lobe with a positive FOD amplitude will be retained.")
 
-        + App::Option ("fmls_peak_ratio_to_merge",
-            "specify the amplitude ratio between a sample and the smallest peak amplitude of the adjoining lobes, above which the lobes will be merged. "
+        + App::Option ("fmls_max_ratio_to_merge",
+            "Specify the ratio between a given FOD amplitude sample between two lobes, and the smallest maximal amplitude of the adjacent lobes, above which those lobes will be merged. "
             "This is the relative amplitude between the smallest of two adjoining lobes, and the 'bridge' between the two lobes. "
-            "A value of 1.0 will never merge two peaks into a single lobe; a value of 0.0 will always merge lobes unless they are bisected by a zero crossing. "
-            "Default: " + str(FMLS_RATIO_TO_PEAK_VALUE_TO_MERGE_DEFAULT, 2) + ".")
+            "A value of 1.0 will never merge two lobes into one; a value of 0.0 will always merge lobes unless they are bisected by a zero-valued crossing. "
+            "Default: " + str(FMLS_RATIO_OF_MAX_VALUES_TO_MERGE_DEFAULT, 2) + ".")
         + App::Argument ("value").type_float (0.0, 1.0);
 
 
@@ -61,7 +61,7 @@ namespace MR {
         const bool no_thresholds = opt.size();
         if (no_thresholds) {
           segmenter.set_integral_threshold (0.0);
-          segmenter.set_peak_value_threshold (0.0);
+          segmenter.set_max_value_threshold (0.0);
         }
 
         opt = get_options ("fmls_integral");
@@ -73,18 +73,18 @@ namespace MR {
           }
         }
 
-        opt = get_options ("fmls_peak_value");
+        opt = get_options ("fmls_max_value");
         if (opt.size()) {
           if (no_thresholds) {
-            WARN ("Option -fmls_peak_value ignored: -fmls_no_thresholds overrides this");
+            WARN ("Option -fmls_max_value ignored: -fmls_no_thresholds overrides this");
           } else {
-            segmenter.set_peak_value_threshold (default_type(opt[0][0]));
+            segmenter.set_max_value_threshold (default_type(opt[0][0]));
           }
         }
 
-        opt = get_options ("fmls_peak_ratio_to_merge");
+        opt = get_options ("fmls_max_ratio_to_merge");
         if (opt.size())
-          segmenter.set_ratio_of_peak_value_to_merge (default_type(opt[0][0]));
+          segmenter.set_ratio_of_max_values_to_merge (default_type(opt[0][0]));
 
       }
 
@@ -139,8 +139,8 @@ namespace MR {
           lmax                         (l),
           precomputer                  (new Math::SH::PrecomputedAL<default_type> (lmax, 2 * dirs.size())),
           integral_threshold           (FMLS_INTEGRAL_THRESHOLD_DEFAULT),
-          peak_value_threshold         (FMLS_PEAK_VALUE_THRESHOLD_DEFAULT),
-          ratio_of_peak_value_to_merge (FMLS_RATIO_TO_PEAK_VALUE_TO_MERGE_DEFAULT),
+          max_value_threshold          (FMLS_MAX_VALUE_THRESHOLD_DEFAULT),
+          ratio_of_max_values_to_merge (FMLS_RATIO_OF_MAX_VALUES_TO_MERGE_DEFAULT),
           create_null_lobe             (false),
           create_lookup_table          (true),
           dilate_lookup_table          (false)
@@ -213,7 +213,7 @@ namespace MR {
             // Changed handling of lobe merges
             // Merge lobes as they appear to be merged, but update the
             //   contents of retrospective_assignments accordingly
-            if (abs (i.first) / out[adj_lobes.back()].get_max_peak_value() > ratio_of_peak_value_to_merge) {
+            if (abs (i.first) / out[adj_lobes.back()].get_max_value() > ratio_of_max_values_to_merge) {
 
               std::sort (adj_lobes.begin(), adj_lobes.end());
               for (size_t j = 1; j != adj_lobes.size(); ++j)
@@ -264,18 +264,17 @@ namespace MR {
 
             // Revise multiple peaks if present
             for (size_t peak_index = 0; peak_index != i->num_peaks(); ++peak_index) {
-              Eigen::Vector3 newton_peak = i->get_peak_dir (peak_index);
-              const default_type newton_peak_value = Math::SH::get_peak (in, lmax, newton_peak, &(*precomputer));
-              if (std::isfinite (newton_peak_value) && newton_peak.allFinite()) {
+              Eigen::Vector3 newton_peak_dir = i->get_peak_dir (peak_index); // to be updated by subsequent Math::SH::get_peak() call
+              const default_type newton_peak_amplitude = Math::SH::get_peak (in, lmax, newton_peak_dir, &(*precomputer));
+              if (std::isfinite (newton_peak_amplitude) && newton_peak_dir.allFinite()) {
 
                 // Ensure that the new peak direction found via Newton optimisation
-                //   is still approximately the same peak as that found via FMLS:
-
-                // - Needs to be closer to this peak than any other peaks within the lobe
+                //   is still approximately the same direction as that found via FMLS:
+                // Also needs to be closer to this peak than any other peaks within the lobe
                 default_type max_dp = 0.0;
                 size_t nearest_original_peak = i->num_peaks();
                 for (size_t j = 0; j != i->num_peaks(); ++j) {
-                  const default_type this_dp = abs (newton_peak.dot (i->get_peak_dir (j)));
+                  const default_type this_dp = abs (newton_peak_dir.dot (i->get_peak_dir (j)));
                   if (this_dp > max_dp) {
                     max_dp = this_dp;
                     nearest_original_peak = j;
@@ -283,15 +282,15 @@ namespace MR {
                 }
                 if (nearest_original_peak == peak_index) {
 
-                  // - Needs to still lie within the lobe: Determined via mask
-                  const index_type newton_peak_closest_dir_index = dirs.select_direction (newton_peak);
+                  // Needs to still lie within the lobe: Determined via mask
+                  const index_type newton_peak_closest_dir_index = dirs.select_direction (newton_peak_dir);
                   if (i->get_mask()[newton_peak_closest_dir_index])
-                    i->revise_peak (peak_index, newton_peak, newton_peak_value);
+                    i->revise_peak (peak_index, newton_peak_dir, newton_peak_amplitude);
 
                 }
               }
             }
-            if (i->get_max_peak_value() < peak_value_threshold) {
+            if (i->get_max_value() < max_value_threshold) {
               i = out.erase (i);
             } else {
               i->finalise();
@@ -457,4 +456,3 @@ namespace MR {
     }
   }
 }
-

--- a/src/dwi/fmls.h
+++ b/src/dwi/fmls.h
@@ -29,8 +29,8 @@
 
 
 #define FMLS_INTEGRAL_THRESHOLD_DEFAULT 0.0 // By default, don't threshold by integral (tough to get a good number)
-#define FMLS_PEAK_VALUE_THRESHOLD_DEFAULT 0.1
-#define FMLS_RATIO_TO_PEAK_VALUE_TO_MERGE_DEFAULT 1.0 // By default, turn all peaks into lobes (discrete peaks are never merged)
+#define FMLS_MAX_VALUE_THRESHOLD_DEFAULT 0.1
+#define FMLS_RATIO_OF_MAX_VALUES_TO_MERGE_DEFAULT 1.0 // By default, never perform merging of lobes generated from discrete peaks such that a single lobe contains multiple peaks
 
 
 // By default, the mean direction of each FOD lobe is calculated by taking a weighted average of the
@@ -67,7 +67,7 @@ namespace MR
           FOD_lobe (const DWI::Directions::Set& dirs, const index_type seed, const default_type value, const default_type weight) :
               mask (dirs),
               values (Eigen::Array<default_type, Eigen::Dynamic, 1>::Zero (dirs.size())),
-              max_peak_value (abs (value)),
+              max_value (abs (value)),
               peak_dirs (1, dirs.get_dir (seed)),
               mean_dir (peak_dirs.front() * abs(value) * weight),
               integral (abs (value * weight)),
@@ -82,7 +82,7 @@ namespace MR
           FOD_lobe (const DWI::Directions::Mask& i) :
               mask (i),
               values (Eigen::Array<default_type, Eigen::Dynamic, 1>::Zero (i.size())),
-              max_peak_value (0.0),
+              max_value (0.0),
               integral (0.0),
               neg (false) { }
 
@@ -98,13 +98,13 @@ namespace MR
             integral += abs (value * weight);
           }
 
-          void revise_peak (const size_t index, const Eigen::Vector3& real_peak, const default_type value)
+          void revise_peak (const size_t index, const Eigen::Vector3& revised_peak, const default_type revised_max)
           {
             assert (!neg);
             assert (index < num_peaks());
-            peak_dirs[index] = real_peak;
+            peak_dirs[index] = revised_peak;
             if (!index)
-              max_peak_value = value;
+              max_value = revised_max;
           }
 
 #ifdef FMLS_OPTIMISE_MEAN_DIR
@@ -127,8 +127,8 @@ namespace MR
             mask |= that.mask;
             for (size_t i = 0; i != mask.size(); ++i)
               values[i] += that.values[i];
-            if (that.max_peak_value > max_peak_value) {
-              max_peak_value = that.max_peak_value;
+            if (that.max_value > max_value) {
+              max_value = that.max_value;
               peak_dirs.insert (peak_dirs.begin(), that.peak_dirs.begin(), that.peak_dirs.end());
             } else {
               peak_dirs.insert (peak_dirs.end(), that.peak_dirs.begin(), that.peak_dirs.end());
@@ -140,7 +140,7 @@ namespace MR
 
           const DWI::Directions::Mask& get_mask() const { return mask; }
           const Eigen::Array<default_type, Eigen::Dynamic, 1>& get_values() const { return values; }
-          default_type get_max_peak_value() const { return max_peak_value; }
+          default_type get_max_value() const { return max_value; }
           size_t num_peaks() const { return peak_dirs.size(); }
           const Eigen::Vector3& get_peak_dir (const size_t i) const { assert (i < num_peaks()); return peak_dirs[i]; }
           const Eigen::Vector3& get_mean_dir() const { return mean_dir; }
@@ -151,7 +151,7 @@ namespace MR
         private:
           DWI::Directions::Mask mask;
           Eigen::Array<default_type, Eigen::Dynamic, 1> values;
-          default_type max_peak_value;
+          default_type max_value;
           vector<Eigen::Vector3> peak_dirs;
           Eigen::Vector3 mean_dir;
           default_type integral;
@@ -242,10 +242,10 @@ namespace MR
 
           default_type get_integral_threshold           ()               const { return integral_threshold; }
           void         set_integral_threshold           (const default_type i) { integral_threshold = i; }
-          default_type get_peak_value_threshold         ()               const { return peak_value_threshold; }
-          void         set_peak_value_threshold         (const default_type i) { peak_value_threshold = i; }
-          default_type get_ratio_of_peak_value_to_merge ()               const { return ratio_of_peak_value_to_merge; }
-          void         set_ratio_of_peak_value_to_merge (const default_type i) { ratio_of_peak_value_to_merge = i; }
+          default_type get_max_value_threshold          ()               const { return max_value_threshold; }
+          void         set_max_value_threshold          (const default_type i) { max_value_threshold = i; }
+          default_type get_ratio_of_max_values_to_merge ()               const { return ratio_of_max_values_to_merge; }
+          void         set_ratio_of_max_values_to_merge (const default_type i) { ratio_of_max_values_to_merge = i; }
           bool         get_create_null_lobe             ()               const { return create_null_lobe; }
           void         set_create_null_lobe             (const bool i)         { create_null_lobe = i; verify_settings(); }
           bool         get_create_lookup_table          ()               const { return create_lookup_table; }
@@ -268,8 +268,8 @@ namespace MR
           std::shared_ptr<IntegrationWeights> weights;
 
           default_type integral_threshold; // Integral of positive lobe must be at least this value
-          default_type peak_value_threshold; // Absolute threshold for the peak amplitude of the lobe
-          default_type ratio_of_peak_value_to_merge; // Determines whether two lobes get agglomerated into one, depending on the FOD amplitude at the current point and how it compares to the peak amplitudes of the lobes to which it could be assigned
+          default_type max_value_threshold; // Absolute threshold for the maximal amplitude of the lobe
+          default_type ratio_of_max_values_to_merge; // Determines whether two lobes get agglomerated into one, depending on the FOD amplitude at the current point and how it compares to the maximal amplitudes of the lobes to which it could be assigned
           bool         create_null_lobe; // If this is set, an additional lobe will be created after segmentation with zero size, containing all directions not assigned to any other lobe
           bool         create_lookup_table; // If this is set, an additional lobe will be created after segmentation with zero size, containing all directions not assigned to any other lobe
           bool         dilate_lookup_table; // If this is set, the lookup table created for each voxel will be dilated so that all directions correspond to the nearest positive non-zero FOD lobe
@@ -298,4 +298,3 @@ namespace MR
 
 
 #endif
-


### PR DESCRIPTION
This kept irking me following discussion in #1874. Going back and looking through the code it was clear that this ambiguity of the word "peak" has been there for a while. Gets worse when talking about things like lobes containing multiple peaks, or merging lobes based on the ratio between the minimum of maximal amplitudes and the amplitude at the bridging dixel...

I had a go at making some changes to try to remove the ambiguity; not wholly sold on all of it (hence draft PR), but there's at least some stuff in there to consider.