### PR TITLE
fixel2voxel none: Revert default fill to 0.0

### DIFF
--- a/cmd/fixel2voxel.cpp
+++ b/cmd/fixel2voxel.cpp
@@ -95,7 +95,7 @@ void usage ()
                       "in the case of operation \"none\", output only the largest N fixels in each voxel.")
       + Argument ("N").type_integer(1)
 
-  + Option ("fill", "for \"none\" operation, specify the value to fill when number of fixels is fewer than the maximum (default: NaN)")
+  + Option ("fill", "for \"none\" operation, specify the value to fill when number of fixels is fewer than the maximum (default: 0.0)")
       + Argument ("value").type_float()
 
   + Option ("weighted", "weight the contribution of each fixel to the per-voxel result according to its volume.")
@@ -157,7 +157,7 @@ struct LoopFixelsInVoxelWithMax { NOMEMALIGN
 class Base
 { NOMEMALIGN
   public:
-    Base (FixelDataType& data, const index_type max_fixels, const bool pad = false, const float pad_value = NaN) :
+    Base (FixelDataType& data, const index_type max_fixels, const bool pad = false, const float pad_value = 0.0) :
         data (data),
         max_fixels (max_fixels),
         pad (pad),
@@ -547,7 +547,7 @@ void run ()
   }
 
   opt = get_options ("fill");
-  float fill_value = NaN;
+  float fill_value = 0.0;
   if (opt.size()) {
     if (op == 12) {
       fill_value = opt[0][0];

--- a/docs/reference/commands/fixel2voxel.rst
+++ b/docs/reference/commands/fixel2voxel.rst
@@ -41,7 +41,7 @@ Options
 
 -  **-number N** use only the largest N fixels in calculation of the voxel-wise statistic; in the case of operation "none", output only the largest N fixels in each voxel.
 
--  **-fill value** for "none" operation, specify the value to fill when number of fixels is fewer than the maximum (default: NaN)
+-  **-fill value** for "none" operation, specify the value to fill when number of fixels is fewer than the maximum (default: 0.0)
 
 -  **-weighted fixel_in** weight the contribution of each fixel to the per-voxel result according to its volume.
 


### PR DESCRIPTION
Placing values of NaN in voxels where there are fewer fixels than the maximum resulted in altered behaviour of the `dwi2response tournier` algorithm in specific instances. This returns the default behaviour of this operation to be the same as the previous "`fixel2voxel split_data`" (changes in #1874). There is already an option "`-fill`" in place to change this at the command-line; only the default behaviour is being changed.

This is what ultimately led to the alteration of outcomes of `dwi2response msmt_5tt` in the script test data that was mentioned in #1943.