### PR TITLE
Reference fixes for website publication crawler

### DIFF
--- a/cmd/dwi2mask.cpp
+++ b/cmd/dwi2mask.cpp
@@ -42,7 +42,7 @@ DESCRIPTION
 REFERENCES
   + "Dhollander T, Raffelt D, Connelly A. " // Internal
     "Unsupervised 3-tissue response function estimation from single-shell or multi-shell diffusion MR data without a co-registered T1 image. "
-    "ISMRM Workshop on Breaking the Barriers of Diffusion MRI, 2016, 5.";
+    "ISMRM Workshop on Breaking the Barriers of Diffusion MRI, 2016, 5";
 
 ARGUMENTS
    + Argument ("input",

--- a/cmd/dwi2tensor.cpp
+++ b/cmd/dwi2tensor.cpp
@@ -95,12 +95,11 @@ void usage ()
    + "References based on fitting algorithm used:"
 
    + "* OLS, WLS:\n"
-     "Basser, P.J.; Mattiello, J.; LeBihan, D."
-     "Estimation of the effective self-diffusion tensor from the NMR spin echo."
+     "Basser, P.J.; Mattiello, J.; LeBihan, D. "
+     "Estimation of the effective self-diffusion tensor from the NMR spin echo. "
      "J Magn Reson B., 1994, 103, 247–254."
 
-
-  +  "* IWLS:\n"
+   + "* IWLS:\n"
      "Veraart, J.; Sijbers, J.; Sunaert, S.; Leemans, A. & Jeurissen, B. " // Internal
      "Weighted linear least squares estimation of diffusion MRI parameters: strengths, limitations, and pitfalls. "
      "NeuroImage, 2013, 81, 335-346";

--- a/cmd/fixelcfestats.cpp
+++ b/cmd/fixelcfestats.cpp
@@ -77,19 +77,19 @@ void usage ()
   + Math::Stats::GLM::column_ones_description;
 
   REFERENCES
-  + "Raffelt, D.; Smith, RE.; Ridgway, GR.; Tournier, JD.; Vaughan, DN.; Rose, S.; Henderson, R.; Connelly, A." // Internal
+  + "Raffelt, D.; Smith, RE.; Ridgway, GR.; Tournier, JD.; Vaughan, DN.; Rose, S.; Henderson, R.; Connelly, A. " // Internal
     "Connectivity-based fixel enhancement: Whole-brain statistical analysis of diffusion MRI measures in the presence of crossing fibres."
     "Neuroimage, 2015, 15(117):40-55"
 
   + "* If not using the -cfe_legacy option: \n"
-    "Smith, RE.; Dimond, D; Vaughan, D.; Parker, D.; Dhollander, T.; Jackson, G.; Connelly, A. \n"
-    "Intrinsic non-stationarity correction for Fixel-Based Analysis. \n"
-    "In Proc OHBM 2019 M789\n"
+    "Smith, RE.; Dimond, D; Vaughan, D.; Parker, D.; Dhollander, T.; Jackson, G.; Connelly, A. "
+    "Intrinsic non-stationarity correction for Fixel-Based Analysis. "
+    "In Proc OHBM 2019 M789"
 
   + "* If using the -nonstationary option: \n"
     "Salimi-Khorshidi, G. Smith, S.M. Nichols, T.E. "
     "Adjusting the effect of nonstationarity in cluster-based and TFCE inference. "
-    "NeuroImage, 2011, 54(3), 2006-19" ;
+    "NeuroImage, 2011, 54(3), 2006-19";
 
   ARGUMENTS
   + Argument ("in_fixel_directory", "the fixel directory containing the data files for each subject (after obtaining fixel correspondence").type_directory_in()

--- a/cmd/fod2dec.cpp
+++ b/cmd/fod2dec.cpp
@@ -51,10 +51,10 @@ void usage ()
   REFERENCES
     + "Dhollander T, Smith RE, Tournier JD, Jeurissen B, Connelly A. " // Internal
       "Time to move on: an FOD-based DEC map to replace DTI's trademark DEC FA. "
-      "Proc Intl Soc Mag Reson Med, 2015, 23, 1027."
+      "Proc Intl Soc Mag Reson Med, 2015, 23, 1027"
     + "Dhollander T, Raffelt D, Smith RE, Connelly A. " // Internal
       "Panchromatic sharpening of FOD-based DEC maps by structural T1 information. "
-      "Proc Intl Soc Mag Reson Med, 2015, 23, 566.";
+      "Proc Intl Soc Mag Reson Med, 2015, 23, 566";
 
   ARGUMENTS
     + Argument ("input","The input FOD image (spherical harmonic coefficients).").type_image_in ()
@@ -281,7 +281,7 @@ void run () {
       }
 
       ThreadedLoop ("computing colours", fod_img, 0, 3)
-        .run (DecComputer (DecTransform (Math::SH::LforN(fod_img.size(3)), dirs, thresh), mask_img, w_img), fod_img, dec_img);  
+        .run (DecComputer (DecTransform (Math::SH::LforN(fod_img.size(3)), dirs, thresh), mask_img, w_img), fod_img, dec_img);
     }
 
     auto out_hdr = map_hdr.valid() ? Header(map_hdr) : Header(dec_img);

