### PR TITLE
progressbar: fix behaviour under redirection

### DIFF
--- a/core/progressbar.cpp
+++ b/core/progressbar.cpp
@@ -106,12 +106,14 @@ namespace MR
       else {
         __need_newline = true;
         if (p.show_percent()) {
-          if (p.value() == 0) {
+          if (p.first_time) {
+             p.first_time = false;
             __print_stderr (printf ("%s: %s%s [",
                   App::NAME.c_str(), p.text().c_str(), p.ellipsis().c_str()));;
           }
-          else if (p.value()%2 == 0) {
+          else while (p.last_value < p.value()) {
             __print_stderr (printf ("="));
+            p.last_value += 2;
           }
         }
         else {
@@ -141,7 +143,7 @@ namespace MR
         if (p.show_percent())
           __print_stderr (printf ("]\n"));
         else
-          __print_stderr (printf (" done\n"));
+          __print_stderr (printf ("done\n"));
       }
       __need_newline = false;
     }

--- a/core/progressbar.h
+++ b/core/progressbar.h
@@ -162,6 +162,9 @@ namespace MR
       static std::mutex mutex;;
       static void* data;
 
+      mutable bool first_time;
+      mutable size_t last_value;
+
     private:
 
       const bool show;
@@ -187,9 +190,11 @@ namespace MR
 
 
   FORCE_INLINE ProgressBar::ProgressBar (const std::string& text, size_t target, int log_level) :
+    first_time (true),
+    last_value (0),
     show (std::this_thread::get_id() == ::MR::App::main_thread_ID && !progressbar_active && App::log_level >= log_level),
     _text (text),
-    _ellipsis ("... "),
+    _ellipsis ("..."),
     _value (0),
     current_val (0),
     next_percent (0),
@@ -211,13 +216,9 @@ namespace MR
       return;
     if (target) {
       _multiplier = 0.01 * target;
-      next_percent = _multiplier;
-      if (!next_percent)
-        next_percent = 1;
     }
     else {
       _multiplier = 0.0;
-      next_time = BUSY_INTERVAL;
       timer.start();
     }
   }


### PR DESCRIPTION
Minor issue reported by @dchristiaens , but fixes a problem left over from #1586. This only influences the progressbar updates when redirected away from the terminal. 

Example for a simple mrconvert DICOM to nii conversion:
```
mrconvert 3dfl/ anat.nii 2> log.txt
```

Content of `log.txt` using current `master`:
```
 done
============================================]
=====================]
```

Content of `log.txt` using this PR:
```
mrconvert: scanning DICOM folder "3dfl/"... done
mrconvert: reading DICOM series "fl3D_1x1x1_tra"... [==================================================]
mrconvert: copying from "XXXXXXXX...ri vol) [MR] fl3D_1x1x1_tra" to "anat.nii"... [==================================================]
```