### PR TITLE
Matlab: Address header keys with spaces

### DIFF
--- a/cmd/fixelcfestats.cpp
+++ b/cmd/fixelcfestats.cpp
@@ -451,11 +451,11 @@ void run()
   matrix_type empirical_cfe_statistic;
   if (do_nonstationarity_adjustment) {
     Stats::PermTest::precompute_empirical_stat (glm_test, cfe_integrator, empirical_skew, empirical_cfe_statistic);
-    output_header.keyval()["nonstationarity adjustment"] = str(true);
+    output_header.keyval()["nonstationarity_adjustment"] = str(true);
     for (size_t i = 0; i != num_hypotheses; ++i)
       write_fixel_output (Path::join (output_fixel_directory, "cfe_empirical" + postfix(i) + ".mif"), empirical_cfe_statistic.col(i), mask, output_header);
   } else {
-    output_header.keyval()["nonstationarity adjustment"] = str(false);
+    output_header.keyval()["nonstationarity_adjustment"] = str(false);
   }
 
   // Precompute default statistic and CFE statistic

--- a/matlab/private/add_field.m
+++ b/matlab/private/add_field.m
@@ -1,0 +1,27 @@
+% Copyright (c) 2008-2019 the MRtrix3 contributors.
+%
+% This Source Code Form is subject to the terms of the Mozilla Public
+% License, v. 2.0. If a copy of the MPL was not distributed with this
+% file, You can obtain one at http://mozilla.org/MPL/2.0/.
+%
+% Covered Software is provided under this License on an "as is"
+% basis, without warranty of any kind, either expressed, implied, or
+% statutory, including, without limitation, warranties that the
+% Covered Software is free of defects, merchantable, fit for a
+% particular purpose or non-infringing.
+% See the Mozilla Public License v. 2.0 for more details.
+%
+% For more details, see http://www.mrtrix.org/.
+
+function data = add_field (data, key, value)
+  key(key==' ') = '_';
+  if isfield (data, key)
+    previous = getfield (data, key);
+    if iscell (previous)
+      data = setfield (data, key, [ previous {value} ]);
+    else
+      data = setfield (data, key, { previous, value });
+    end
+  else
+    data = setfield (data, key, value);
+  end

--- a/matlab/read_mrtrix.m
+++ b/matlab/read_mrtrix.m
@@ -131,15 +131,3 @@ function S = split_strings (V, delim)
 
 
 
-
-function image = add_field (image, key, value)
-  if isfield (image, key)
-    previous = getfield (image, key);
-    if iscell (previous)
-      image = setfield (image, key, [ previous {value} ]);
-    else
-      image = setfield (image, key, { previous, value });
-    end
-  else
-    image = setfield (image, key, value);
-  end

--- a/matlab/read_mrtrix_tracks.m
+++ b/matlab/read_mrtrix_tracks.m
@@ -93,18 +93,3 @@ for n = 1:(prod(size(k))-1)
   tracks.data{end+1} = data(pk:(k(n)-1),:);
   pk = k(n)+1;
 end
-
-
-
-
-function image = add_field (image, key, value)
-  if isfield (image, key)
-    previous = getfield (image, key);
-    if iscell (previous)
-      image = setfield (image, key, [ previous {value} ]);
-    else
-      image = setfield (image, key, { previous, value });
-    end
-  else
-    image = setfield (image, key, value);
-  end

--- a/matlab/read_mrtrix_tsf.m
+++ b/matlab/read_mrtrix_tsf.m
@@ -50,7 +50,7 @@ while 1
     elseif strcmp(key, 'datatype')
       tsf.datatype = value;
     else
-      tsf = setfield (tsf, key, value);
+      tsf = add_field (tsf, key, value);
     end
   end
 end
@@ -104,5 +104,3 @@ for n = 1:(prod(size(k)))
   tsf.data{end+1} = data(pk:(k(n)-1),:);
   pk = k(n)+1;
 end
-
-


### PR DESCRIPTION
- `fixelcfestats`: Rename header key-value field "`nonstationarity adjustment`" to no longer contain a space.

- MatLab `read_*()` functions: For incoming header key-values, replace spaces with underscores in field names.

Closes #1633.
