### PR TITLE
Header::merge_keyval(): Add tolerance for slice timing differences

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -162,7 +162,7 @@ jobs:
 
 
     - name: check syntax
-      run: ./check_syntax
+      run: ./check_syntax || { cat syntax.log; false; }
 
     - name: pylint (Python 2)
       run: |

--- a/bin/dwifslpreproc
+++ b/bin/dwifslpreproc
@@ -243,6 +243,8 @@ def execute(): #pylint: disable=unused-variable
         raise MRtrixError('Cannot perform slice-to-volume correction in eddy: No slspec file provided, and no slice timing information present in header')
       slice_timing = dwi_header.keyval()['SliceTiming']
       app.debug('Initial slice timing contents from header: ' + str(slice_timing))
+      if slice_timing in ['invalid', 'variable']:
+        app.error('Cannot use slice timing information in image header for slice-to-volume correction: data flagged as "' + slice_timing + '"')
       # Fudges necessary to maniupulate nature of slice timing data in cases where
       #   bad JSON formatting has led to the data not being simply a list of floats
       #   (whether from MRtrix3 DICOM conversion or from anything else)

--- a/core/header.cpp
+++ b/core/header.cpp
@@ -91,7 +91,7 @@ namespace MR
           DEBUG ("Error converting slice timing vector to floating-point");
           return "invalid";
         }
-        const default_type diff = std::abs (f_two - f_one);
+        const default_type diff = abs (f_two - f_one);
         if (diff > 0.00375) {
           DEBUG ("Supra-threshold difference of " + str(diff) + "s in slice times");
           return "variable";

--- a/core/header.cpp
+++ b/core/header.cpp
@@ -69,6 +69,40 @@ namespace MR
 
 
 
+  namespace {
+    std::string resolve_slice_timing (const std::string& one, const std::string& two)
+    {
+      if (one == "variable" || two == "variable")
+        return "variable";
+      vector<std::string> one_split = split (one, ",");
+      vector<std::string> two_split = split (two, ",");
+      if (one_split.size() != two_split.size()) {
+        DEBUG ("Slice timing vectors of inequal length");
+        return "invalid";
+      }
+      // Siemens CSA reports with 2.5ms precision = 0.0025s
+      // Allow slice times to vary by 1.5x this amount, but no more
+      for (size_t i = 0; i != one_split.size(); ++i) {
+        default_type f_one, f_two;
+        try {
+          f_one = to<default_type> (one_split[i]);
+          f_two = to<default_type> (two_split[i]);
+        } catch (Exception& e) {
+          DEBUG ("Error converting slice timing vector to floating-point");
+          return "invalid";
+        }
+        const default_type diff = std::abs (f_two - f_one);
+        if (diff > 0.00375) {
+          DEBUG ("Supra-threshold difference of " + str(diff) + "s in slice times");
+          return "variable";
+        }
+      }
+      return one;
+    }
+  }
+
+
+
   void Header::merge_keyval (const Header& H)
   {
     std::map<std::string, std::string> new_keyval;
@@ -96,6 +130,8 @@ namespace MR
         auto it = keyval().find (item.first);
         if (it == keyval().end() || it->second == item.second)
           new_keyval.insert (item);
+        else if (item.first == "SliceTiming")
+          new_keyval["SliceTiming"] = resolve_slice_timing (item.second, it->second);
         else
           new_keyval[item.first] = "variable";
       }


### PR DESCRIPTION
Closes #1956.

Using a fixed threshold difference in slice timing based on observation of precision of data in Siemens Mosaic CSAs.