### PR TITLE
write_mrtrix.m: fix handling of .mih outputs

### DIFF
--- a/matlab/read_mrtrix.m
+++ b/matlab/read_mrtrix.m
@@ -100,7 +100,7 @@ image.data = reshape (image.data, image.dim(order));
 image.data = ipermute (image.data, order);
 for i=1:size(order,2)
   if layout{i}(1) == '-'
-    image.data = flipdim(image.data, i);
+    image.data = flip(image.data, i);
   end
 end
 

--- a/matlab/write_mrtrix.m
+++ b/matlab/write_mrtrix.m
@@ -139,7 +139,7 @@ end
 
 fclose(fid);
 
-fid = fopen (datafile, 'w+', byteorder)
+fid = fopen (datafile, 'w+', byteorder);
 fseek (fid, dataoffset, -1);
 
 if isstruct(image)

--- a/matlab/write_mrtrix.m
+++ b/matlab/write_mrtrix.m
@@ -129,7 +129,7 @@ if strcmp(filename(end-3:end), '.mif')
   dataoffset = ftell (fid) + 24;
   fprintf (fid, '\nfile: . %d\nEND\n                         ', dataoffset);
 elseif strcmp(filename(end-3:end), '.mih')
-  datafile = [ filename(end-3:end) '.dat' ];
+  datafile = [ filename(1:end-4) '.dat' ];
   dataoffset = 0;
   fprintf (fid, '\nfile: %s %d\nEND\n', datafile, dataoffset);
 else
@@ -139,7 +139,7 @@ end
 
 fclose(fid);
 
-fid = fopen (datafile, 'r+', byteorder);
+fid = fopen (datafile, 'w+', byteorder)
 fseek (fid, dataoffset, -1);
 
 if isstruct(image)

--- a/matlab/write_mrtrix.m
+++ b/matlab/write_mrtrix.m
@@ -122,25 +122,23 @@ if isstruct (image)
     end
   end
 end
- 
+
+fprintf (fid, '\nfile: ')
 
 if strcmp(filename(end-3:end), '.mif')
-  datafile = filename;
-  dataoffset = ftell (fid) + 24;
-  fprintf (fid, '\nfile: . %d\nEND\n                         ', dataoffset);
+  dataoffset = ftell (fid) + 18;
+  dataoffset += mod((4 - mod(dataoffset, 4)), 4);
+  fprintf (fid, '. %d\nEND\n              ', dataoffset);
+  fseek (fid, dataoffset);
 elseif strcmp(filename(end-3:end), '.mih')
   datafile = [ filename(1:end-4) '.dat' ];
-  dataoffset = 0;
-  fprintf (fid, '\nfile: %s %d\nEND\n', datafile, dataoffset);
+  fprintf (fid, '%s 0\nEND\n', datafile);
+  fclose(fid);
+  fid = fopen (datafile, 'w', byteorder);
 else
   fclose(fid);
   error('unknown file suffix - aborting');
 end
-
-fclose(fid);
-
-fid = fopen (datafile, 'w+', byteorder);
-fseek (fid, dataoffset, -1);
 
 if isstruct(image)
   fwrite (fid, image.data, precision);


### PR DESCRIPTION
Closes #2016 
Given the fix, I've no idea how this ever worked for `.mif` outputs...