### PR TITLE
GitHub Actions: don't trigger on pull request edited

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,10 +2,12 @@ name: checks
 
 on:
   pull_request:
-    types: [opened, synchronize, edited]
+    types: [opened, synchronize]
     branches:
       - master
       - dev
+
+
 
 jobs:
   linux-clang-build:


### PR DESCRIPTION
This is to avoid cluster of actions getting triggered every time a pull request is commented on or mentioned in a separate issue, etc... :angry: 