### PR TITLE
mrview: add viridis colour maps and fix PET colour map

### DIFF
--- a/cmd/mrcolour.cpp
+++ b/cmd/mrcolour.cpp
@@ -114,12 +114,12 @@ void run ()
   }
 
   auto in = H_in.get_image<float>();
-  float lower = int(argument[1]) == 6 ? 0.0 : get_option_value ("lower", NaN);
+  float lower = colourmap.is_rgb ? 0.0 : get_option_value ("lower", NaN);
   float upper = get_option_value ("upper", NaN);
   if (!std::isfinite (lower) || !std::isfinite (upper)) {
     float image_min = NaN, image_max = NaN;
     min_max (in, image_min, image_max);
-    if (int(argument[1]) == 6) { // RGB
+    if (colourmap.is_rgb) { // RGB
       image_max = std::max (MR::abs (image_min), MR::abs (image_max));
     } else {
       if (!std::isfinite (lower)) {

--- a/docs/reference/commands/mrcolour.rst
+++ b/docs/reference/commands/mrcolour.rst
@@ -16,7 +16,7 @@ Usage
     mrcolour [ options ]  input map output
 
 -  *input*: the input image
--  *map*: the colourmap to apply; choices are: gray,hot,cool,jet,pet,colour,rgb
+-  *map*: the colourmap to apply; choices are: gray,hot,cool,jet,inferno,viridis,pet,colour,rgb
 -  *output*: the output image
 
 Description

--- a/src/colourmap.cpp
+++ b/src/colourmap.cpp
@@ -98,12 +98,12 @@ namespace MR
               }),
 
           Entry ("PET",
-              "color.r = 2.0*amplitude - 0.5;\n"
+              "color.r = clamp (2.0*amplitude - 0.5, 0.0, 1.0);\n"
               "color.g = clamp (2.0 * (0.25 - abs (amplitude - 0.25)), 0.0, 1.0) + clamp (2.0*amplitude - 1.0, 0.0, 1.0);\n"
               "color.b = 1.0 - (clamp (1.0 - 2.0 * amplitude, 0.0, 1.0) + clamp (1.0 - 4.0 * abs (amplitude - 0.75), 0.0, 1.0));\n",
               [] (float amplitude) { return Eigen::Array3f (clamp (2.0f * amplitude - 0.5f),
-                                                            clamp (0.25f - abs (amplitude - 0.25f)) + clamp (2.0f * (amplitude - 0.5)),
-                                                            clamp (1.0f - 2.0f * amplitude) + clamp (1.0 - 4.0 * abs (amplitude - 0.75))); }),
+                                                            clamp (2.0f * (0.25f - abs (amplitude - 0.25f))) + clamp (2.0f * amplitude - 1.0f),
+                                                            1.0f - (clamp (1.0f - 2.0f * amplitude) + clamp (1.0f - 4.0f * abs (amplitude - 0.75f)))); }),
 
           Entry ("Colour",
               "color.rgb = amplitude * colourmap_colour;\n",

--- a/src/colourmap.cpp
+++ b/src/colourmap.cpp
@@ -50,6 +50,53 @@ namespace MR
                                                             clamp (1.5f - 4.0f * abs (1.0f - amplitude - 0.5f)),
                                                             clamp (1.5f - 4.0f * abs (1.0f - amplitude - 0.75f))); }),
 
