### PR TITLE
docs: add MRtrix3 paper and mention Unix tutorial

### DIFF
--- a/docs/getting_started/beginner_dwi_tutorial.rst
+++ b/docs/getting_started/beginner_dwi_tutorial.rst
@@ -1,7 +1,21 @@
 Beginner DWI tutorial
 =====================
 
-.. WARNING:: This tutorial is not intended to show the optimal or even recommended way of processing. It is merely a simplified example, intended to familiarise the user with the typical command line interface of certain basic processing steps.
+.. TIP::
+
+  Some proficiency with the Unix command-line is required to make the best use
+  of this software. There are many resources online to help you get
+  started if you are not already familiar with it. We also recommend our own
+  `Introduction to the Unix command-line
+  <https://command-line-tutorial.readthedocs.io/>`__, which was written with a
+  particular focus on the types of use that are common when using *MRtrix3*.
+
+.. WARNING::
+
+  This tutorial is not intended to show the optimal or even recommended way of
+  processing. It is merely a simplified example, intended to familiarise the
+  user with the typical command line interface of certain basic processing
+  steps.
 
 This tutorial will hopefully provide enough information for a novice
 user to get from the raw DW image data to performing some streamlines
@@ -103,4 +117,8 @@ particularly when a very large number of streamlines is generated.
 
     $ tckmap <Input track file> <Output TDI> -vox <Voxel size in mm>
     $ mrview <Output TDI>
+
+
+
+
 

--- a/docs/getting_started/key_features.rst
+++ b/docs/getting_started/key_features.rst
@@ -27,3 +27,13 @@ which will be invisible to the end-user. Specifically, *MRtrix3* features:
 -  a consistent :ref:`image_coord_system` with most
    operations performed in scanner/world coordinates where possible.
 
+.. TIP:: 
+
+  Some proficiency with the Unix command-line is required to make the best use
+  of this software. There are many resources online to help you get
+  started if you are not already familiar with it. We also recommend our own
+  `Introduction to the Unix command-line
+  <https://command-line-tutorial.readthedocs.io/>`__, which was written with a
+  particular focus on the types of use that are common when using *MRtrix3*.
+
+

--- a/docs/installation/before_install.rst
+++ b/docs/installation/before_install.rst
@@ -5,11 +5,25 @@ Before you install
 Acknowledging this work
 ----------------------------------
 
-If you wish to include results generated using the *MRtrix3* package in a publication, please include a line such as the following to acknowledge the work of our developers:
+If you wish to include results generated using the *MRtrix3* package in a
+publication, please include a line such as the following to acknowledge the
+work of our developers:
 
-* Processing was performed using the MRtrix3 package (www.mrtrix.org).
+* Processing was performed using the MRtrix3 package (`Tournier et al., 2019
+  <https://doi.org/10.1016/j.neuroimage.2019.116137>`__).
 
-.. NOTE:: Many individual methods included in the MRtrix3 software have been published in scientific journals and should be cited as such. Please check the references listed on the specific :ref:`application's page <list-of-mrtrix3-commands>` to ensure the appropriate reference is included, so that the scientists behind all methods receive proper acknowledgement.
+  *Tournier, J.-D.; Smith, R. E.; Raffelt, D.; Tabbara, R.; Dhollander, T.;
+     Pietsch, M.; Christiaens, D.; Jeurissen, B.; Yeh, C.-H. & Connelly, A.<br>
+     MRtrix3: A fast, flexible and open software framework for medical image
+     processing and visualisation. NeuroImage, 2019, 202, 116137*
+
+.. NOTE::
+
+  Many individual methods included in the MRtrix3 software have been published
+  in scientific journals and should be cited as such. Please check the
+  references listed on the specific :ref:`application's page
+  <list-of-mrtrix3-commands>` to ensure the appropriate reference is included,
+  so that the scientists behind all methods receive proper acknowledgement.
 
 
 Warranty
@@ -24,6 +38,17 @@ MRtrix is free software: you can redistribute it and/or modify it under the term
 
 MRtrix is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the `Mozilla Public License`_ for more details.
 You should have received a copy of `Mozilla Public License`_ along with MRtrix. If not, see `<http://mozilla.org/MPL/2.0/>`_.
+
+
+.. TIP::
+
+  Some proficiency with the Unix command-line is required to make the best use
+  of this software. There are many resources online to help you get
+  started if you are not already familiar with it. We also recommend our own
+  `Introduction to the Unix command-line
+  <https://command-line-tutorial.readthedocs.io/>`__, which was written with a
+  particular focus on the types of use that are common when using *MRtrix3*.
+
 
 .. _Free Software Foundation: http://www.fsf.org/
 .. _Mozilla Public License: http://mozilla.org/MPL/2.0/

--- a/docs/installation/before_install.rst
+++ b/docs/installation/before_install.rst
@@ -12,10 +12,10 @@ work of our developers:
 * Processing was performed using the MRtrix3 package (`Tournier et al., 2019
   <https://doi.org/10.1016/j.neuroimage.2019.116137>`__).
 
-  *Tournier, J.-D.; Smith, R. E.; Raffelt, D.; Tabbara, R.; Dhollander, T.;
-     Pietsch, M.; Christiaens, D.; Jeurissen, B.; Yeh, C.-H. & Connelly, A.<br>
-     MRtrix3: A fast, flexible and open software framework for medical image
-     processing and visualisation. NeuroImage, 2019, 202, 116137*
+  J.-D. Tournier, R. E. Smith, D. Raffelt, R. Tabbara, T. Dhollander, M.
+  Pietsch, D. Christiaens, B. Jeurissen, C.-H. Yeh, and A. Connelly.
+  *MRtrix3*: A fast, flexible and open software framework for medical image
+  processing and visualisation. NeuroImage, 202 (2019), pp. 116–37.
 
 .. NOTE::
 


### PR DESCRIPTION
Simply mentions the availability of the Unix tutorial in a few places, and also suggests citing the paper rather than the website in publications (a bit overdue, that one...). 