### PR TITLE
run_tests: Permit running with manually-downloaded test data

### DIFF
--- a/run_tests
+++ b/run_tests
@@ -82,13 +82,17 @@ EOD
 
 
 if [ ! -z $datadir ]; then
-  echo -n "fetching requisite test data... "
+  echo -n "checking for requisite test data... "
   git submodule update --init $datadir >> $LOGFILE 2>&1
   if [ $? != 0 ]; then
-    echo ERROR!
-    exit 1
+    if [[ -e $datadir && ! -z $(ls -A $datadir) ]]; then
+      echo "Found; UNABLE TO VERIFY VERSION MATCH"
+    else
+      echo "ERROR!"
+      exit 1
+    fi
   else
-    echo OK
+    echo "Synchronized OK"
   fi
 fi
 


### PR DESCRIPTION
As discussed in #1517.

Will permit execution of tests when using pre-compiled binaries by explicitly downloading the relevant test data into the appropriate location. No guarantee is provided with respect to correspondence between software and test data versions.