### PR TITLE
dwinormalise warp fix

### DIFF
--- a/lib/mrtrix3/dwinormalise/group.py
+++ b/lib/mrtrix3/dwinormalise/group.py
@@ -91,7 +91,17 @@ def execute(): #pylint: disable=unused-variable
   progress.done()
 
   app.console('Generating FA population template')
-  run.command('population_template fa -mask_dir ' + mask_dir + ' fa_template.mif -type rigid_affine_nonlinear -rigid_scale 0.25,0.5,0.8,1.0 -affine_scale 0.7,0.8,1.0,1.0 -nl_scale 0.5,0.75,1.0,1.0,1.0 -nl_niter 5,5,5,5,5 -warp_dir warps -linear_no_pause -nocleanup')
+  run.command('population_template fa fa_template.mif'
+              + ' -mask_dir ' + mask_dir
+              + ' -type rigid_affine_nonlinear'
+              + ' -rigid_scale 0.25,0.5,0.8,1.0'
+              + ' -affine_scale 0.7,0.8,1.0,1.0'
+              + ' -nl_scale 0.5,0.75,1.0,1.0,1.0'
+              + ' -nl_niter 5,5,5,5,5'
+              + ' -warp_dir warps'
+              + ' -linear_no_pause'
+              + ' -scratch population_template'
+              + ('' if app.DO_CLEANUP else ' -nocleanup'))
 
   app.console('Generating WM mask in template space')
   run.command('mrthreshold fa_template.mif -abs ' +  app.ARGS.fa_threshold + ' template_wm_mask.mif')

--- a/lib/mrtrix3/dwinormalise/group.py
+++ b/lib/mrtrix3/dwinormalise/group.py
@@ -91,7 +91,7 @@ def execute(): #pylint: disable=unused-variable
   progress.done()
 
   app.console('Generating FA population template')
-  run.command('population_template fa -mask_dir ' + mask_dir + ' fa_template.mif -type rigid_affine_nonlinear -rigid_scale 0.25,0.5,0.8,1.0 -affine_scale 0.7,0.8,1.0,1.0 -nl_scale 0.5,0.75,1.0,1.0,1.0 -nl_niter 5,5,5,5,5 -scratch population_template -linear_no_pause -nocleanup')
+  run.command('population_template fa -mask_dir ' + mask_dir + ' fa_template.mif -type rigid_affine_nonlinear -rigid_scale 0.25,0.5,0.8,1.0 -affine_scale 0.7,0.8,1.0,1.0 -nl_scale 0.5,0.75,1.0,1.0,1.0 -nl_niter 5,5,5,5,5 -warp_dir warps -linear_no_pause -nocleanup')
 
   app.console('Generating WM mask in template space')
   run.command('mrthreshold fa_template.mif -abs ' +  app.ARGS.fa_threshold + ' template_wm_mask.mif')
@@ -100,7 +100,7 @@ def execute(): #pylint: disable=unused-variable
   path.make_dir(path.from_user(app.ARGS.output_dir, False))
   path.make_dir('wm_mask_warped')
   for i in input_list:
-    run.command('mrtransform template_wm_mask.mif -interp nearest -warp_full ' + os.path.join('population_template', 'warps', i.prefix + '.mif') + ' ' + os.path.join('wm_mask_warped', i.prefix + '.mif') + ' -from 2 -template ' + os.path.join('fa', i.prefix + '.mif'))
+    run.command('mrtransform template_wm_mask.mif -interp nearest -warp_full ' + os.path.join('warps', i.prefix + '.mif') + ' ' + os.path.join('wm_mask_warped', i.prefix + '.mif') + ' -from 2 -template ' + os.path.join('fa', i.prefix + '.mif'))
     run.command('dwinormalise individual ' + path.quote(os.path.join(input_dir, i.filename)) + ' ' + os.path.join('wm_mask_warped', i.prefix + '.mif') + ' temp.mif')
     run.command('mrconvert temp.mif ' + path.from_user(os.path.join(app.ARGS.output_dir, i.filename)), mrconvert_keyval=path.from_user(os.path.join(input_dir, i.filename), False), force=app.FORCE_OVERWRITE)
     os.remove('temp.mif')


### PR DESCRIPTION
fix to `dwinormalise group` necessitated by name changes of temporary files within the `population_tempalte` scratch directory.