### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,6 +14,5 @@
 
 # Auxillary files
 *.svg       binary -diff
-share/*.txt text -diff
 
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,19 @@
+# Sources
+*.h     text diff=cpp
+*.cpp   text diff=cpp
+*.py    text diff=python
+*.m     text diff=matlab
+
+
+# Documentation
+*.md    text
+*.rst   text
+*.html  text -diff
+*.css   text -diff
+
+
+# Auxillary files
+*.svg       binary -diff
+share/*.txt text -diff
+
+


### PR DESCRIPTION
Adds a `.gitattributes` file to set `git diff` attributes for the most common file types in the repo. This allows to specify the programming language where Linguist doesn't detect it correctly (that 0.2% C, for instance), and also to exclude the SVG icons and the atlas parcellation files from the `git` stats.

We may want to discuss if we want to count the user documentation as part of the code base or not. Currently, they show up in the stats and account for a fair number of line changes because of their verbosity. If we want to, we should be able to suppress them by adding a `-diff` flag in the `.gitattributes` file.