### PR TITLE
dwifslpreproc: Changes to slice timing handling

### DIFF
--- a/bin/dwifslpreproc
+++ b/bin/dwifslpreproc
@@ -240,8 +240,29 @@ def execute(): #pylint: disable=unused-variable
     else:
       if 'SliceTiming' not in dwi_header.keyval():
         raise MRtrixError('Cannot perform slice-to-volume correction in eddy: No slspec file provided, and no slice timing information present in header')
-      slice_timing = dwi_header.keyval()['SliceTiming'][0]
-      app.debug('Slice timing from header: ' + str(slice_timing))
+      slice_timing = dwi_header.keyval()['SliceTiming']
+      app.debug('Initial slice timing contents from header: ' + str(slice_timing))
+      # Fudges necessary to maniupulate nature of slice timing data in cases where
+      #   bad JSON formatting has led to the data not being simply a list of floats
+      #   (whether from MRtrix3 DICOM conversion or from anything else)
+      if isinstance(slice_timing, utils.STRING_TYPES):
+        slice_timing = slice_timing.split()
+      if not isinstance(slice_timing, list):
+        app.error('Cannot use slice timing information in image header for slice-to-volume correction: Data is not a list')
+      if len(slice_timing) == 1:
+        slice_timing = slice_timing[0]
+        if not isinstance(slice_timing, list):
+          app.error('Cannot use slice timing information in image header for slice-to-volume correction: Unexpected data format')
+      if isinstance(slice_timing[0], list):
+        if not all( [ len(entry) == 1 for entry in slice_timing ] ):
+          app.error('Cannot use slice timing information in image header for slice-to-volume correction: Data do not appear to be 1D')
+        slice_timing = [ entry[0] for entry in slice_timing ]
+      if not all( [ isinstance(entry, float) for entry in slice_timing ] ):
+        try:
+          slice_timing = [ float(entry) for entry in slice_timing ]
+        except ValueError:
+          app.error('Cannot use slice timing information in image header for slice-to-volume correction: Data are not numeric')
+      app.debug('Re-formatted slice timing contents from header: ' + str(slice_timing))
       if len(slice_timing) != dwi_num_slices:
         raise MRtrixError('Cannot use slice timing information in image header for slice-to-volume correction: Number of entries (' + len(slice_timing) + ') does not match number of slices (' + dwi_header.size()[2] + ')')
 

--- a/core/file/dicom/mapper.cpp
+++ b/core/file/dicom/mapper.cpp
@@ -255,7 +255,6 @@ namespace MR {
             min_time_after_start = std::min (min_time_after_start, frames[n]->time_after_start);
           for (size_t n = 0; n != dim[1]; ++n)
             slices_timing.push_back (frames[n]->time_after_start - min_time_after_start);
-          H.keyval()["SliceTiming"] = join (slices_timing, ",");
         } else if (std::isfinite (static_cast<default_type>(frame.acquisition_time))) {
           DEBUG ("Estimating slice timing from DICOM AcquisitionTime field");
           default_type min_acquisition_time = std::numeric_limits<default_type>::infinity();
@@ -267,7 +266,7 @@ namespace MR {
         if (slices_timing.size()) {
           const size_t slices_acquired_at_zero = std::count (slices_timing.begin(), slices_timing.end(), 0.0f);
           if (slices_acquired_at_zero < (image.images_in_mosaic ? image.images_in_mosaic : dim[1])) {
-            H.keyval()["SliceTiming"] = join (slices_timing, ",");
+            H.keyval()["SliceTiming"] = join (slices_timing, " ");
             H.keyval()["MultibandAccelerationFactor"] = str (slices_acquired_at_zero);
             H.keyval()["SliceEncodingDirection"] = "k";
           } else {


### PR DESCRIPTION
Extracted changes from #1735 in order to apply to dev. In dwifslpreproc, perform a robust parsing of slice timing information from the image header.

During DICOM import, separate slice timings by space rather than comma; although the results of JSON export should be the same following #1771 / #1843, use of space delimiter for vector data is more consistent with other multi-dimensional data handling in image headers.

While #1735 was closed in part because it was targeted at `master`, I think that the changes there should nevertheless have been brought into `dev`. Currently `dwifslpreproc` fails on `dev` when utilising S2V due to [this line](https://github.com/MRtrix3/mrtrix3/blob/ce5bfd6c35369885de48a4e7179c226d0cfd3955/bin/dwifslpreproc#L244) having been tailored for erroneous slice timing data import. Rather than just fix that, might as well bring in the rest of the stuff I did in #1735, which should enable processing of retrospective data where the slice timing is erroneously a list-of-lists.