### PR TITLE
dwifslpreproc: eddy error message

### DIFF
--- a/bin/dwifslpreproc
+++ b/bin/dwifslpreproc
@@ -907,13 +907,45 @@ def execute(): #pylint: disable=unused-variable
     # If running CUDA version, but OpenMP version is also available, don't stop the script if the CUDA version fails
     try:
       eddy_output = run.command(eddy_cuda_cmd + ' ' + eddy_all_options)
-    except run.MRtrixCmdError as exception:
+    except run.MRtrixCmdError as exception_cuda:
       if not eddy_openmp_cmd:
         raise
       with open('eddy_cuda_failure_output.txt', 'w') as eddy_output_file:
-        eddy_output_file.write(exception.stdout + '\n' + exception.stderr + '\n')
+        eddy_output_file.write(str(exception_cuda))
       app.console('CUDA version of \'eddy\' was not successful; attempting OpenMP version')
-      eddy_output = run.command(eddy_openmp_cmd + ' ' + eddy_all_options)
+      try:
+        eddy_output = run.command(eddy_openmp_cmd + ' ' + eddy_all_options)
+      except run.MRtrixCmdError as exception_openmp:
+        with open('eddy_openmp_failure_output.txt', 'w') as eddy_output_file:
+          eddy_output_file.write(str(exception_openmp))
+        # Both have failed; want to combine error messages
+        eddy_cuda_header = ('=' * len(exception_cuda.cmd)) \
+                           + '\n' \
+                           + exception_cuda.cmd \
+                           + '\n' \
+                           + ('=' * len(exception_cuda.cmd)) \
+                           + '\n'
+        eddy_openmp_header = ('=' * len(exception_openmp.cmd)) \
+                             + '\n' \
+                             + exception_openmp.cmd \
+                             + '\n' \
+                             + ('=' * len(exception_openmp.cmd)) \
+                             + '\n'
+        exception_stdout = eddy_cuda_header \
+                           + exception_cuda.stdout \
+                           + '\n\n' \
+                           + eddy_openmp_header \
+                           + exception_openmp.stdout
+        exception_stderr = eddy_cuda_header \
+                           + exception_cuda.stderr \
+                           + '\n\n'
+                           + eddy_openmp_header \
+                           + exception_openmp.stderr
+        raise run.MRtrixCmdError('eddy* ' + eddy_all_options,
+                                 1,
+                                 exception_stdout,
+                                 exception_stderr)
+
   else:
     eddy_output = run.command(eddy_openmp_cmd + ' ' + eddy_all_options)
   with open('eddy_output.txt', 'w') as eddy_output_file:

--- a/bin/dwifslpreproc
+++ b/bin/dwifslpreproc
@@ -938,7 +938,7 @@ def execute(): #pylint: disable=unused-variable
                            + exception_openmp.stdout
         exception_stderr = eddy_cuda_header \
                            + exception_cuda.stderr \
-                           + '\n\n'
+                           + '\n\n' \
                            + eddy_openmp_header \
                            + exception_openmp.stderr
         raise run.MRtrixCmdError('eddy* ' + eddy_all_options,

--- a/bin/dwifslpreproc
+++ b/bin/dwifslpreproc
@@ -919,28 +919,30 @@ def execute(): #pylint: disable=unused-variable
         with open('eddy_openmp_failure_output.txt', 'w') as eddy_output_file:
           eddy_output_file.write(str(exception_openmp))
         # Both have failed; want to combine error messages
-        eddy_cuda_header = ('=' * len(exception_cuda.cmd)) \
+        eddy_cuda_header = ('=' * len(eddy_cuda_cmd)) \
                            + '\n' \
-                           + exception_cuda.cmd \
+                           + eddy_cuda_cmd \
                            + '\n' \
-                           + ('=' * len(exception_cuda.cmd)) \
+                           + ('=' * len(eddy_cuda_cmd)) \
                            + '\n'
-        eddy_openmp_header = ('=' * len(exception_openmp.cmd)) \
+        eddy_openmp_header = ('=' * len(eddy_openmp_cmd)) \
                              + '\n' \
-                             + exception_openmp.cmd \
+                             + eddy_openmp_cmd \
                              + '\n' \
-                             + ('=' * len(exception_openmp.cmd)) \
+                             + ('=' * len(eddy_openmp_cmd)) \
                              + '\n'
         exception_stdout = eddy_cuda_header \
                            + exception_cuda.stdout \
                            + '\n\n' \
                            + eddy_openmp_header \
-                           + exception_openmp.stdout
+                           + exception_openmp.stdout \
+                           + '\n\n'
         exception_stderr = eddy_cuda_header \
                            + exception_cuda.stderr \
                            + '\n\n' \
                            + eddy_openmp_header \
-                           + exception_openmp.stderr
+                           + exception_openmp.stderr \
+                           + '\n\n'
         raise run.MRtrixCmdError('eddy* ' + eddy_all_options,
                                  1,
                                  exception_stdout,


### PR DESCRIPTION
Modification resulting from my own needing to be able to catch eddy errors and modify parameters accordingly within an automated pipeline; but likely beneficial for users executing the script directly as well.

Basically, if the CUDA version of `eddy` fails, the resulting error message gets essentially hidden, because the exception is caught, the OpenMP version is run, and the error message produced by that version may give no insight into why the CUDA version failed.

With this change, if both the CUDA and OpenMP versions of `eddy` fail, the resulting error messages are concatenated into a single exception. When that is raised, the user (/ wrapping script) is provided with the terminal outputs generated by both versions of the command, enabling proper diagnosis.