### PR TITLE
dirmerge: Fix -unipolar_weight option

### DIFF
--- a/docs/reference/commands/dirmerge.rst
+++ b/docs/reference/commands/dirmerge.rst
@@ -22,7 +22,7 @@ Usage
 Options
 -------
 
--  **-unipolar_weight** set the weight given to the unipolar electrostatic repulsion model compared to the bipolar model (default: 0.2).
+-  **-unipolar_weight value** set the weight given to the unipolar electrostatic repulsion model compared to the bipolar model (default: 0.2).
 
 Standard options
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Went to give this option a go as I wanted to prioritise reduction of long-term eddy currents over truncation optimisation, and was met with `SIGSEGV`.

Flagging @jdtournier in case of objection against increasing the precision of the output directions.