--- a/cmd/fod2fixel.cpp
+++ b/cmd/fod2fixel.cpp
@@ -76,7 +76,7 @@ void usage ()
     + "* Reference for Apparent Fibre Density (AFD):\n"
     "Raffelt, D.; Tournier, J.-D.; Rose, S.; Ridgway, G.R.; Henderson, R.; Crozier, S.; Salvado, O.; Connelly, A. " // Internal
     "Apparent Fibre Density: a novel measure for the analysis of diffusion-weighted magnetic resonance images."
-    "Neuroimage, 2012, 15;59(4), 3976-94.";
+    "Neuroimage, 2012, 15;59(4), 3976-94";
 
   ARGUMENTS
   + Argument ("fod", "the input fod image.").type_image_in ()

--- a/cmd/mrtransform.cpp
+++ b/cmd/mrtransform.cpp
@@ -86,7 +86,7 @@ void usage ()
     + "* If FOD modulation is being performed:\n"
     "Raffelt, D.; Tournier, J.-D.; Rose, S.; Ridgway, G.R.; Henderson, R.; Crozier, S.; Salvado, O.; Connelly, A.; " // Internal
     "Apparent Fibre Density: a novel measure for the analysis of diffusion-weighted magnetic resonance images. "
-    "NeuroImage, 2012, 15;59(4), 3976-94.";
+    "NeuroImage, 2012, 15;59(4), 3976-94";
 
   ARGUMENTS
   + Argument ("input", "input image to be transformed.").type_image_in ()

--- a/cmd/mtnormalise.cpp
+++ b/cmd/mtnormalise.cpp
@@ -40,11 +40,6 @@ void usage ()
 
   SYNOPSIS = "Multi-tissue informed log-domain intensity normalisation";
 
-  REFERENCES
-    + "Raffelt, D.; Dhollander, T.; Tournier, J.-D.; Tabbara, R.; Smith, R. E.; Pierre, E. & Connelly, A. " // Internal
-    "Bias Field Correction and Intensity Normalisation for Quantitative Analysis of Apparent Fibre Density. "
-    "In Proc. ISMRM, 2017, 26, 3541";
-
   DESCRIPTION
     + "This command takes as input any number of tissue components (e.g. from "
     "multi-tissue CSD) and outputs corresponding normalised tissue components "
@@ -105,6 +100,11 @@ void usage ()
 
     + Option ("check_factors", "output the tissue balance factors computed during normalisation.")
     + Argument ("file").type_file_out ();
+
+    REFERENCES
+    + "Raffelt, D.; Dhollander, T.; Tournier, J.-D.; Tabbara, R.; Smith, R. E.; Pierre, E. & Connelly, A. " // Internal
+    "Bias Field Correction and Intensity Normalisation for Quantitative Analysis of Apparent Fibre Density. "
+    "In Proc. ISMRM, 2017, 26, 3541";
 
 }
 

--- a/cmd/warp2metric.cpp
+++ b/cmd/warp2metric.cpp
@@ -37,7 +37,7 @@ void usage ()
   REFERENCES
   + "Raffelt, D.; Tournier, JD/; Smith, RE.; Vaughan, DN.; Jackson, G.; Ridgway, GR. Connelly, A." // Internal
     "Investigating White Matter Fibre Density and Morphology using Fixel-Based Analysis. "
-    "Neuroimage, 2016, 10.1016/j.neuroimage.2016.09.029";
+    "Neuroimage, 2017, 144, 58-73, doi: 10.1016/j.neuroimage.2016.09.029";
 
   ARGUMENTS
   + Argument ("in", "the input deformation field").type_image_in();

--- a/docs/reference/commands/dwi2mask.rst
+++ b/docs/reference/commands/dwi2mask.rst
@@ -59,7 +59,7 @@ Standard options
 References
 ^^^^^^^^^^
 
