### PR TITLE
CohortDataImport::initialise(): Fix for cwd

### DIFF
--- a/core/math/stats/import.h
+++ b/core/math/stats/import.h
@@ -146,7 +146,9 @@ namespace MR
         }
 
         vector<std::string> directories { Path::dirname (listpath) };
-        if (directories[0].size() && directories[0] != ".")
+        if (directories[0].empty())
+          directories[0] = ".";
+        else if (directories[0] != ".")
           directories.push_back (".");
         if (explicit_from_directory.size())
           directories.insert (directories.begin(), explicit_from_directory);


### PR DESCRIPTION
Fixes issue reported on [forum](https://community.mrtrix.org/t/connectomestats-unable-to-load-all-input-data-error/3595/5).

Fixes issue where an exception is erroneously thrown when the subject filename list resides in the current working directory, and no template directory is defined. 

Error arising from #1977.

It is possible to bypass the issue by simply prepending the path to the subject file list with "`./`"; nevertheless targeting at `master` since it's a bug.