### PR TITLE
fix transformcalc header

### DIFF
--- a/cmd/transformcalc.cpp
+++ b/cmd/transformcalc.cpp
@@ -67,7 +67,8 @@ void usage ()
              "")
 
   + Example ("Calculate the transformation matrix from an original image and an image with modified header",
-             "transformcalc mov mapmovhdr header output",
+             "transformcalc original.mif modified.mif header output",
+             "This transformation can be used for instance: mrtransform original_too.mif -linear output modified_too.mif"
              "")
 
   + Example ("Calculate the average affine matrix of a set of input matrices",
@@ -202,6 +203,7 @@ void run ()
     case 3: { // header
       if (num_inputs != 2)
         throw Exception ("header requires 2 inputs");
+      Header::do_realign_transform = false;
       auto orig_header = Header::open (argument[0]);
       auto modified_header = Header::open (argument[1]);
 

--- a/docs/reference/commands/transformcalc.rst
+++ b/docs/reference/commands/transformcalc.rst
@@ -36,7 +36,9 @@ Example usages
 
 -   *Calculate the transformation matrix from an original image and an image with modified header*::
 
-        $ transformcalc mov mapmovhdr header output
+        $ transformcalc original.mif modified.mif header output
+
+    This transformation can be used for instance: mrtransform original_too.mif -linear output modified_too.mif
 
 -   *Calculate the average affine matrix of a set of input matrices*::
 


### PR DESCRIPTION
As reported on the [forum](https://community.mrtrix.org/t/2-questions-about-mrview-and-mrregister/3824), `transformcalc header` fails for large rotations in `mrview`'s transformation tool due to the axis interpretation. 

The proposed solution is to set `Header::do_realign_transform = false;`. I think this is sensible given the purpose of the tool but I am not sure if this brings any negative side effects for other use cases. Any opinions?