### PR TITLE
tck2fixel: detect corruption in index file

### DIFF
--- a/cmd/tck2fixel.cpp
+++ b/cmd/tck2fixel.cpp
@@ -147,8 +147,12 @@ void run ()
     Transform image_transform (index_image);
     for (auto i = Loop ("loading template fixel directions and positions", index_image, 0, 3)(index_image); i; ++i) {
       const Eigen::Vector3 vox ((default_type)index_image.index(0), (default_type)index_image.index(1), (default_type)index_image.index(2));
+      index_image.index(3) = 0;
+      index_type num = index_image.value();
       index_image.index(3) = 1;
       index_type offset = index_image.value();
+      if (offset + num > num_fixels)
+        throw Exception ("fixel index \"" + index_image.name() + "\" makes reference to out of bounds fixel!");
       index_type fixel_index = 0;
       for (auto f = Fixel::Loop (index_image) (directions_data); f; ++f, ++fixel_index) {
         directions[offset + fixel_index] = directions_data.row(1);


### PR DESCRIPTION
Just came across a case where the user's index file was totally borked. Not sure how that happened, but it clearly contained garbage, while the `nfixels` header entry was preserved and correct (as in, it matched the dimensions of the directions file). This means the `Fixel::get_number_of_fixels()` returns the header value straightaway without actually checking the contents of the index map. Took quite a while to figure out what the problem was... 

I'm not sure my proposed fix is the best way to handle this, it may be better to use a more generic way to detect this across fixel apps more broadly - perhaps in `Fixel::get_number_of_fixels()`? Basically, always check the `nfixel` value against the contents of the file regardless. I have a feeling something like this might already have been discussed, but I can't remember where...

We might also want to have a more informative error message here. So this remains a draft for now.