### PR TITLE
mrview use comma as separator when copying focus position

### DIFF
--- a/src/gui/mrview/tool/view.cpp
+++ b/src/gui/mrview/tool/view.cpp
@@ -587,7 +587,7 @@ namespace MR
             return;
 
           Eigen::VectorXf focus (window().focus());
-          Eigen::IOFormat fmt(Eigen::FullPrecision, Eigen::DontAlignCols, " ", "\n", "", "", "", "");
+          Eigen::IOFormat fmt(Eigen::FullPrecision, Eigen::DontAlignCols, ",", "\n", "", "", "", "");
           std::cout << focus.transpose().format(fmt) << "\n";
 
           QClipboard *clip = QApplication::clipboard();
@@ -601,7 +601,7 @@ namespace MR
             return;
 
           Eigen::VectorXf focus = window().image()->transform().scanner2voxel.cast<float>() * window().focus();
-          Eigen::IOFormat fmt(Eigen::FullPrecision, Eigen::DontAlignCols, " ", "\n", "", "", "", "");
+          Eigen::IOFormat fmt(Eigen::FullPrecision, Eigen::DontAlignCols, ",", "\n", "", "", "", "");
           std::cout << focus.transpose().format(fmt) << "\n";
 
           QClipboard *clip = QApplication::clipboard();


### PR DESCRIPTION
In the View tool, the copy buttons previously used a space as the separator for the pasted text, which made it unwieldy for pasting directly into e.g. a `tckgen` command. This uses a comma instead. 