### PR TITLE
mrconvert: Avoid unnecessary warning

### DIFF
--- a/cmd/mrconvert.cpp
+++ b/cmd/mrconvert.cpp
@@ -421,7 +421,9 @@ void run ()
       add_to_command_history = false;
     auto entry = header_out.keyval().find (opt[n][0]);
     if (entry == header_out.keyval().end()) {
-      WARN ("No header key/value entry \"" + opt[n][0] + "\" found; ignored");
+      if (std::string(opt[n][0]) != "command_history") {
+        WARN ("No header key/value entry \"" + opt[n][0] + "\" found; ignored");
+      }
     } else {
       header_out.keyval().erase (entry);
     }


### PR DESCRIPTION
`mrconvert` calls can include `-clear_property command_history` to prevent propagation or generation of identifying information. This includes suppressing the addition of the currently executing command to the end of `command_history`.

When doing so when the input image does not itself contain `command_history`, the command will currently generate a warning to say that that field does not exist. This shouldn't occur, as specifying `-clear_property command_history` is still serving a purpose even if not currently present.