### PR TITLE
add 404 page to docs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -160,7 +160,8 @@ jobs:
     - name: install dependencies
       run: |
          sudo apt-get update
-         sudo apt-get install pylint pylint3 python3-sphinx sphinx-rtd-theme-common python3-recommonmark python3-sphinx-rtd-theme
+         sudo apt-get install pylint pylint3 python3-sphinx sphinx-rtd-theme-common python3-recommonmark python3-sphinx-rtd-theme python3-pip
+         pip3 install sphinx-notfound-page
 
 
     - name: check syntax

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,25 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Build documentation with MkDocs
+#mkdocs:
+#  configuration: mkdocs.yml
+
+# Optionally build your docs in additional formats such as PDF
+formats:
+  - pdf
+  - epub
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+   version: 3.7
+   install:
+      - requirements: docs/requirements.txt

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ The [online documentation for *MRtrix3*](http://mrtrix.readthedocs.org/) is gene
 
 3. Install requisite Python packages using `pip` (may require `sudo`):
 
-   -  `pip install recommonmark sphinx sphinx_rtd_theme typing`
+   -  `pip install recommonmark sphinx sphinx_rtd_theme typing notfound.extension`
       (should not need to include `sphinx` in this list if it was installed via the distribution package manager in step 2)
 
 4. Compile the documentation:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ import os
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [ 'sphinx.ext.mathjax' ]
+extensions = [ 'sphinx.ext.mathjax', 'notfound.extension' ]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -308,3 +308,9 @@ else:
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
+
+
+# --- options for 404 sphinx-notfound-page
+
+notfound_context = {'title': 'Page not found', 'body': '<h1>Page not found</h1>\n\nThis page does not exist in this version of the MRtrix3 docs. Sorry about that. Please select the appropriate version and use the menu or search functionality.'}
+

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+sphinx-notfound-page


### PR DESCRIPTION
implements a 404 page, replacing the default Maze page

- uses the [sphinx-notfound-page](https://sphinx-notfound-page.readthedocs.io/) plugin
- had to install it explicitly via pip in github workflow, updated the README and added a requirements.txt file in docs/
- added the dependency to a new readthedocs yml config file

With this plugin, loading a nonexistent URL still emits a 404 signal. 

One issue is that on the 404.html page, if one selects a different version of the docs from the menu, one is redirected to a 404.html page relative to that version (which does not exist for older versions) instead of reusing and following the actual link. 
For instance: https://mrtrix.readthedocs.io/en/docs_404/does_not_exist --> https://mrtrix.readthedocs.io/en/latest/404.html instead of 
https://mrtrix.readthedocs.io/en/latest/does_not_exist