### PR TITLE
DICOM: improve handling of time fields

### DIFF
--- a/core/file/dicom/element.h
+++ b/core/file/dicom/element.h
@@ -55,11 +55,14 @@ namespace MR {
 
       class Time { NOMEMALIGN
         public:
-          Time (const std::string& entry) :
-              hour     (to<uint32_t> (entry.substr (0, 2))),
-              minute   (to<uint32_t> (entry.substr (2, 2))),
-              second   (to<uint32_t> (entry.substr (4, 2))),
-              fraction (entry.size() > 6 ? to<default_type> (entry.substr (6)) : 0.0) { }
+          Time (const std::string& entry) : Time() {
+            if (entry.size() < 6)
+              throw Exception ("field \"" + entry + "\" is too short to be interpreted as a time");
+            hour  = to<uint32_t> (entry.substr (0, 2));
+            minute = to<uint32_t> (entry.substr (2, 2));
+            second = to<uint32_t> (entry.substr (4, 2));
+            fraction = entry.size() > 6 ? to<default_type> (entry.substr (6)) : 0.0;
+          }
           Time (default_type i)
           {
             if (i < 0.0)

--- a/core/file/dicom/image.cpp
+++ b/core/file/dicom/image.cpp
@@ -312,8 +312,8 @@ namespace MR {
               parse_item (item);
             }
             catch (Exception& E) {
-              WARN (printf ("error reading tag (%04X,%04X):", item.group, item.element));
-              E.display(1);
+              DEBUG (printf ("error reading tag (%04X,%04X):", item.group, item.element));
+              E.display(3);
             }
           }
 


### PR DESCRIPTION
Relegate warnings due to empty acquisition time fields in the DICOM headers to debug level - these are otherwise very annoying when loading a DICOM data set in `mrview` (you get a warning per affected slice...). Reported by @bjeurissen. 

Also a minor improvement in how these fields are parsed - might avoid segfaults in the future... 