-Dhollander T, Raffelt D, Connelly A. Unsupervised 3-tissue response function estimation from single-shell or multi-shell diffusion MR data without a co-registered T1 image. ISMRM Workshop on Breaking the Barriers of Diffusion MRI, 2016, 5.
+Dhollander T, Raffelt D, Connelly A. Unsupervised 3-tissue response function estimation from single-shell or multi-shell diffusion MR data without a co-registered T1 image. ISMRM Workshop on Breaking the Barriers of Diffusion MRI, 2016, 5
 
 Tournier, J.-D.; Smith, R. E.; Raffelt, D.; Tabbara, R.; Dhollander, T.; Pietsch, M.; Christiaens, D.; Jeurissen, B.; Yeh, C.-H. & Connelly, A. MRtrix3: A fast, flexible and open software framework for medical image processing and visualisation. NeuroImage, 2019, 202, 116137
 

--- a/docs/reference/commands/dwi2tensor.rst
+++ b/docs/reference/commands/dwi2tensor.rst
@@ -83,7 +83,7 @@ References
 References based on fitting algorithm used:
 
 * OLS, WLS: |br|
-  Basser, P.J.; Mattiello, J.; LeBihan, D.Estimation of the effective self-diffusion tensor from the NMR spin echo.J Magn Reson B., 1994, 103, 247–254.
+  Basser, P.J.; Mattiello, J.; LeBihan, D. Estimation of the effective self-diffusion tensor from the NMR spin echo. J Magn Reson B., 1994, 103, 247–254.
 
 * IWLS: |br|
   Veraart, J.; Sijbers, J.; Sunaert, S.; Leemans, A. & Jeurissen, B. Weighted linear least squares estimation of diffusion MRI parameters: strengths, limitations, and pitfalls. NeuroImage, 2013, 81, 335-346

--- a/docs/reference/commands/fixelcfestats.rst
+++ b/docs/reference/commands/fixelcfestats.rst
@@ -107,13 +107,10 @@ Standard options
 References
 ^^^^^^^^^^
 
-Raffelt, D.; Smith, RE.; Ridgway, GR.; Tournier, JD.; Vaughan, DN.; Rose, S.; Henderson, R.; Connelly, A.Connectivity-based fixel enhancement: Whole-brain statistical analysis of diffusion MRI measures in the presence of crossing fibres.Neuroimage, 2015, 15(117):40-55
+Raffelt, D.; Smith, RE.; Ridgway, GR.; Tournier, JD.; Vaughan, DN.; Rose, S.; Henderson, R.; Connelly, A. Connectivity-based fixel enhancement: Whole-brain statistical analysis of diffusion MRI measures in the presence of crossing fibres.Neuroimage, 2015, 15(117):40-55
 
 * If not using the -cfe_legacy option:  |br|
-  Smith, RE.; Dimond, D; Vaughan, D.; Parker, D.; Dhollander, T.; Jackson, G.; Connelly, A.  |br|
-  Intrinsic non-stationarity correction for Fixel-Based Analysis.  |br|
-  In Proc OHBM 2019 M789 |br|
-  
+  Smith, RE.; Dimond, D; Vaughan, D.; Parker, D.; Dhollander, T.; Jackson, G.; Connelly, A. Intrinsic non-stationarity correction for Fixel-Based Analysis. In Proc OHBM 2019 M789
 
 * If using the -nonstationary option:  |br|
   Salimi-Khorshidi, G. Smith, S.M. Nichols, T.E. Adjusting the effect of nonstationarity in cluster-based and TFCE inference. NeuroImage, 2011, 54(3), 2006-19

--- a/docs/reference/commands/fod2dec.rst
+++ b/docs/reference/commands/fod2dec.rst
@@ -65,9 +65,9 @@ Standard options
 References
 ^^^^^^^^^^
 
-Dhollander T, Smith RE, Tournier JD, Jeurissen B, Connelly A. Time to move on: an FOD-based DEC map to replace DTI's trademark DEC FA. Proc Intl Soc Mag Reson Med, 2015, 23, 1027.
+Dhollander T, Smith RE, Tournier JD, Jeurissen B, Connelly A. Time to move on: an FOD-based DEC map to replace DTI's trademark DEC FA. Proc Intl Soc Mag Reson Med, 2015, 23, 1027
 
-Dhollander T, Raffelt D, Smith RE, Connelly A. Panchromatic sharpening of FOD-based DEC maps by structural T1 information. Proc Intl Soc Mag Reson Med, 2015, 23, 566.
+Dhollander T, Raffelt D, Smith RE, Connelly A. Panchromatic sharpening of FOD-based DEC maps by structural T1 information. Proc Intl Soc Mag Reson Med, 2015, 23, 566
 
 Tournier, J.-D.; Smith, R. E.; Raffelt, D.; Tabbara, R.; Dhollander, T.; Pietsch, M.; Christiaens, D.; Jeurissen, B.; Yeh, C.-H. & Connelly, A. MRtrix3: A fast, flexible and open software framework for medical image processing and visualisation. NeuroImage, 2019, 202, 116137
 

