### PR TITLE
mtnormalise: warn if only one contrast provided

### DIFF
--- a/cmd/mtnormalise.cpp
+++ b/cmd/mtnormalise.cpp
@@ -487,6 +487,8 @@ void run ()
 {
   if (argument.size() % 2)
     throw Exception ("The number of arguments must be even, provided as pairs of each input and its corresponding output file.");
+  if (argument.size() == 2)
+    WARN("Only one contrast provided. If multi-tissue CSD was performed, provide all components to mtnormalise.");
 
   const int order = get_option_value<int> ("order", DEFAULT_POLY_ORDER);
   const float reference_value = get_option_value ("reference", DEFAULT_REFERENCE_VALUE);


### PR DESCRIPTION
I'd add a warning to prevent accidental use of only one component in `mtnormalise`. This issue came up when debugging a user's analysis.

```
$ mtnormalise wm.mif wm_norm.mif -mask mask.mif
mtnormalise: [WARNING] Only one contrast provided. If multi-tissue CSD was performed, provide all components to mtnormalise.
mtnormalise: [100%] performing log-domain intensity normalisation
```