### PR TITLE
dwi2fod: Improve error messages

### DIFF
--- a/cmd/dwi2fod.cpp
+++ b/cmd/dwi2fod.cpp
@@ -318,7 +318,10 @@ void run ()
 
     MSMT_Processor processor (shared, mask, odfs, dwi_modelled);
     auto dwi = header_in.get_image<float>().with_direct_io (3);
-    ThreadedLoop ("performing multi-shell, multi-tissue CSD", dwi, 0, 3)
+    ThreadedLoop ("performing MSMT CSD ("
+                  + str(shared.num_shells()) + " shell" + (shared.num_shells() > 1 ? "s" : "") + ", "
+                  + str(num_tissues) + " tissue" + (num_tissues > 1 ? "s" : "") + ")",
+                  dwi, 0, 3)
         .run (processor, dwi);
 
   } else {

--- a/core/math/math.h
+++ b/core/math/math.h
@@ -148,6 +148,8 @@ namespace MR
     vector<vector<ValueType>> load_matrix_2D_vector (const std::string& filename, vector<std::string>* comments = nullptr)
     {
       std::ifstream stream (filename, std::ios_base::in | std::ios_base::binary);
+      if (!stream)
+        throw Exception ("Unable to open numerical data text file \"" + filename + "\": " + strerror(errno));
       vector<vector<ValueType>> V;
       std::string sbuf, cbuf;
       size_t hash;

--- a/src/dwi/sdeconv/msmt_csd.h
+++ b/src/dwi/sdeconv/msmt_csd.h
@@ -77,7 +77,7 @@ namespace MR
               void set_responses (const vector<std::string>& files)
               {
                 lmax_response.clear();
-                for (const auto s : files) {
+                for (const auto& s : files) {
                   Eigen::MatrixXd r;
                   try {
                     r = load_matrix (s);
@@ -87,6 +87,7 @@ namespace MR
                   responses.push_back (std::move (r));
                 }
                 prepare_responses();
+                response_files = files;
               }
 
               void set_responses (const vector<Eigen::MatrixXd>& matrices)
@@ -106,7 +107,7 @@ namespace MR
                   }
                 } else {
                   if (lmax.size() != num_tissues())
-                    throw Exception ("Number of lmaxes specified does not match number of tissues");
+                    throw Exception ("Number of lmaxes specified (" + str(lmax.size()) + ") does not match number of tissues (" + str(num_tissues()) + ")");
                   for (const auto i : lmax) {
                     if (i < 0 || i % 2)
                       throw Exception ("Each value of lmax must be a non-negative even integer");
@@ -115,7 +116,8 @@ namespace MR
 
                 for (size_t t = 0; t != num_tissues(); ++t) {
                   if (size_t(responses[t].rows()) != num_shells())
-                    throw Exception ("number of rows in response function must match number of b-value shells");
+                    throw Exception ("number of rows in response functions must match number of b-value shells; "
+                                     "number of shells is " + str(num_shells()) + ", but file \"" + response_files[t] + "\" contains " + str(responses[t].rows()) + " rows");
                   // Pad response functions out to the requested lmax for this tissue
                   responses[t].conservativeResizeLike (Eigen::MatrixXd::Zero (num_shells(), Math::ZSH::NforL (lmax[t])));
                 }
@@ -226,6 +228,7 @@ namespace MR
               Eigen::MatrixXd HR_dirs;
               vector<int> lmax, lmax_response;
               vector<Eigen::MatrixXd> responses;
+              vector<std::string> response_files;
               Math::ICLS::Problem<double> problem;
               double solution_min_norm_regularisation, constraint_min_norm_regularisation;
 


### PR DESCRIPTION
Some of the error messages people were getting stuck on today could be a bit more verbose.

The more egregious one is "`no data in matrix file`" when in actual fact the file doesn't exist, because the initial state of the input stream wasn't checked.