--- a/docs/reference/commands/fod2fixel.rst
+++ b/docs/reference/commands/fod2fixel.rst
@@ -78,7 +78,7 @@ References
   Smith, R. E.; Tournier, J.-D.; Calamante, F. & Connelly, A. SIFT: Spherical-deconvolution informed filtering of tractograms. NeuroImage, 2013, 67, 298-312 (Appendix 2)
 
 * Reference for Apparent Fibre Density (AFD): |br|
-  Raffelt, D.; Tournier, J.-D.; Rose, S.; Ridgway, G.R.; Henderson, R.; Crozier, S.; Salvado, O.; Connelly, A. Apparent Fibre Density: a novel measure for the analysis of diffusion-weighted magnetic resonance images.Neuroimage, 2012, 15;59(4), 3976-94.
+  Raffelt, D.; Tournier, J.-D.; Rose, S.; Ridgway, G.R.; Henderson, R.; Crozier, S.; Salvado, O.; Connelly, A. Apparent Fibre Density: a novel measure for the analysis of diffusion-weighted magnetic resonance images.Neuroimage, 2012, 15;59(4), 3976-94
 
 Tournier, J.-D.; Smith, R. E.; Raffelt, D.; Tabbara, R.; Dhollander, T.; Pietsch, M.; Christiaens, D.; Jeurissen, B.; Yeh, C.-H. & Connelly, A. MRtrix3: A fast, flexible and open software framework for medical image processing and visualisation. NeuroImage, 2019, 202, 116137
 

--- a/docs/reference/commands/mrtransform.rst
+++ b/docs/reference/commands/mrtransform.rst
@@ -137,7 +137,7 @@ References
   Raffelt, D.; Tournier, J.-D.; Crozier, S.; Connelly, A. & Salvado, O. Reorientation of fiber orientation distributions using apodized point spread functions. Magnetic Resonance in Medicine, 2012, 67, 844-855
 
 * If FOD modulation is being performed: |br|
-  Raffelt, D.; Tournier, J.-D.; Rose, S.; Ridgway, G.R.; Henderson, R.; Crozier, S.; Salvado, O.; Connelly, A.; Apparent Fibre Density: a novel measure for the analysis of diffusion-weighted magnetic resonance images. NeuroImage, 2012, 15;59(4), 3976-94.
+  Raffelt, D.; Tournier, J.-D.; Rose, S.; Ridgway, G.R.; Henderson, R.; Crozier, S.; Salvado, O.; Connelly, A.; Apparent Fibre Density: a novel measure for the analysis of diffusion-weighted magnetic resonance images. NeuroImage, 2012, 15;59(4), 3976-94
 
 Tournier, J.-D.; Smith, R. E.; Raffelt, D.; Tabbara, R.; Dhollander, T.; Pietsch, M.; Christiaens, D.; Jeurissen, B.; Yeh, C.-H. & Connelly, A. MRtrix3: A fast, flexible and open software framework for medical image processing and visualisation. NeuroImage, 2019, 202, 116137
 

--- a/docs/reference/commands/warp2metric.rst
+++ b/docs/reference/commands/warp2metric.rst
@@ -48,7 +48,7 @@ Standard options
 References
 ^^^^^^^^^^
 
-Raffelt, D.; Tournier, JD/; Smith, RE.; Vaughan, DN.; Jackson, G.; Ridgway, GR. Connelly, A.Investigating White Matter Fibre Density and Morphology using Fixel-Based Analysis. Neuroimage, 2016, 10.1016/j.neuroimage.2016.09.029
+Raffelt, D.; Tournier, JD/; Smith, RE.; Vaughan, DN.; Jackson, G.; Ridgway, GR. Connelly, A.Investigating White Matter Fibre Density and Morphology using Fixel-Based Analysis. Neuroimage, 2017, 144, 58-73, doi: 10.1016/j.neuroimage.2016.09.029
 
 Tournier, J.-D.; Smith, R. E.; Raffelt, D.; Tabbara, R.; Dhollander, T.; Pietsch, M.; Christiaens, D.; Jeurissen, B.; Yeh, C.-H. & Connelly, A. MRtrix3: A fast, flexible and open software framework for medical image processing and visualisation. NeuroImage, 2019, 202, 116137
 


### PR DESCRIPTION
Moving the `REFERENCES` section in `mtnormalise` was necessary to prevent the website publication crawler script from crashing out. The rest are just small fixes to the formatting that comes out of that script.