### PR TITLE
DWI::Shells: Classify b=0 before clustering

### DIFF
--- a/src/dwi/shells.cpp
+++ b/src/dwi/shells.cpp
@@ -351,6 +351,14 @@ namespace MR
       size_t clusterIdx = 0;
 
       for (ssize_t ii = 0; ii != bvals.size(); ii++) {
+        if (bvals[ii] <= bzero_threshold()) {
+          visited[ii] = true;
+          clusterIdx = 1;
+          clusters[ii] = 1;
+        }
+      }
+
+      for (ssize_t ii = 0; ii != bvals.size(); ii++) {
         if (!visited[ii]) {
 
           visited[ii] = true;
@@ -391,7 +399,7 @@ namespace MR
     void Shells::regionQuery (const BValueList& bvals, const default_type b, vector<size_t>& idx) const
     {
       for (ssize_t i = 0; i < bvals.size(); i++) {
-        if (abs (b - bvals[i]) < bvalue_epsilon())
+        if (bvals[i] > bzero_threshold() && abs (b - bvals[i]) < bvalue_epsilon())
           idx.push_back (i);
       }
     }


### PR DESCRIPTION
Spawned by [forum thread](https://community.mrtrix.org/t/wrong-number-of-shells-after-mrconvert/3509).

```
$ mrinfo test.mif -dwgrad
   0    0    0    0
   0    0    1  100
   0    0    1  100
   0    0    1  100
   0    0    1  100
   0    0    1  100
   0    0    1  100
   0    0    1  700
   0    0    1  700
   0    0    1  700
   0    0    1  700
   0    0    1  700
   0    0    1  700
   0    0    1 1400
   0    0    1 1400
   0    0    1 1400
   0    0    1 1400
   0    0    1 1400
   0    0    1 1400
   0    0    1 1400
   0    0    1 1400
   0    0    1 1400
   0    0    1 1400
   0    0    1 1400
   0    0    1 1400
   0    0    1 2000
   0    0    1 2000
   0    0    1 2000
   0    0    1 2000
   0    0    1 2000
   0    0    1 2000
   0    0    1 2000
   0    0    1 2000
   0    0    1 2000
   0    0    1 2000
   0    0    1 2000
   0    0    1 2000
   0    0    1 2000
   0    0    1 2000
   0    0    1 2000
   0    0    1 2000

$  ~/src/dev/bin/mrinfo test_grad2.mif -shell_bvalues -shell_sizes -config BValueEpsilon 200
85.7143 700 1400 2000
7 6 12 16

$ mrinfo test_grad2.mif -shell_bvalues -config BValueEpsilon 200
0 100 700 1400 2000
1 6 6 12 16
```

On a related note: Given `mrinfo` has the `-shell_*` options, should `src/dwi/shells.*` in fact more appropriately reside in `core/dwi/`?