### PR TITLE
tck2connectome: Increase default radial search

### DIFF
--- a/docs/quantitative_structural_connectivity/structural_connectome.rst
+++ b/docs/quantitative_structural_connectivity/structural_connectome.rst
@@ -54,7 +54,7 @@ influence on the resulting connectomes. This is one aspect where
 white matter interface, within sub-cortical grey matter, or at the
 inferior edge of the image, this assignment becomes relatively trivial.
 The default assignment mechanism is a radial search outwards from the
-streamline termination point, out to a maximum radius of 2mm; and the
+streamline termination point, out to a maximum radius of 4mm; and the
 streamline endpoint is only assigned to the first non-zero node index.
 If you do not have the image data necessary to use the ACT framework,
 see the 'No DWI distortion correction available' section below.

--- a/docs/reference/commands/tck2connectome.rst
+++ b/docs/reference/commands/tck2connectome.rst
@@ -54,7 +54,7 @@ Structural connectome streamline assignment option
 
 -  **-assignment_end_voxels** use a simple voxel lookup value at each streamline endpoint
 
--  **-assignment_radial_search radius** perform a radial search from each streamline endpoint to locate the nearest node. Argument is the maximum radius in mm; if no node is found within this radius, the streamline endpoint is not assigned to any node. Default search distance is 2mm.
+-  **-assignment_radial_search radius** perform a radial search from each streamline endpoint to locate the nearest node. Argument is the maximum radius in mm; if no node is found within this radius, the streamline endpoint is not assigned to any node. Default search distance is 4mm.
 
 -  **-assignment_reverse_search max_dist** traverse from each streamline endpoint inwards along the streamline, in search of the last node traversed by the streamline. Argument is the maximum traversal length in mm (set to 0 to allow search to continue to the streamline midpoint).
 

--- a/src/dwi/tractography/connectome/connectome.h
+++ b/src/dwi/tractography/connectome/connectome.h
@@ -32,7 +32,7 @@ namespace Connectome {
 
 
 
-#define TCK2NODES_RADIAL_DEFAULT_DIST 2.0
+#define TCK2NODES_RADIAL_DEFAULT_DIST 4.0
 #define TCK2NODES_REVSEARCH_DEFAULT_DIST 0.0 // Default = no distance limit, reverse search all the way to the streamline midpoint
 #define TCK2NODES_FORWARDSEARCH_DEFAULT_DIST 3.0
 


### PR DESCRIPTION
Feedback from collaborators operating on a wider gamut of data has been that the default maximal radial search distance is too restrictive, and leads to too many false negatives relative to the false positives introduced by increasing the limit (which many have been doing manually).