### PR TITLE
Update MRTRIX_BASE_VERSION to "3.0.0"

### DIFF
--- a/core/version.h
+++ b/core/version.h
@@ -9,7 +9,7 @@
 //   git tag -s 3.3
 //   git push --follow-tags
 
-#define MRTRIX_BASE_VERSION "3.0_RC4"
+#define MRTRIX_BASE_VERSION "3.0.0"
 
 #endif
 


### PR DESCRIPTION
Necessary for builds triggered for GitHub release to function.

I think that in order to have the CI tests pass at every step:

- Leave `core/version.h` not updated for #2021 for CI tests to pass;

- Create the tag based on the outcome of merging #2021;

- Make a new PR that just makes the update to `core/version.h`;

- Generate the release after that PR is merged.