### PR TITLE
dwi2response: Fixes for #1874

### DIFF
--- a/docs/reference/commands/fixel2peaks.rst
+++ b/docs/reference/commands/fixel2peaks.rst
@@ -26,6 +26,8 @@ If a fixel data file is provided as input, then the 3-vectors in the output imag
 Options
 -------
 
+-  **-number value** maximum number of fixels in each voxel (default: based on input data)
+
 -  **-nan** fill excess peak data with NaNs rather than zeroes
 
 Standard options

--- a/lib/mrtrix3/dwi2response/tax.py
+++ b/lib/mrtrix3/dwi2response/tax.py
@@ -91,14 +91,12 @@ def execute(): #pylint: disable=unused-variable
     # Get amplitudes of two largest peaks, and directions of largest
     run.command('fod2fixel ' + prefix + 'FOD.mif ' + prefix + 'fixel -peak peaks.mif -mask ' + mask_in_path + ' -fmls_no_thresholds')
     app.cleanup(prefix + 'FOD.mif')
-    run.command('fixel2voxel ' + prefix + 'fixel/peaks.mif split_data ' + prefix + 'amps.mif')
+    run.command('fixel2voxel ' + prefix + 'fixel/peaks.mif none ' + prefix + 'amps.mif')
     run.command('mrconvert ' + prefix + 'amps.mif ' + prefix + 'first_peaks.mif -coord 3 0 -axes 0,1,2')
     run.command('mrconvert ' + prefix + 'amps.mif ' + prefix + 'second_peaks.mif -coord 3 1 -axes 0,1,2')
     app.cleanup(prefix + 'amps.mif')
-    run.command('fixel2voxel ' + prefix + 'fixel/directions.mif split_dir ' + prefix + 'all_dirs.mif')
+    run.command('fixel2peaks ' + prefix + 'fixel/directions.mif ' + prefix + 'first_dir.mif -number 1')
     app.cleanup(prefix + 'fixel')
-    run.command('mrconvert ' + prefix + 'all_dirs.mif ' + prefix + 'first_dir.mif -coord 3 0:2')
-    app.cleanup(prefix + 'all_dirs.mif')
     # Revise single-fibre voxel selection based on ratio of tallest to second-tallest peak
     run.command('mrcalc ' + prefix + 'second_peaks.mif ' + prefix + 'first_peaks.mif -div ' + prefix + 'peak_ratio.mif')
     app.cleanup(prefix + 'first_peaks.mif')

--- a/lib/mrtrix3/dwi2response/tournier.py
+++ b/lib/mrtrix3/dwi2response/tournier.py
@@ -88,14 +88,12 @@ def execute(): #pylint: disable=unused-variable
     app.cleanup(prefix + 'FOD.mif')
     if iteration:
       app.cleanup(mask_in_path)
-    run.command('fixel2voxel ' + prefix + 'fixel/peaks.mif split_data ' + prefix + 'amps.mif -number 2')
+    run.command('fixel2voxel ' + prefix + 'fixel/peaks.mif none ' + prefix + 'amps.mif -number 2')
     run.command('mrconvert ' + prefix + 'amps.mif ' + prefix + 'first_peaks.mif -coord 3 0 -axes 0,1,2')
     run.command('mrconvert ' + prefix + 'amps.mif ' + prefix + 'second_peaks.mif -coord 3 1 -axes 0,1,2')
     app.cleanup(prefix + 'amps.mif')
-    run.command('fixel2voxel ' + prefix + 'fixel/directions.mif split_dir ' + prefix + 'all_dirs.mif -number 1')
+    run.command('fixel2peaks ' + prefix + 'fixel/directions.mif ' + prefix + 'first_dir.mif -number 1')
     app.cleanup(prefix + 'fixel')
-    run.command('mrconvert ' + prefix + 'all_dirs.mif ' + prefix + 'first_dir.mif -coord 3 0:2')
-    app.cleanup(prefix + 'all_dirs.mif')
     # Calculate the 'cost function' Donald derived for selecting single-fibre voxels
     # https://github.com/MRtrix3/mrtrix3/pull/426
     #  sqrt(|peak1|) * (1 - |peak2| / |peak1|)^2


### PR DESCRIPTION
Update `dwi2response` `tournier` and `tax` algorithms to reflect changes in #1874 to the `fixel2voxel` command and new commands `fixel2peaks` / `peaks2fixel`.

Also includes `-number` option to `fixel2peaks`.

This gets `./run_tests scripts` to pass for these two algorithms; there is however a change elsewhere that has resulted in the outcomes of `dwi2response msmt_5tt` changing, which I'll look into separately.

Closes #1942.