### PR TITLE
DWI::Tractography::TrackScalar: Fix compilation on G++5

### DIFF
--- a/cmd/tsfmult.cpp
+++ b/cmd/tsfmult.cpp
@@ -17,6 +17,7 @@
 #include "command.h"
 #include "dwi/tractography/properties.h"
 #include "dwi/tractography/scalar_file.h"
+#include "dwi/tractography/streamline.h"
 
 
 using namespace MR;

--- a/cmd/tsfsmooth.cpp
+++ b/cmd/tsfsmooth.cpp
@@ -18,6 +18,7 @@
 #include "math/median.h"
 #include "dwi/tractography/properties.h"
 #include "dwi/tractography/scalar_file.h"
+#include "dwi/tractography/streamline.h"
 
 
 #define DEFAULT_SMOOTHING 4.0

--- a/cmd/tsfthreshold.cpp
+++ b/cmd/tsfthreshold.cpp
@@ -17,6 +17,7 @@
 #include "command.h"
 #include "dwi/tractography/properties.h"
 #include "dwi/tractography/scalar_file.h"
+#include "dwi/tractography/streamline.h"
 
 
 using namespace MR;

--- a/src/dwi/tractography/streamline.h
+++ b/src/dwi/tractography/streamline.h
@@ -62,6 +62,7 @@ namespace MR
         public:
           using value_type = ValueType;
           using vector<ValueType>::vector;
+          TrackScalar () = default;
           TrackScalar (const TrackScalar&) = default;
           TrackScalar (TrackScalar&& that) :
               vector<value_type> (std::move (that)),


### PR DESCRIPTION
Resolution of compilation issue introduced in #1988.