+          // The Inferno and Viridis colour maps are implemented using a 6th order polynomial approximation of the originals,
+          // ported from https://www.shadertoy.com/view/WlfXRN (public domain; CC0 license).
+
+          Entry ("Inferno",
+              "const vec3 c0 = vec3(0.0002189403691192265, 0.001651004631001012, -0.01948089843709184);\n"
+              "const vec3 c1 = vec3(0.1065134194856116, 0.5639564367884091, 3.932712388889277);\n"
+              "const vec3 c2 = vec3(11.60249308247187, -3.972853965665698, -15.9423941062914);\n"
+              "const vec3 c3 = vec3(-41.70399613139459, 17.43639888205313, 44.35414519872813);\n"
+              "const vec3 c4 = vec3(77.162935699427, -33.40235894210092, -81.80730925738993);\n"
+              "const vec3 c5 = vec3(-71.31942824499214, 32.62606426397723, 73.20951985803202);\n"
+              "const vec3 c6 = vec3(25.13112622477341, -12.24266895238567, -23.07032500287172);\n"
+              "color.rgb = clamp( c0 + amplitude*(c1 + amplitude*(c2 + amplitude*(c3 + amplitude*(c4 + amplitude*(c5 + amplitude*c6))))), 0.0, 1.0);\n",
+              [] (float amplitude) {
+                Eigen::Array3f c0 (0.0002189403691192265, 0.001651004631001012, -0.01948089843709184);
+                Eigen::Array3f c1 (0.1065134194856116, 0.5639564367884091, 3.932712388889277);
+                Eigen::Array3f c2 (11.60249308247187, -3.972853965665698, -15.9423941062914);
+                Eigen::Array3f c3 (-41.70399613139459, 17.43639888205313, 44.35414519872813);
+                Eigen::Array3f c4 (77.162935699427, -33.40235894210092, -81.80730925738993);
+                Eigen::Array3f c5 (-71.31942824499214, 32.62606426397723, 73.20951985803202);
+                Eigen::Array3f c6 (25.13112622477341, -12.24266895238567, -23.07032500287172);  
+                Eigen::Array3f rgb = c0 + amplitude*(c1 + amplitude*(c2 + amplitude*(c3 + amplitude*(c4 + amplitude*(c5 + amplitude*c6)))));
+                rgb = rgb.max(0.0).min(1.0);
+                return rgb;
+              }),
+          
+          Entry ("Viridis",
+              "const vec3 c0 = vec3(0.2777273272234177, 0.005407344544966578, 0.3340998053353061);\n"
+              "const vec3 c1 = vec3(0.1050930431085774, 1.404613529898575, 1.384590162594685);\n"
+              "const vec3 c2 = vec3(-0.3308618287255563, 0.214847559468213, 0.09509516302823659);\n"
+              "const vec3 c3 = vec3(-4.634230498983486, -5.799100973351585, -19.33244095627987);\n"
+              "const vec3 c4 = vec3(6.228269936347081, 14.17993336680509, 56.69055260068105);\n"
+              "const vec3 c5 = vec3(4.776384997670288, -13.74514537774601, -65.35303263337234);\n"
+              "const vec3 c6 = vec3(-5.435455855934631, 4.645852612178535, 26.3124352495832);\n"
+              "color.rgb = clamp( c0 + amplitude*(c1 + amplitude*(c2 + amplitude*(c3 + amplitude*(c4 + amplitude*(c5 + amplitude*c6))))), 0.0, 1.0);\n",
+              [] (float amplitude) {
+                Eigen::Array3f c0 (0.2777273272234177, 0.005407344544966578, 0.3340998053353061);
+                Eigen::Array3f c1 (0.1050930431085774, 1.404613529898575, 1.384590162594685);
+                Eigen::Array3f c2 (-0.3308618287255563, 0.214847559468213, 0.09509516302823659);
+                Eigen::Array3f c3 (-4.634230498983486, -5.799100973351585, -19.33244095627987);
+                Eigen::Array3f c4 (6.228269936347081, 14.17993336680509, 56.69055260068105);
+                Eigen::Array3f c5 (4.776384997670288, -13.74514537774601, -65.35303263337234);
+                Eigen::Array3f c6 (-5.435455855934631, 4.645852612178535, 26.3124352495832);
+                Eigen::Array3f rgb = c0 + amplitude*(c1 + amplitude*(c2 + amplitude*(c3 + amplitude*(c4 + amplitude*(c5 + amplitude*c6)))));
+                rgb = rgb.max(0.0).min(1.0);
+                return rgb;
+              }),
+
           Entry ("PET",
               "color.r = 2.0*amplitude - 0.5;\n"
               "color.g = clamp (2.0 * (0.25 - abs (amplitude - 0.25)), 0.0, 1.0) + clamp (2.0*amplitude - 1.0, 0.0, 1.0);\n"

--- a/testing/binaries/tests/mrcolour
+++ b/testing/binaries/tests/mrcolour
@@ -3,6 +3,8 @@ mrcolour dwi_mean.mif gray - | testing_diff_image - mrcolour/gray.mif
 mrcolour dwi_mean.mif hot - | testing_diff_image - mrcolour/hot.mif
 mrcolour dwi_mean.mif cool - | testing_diff_image - mrcolour/cool.mif
 mrcolour dwi_mean.mif jet - | testing_diff_image - mrcolour/jet.mif
+mrcolour dwi_mean.mif inferno - | testing_diff_image - mrcolour/inferno.mif
+mrcolour dwi_mean.mif viridis - | testing_diff_image - mrcolour/viridis.mif
 mrcolour dwi_mean.mif pet - | testing_diff_image - mrcolour/pet.mif
 mrcolour unit_warp.mif rgb - | testing_diff_image - $(mrcalc unit_warp.mif $(mrstats unit_warp.mif -output max -allvolumes) -div -) -frac 1e-6
 mrcolour dwi_mean.mif gray -upper 80 - | testing_diff_image - mrcolour/upper.mif


### PR DESCRIPTION
This PR adds two of my favourite colour maps, [viridis and inferno](https://bids.github.io/colormap/) to `mrview` and `mrcolour`. As opposed to _jet_ and others, these are perceptually uniform and also much more friendly to colourblind people.

Viridis:
<img width="809" alt="Screenshot 2020-06-17 at 18 27 34" src="https://user-images.githubusercontent.com/7466983/84929845-4f622000-b0c8-11ea-9795-980f0defe141.png">

Inferno:
<img width="809" alt="Screenshot 2020-06-17 at 18 27 42" src="https://user-images.githubusercontent.com/7466983/84929856-538e3d80-b0c8-11ea-8d32-f8c1b700eaa9.png">


The implementation uses a 6th order polynomial approximation published [here](https://www.shadertoy.com/view/WlfXRN) (public domain; CC0 license). Using this approximation seems a better fit with the MRtrix3 codebase than defining the [lookup tables](https://github.com/BIDS/colormap/blob/master/colormaps.py) of the original colour maps. I have compared them in python and they seem to be a fairly good match (shown here for inferno).
![Figure_1](https://user-images.githubusercontent.com/7466983/84930544-60f7f780-b0c9-11ea-8499-0360ebe1a5cb.png)

**Question:** Personally, I strongly prefer _inferno_ and _viridis_ over the _hot_ and _cool_ colour maps currently provided. To avoid overinflating the number of options in `mrview`, I would advocate to remove the _hot_ and _cool_ schemes from the menu. We could still offer them through `mrcolour` if people really want them. How do people feel about deprecating _hot_ and _cool_?