### PR TITLE
Support images with axis size greater than 2^31

### DIFF
--- a/cmd/amp2response.cpp
+++ b/cmd/amp2response.cpp
@@ -244,20 +244,18 @@ void run ()
     }
   }
 
-  vector<int> lmax;
-  int max_lmax = 0;
+  vector<uint32_t> lmax;
+  uint32_t max_lmax = 0;
   opt = get_options ("lmax");
   if (get_options("isotropic").size()) {
     for (size_t i = 0; i != dirs_azel.size(); ++i)
       lmax.push_back (0);
     max_lmax = 0;
   } else if (opt.size()) {
-    lmax = parse_ints (opt[0][0]);
+    lmax = parse_ints<uint32_t> (opt[0][0]);
     if (lmax.size() != dirs_azel.size())
       throw Exception ("Number of lmax\'s specified (" + str(lmax.size()) + ") does not match number of b-value shells (" + str(dirs_azel.size()) + ")");
     for (auto i : lmax) {
-      if (i < 0)
-        throw Exception ("Values specified for lmax must be non-negative");
       if (i%2)
         throw Exception ("Values specified for lmax must be even");
       max_lmax = std::max (max_lmax, i);

--- a/cmd/connectome2tck.cpp
+++ b/cmd/connectome2tck.cpp
@@ -222,14 +222,14 @@ void run ()
   bool manual_node_list = false;
   if (opt.size()) {
     manual_node_list = true;
-    vector<int> data = parse_ints (opt[0][0]);
+    const auto data = parse_ints<node_t> (opt[0][0]);
     bool zero_in_list = false;
-    for (vector<int>::const_iterator i = data.begin(); i != data.end(); ++i) {
-      if (size_t(*i) > max_node_index) {
-        WARN ("Node of interest " + str(*i) + " is above the maximum detected node index of " + str(max_node_index));
+    for (auto i : data) {
+      if (i > max_node_index) {
+        WARN ("Node of interest " + str(i) + " is above the maximum detected node index of " + str(max_node_index));
       } else {
-        nodes.push_back (node_t (*i));
-        if (!*i)
+        nodes.push_back (i);
+        if (!i)
           zero_in_list = true;
       }
     }

--- a/cmd/dwidenoise.cpp
+++ b/cmd/dwidenoise.cpp
@@ -129,7 +129,7 @@ public:
   using MatrixType = Eigen::Matrix<F, Eigen::Dynamic, Eigen::Dynamic>;
   using SValsType = Eigen::VectorXd;
 
-  DenoisingFunctor (int ndwi, const vector<int>& extent,
+  DenoisingFunctor (int ndwi, const vector<uint32_t>& extent,
                     Image<bool>& mask, Image<real_type>& noise, bool exp1)
     : extent {{extent[0]/2, extent[1]/2, extent[2]/2}},
       m (ndwi), n (extent[0]*extent[1]*extent[2]),
@@ -246,7 +246,7 @@ private:
 
 template <typename T>
 void process_image (Header& data, Image<bool>& mask, Image<real_type> noise,
-                    const std::string& output_name, const vector<int>& extent, bool exp1)
+                    const std::string& output_name, const vector<uint32_t>& extent, bool exp1)
   {
     auto input = data.get_image<T>().with_direct_io(3);
     // create output
@@ -275,9 +275,9 @@ void run ()
   }
 
   opt = get_options("extent");
-  vector<int> extent;
+  vector<uint32_t> extent;
   if (opt.size()) {
-    extent = parse_ints(opt[0][0]);
+    extent = parse_ints<uint32_t> (opt[0][0]);
     if (extent.size() == 1)
       extent = {extent[0], extent[0], extent[0]};
     if (extent.size() != 3)
@@ -287,7 +287,7 @@ void run ()
         throw Exception ("-extent must be a (list of) odd numbers");
     INFO("user defined patch size " + str(extent[0]) + " x " + str(extent[1]) + " x " + str(extent[2]) + ".");
   } else {
-    int e = 1;
+    uint32_t e = 1;
     while (e*e*e < dwi.size(3))
       e += 2;
     extent = {e, e, e};

--- a/cmd/dwiextract.cpp
+++ b/cmd/dwiextract.cpp
@@ -71,7 +71,7 @@ void run()
 
   // Want to support non-shell-like data if it's just a straight extraction
   //   of all dwis or all bzeros i.e. don't initialise the Shells class
-  vector<int> volumes;
+  vector<uint32_t> volumes;
   bool bzero = get_options ("bzero").size();
   if (get_options ("shells").size() || get_options ("singleshell").size()) {
     DWI::Shells shells (grad);
@@ -94,7 +94,7 @@ void run()
   } else {
     // "pe" option has been provided - need to initialise list of volumes
     //   to include all voxels, as the PE selection filters from this
-    for (int i = 0; i != grad.rows(); ++i)
+    for (uint32_t i = 0; i != grad.rows(); ++i)
       volumes.push_back (i);
   }
 
@@ -106,7 +106,7 @@ void run()
     const auto filter = parse_floats (opt[0][0]);
     if (!(filter.size() == 3 || filter.size() == 4))
       throw Exception ("Phase encoding filter must be a comma-separated list of either 3 or 4 numbers");
-    vector<int> new_volumes;
+    vector<uint32_t> new_volumes;
     for (const auto i : volumes) {
       bool keep = true;
       for (size_t axis = 0; axis != 3; ++axis) {

--- a/cmd/maskfilter.cpp
+++ b/cmd/maskfilter.cpp
@@ -183,7 +183,7 @@ void run () {
     Filter::Median filter (input_image, std::string("applying median filter to image ") + Path::basename (argument[0]));
     auto opt = get_options ("extent");
     if (opt.size())
-      filter.set_extent (parse_ints (opt[0][0]));
+      filter.set_extent (parse_ints<uint32_t> (opt[0][0]));
 
     Stride::set_from_command_line (filter);
     filter.datatype() = DataType::Bit;

--- a/cmd/mrconvert.cpp
+++ b/cmd/mrconvert.cpp
@@ -301,9 +301,9 @@ inline vector<int> set_header (Header& header, const ImageType& input)
   header.transform() = input.transform();
 
   auto opt = get_options ("axes");
-  vector<int> axes;
+  vector<int32_t> axes;
   if (opt.size()) {
-    axes = opt[0][0];
+    axes = parse_ints<int32_t> (opt[0][0]);
     header.ndim() = axes.size();
     for (size_t i = 0; i < axes.size(); ++i) {
       if (axes[i] >= static_cast<int> (input.ndim()))
@@ -363,7 +363,7 @@ void copy_permute (const InputType& in, Header& header_out, const std::string& o
 
 
 template <typename T>
-void extract (Header& header_in, Header& header_out, const vector<vector<int>>& pos, const std::string& output_filename)
+void extract (Header& header_in, Header& header_out, const vector<vector<uint32_t>>& pos, const std::string& output_filename)
 {
   auto in = header_in.get_image<T>();
   if (pos.empty()) {
@@ -460,16 +460,16 @@ void run ()
 
 
   opt = get_options ("coord");
-  vector<vector<int>> pos;
+  vector<vector<uint32_t>> pos;
   if (opt.size()) {
-    pos.assign (header_in.ndim(), vector<int>());
+    pos.assign (header_in.ndim(), vector<uint32_t>());
     for (size_t n = 0; n < opt.size(); n++) {
-      int axis = opt[n][0];
-      if (axis >= (int)header_in.ndim())
+      size_t axis = opt[n][0];
+      if (axis >= header_in.ndim())
         throw Exception ("axis " + str(axis) + " provided with -coord option is out of range of input image");
       if (pos[axis].size())
         throw Exception ("\"coord\" option specified twice for axis " + str (axis));
-      pos[axis] = parse_ints (opt[n][1], header_in.size(axis)-1);
+      pos[axis] = parse_ints<uint32_t> (opt[n][1], header_in.size(axis)-1);
 
       auto minval = std::min_element(std::begin(pos[axis]), std::end(pos[axis]));
       if (*minval < 0)
@@ -511,7 +511,7 @@ void run ()
     for (size_t n = 0; n < header_in.ndim(); ++n) {
       if (pos[n].empty()) {
         pos[n].resize (header_in.size (n));
-        for (size_t i = 0; i < pos[n].size(); i++)
+        for (uint32_t i = 0; i < uint32_t(pos[n].size()); i++)
           pos[n][i] = i;
       }
     }

--- a/cmd/mrdegibbs.cpp
+++ b/cmd/mrdegibbs.cpp
@@ -318,7 +318,7 @@ void run ()
   auto opt = get_options ("axes");
   const bool axes_set_manually = opt.size();
   if (opt.size()) {
-    vector<int> axes = opt[0][0];
+    vector<uint32_t> axes = parse_ints<uint32_t> (opt[0][0]);
     if (axes.size() != 2)
       throw Exception ("slice axes must be specified as a comma-separated 2-vector");
     if (size_t(std::max (axes[0], axes[1])) >= header.ndim())

--- a/cmd/mredit.cpp
+++ b/cmd/mredit.cpp
@@ -128,7 +128,7 @@ void run ()
   operation_count += opt.size();
   for (auto p : opt) {
     const size_t axis = p[0];
-    const auto coords = parse_ints (p[1]);
+    const auto coords = parse_ints<uint32_t> (p[1]);
     const float value = p[2];
     const std::array<size_t, 2> loop_axes { { axis == 0 ? size_t(1) : size_t(0), axis == 2 ? size_t(1) : size_t(2) } };
     for (auto c : coords) {

--- a/cmd/mrfilter.cpp
+++ b/cmd/mrfilter.cpp
@@ -159,7 +159,7 @@ void run () {
 
       auto opt = get_options ("axes");
       if (opt.size())
-        filter.set_axes (opt[0][0]);
+        filter.set_axes (parse_ints<uint32_t> (opt[0][0]));
       filter.set_centre_zero (get_options ("centre_zero").size());
       Stride::set_from_command_line (filter);
       filter.set_message (std::string("applying FFT filter to image " + std::string(argument[0])));
@@ -215,7 +215,7 @@ void run () {
 
       auto opt = get_options ("extent");
       if (opt.size())
-        filter.set_extent (parse_ints (opt[0][0]));
+        filter.set_extent (parse_ints<uint32_t> (opt[0][0]));
       filter.set_message (std::string("applying ") + std::string(argument[1]) + " filter to image " + std::string(argument[0]));
       Stride::set_from_command_line (filter);
 
@@ -245,7 +245,7 @@ void run () {
       }
       opt = get_options ("extent");
       if (opt.size())
-        filter.set_extent (parse_ints (opt[0][0]));
+        filter.set_extent (parse_ints<uint32_t> (opt[0][0]));
       filter.set_message (std::string("applying ") + std::string(argument[1]) + " filter to image " + std::string(argument[0]));
       Stride::set_from_command_line (filter);
 
@@ -263,7 +263,7 @@ void run () {
 
       auto opt = get_options ("extent");
       if (opt.size())
-        filter.set_extent (parse_ints (opt[0][0]));
+        filter.set_extent (parse_ints<uint32_t> (opt[0][0]));
       filter.set_message (std::string("applying ") + std::string(argument[1]) + " filter to image " + std::string(argument[0]) + "...");
       Stride::set_from_command_line (filter);
 

--- a/cmd/mrgrid.cpp
+++ b/cmd/mrgrid.cpp
@@ -168,10 +168,10 @@ void run () {
     }
 
     // over-sampling
-    vector<int> oversample = Adapter::AutoOverSample;
+    vector<uint32_t> oversample = Adapter::AutoOverSample;
     opt = get_options ("oversample");
     if (opt.size()) {
-      oversample = opt[0][0];
+      oversample = parse_ints<uint32_t> (opt[0][0]);
     }
 
     Header template_header;
@@ -202,10 +202,10 @@ void run () {
       ++resize_option_count;
     }
 
-    vector<int> image_size;
+    vector<uint32_t> image_size;
     opt = get_options ("size");
     if (opt.size()) {
-      image_size = parse_ints (opt[0][0]);
+      image_size = parse_ints<uint32_t> (opt[0][0]);
       regrid_filter.set_size (image_size);
       ++resize_option_count;
     }
@@ -362,7 +362,7 @@ void run () {
       end = spec.find_first_of(":", start);
       if (end == std::string::npos) { // spec = delta_lower,delta_upper
         vector<int> delta; // 0: not changed, > 0: pad, < 0: crop
-        try { delta = parse_ints (opt[i][1]); }
+        try { delta = parse_ints<int> (opt[i][1]); }
         catch (Exception& E) { Exception (E, "-axis " + str(axis) + ": can't parse delta specifier \"" + spec + "\""); }
         if (delta.size() != 2)
           throw Exception ("-axis " + str(axis) + ": can't parse delta specifier \"" + spec + "\"");

--- a/cmd/mrregister.cpp
+++ b/cmd/mrregister.cpp
@@ -409,7 +409,7 @@ void run () {
   if (opt.size ()) {
     if (!do_rigid)
       throw Exception ("the number of rigid iterations have been input when no rigid registration is requested");
-    rigid_registration.set_max_iter (parse_ints (opt[0][0]));
+    rigid_registration.set_max_iter (parse_ints<uint32_t> (opt[0][0]));
   }
 
   opt = get_options ("rigid_metric");
@@ -451,13 +451,13 @@ void run () {
   }
 
   opt = get_options ("rigid_lmax");
-  vector<int> rigid_lmax;
+  vector<uint32_t> rigid_lmax;
   if (opt.size ()) {
     if (!do_rigid)
       throw Exception ("the -rigid_lmax option has been set when no rigid registration is requested");
     if (max_mc_image_lmax == 0)
       throw Exception ("-rigid_lmax option is not valid if no input image is FOD image");
-    rigid_lmax = parse_ints (opt[0][0]);
+    rigid_lmax = parse_ints<uint32_t> (opt[0][0]);
     for (size_t i = 0; i < rigid_lmax.size (); ++i)
        if (rigid_lmax[i] > max_mc_image_lmax) {
         WARN ("the requested -rigid_lmax exceeds the lmax of the input images, setting it to " + str(max_mc_image_lmax));
@@ -599,17 +599,17 @@ void run () {
   if (opt.size ()) {
     if (!do_affine)
       throw Exception ("the number of affine iterations have been input when no affine registration is requested");
-    affine_registration.set_max_iter (parse_ints (opt[0][0]));
+    affine_registration.set_max_iter (parse_ints<uint32_t> (opt[0][0]));
   }
 
   opt = get_options ("affine_lmax");
-  vector<int> affine_lmax;
+  vector<uint32_t> affine_lmax;
   if (opt.size ()) {
     if (!do_affine)
       throw Exception ("the -affine_lmax option has been set when no affine registration is requested");
     if (max_mc_image_lmax == 0)
       throw Exception ("-affine_lmax option is not valid if no input image is FOD image");
-    affine_lmax = parse_ints (opt[0][0]);
+    affine_lmax = parse_ints<uint32_t> (opt[0][0]);
     for (size_t i = 0; i < affine_lmax.size (); ++i)
       if (affine_lmax[i] > max_mc_image_lmax) {
         WARN ("the requested -affine_lmax exceeds the lmax of the input images, setting it to " + str(max_mc_image_lmax));
@@ -725,7 +725,7 @@ void run () {
   if (opt.size ()) {
     if (!do_nonlinear)
       throw Exception ("the number of non-linear iterations have been input when no non-linear registration is requested");
-    vector<int> iterations_per_level = parse_ints (opt[0][0]);
+    vector<uint32_t> iterations_per_level = parse_ints<uint32_t> (opt[0][0]);
     if (nonlinear_init && iterations_per_level.size() > 1)
       throw Exception ("when initialising the non-linear registration the max number of iterations can only be defined for a single level");
     else
@@ -754,13 +754,13 @@ void run () {
   }
 
   opt = get_options ("nl_lmax");
-  vector<int> nl_lmax;
+  vector<uint32_t> nl_lmax;
   if (opt.size()) {
     if (!do_nonlinear)
       throw Exception ("the -nl_lmax option has been set when no non-linear registration is requested");
     if (input1[0].ndim() < 4)
       throw Exception ("-nl_lmax option is not valid with 3D images");
-    nl_lmax = parse_ints (opt[0][0]);
+    nl_lmax = parse_ints<uint32_t> (opt[0][0]);
     nl_registration.set_lmax (nl_lmax);
     for (size_t i = 0; i < (nl_lmax).size (); ++i)
       if ((nl_lmax)[i] > max_mc_image_lmax)

--- a/cmd/mrtransform.cpp
+++ b/cmd/mrtransform.cpp
@@ -208,7 +208,7 @@ void usage ()
 }
 
 void apply_warp (Image<float>& input, Image<float>& output, Image<default_type>& warp,
-  const int interp, const float out_of_bounds_value, const vector<int>& oversample, const bool jacobian_modulate = false) {
+  const int interp, const float out_of_bounds_value, const vector<uint32_t>& oversample, const bool jacobian_modulate = false) {
   switch (interp) {
   case 0:
     Filter::warp<Interp::Nearest> (input, output, warp, out_of_bounds_value, oversample, jacobian_modulate);
@@ -360,7 +360,7 @@ void run ()
   // Flip
   opt = get_options ("flip");
   if (opt.size()) {
-    vector<int> axes = opt[0][0];
+    vector<int32_t> axes = parse_ints<int32_t> (opt[0][0]);
     transform_type flip;
     flip.setIdentity();
     for (size_t i = 0; i < axes.size(); ++i) {
@@ -527,12 +527,12 @@ void run ()
   }
 
   // over-sampling
-  vector<int> oversample = Adapter::AutoOverSample;
+  vector<uint32_t> oversample = Adapter::AutoOverSample;
   opt = get_options ("oversample");
   if (opt.size()) {
     if (!template_header.valid() && !warp)
       throw Exception ("-oversample option applies only to regridding using the template option or to non-linear transformations");
-    oversample = opt[0][0];
+    oversample = parse_ints<uint32_t> (opt[0][0]);
     if (oversample.size() == 1)
       oversample.resize (3, oversample[0]);
     else if (oversample.size() != 3)

--- a/cmd/mtnormalise.cpp
+++ b/cmd/mtnormalise.cpp
@@ -498,12 +498,12 @@ void run ()
   size_t max_balance_iter = DEFAULT_BALANCE_MAXITER_VALUE;
   auto opt = get_options ("niter");
   if (opt.size()) {
-    vector<int> num = opt[0][0];
+    vector<size_t> num = parse_ints<size_t> (opt[0][0]);
     if (num.size() < 1 && num.size() > 2)
-      throw Exception ("unexpected number of entries provided to option \"niter\"");
-    for (const int n : num)
-      if (n < 1)
-        throw Exception ("number of iterations must be positive");
+      throw Exception ("unexpected number of entries provided to option \"-niter\"");
+    for (auto n : num)
+      if (!n)
+        throw Exception ("number of iterations must be nonzero");
 
     max_iter = num[0];
     if (num.size() > 1)

--- a/cmd/tckconvert.cpp
+++ b/cmd/tckconvert.cpp
@@ -297,7 +297,7 @@ class ASCIIWriter: public WriterInterface<float> { MEMALIGN(ASCIIWriter)
 
   private:
     File::NameParser parser;
-    vector<int> count;
+    vector<uint32_t> count;
 
 };
 

--- a/cmd/tcksift.cpp
+++ b/cmd/tcksift.cpp
@@ -47,7 +47,7 @@ void usage ()
 
   SYNOPSIS = "Filter a whole-brain fibre-tracking data set such that the streamline densities match the FOD lobe integrals";
 
-  REFERENCES 
+  REFERENCES
     + "Smith, R. E.; Tournier, J.-D.; Calamante, F. & Connelly, A. " // Internal
     "SIFT: Spherical-deconvolution informed filtering of tractograms. "
     "NeuroImage, 2013, 67, 298-312";
@@ -123,7 +123,7 @@ void run ()
       sifter.set_csv_path (opt[0][0]);
     opt = get_options ("output_at_counts");
     if (opt.size()) {
-      vector<int> counts = parse_ints (opt[0][0]);
+      vector<uint32_t> counts = parse_ints<uint32_t> (opt[0][0]);
       sifter.set_regular_outputs (counts, out_debug);
     }
 

--- a/cmd/tensor2metric.cpp
+++ b/cmd/tensor2metric.cpp
@@ -116,7 +116,7 @@ class Processor { MEMALIGN(Processor)
         Image<value_type>& cs_img,
         Image<value_type>& value_img,
         Image<value_type>& vector_img,
-        vector<int>& vals,
+        vector<uint32_t>& vals,
         int modulate) :
       mask_img (mask_img),
       adc_img (adc_img),
@@ -260,7 +260,7 @@ class Processor { MEMALIGN(Processor)
     Image<value_type> cs_img;
     Image<value_type> value_img;
     Image<value_type> vector_img;
-    vector<int> vals;
+    vector<uint32_t> vals;
     int modulate;
 };
 
@@ -341,10 +341,10 @@ void run ()
     metric_count++;
   }
 
-  vector<int> vals = {1};
+  vector<uint32_t> vals = {1};
   opt = get_options ("num");
   if (opt.size()) {
-    vals = opt[0][0];
+    vals = parse_ints<uint32_t> (opt[0][0]);
     if (vals.empty())
       throw Exception ("invalid eigenvalue/eigenvector number specifier");
     for (size_t i = 0; i < vals.size(); ++i)

--- a/core/adapter/extract.h
+++ b/core/adapter/extract.h
@@ -135,10 +135,8 @@ namespace MR
                 indices[2][0] * spacing (2)
                 );
 
-            for (auto& idx : this->indices) {
-              sizes.push_back (idx.size());
-              idx.push_back (idx.back());
-            }
+            for (const auto& i : indices)
+              sizes.push_back (i.size());
           }
 
 
@@ -155,13 +153,17 @@ namespace MR
 
         ssize_t get_index (size_t axis) const { return current_pos[axis]; }
         void move_index (size_t axis, ssize_t increment) {
-          ssize_t prev = current_pos[axis];
           current_pos[axis] += increment;
-          parent().index (axis) += indices[axis][current_pos[axis]] - indices[axis][prev];
+          if (current_pos[axis] < 0)
+            parent().index (axis) = -1;
+          else if (current_pos[axis] >= sizes[axis])
+            parent().index (axis) = parent().size (axis);
+          else
+            parent().index (axis) = indices[axis][current_pos[axis]];
         }
 
       private:
-        vector<size_t> current_pos;
+        vector<ssize_t> current_pos;
         vector<vector<uint32_t> > indices;
         vector<ssize_t> sizes;
         transform_type trans;

--- a/core/adapter/extract.h
+++ b/core/adapter/extract.h
@@ -24,9 +24,9 @@ namespace MR
   namespace Adapter
   {
 
-    template <class ImageType> 
-      class Extract1D : 
-        public Base<Extract1D<ImageType>,ImageType> 
+    template <class ImageType>
+      class Extract1D :
+        public Base<Extract1D<ImageType>,ImageType>
     { MEMALIGN (Extract1D<ImageType>)
       public:
 
@@ -38,7 +38,7 @@ namespace MR
         using base_type::parent;
 
 
-        Extract1D (const ImageType& original, const size_t axis, const vector<int>& indices) :
+        Extract1D (const ImageType& original, const size_t axis, const vector<uint32_t>& indices) :
           base_type (original),
           extract_axis (axis),
           indices (indices),
@@ -57,7 +57,7 @@ namespace MR
 
 
         void reset () {
-          for (size_t n = 0; n < ndim(); ++n) 
+          for (size_t n = 0; n < ndim(); ++n)
             parent().index(n) = ( n == extract_axis ? indices[0] : 0 );
           current_pos = 0;
         }
@@ -66,26 +66,26 @@ namespace MR
           return ( axis == extract_axis ? nsize : base_type::size (axis) );
         }
 
-        const transform_type& transform () const { return trans; } 
+        const transform_type& transform () const { return trans; }
 
         ssize_t get_index (size_t axis) const { return ( axis == extract_axis ? current_pos : parent().index(axis) ); }
         void move_index (size_t axis, ssize_t increment) {
           if (axis == extract_axis) {
             ssize_t prev_pos = current_pos < nsize ? indices[current_pos] : 0;
             current_pos += increment;
-            if (current_pos < nsize) 
+            if (current_pos < nsize)
               parent().index(axis) += indices[current_pos] - prev_pos;
             else
               parent().index(axis) = 0;
           }
-          else 
+          else
             parent().index(axis) += increment;
         }
 
 
         friend std::ostream& operator<< (std::ostream& stream, const Extract1D& V) {
           stream << "Extract1D adapter for image \"" << V.name() << "\", position [ ";
-          for (size_t n = 0; n < V.ndim(); ++n) 
+          for (size_t n = 0; n < V.ndim(); ++n)
             stream << V.index(n) << " ";
           stream << "], value = " << V.value();
           return stream;
@@ -93,7 +93,7 @@ namespace MR
 
       private:
         const size_t extract_axis;
-        vector<int> indices;
+        vector<uint32_t> indices;
         const ssize_t nsize;
         transform_type trans;
         ssize_t current_pos;
@@ -109,8 +109,8 @@ namespace MR
 
 
 
-    template <class ImageType> 
-      class Extract : 
+    template <class ImageType>
+      class Extract :
         public Base<Extract<ImageType>,ImageType>
     { MEMALIGN (Extract<ImageType>)
       public:
@@ -123,16 +123,16 @@ namespace MR
         using base_type::parent;
 
 
-        Extract (const ImageType& original, const vector<vector<int>>& indices) :
+        Extract (const ImageType& original, const vector<vector<uint32_t>>& indices) :
           base_type (original),
-          current_pos (ndim()), 
+          current_pos (ndim()),
           indices (indices),
           trans (original.transform()) {
             reset();
             trans.translation() = trans * Eigen::Vector3d (
-                indices[0][0] * spacing (0), 
-                indices[1][0] * spacing (1), 
-                indices[2][0] * spacing (2) 
+                indices[0][0] * spacing (0),
+                indices[1][0] * spacing (1),
+                indices[2][0] * spacing (2)
                 );
 
             for (auto& idx : this->indices) {
@@ -162,7 +162,7 @@ namespace MR
 
       private:
         vector<size_t> current_pos;
-        vector<vector<int> > indices;
+        vector<vector<uint32_t> > indices;
         vector<ssize_t> sizes;
         transform_type trans;
     };

--- a/core/adapter/median.h
+++ b/core/adapter/median.h
@@ -22,13 +22,13 @@
 
 namespace MR
 {
-    namespace Adapter 
+    namespace Adapter
     {
 
 
     template <class ImageType>
-        class Median : 
-          public Base<Median<ImageType>,ImageType> 
+        class Median :
+          public Base<Median<ImageType>,ImageType>
       { MEMALIGN(Median<ImageType>)
       public:
 
@@ -45,20 +45,20 @@ namespace MR
             set_extent (vector<int>(1,3));
           }
 
-        Median (const ImageType& parent, const vector<int>& extent) :
+        Median (const ImageType& parent, const vector<uint32_t>& extent) :
           base_type (parent) {
             set_extent (extent);
           }
 
-        void set_extent (const vector<int>& ext)
+        void set_extent (const vector<uint32_t>& ext)
         {
           for (size_t i = 0; i < ext.size(); ++i)
-            if (! (ext[i] & int(1)))
+            if (! (ext[i] & uint32_t(1)))
               throw Exception ("expected odd number for extent");
           if (ext.size() != 1 && ext.size() != 3)
             throw Exception ("unexpected number of elements specified in extent");
           if (ext.size() == 1)
-            extent = vector<int> (3, ext[0]);
+            extent = vector<uint32_t> (3, ext[0]);
           else
             extent = ext;
 
@@ -99,7 +99,7 @@ namespace MR
         }
 
       protected:
-        vector<int> extent;
+        vector<uint32_t> extent;
         vector<value_type> values;
       };
 

--- a/core/adapter/normalise3D.h
+++ b/core/adapter/normalise3D.h
@@ -21,13 +21,13 @@
 
 namespace MR
 {
-    namespace Adapter 
+    namespace Adapter
     {
 
 
     template <class ImageType>
-      class Normalise3D : 
-        public Base<Normalise3D<ImageType>,ImageType> 
+      class Normalise3D :
+        public Base<Normalise3D<ImageType>,ImageType>
     { MEMALIGN(Normalise3D<ImageType>)
       public:
 
@@ -44,20 +44,20 @@ namespace MR
             set_extent (vector<int>(1,3));
           }
 
-        Normalise3D (const ImageType& parent, const vector<int>& extent) :
+        Normalise3D (const ImageType& parent, const vector<uint32_t>& extent) :
           base_type (parent) {
             set_extent (extent);
           }
 
-        void set_extent (const vector<int>& ext)
+        void set_extent (const vector<uint32_t>& ext)
         {
           for (size_t i = 0; i < ext.size(); ++i)
-            if (! (ext[i] & int(1)))
+            if (! (ext[i] & uint32_t(1)))
               throw Exception ("expected odd number for extent");
           if (ext.size() != 1 && ext.size() != 3)
             throw Exception ("unexpected number of elements specified in extent");
           if (ext.size() == 1)
-            extent = vector<int> (3, ext[0]);
+            extent = vector<uint32_t> (3, ext[0]);
           else
             extent = ext;
 
@@ -104,7 +104,7 @@ namespace MR
         }
 
       protected:
-        vector<int> extent;
+        vector<uint32_t> extent;
         value_type mean;
         value_type pos_value;
         size_t nelements;

--- a/core/adapter/reslice.cpp
+++ b/core/adapter/reslice.cpp
@@ -21,7 +21,7 @@ namespace MR
   namespace Adapter
   {
     const transform_type NoTransform = transform_type::Identity();
-    const vector<int> AutoOverSample;
+    const vector<uint32_t> AutoOverSample;
   }
 }
 

--- a/core/adapter/reslice.h
+++ b/core/adapter/reslice.h
@@ -61,7 +61,7 @@ namespace MR
 
 
     extern const transform_type NoTransform;
-    extern const vector<int> AutoOverSample;
+    extern const vector<uint32_t> AutoOverSample;
 
     //! \addtogroup interp
     // @{
@@ -118,7 +118,7 @@ namespace MR
           Reslice (const ImageType& original,
                    const HeaderType& reference,
                    const transform_type& transform = NoTransform,
-                   const vector<int>& oversample = AutoOverSample,
+                   const vector<uint32_t>& oversample = AutoOverSample,
                    const value_type value_when_out_of_bounds = Interp::Base<ImageType>::default_out_of_bounds_value()) :
             interp (original, value_when_out_of_bounds),
             x { 0, 0, 0 },
@@ -214,7 +214,7 @@ namespace MR
         const ssize_t dim[3];
         const default_type vox[3];
         bool oversampling;
-        int OS[3];
+        uint32_t OS[3];
         default_type from[3], inc[3];
         default_type norm;
         const transform_type transform_, direct_transform;

--- a/core/adapter/reslice.h
+++ b/core/adapter/reslice.h
@@ -185,11 +185,11 @@ namespace MR
             Vector3 d (x[0]+from[0], x[1]+from[1], x[2]+from[2]);
             default_type sum (0.0);
             Vector3 s;
-            for (int z = 0; z < OS[2]; ++z) {
+            for (uint32_t z = 0; z < OS[2]; ++z) {
               s[2] = d[2] + z*inc[2];
-              for (int y = 0; y < OS[1]; ++y) {
+              for (uint32_t y = 0; y < OS[1]; ++y) {
                 s[1] = d[1] + y*inc[1];
-                for (int x = 0; x < OS[0]; ++x) {
+                for (uint32_t x = 0; x < OS[0]; ++x) {
                   s[0] = d[0] + x*inc[0];
                   if (interp.voxel (direct_transform * s))
                     sum += interp.value();

--- a/core/app.h
+++ b/core/app.h
@@ -216,11 +216,18 @@ namespace MR
         uint64_t as_uint () const { return uint64_t (as_int()); }
         default_type as_float () const;
 
-        vector<int> as_sequence_int () const {
+        vector<int32_t> as_sequence_int () const {
           assert (arg->type == IntSeq);
-          try { return parse_ints (p); }
+          try { return parse_ints<int32_t> (p); }
           catch (Exception& e) { error (e); }
-          return vector<int>();
+          return vector<int32_t>();
+        }
+
+        vector<uint32_t> as_sequence_uint () const {
+          assert (arg->type == IntSeq);
+          try { return parse_ints<uint32_t> (p); }
+          catch (Exception& e) { error (e); }
+          return vector<uint32_t>();
         }
 
         vector<default_type> as_sequence_float () const {
@@ -239,7 +246,8 @@ namespace MR
         operator long long unsigned int () const { return as_uint(); }
         operator float () const { return as_float(); }
         operator double () const { return as_float(); }
-        operator vector<int> () const { return as_sequence_int(); }
+        operator vector<int32_t> () const { return as_sequence_int(); }
+        operator vector<uint32_t> () const { return as_sequence_uint(); }
         operator vector<default_type> () const { return as_sequence_float(); }
 
         const char* c_str () const { return p; }

--- a/core/file/dicom/select_cmdline.cpp
+++ b/core/file/dicom/select_cmdline.cpp
@@ -191,11 +191,11 @@ namespace MR {
             if (buf[0] == 'q' || buf[0] == 'Q')
               throw CancelException();
             if (isdigit (buf[0])) {
-              vector<int> seq;
+              vector<uint32_t> seq;
               try {
-                seq = parse_ints (buf);
+                seq = parse_ints<uint32_t> (buf);
                 for (size_t i = 0; i < seq.size(); i++) {
-                  if (seq[i] < 0 || seq[i] >= (int) study.size()) {
+                  if (seq[i] < 0 || seq[i] >= (uint32_t) study.size()) {
                     series.clear();
                     break;
                   }

--- a/core/file/name_parser.cpp
+++ b/core/file/name_parser.cpp
@@ -26,7 +26,7 @@ namespace MR
     namespace
     {
 
-      inline bool in_seq (const vector<uint32_t>& seq, int val)
+      inline bool in_seq (const vector<uint32_t>& seq, uint32_t val)
       {
         if (seq.size() == 0)
           return true;
@@ -278,7 +278,7 @@ namespace MR
 
       for (size_t n = 0; n < dim.size(); n++)
         if (parser.sequence (n).size())
-          if (dim[n] != (int) parser.sequence (n).size())
+          if (dim[n] != parser.sequence (n).size())
             throw Exception ("number of files found does not match specification \"" + specifier + "\"");
 
       return dim;

--- a/core/file/name_parser.cpp
+++ b/core/file/name_parser.cpp
@@ -26,9 +26,9 @@ namespace MR
     namespace
     {
 
-      inline bool in_seq (const vector<int>& seq, int val)
+      inline bool in_seq (const vector<uint32_t>& seq, int val)
       {
-        if (seq.size() == 0) 
+        if (seq.size() == 0)
           return true;
         for (size_t i = 0; i < seq.size(); i++)
           if (seq[i] == val)
@@ -97,12 +97,12 @@ namespace MR
 
     std::ostream& operator<< (std::ostream& stream, const NameParser::Item& item)
     {
-      if (item.is_string()) 
+      if (item.is_string())
         stream << "\"" << item.string() << "\"";
       else {
-        if (item.sequence().size()) 
+        if (item.sequence().size())
           stream << item.sequence();
-        else 
+        else
           stream << "[ any ]";
       }
       return stream;
@@ -129,26 +129,26 @@ namespace MR
 
 
 
-    bool NameParser::match (const std::string& file_name, vector<int>& indices) const
+    bool NameParser::match (const std::string& file_name, vector<uint32_t>& indices) const
     {
-      int current = 0;
+      uint32_t current = 0;
       size_t num = 0;
       indices.resize (seq_index.size());
 
       for (size_t i = 0; i < array.size(); i++) {
         if (array[i].is_string()) {
-          if (file_name.substr (current, array[i].string().size()) != array[i].string()) 
+          if (file_name.substr (current, array[i].string().size()) != array[i].string())
             return false;
           current += array[i].string().size();
         }
         else {
-          int x = current;
+          uint32_t x = current;
           while (isdigit (file_name[current]))
             current++;
-          if (x == current) 
+          if (x == current)
             return false;
-          x = to<int> (file_name.substr (x, current-x));
-          if (!in_seq (array[i].sequence(), x)) 
+          x = to<uint32_t> (file_name.substr (x, current-x));
+          if (!in_seq (array[i].sequence(), x))
             return false;
           indices[num] = x;
           num++;
@@ -160,7 +160,7 @@ namespace MR
 
 
 
-    void NameParser::calculate_padding (const vector<int>& maxvals)
+    void NameParser::calculate_padding (const vector<uint32_t>& maxvals)
     {
       assert (maxvals.size() == seq_index.size());
       for (size_t n = 0; n < seq_index.size(); n++)
@@ -205,7 +205,7 @@ namespace MR
 
 
 
-    std::string NameParser::name (const vector<int>& indices)
+    std::string NameParser::name (const vector<uint32_t>& indices)
     {
       if (!seq_index.size())
         return Path::join (folder_name, array[0].string());
@@ -231,7 +231,7 @@ namespace MR
 
 
 
-    std::string NameParser::get_next_match (vector<int>& indices, bool return_seq_index)
+    std::string NameParser::get_next_match (vector<uint32_t>& indices, bool return_seq_index)
     {
       if (!folder)
         folder.reset (new Path::Dir (folder_name));
@@ -242,7 +242,7 @@ namespace MR
           if (return_seq_index) {
             for (size_t i = 0; i < ndim(); i++) {
               if (sequence (i).size()) {
-                size_t n = 0;
+                uint32_t n = 0;
                 while (indices[i] != sequence (i) [n]) n++;
                 indices[i] = n;
               }
@@ -267,14 +267,14 @@ namespace MR
 
 
 
-    vector<int> ParsedName::List::parse_scan_check (const std::string& specifier, size_t max_num_sequences)
+    vector<uint32_t> ParsedName::List::parse_scan_check (const std::string& specifier, size_t max_num_sequences)
     {
       NameParser parser;
       parser.parse (specifier);
 
       scan (parser);
       std::sort (list.begin(), list.end(), compare_ptr_contents());
-      vector<int> dim = count();
+      vector<uint32_t> dim = count();
 
       for (size_t n = 0; n < dim.size(); n++)
         if (parser.sequence (n).size())
@@ -291,7 +291,7 @@ namespace MR
 
     void ParsedName::List::scan (NameParser& parser)
     {
-      vector<int> index;
+      vector<uint32_t> index;
       if (parser.ndim() == 0) {
         list.push_back (std::shared_ptr<ParsedName> (new ParsedName (parser.name (index), index)));
         return;
@@ -311,14 +311,14 @@ namespace MR
 
 
 
-    vector<int> ParsedName::List::count () const
+    vector<uint32_t> ParsedName::List::count () const
     {
       if (! list[0]->ndim()) {
-        if (size() == 1) return (vector<int>());
+        if (size() == 1) return (vector<uint32_t>());
         else throw Exception ("image number mismatch");
       }
 
-      vector<int> dim ( list[0]->ndim(), 0);
+      vector<uint32_t> dim ( list[0]->ndim(), 0);
       size_t current_entry = 0;
 
       count_dim (dim, current_entry, 0);
@@ -329,17 +329,17 @@ namespace MR
 
 
 
-    void ParsedName::List::count_dim (vector<int>& dim, size_t& current_entry, size_t current_dim) const
+    void ParsedName::List::count_dim (vector<uint32_t>& dim, size_t& current_entry, size_t current_dim) const
     {
-      int n;
+      uint32_t n;
       bool stop = false;
       std::shared_ptr<const ParsedName> first_entry ( list[current_entry]);
 
       for (n = 0; current_entry < size(); n++) {
         for (size_t d = 0; d < current_dim; d++)
-          if ( list[current_entry]->index (d) != first_entry->index (d)) 
+          if ( list[current_entry]->index (d) != first_entry->index (d))
             stop = true;
-        if (stop) 
+        if (stop)
           break;
 
         if (current_dim < list[0]->ndim()-1)
@@ -358,7 +358,7 @@ namespace MR
 
 
 
-    std::ostream& operator<< (std::ostream& stream, const ParsedName::List& list) 
+    std::ostream& operator<< (std::ostream& stream, const ParsedName::List& list)
     {
       stream << "parsed name list, size " << list.size() << ", counts " << list.count() << "\n";
       for (const auto& entry : list.list)

--- a/core/file/name_parser.h
+++ b/core/file/name_parser.h
@@ -42,7 +42,7 @@ namespace MR
 
             void set_seq (const std::string& s) {
               clear ();
-              if (s.size()) seq = parse_ints (s);
+              if (s.size()) seq = parse_ints<uint32_t> (s);
               seq_length = 1;
             }
 
@@ -56,11 +56,11 @@ namespace MR
               return (str);
             }
 
-            const vector<int>& sequence () const {
+            const vector<uint32_t>& sequence () const {
               return (seq);
             }
 
-            vector<int>& sequence () {
+            vector<uint32_t>& sequence () {
               return (seq);
             }
 
@@ -83,7 +83,7 @@ namespace MR
           protected:
             size_t seq_length;
             std::string str;
-            vector<int> seq;
+            vector<uint32_t> seq;
         };
 
 
@@ -101,7 +101,7 @@ namespace MR
           return (array[i]);
         }
 
-        const vector<int>& sequence (size_t index) const {
+        const vector<uint32_t>& sequence (size_t index) const {
           return (array[seq_index[index]].sequence());
         }
 
@@ -113,10 +113,10 @@ namespace MR
           return (seq_index[number]);
         }
 
-        bool match (const std::string& file_name, vector<int>& indices) const;
-        void calculate_padding (const vector<int>& maxvals);
-        std::string name (const vector<int>& indices);
-        std::string get_next_match (vector<int>& indices, bool return_seq_index = false);
+        bool match (const std::string& file_name, vector<uint32_t>& indices) const;
+        void calculate_padding (const vector<uint32_t>& maxvals);
+        std::string name (const vector<uint32_t>& indices);
+        std::string get_next_match (vector<uint32_t>& indices, bool return_seq_index = false);
 
         friend std::ostream& operator<< (std::ostream& stream, const NameParser& parser);
 
@@ -150,17 +150,17 @@ namespace MR
     //! a class to hold a parsed image filename
     class ParsedName { NOMEMALIGN
       public:
-        ParsedName (const std::string& name, const vector<int>& index) : indices (index), filename (name) { }
+        ParsedName (const std::string& name, const vector<uint32_t>& index) : indices (index), filename (name) { }
 
         //! a class to hold a set of parsed image filenames
         class List { NOMEMALIGN
           public:
-            vector<int> parse_scan_check (const std::string& specifier, 
-                size_t max_num_sequences = std::numeric_limits<size_t>::max());
+            vector<uint32_t> parse_scan_check (const std::string& specifier,
+                                               size_t max_num_sequences = std::numeric_limits<size_t>::max());
 
             void scan (NameParser& parser);
 
-            vector<int> count () const;
+            vector<uint32_t> count () const;
 
             size_t biggest_filename_size () const {
               return max_name_size;
@@ -174,7 +174,7 @@ namespace MR
 
           protected:
             vector<std::shared_ptr<ParsedName>> list;
-            void count_dim (vector<int>& dim, size_t& current_entry, size_t current_dim) const;
+            void count_dim (vector<uint32_t>& dim, size_t& current_entry, size_t current_dim) const;
             size_t max_name_size;
         };
 
@@ -186,7 +186,7 @@ namespace MR
         size_t ndim () const {
           return indices.size();
         }
-        int index (size_t num) const {
+        uint32_t index (size_t num) const {
           return indices[num];
         }
 
@@ -194,8 +194,8 @@ namespace MR
         friend std::ostream& operator<< (std::ostream& stream, const ParsedName& pin);
 
       protected:
-        vector<int>    indices;
-        std::string         filename;
+        vector<uint32_t> indices;
+        std::string filename;
 
     };
 

--- a/core/filter/fft.h
+++ b/core/filter/fft.h
@@ -63,15 +63,13 @@ namespace MR
         }
 
 
-        void set_axes (const vector<int>& in)
+        void set_axes (const vector<uint32_t>& in)
         {
           axes_to_process.clear();
-          for (vector<int>::const_iterator i = in.begin(); i != in.end(); ++i) {
-            if (*i < 0)
-              throw Exception ("Axis indices for FFT image filter must be positive");
-            if (*i >= (int)this->ndim())
-              throw Exception ("Axis index " + str(*i) + " for FFT image filter exceeds number of image dimensions (" + str(this->ndim()) + ")");
-            axes_to_process.push_back (*i);
+          for (auto i : in) {
+            if (i >= this->ndim())
+              throw Exception ("Axis index " + str(i) + " for FFT image filter exceeds number of image dimensions (" + str(this->ndim()) + ")");
+            axes_to_process.push_back (i);
           }
         }
 

--- a/core/filter/median.h
+++ b/core/filter/median.h
@@ -53,33 +53,31 @@ namespace MR
         template <class HeaderType>
           Median (const HeaderType& in, const std::string& message) :
             Base (in, message),
-            extent (1,3) { 
+            extent (1,3) {
               datatype() = DataType::Float32;
             }
 
         template <class HeaderType>
-        Median (const HeaderType& in, const vector<int>& extent) :
+        Median (const HeaderType& in, const vector<uint32_t>& extent) :
             Base (in),
             extent (extent) {
           datatype() = DataType::Float32;
         }
 
         template <class HeaderType>
-          Median (const HeaderType& in, const std::string& message, const vector<int>& extent) :
+          Median (const HeaderType& in, const std::string& message, const vector<uint32_t>& extent) :
             Base (in, message),
-            extent (extent) { 
+            extent (extent) {
               datatype() = DataType::Float32;
             }
 
         //! Set the extent of median filtering neighbourhood in voxels.
         //! This must be set as a single value for all three dimensions
         //! or three values, one for each dimension. Default 3x3x3.
-        void set_extent (const vector<int>& ext) {
+        void set_extent (const vector<uint32_t>& ext) {
           for (size_t i = 0; i < ext.size(); ++i) {
             if (!(ext[i] & int (1)))
               throw Exception ("expected odd number for extent");
-            if (ext[i] < 0)
-              throw Exception ("the kernel extent must be positive");
           }
           extent = ext;
         }
@@ -94,7 +92,7 @@ namespace MR
         }
 
     protected:
-        vector<int> extent;
+        vector<uint32_t> extent;
     };
     //! @}
   }

--- a/core/filter/normalise.h
+++ b/core/filter/normalise.h
@@ -53,33 +53,31 @@ namespace MR
         template <class HeaderType>
           Normalise (const HeaderType& in, const std::string& message) :
             Base (in, message),
-            extent (1,3) { 
+            extent (1,3) {
               datatype() = DataType::Float32;
             }
 
         template <class HeaderType>
-        Normalise (const HeaderType& in, const vector<int>& extent) :
+        Normalise (const HeaderType& in, const vector<uint32_t>& extent) :
             Base (in),
             extent (extent) {
           datatype() = DataType::Float32;
         }
 
         template <class HeaderType>
-          Normalise (const HeaderType& in, const std::string& message, const vector<int>& extent) :
+          Normalise (const HeaderType& in, const std::string& message, const vector<uint32_t>& extent) :
             Base (in, message),
-            extent (extent) { 
+            extent (extent) {
               datatype() = DataType::Float32;
             }
 
         //! Set the extent of normalise filtering neighbourhood in voxels.
         //! This must be set as a single value for all three dimensions
         //! or three values, one for each dimension. Default 3x3x3.
-        void set_extent (const vector<int>& ext) {
+        void set_extent (const vector<uint32_t>& ext) {
           for (size_t i = 0; i < ext.size(); ++i) {
-            if (!(ext[i] & int (1)))
+            if (!(ext[i] & uint32_t(1)))
               throw Exception ("expected odd number for extent");
-            if (ext[i] < 0)
-              throw Exception ("the kernel extent must be positive");
           }
           extent = ext;
         }
@@ -94,7 +92,7 @@ namespace MR
         }
 
     protected:
-        vector<int> extent;
+        vector<uint32_t> extent;
     };
     //! @}
   }

--- a/core/filter/resize.h
+++ b/core/filter/resize.h
@@ -69,7 +69,7 @@ namespace MR
         ~Resize () { delete out_of_bounds_value; }
 
         void set_voxel_size (default_type size) {
-          vector <default_type> voxel_size (3, size);
+          vector<default_type> voxel_size (3, size);
           set_voxel_size (voxel_size);
         }
 
@@ -93,7 +93,7 @@ namespace MR
         }
 
 
-        void set_size (const vector<int>& image_res) {
+        void set_size (const vector<uint32_t>& image_res) {
           if (image_res.size() != 3)
             throw Exception ("the image resolution must be defined for 3 spatial dimensions");
           vector<default_type> new_voxel_size (3);
@@ -123,7 +123,7 @@ namespace MR
           set_voxel_size (new_voxel_size);
         }
 
-        void set_oversample (vector<int> oversample) {
+        void set_oversample (vector<uint32_t> oversample) {
           if (oversample.size() == 1)
             oversample.resize (3, oversample[0]);
           else if (oversample.size() != 3 and oversample.size() != 0)
@@ -138,7 +138,7 @@ namespace MR
         void set_interp_type (int type) {
           interp_type = type;
           if (interp_type == 0) // nearest
-            set_oversample (vector<int> (3, 1));
+            set_oversample (vector<uint32_t> (3, 1));
         }
 
         void set_transform (const transform_type& trafo) {
@@ -177,7 +177,7 @@ namespace MR
       protected:
         int interp_type;
         transform_type transformation;
-        vector<int> oversampling;
+        vector<uint32_t> oversampling;
         default_type *out_of_bounds_value;
     };
     //! @}

--- a/core/filter/reslice.h
+++ b/core/filter/reslice.h
@@ -49,7 +49,7 @@ namespace MR
           ImageTypeSource& source,
           ImageTypeDestination& destination,
           const transform_type& transform = Adapter::NoTransform,
-          const vector<int>& oversampling = Adapter::AutoOverSample,
+          const vector<uint32_t>& oversampling = Adapter::AutoOverSample,
           const typename ImageTypeDestination::value_type value_when_out_of_bounds = Interp::Base<ImageTypeDestination>::default_out_of_bounds_value())
       {
         Adapter::Reslice<Interpolator, ImageTypeSource> interp (source, destination, transform, oversampling, value_when_out_of_bounds);

--- a/core/filter/smooth.h
+++ b/core/filter/smooth.h
@@ -75,18 +75,16 @@ namespace MR
         //! Set the extent of smoothing kernel in voxels.
         //! This can be set as a single value to be used for the first 3 dimensions
         //! or separate values, one for each dimension. (Default: 4 standard deviations)
-        void set_extent (const vector<int>& new_extent)
+        void set_extent (const vector<uint32_t>& new_extent)
         {
           if (new_extent.size() != 1 && new_extent.size() != 3)
             throw Exception ("Please supply a single kernel extent value, or three values (one for each spatial dimension)");
           for (size_t i = 0; i < new_extent.size(); ++i) {
-            if (!(new_extent[i] & int (1)))
+            if (!(new_extent[i] & uint32_t(1)))
               throw Exception ("expected odd number for extent");
-            if (new_extent[i] < 0)
-              throw Exception ("the kernel extent must be positive");
           }
           if (new_extent.size() == 1)
-            for (unsigned int i = 0; i < 3; i++)
+            for (size_t i = 0; i < 3; i++)
               extent[i] = new_extent[0];
           else
             extent = new_extent;
@@ -183,7 +181,7 @@ namespace MR
         }
 
       protected:
-        vector<int> extent;
+        vector<uint32_t> extent;
         vector<default_type> stdev;
         const vector<size_t> stride_order;
         bool zero_boundary;

--- a/core/filter/warp.h
+++ b/core/filter/warp.h
@@ -67,7 +67,7 @@ namespace MR
           ImageTypeDestination& destination,
           WarpType& warp,
           const typename ImageTypeDestination::value_type value_when_out_of_bounds = Interpolator<ImageTypeSource>::default_out_of_bounds_value(),
-          vector<int> oversample = Adapter::AutoOverSample,
+          const vector<uint32_t> oversample = Adapter::AutoOverSample,
           const bool jacobian_modulate = false )
       {
 

--- a/core/formats/mrtrix_sparse_legacy.cpp
+++ b/core/formats/mrtrix_sparse_legacy.cpp
@@ -77,7 +77,7 @@ namespace MR
       get_mrtrix_file_path (H, "file", image_fname, image_offset);
 
       File::ParsedName::List image_list;
-      vector<int> image_num = image_list.parse_scan_check (image_fname);
+      image_list.parse_scan_check (image_fname);
 
       get_mrtrix_file_path (H, "sparse_file", sparse_fname, sparse_offset);
 

--- a/core/formats/mrtrix_utils.h
+++ b/core/formats/mrtrix_utils.h
@@ -64,14 +64,14 @@ namespace MR
       void read_mrtrix_header (Header& H, SourceType& kv)
       {
         std::string dtype, layout;
-        vector<int> dim;
+        vector<uint64_t> dim;
         vector<default_type> vox, scaling;
         vector<vector<default_type>> transform;
 
         std::string key, value;
         while (next_keyvalue (kv, key, value)) {
           const std::string lkey = lowercase (key);
-          if (lkey == "dim") dim = parse_ints (value);
+          if (lkey == "dim") dim = parse_ints<uint64_t> (value);
           else if (lkey == "vox") vox = parse_floats (value);
           else if (lkey == "layout") layout = value;
           else if (lkey == "datatype") dtype = value;

--- a/core/header.cpp
+++ b/core/header.cpp
@@ -174,7 +174,7 @@ namespace MR
       INFO ("opening image \"" + image_name + "\"...");
 
       File::ParsedName::List list;
-      const vector<int> num = list.parse_scan_check (image_name);
+      const auto num = list.parse_scan_check (image_name);
 
       const Formats::Base** format_handler = Formats::handlers;
       size_t item_index = 0;
@@ -324,7 +324,7 @@ namespace MR
 
       File::NameParser parser;
       parser.parse (image_name);
-      vector<int> Pdim (parser.ndim());
+      vector<uint32_t> Pdim (parser.ndim());
 
       vector<int> Hdim (H.ndim());
       for (size_t i = 0; i < H.ndim(); ++i)
@@ -394,7 +394,7 @@ namespace MR
 
 
       Header header (H);
-      vector<int> num (Pdim.size());
+      vector<uint32_t> num (Pdim.size());
 
       if (image_name != "-")
         H.name() = parser.name (num);

--- a/core/mrtrix.cpp
+++ b/core/mrtrix.cpp
@@ -67,69 +67,6 @@ namespace MR
 
 
 
-  vector<int> parse_ints (const std::string& spec, int last)
-  {
-    vector<int> V;
-    if (!spec.size()) throw Exception ("integer sequence specifier is empty");
-    std::string::size_type start = 0, end;
-    int num[3];
-    int i = 0;
-    try {
-      do {
-        start = spec.find_first_not_of (" \t", start);
-        if (start == std::string::npos)
-          break;
-        end = spec.find_first_of (" \t,:", start);
-        std::string token (strip (spec.substr (start, end-start)));
-        if (lowercase (token) == "end") {
-          if (last == std::numeric_limits<int>::max())
-            throw Exception ("value of \"end\" is not known in number sequence \"" + spec + "\"");
-          num[i] = last;
-        }
-        else num[i] = to<int> (spec.substr (start, end-start));
-
-        end = spec.find_first_not_of (" \t", end);
-        char last_char = end < spec.size() ? spec[end] : '\0';
-        if (last_char == ':') {
-          ++i;
-          ++end;
-          if (i > 2) throw Exception ("invalid number range in number sequence \"" + spec + "\"");
-        } else {
-          if (i) {
-            int inc, last;
-            if (i == 2) {
-              inc = num[1];
-              last = num[2];
-            }
-            else {
-              inc = 1;
-              last = num[1];
-            }
-            if (inc * (last - num[0]) < 0) inc = -inc;
-            for (; (inc > 0 ? num[0] <= last : num[0] >= last) ; num[0] += inc) V.push_back (num[0]);
-          }
-          else V.push_back (num[0]);
-          i = 0;
-        }
-
-        start = end;
-        if (last_char == ',')
-          ++start;
-      }
-      while (end < spec.size());
-    }
-    catch (Exception& E) {
-      throw Exception (E, "can't parse integer sequence specifier \"" + spec + "\"");
-    }
-
-    return (V);
-  }
-
-
-
-
-
-
 
   vector<std::string> split (const std::string& string, const char* delimiters, bool ignore_empty_fields, size_t num)
   {

--- a/core/mrtrix.h
+++ b/core/mrtrix.h
@@ -184,8 +184,8 @@ namespace MR
     return split (string, "\n", ignore_empty_fields, num);
   }
 
-  vector<default_type> parse_floats (const std::string& spec);
-  vector<int> parse_ints (const std::string& spec, int last = std::numeric_limits<int>::max());
+
+
 
   /*
   inline int round (default_type x)
@@ -364,6 +364,86 @@ namespace MR
         throw Exception ("error converting string \"" + string + "\" to complex double (ambiguity in imaginary component)");
     }
     return candidates[0];
+  }
+
+
+
+
+
+
+
+  vector<default_type> parse_floats (const std::string& spec);
+
+
+
+  template <typename IntType>
+  vector<IntType> parse_ints (const std::string& spec, const IntType last = std::numeric_limits<IntType>::max())
+  {
+    typedef typename std::make_signed<IntType>::type SignedIntType;
+    if (!spec.size()) throw Exception ("integer sequence specifier is empty");
+
+    auto to_unsigned = [&] (const SignedIntType value)
+    {
+      if (std::is_unsigned<IntType>::value && value < 0)
+        throw Exception ("Impermissible negative value present in sequence \"" + spec + "\"");
+      return IntType(value);
+    };
+
+    vector<IntType> V;
+    std::string::size_type start = 0, end;
+    std::array<SignedIntType, 3> num;
+    size_t i = 0;
+    try {
+      do {
+        start = spec.find_first_not_of (" \t", start);
+        if (start == std::string::npos)
+          break;
+        end = spec.find_first_of (" \t,:", start);
+        std::string token (strip (spec.substr (start, end-start)));
+        if (lowercase (token) == "end") {
+          if (last == std::numeric_limits<IntType>::max())
+            throw Exception ("value of \"end\" is not known in number sequence \"" + spec + "\"");
+          num[i] = SignedIntType(last);
+        }
+        else num[i] = to<SignedIntType> (spec.substr (start, end-start));
+
+        end = spec.find_first_not_of (" \t", end);
+        char last_char = end < spec.size() ? spec[end] : '\0';
+        if (last_char == ':') {
+          ++i;
+          ++end;
+          if (i > 2) throw Exception ("invalid number range in number sequence \"" + spec + "\"");
+        } else {
+          if (i) {
+            SignedIntType inc, last;
+            if (i == 2) {
+              inc = num[1];
+              last = num[2];
+            }
+            else {
+              inc = 1;
+              last = num[1];
+            }
+            if (inc * (last - num[0]) < 0)
+              inc = -inc;
+            for (; (inc > 0 ? num[0] <= last : num[0] >= last) ; num[0] += inc)
+              V.push_back (to_unsigned(num[0]));
+          }
+          else V.push_back (to_unsigned(num[0]));
+          i = 0;
+        }
+
+        start = end;
+        if (last_char == ',')
+          ++start;
+      }
+      while (end < spec.size());
+    }
+    catch (Exception& E) {
+      throw Exception (E, "can't parse integer sequence specifier \"" + spec + "\"");
+    }
+
+    return (V);
   }
 
 

--- a/core/stride.cpp
+++ b/core/stride.cpp
@@ -91,7 +91,7 @@ namespace MR
       catch (Exception& E) {
         E.display (3);
         try {
-          auto tmp = parse_ints (opt[0][0]);
+          auto tmp = parse_ints<int> (opt[0][0]);
           for (auto x : tmp)
             strides.push_back (x);
         }

--- a/src/dwi/sdeconv/csd.h
+++ b/src/dwi/sdeconv/csd.h
@@ -72,7 +72,7 @@ namespace MR
               using namespace App;
               auto opt = get_options ("lmax");
               if (opt.size()) {
-                auto list = parse_ints (opt[0][0]);
+                auto list = parse_ints<uint32_t> (opt[0][0]);
                 if (list.size() != 1)
                   throw Exception ("CSD algorithm expects a single lmax to be specified");
                 lmax_cmdline = list.front();
@@ -123,7 +123,7 @@ namespace MR
               if (lmax_response <= 0)
                 throw Exception ("response function does not contain anisotropic terms");
 
-              lmax = ( lmax_cmdline ? lmax_cmdline : std::min (lmax_response, DEFAULT_CSD_LMAX) );
+              lmax = ( lmax_cmdline ? lmax_cmdline : std::min (lmax_response, uint32_t(DEFAULT_CSD_LMAX)) );
 
               if (lmax <= 0 || lmax % 2)
                 throw Exception ("lmax must be a positive even integer");
@@ -206,7 +206,7 @@ namespace MR
             Eigen::MatrixXd rconv, HR_trans, M, Mt_M;
             default_type neg_lambda, norm_lambda, threshold;
             vector<size_t> dwis;
-            int lmax_response, lmax_data, lmax_cmdline, lmax;
+            uint32_t lmax_response, lmax_data, lmax_cmdline, lmax;
             size_t niter;
         };
 

--- a/src/dwi/sdeconv/msmt_csd.h
+++ b/src/dwi/sdeconv/msmt_csd.h
@@ -59,7 +59,7 @@ namespace MR
                 using namespace App;
                 auto opt = get_options ("lmax");
                 if (opt.size())
-                  lmax = parse_ints (opt[0][0]);
+                  lmax = parse_ints<uint32_t> (opt[0][0]);
                 opt = get_options ("directions");
                 if (opt.size())
                   HR_dirs = load_matrix (opt[0][0]);
@@ -102,13 +102,13 @@ namespace MR
                 if (lmax.empty()) {
                   lmax = lmax_response;
                   for (size_t t = 0; t != num_tissues(); ++t) {
-                    lmax[t] = std::min (DEFAULT_MSMTCSD_LMAX, lmax[t]);
+                    lmax[t] = std::min (uint32_t(DEFAULT_MSMTCSD_LMAX), lmax[t]);
                   }
                 } else {
                   if (lmax.size() != num_tissues())
                     throw Exception ("Number of lmaxes specified (" + str(lmax.size()) + ") does not match number of tissues (" + str(num_tissues()) + ")");
                   for (const auto i : lmax) {
-                    if (i < 0 || i % 2)
+                    if (i % 2)
                       throw Exception ("Each value of lmax must be a non-negative even integer");
                   }
                 }
@@ -126,7 +126,7 @@ namespace MR
                 //////////////////////////////////////////////////
 
                 size_t nparams = 0;
-                int maxlmax = 0;
+                uint32_t maxlmax = 0;
                 for (size_t i = 0; i < num_tissues(); i++) {
                   nparams += Math::SH::NforL (lmax[i]);
                   maxlmax = std::max (maxlmax, lmax[i]);
@@ -225,7 +225,7 @@ namespace MR
               const Eigen::MatrixXd grad;
               DWI::Shells shells;
               Eigen::MatrixXd HR_dirs;
-              vector<int> lmax, lmax_response;
+              vector<uint32_t> lmax, lmax_response;
               vector<Eigen::MatrixXd> responses;
               vector<std::string> response_files;
               Math::ICLS::Problem<double> problem;

--- a/src/dwi/tractography/SIFT/sifter.cpp
+++ b/src/dwi/tractography/SIFT/sifter.cpp
@@ -359,11 +359,11 @@ namespace MR
 
 
 
-      void SIFTer::set_regular_outputs (const vector<int>& in, const bool b)
+      void SIFTer::set_regular_outputs (const vector<uint32_t>& in, const bool b)
       {
-        for (vector<int>::const_iterator i = in.begin(); i != in.end(); ++i) {
-          if (*i > 0 && *i <= (int)contributions.size())
-            output_at_counts.push_back (*i);
+        for (auto i : in) {
+          if (i > 0 && i <= contributions.size())
+            output_at_counts.push_back (i);
         }
         sort (output_at_counts.begin(), output_at_counts.end());
         output_debug = b;

--- a/src/dwi/tractography/SIFT/sifter.h
+++ b/src/dwi/tractography/SIFT/sifter.h
@@ -79,7 +79,7 @@ namespace MR
         void set_term_mu     (const float i)        { term_mu = i; }
         void set_csv_path    (const std::string& i) { csv_path = i; }
 
-        void set_regular_outputs (const vector<int>&, const bool);
+        void set_regular_outputs (const vector<uint32_t>&, const bool);
 
 
         // DEBUGGING

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -136,9 +136,9 @@ namespace MR
         //CONF Initial window size of MRView in pixels.
         //CONF default: 512,512
         std::string init_size_string = lowercase (MR::File::Config::get ("MRViewInitWindowSize"));
-        vector<int> init_window_size;
+        vector<uint32_t> init_window_size;
         if (init_size_string.length())
-          init_window_size = parse_ints(init_size_string);
+          init_window_size = parse_ints<uint32_t> (init_size_string);
         if (init_window_size.size() == 2)
           return QSize (init_window_size[0], init_window_size[1]);
         else
@@ -1895,7 +1895,7 @@ namespace MR
           }
 
           if (opt.opt->is ("size")) {
-            vector<int> glsize = parse_ints (opt[0]);
+            vector<uint32_t> glsize = parse_ints<uint32_t> (opt[0]);
             if (glsize.size() != 2)
               throw Exception ("invalid argument \"" + std::string(opt.args[0]) + "\" to -size batch command");
             if (glsize[0] < 1 || glsize[1] < 1)
@@ -1961,9 +1961,9 @@ namespace MR
 
           if (opt.opt->is ("volume")) {
             if (image()) {
-              auto pos = parse_ints (opt[0]);
+              auto pos = parse_ints<uint32_t> (opt[0]);
               for (size_t n = 0; n < std::min (pos.size(), image()->image.ndim()); ++n) {
-                if (pos[n] < 0 || pos[n] >= image()->image.size(n+3))
+                if (pos[n] >= image()->image.size(n+3))
                   throw Exception ("volume index outside of image dimensions");
                 set_image_volume (n+3, pos[n]);
                 set_image_navigation_menu();
@@ -2046,7 +2046,7 @@ namespace MR
           }
 
           if (opt.opt->is ("position")) {
-            vector<int> pos = opt[0];
+            vector<int> pos = parse_ints<int> (opt[0]);
             if (pos.size() != 2)
               throw Exception ("invalid argument \"" + std::string(opt[0]) + "\" to -position option");
             move (pos[0], pos[1]);

--- a/src/registration/linear.cpp
+++ b/src/registration/linear.cpp
@@ -119,10 +119,10 @@ namespace MR
 
       opt = get_options("linstage.iterations");
       if (opt.size()) {
-        vector<int> iterations = parse_ints (opt[0][0]);
+        const auto iterations = parse_ints<uint32_t> (opt[0][0]);
         registration.set_stage_iterations (iterations);
       } else {
-        registration.set_stage_iterations (vector<int> {1});
+        registration.set_stage_iterations (vector<uint32_t> {1});
       }
 
       opt = get_options("linstage.diagnostics.prefix");

--- a/src/registration/linear.h
+++ b/src/registration/linear.h
@@ -154,9 +154,9 @@ namespace MR
             stage.optimiser_last = type;
         }
 
-        void set_stage_iterations (const vector<int>& it) {
+        void set_stage_iterations (const vector<uint32_t>& it) {
           for (size_t i = 0; i < it.size (); ++i)
-            if (it[i] <= 0)
+            if (!it[i])
               throw Exception ("the number of stage iterations must be positive");
           if (it.size() == stages.size()) {
             for (size_t i = 0; i < stages.size (); ++i)
@@ -174,10 +174,7 @@ namespace MR
           }
         }
 
-        void set_max_iter (const vector<int>& maxiter) {
-          for (size_t i = 0; i < maxiter.size (); ++i)
-            if (maxiter[i] < 0)
-              throw Exception ("the number of iterations must be non-negative");
+        void set_max_iter (const vector<uint32_t>& maxiter) {
           if (maxiter.size() == stages.size()) {
             for (size_t i = 0; i < stages.size (); ++i)
               stages[i].gd_max_iter = maxiter[i];
@@ -194,10 +191,10 @@ namespace MR
           do_reorientation = true;
         }
 
-        void set_lmax (const vector<int>& lmax) {
+        void set_lmax (const vector<uint32_t>& lmax) {
           for (size_t i = 0; i < lmax.size (); ++i)
-            if (lmax[i] < 0 || lmax[i] % 2)
-              throw Exception ("the input lmax must be positive and even");
+            if (lmax[i] % 2)
+              throw Exception ("the input lmax must be even");
           if (lmax.size() == stages.size()) {
             for (size_t i = 0; i < stages.size (); ++i)
               stages[i].fod_lmax = lmax[i];

--- a/src/registration/metric/local_cross_correlation.h
+++ b/src/registration/metric/local_cross_correlation.h
@@ -163,7 +163,7 @@ namespace MR
                 auto cc_mask_header = Header::scratch (parameters.midway_image);
 
                 auto cc_image = cc_image_header.template get_image <ProcessedImageValueType>().with_direct_io(Stride::contiguous_along_axis(3));
-                vector<int> NoOversample;
+                vector<uint32_t> NoOversample;
                 {
                   LogLevelLatch log_level (0);
                   if (parameters.im1_mask.valid() or parameters.im2_mask.valid())

--- a/src/registration/metric/params.h
+++ b/src/registration/metric/params.h
@@ -174,7 +174,7 @@ namespace MR
               header.keyval()["trafo2"] = str(trafo2.matrix());
               auto check = Image<default_type>::create (image_path, header);
 
-              vector<int> no_oversampling (3,1);
+              vector<uint32_t> no_oversampling (3,1);
               Adapter::Reslice<Interp::Linear, Im1ImageType > im1_reslicer (
                 im1_image, midway_image, trafo1, no_oversampling, NAN);
               Adapter::Reslice<Interp::Linear, Im2ImageType > im2_reslicer (

--- a/src/registration/multi_resolution_lmax.h
+++ b/src/registration/multi_resolution_lmax.h
@@ -31,10 +31,10 @@ namespace MR
     FORCE_INLINE ImageType multi_resolution_lmax (ImageType& input,
                                                   const default_type scale_factor,
                                                   const bool do_reorientation = false,
-                                                  const int lmax = 0)
+                                                  const uint32_t lmax = 0)
     {
-      vector<int> from (input.ndim(), 0);
-      vector<int> size (input.ndim());
+      vector<uint32_t> from (input.ndim(), 0);
+      vector<uint32_t> size (input.ndim());
       for (size_t dim = 0; dim < input.ndim(); ++dim)
         size[dim] = input.size(dim);
       if (do_reorientation)
@@ -63,13 +63,13 @@ namespace MR
                                                   const vector<MultiContrastSetting>& contrast,
                                                   vector<MultiContrastSetting>* contrast_updated = nullptr)
     {
-      vector<int> volume_indices;
+      vector<uint32_t> volume_indices;
       size_t start = 0;
       for (size_t ic = 0; ic < contrast.size(); ic++) {
         const auto & mc = contrast[ic];
         assert (mc.nvols > 0);
         for (size_t i = 0; i < mc.nvols; i++)
-          volume_indices.push_back((int) (mc.start + i));
+          volume_indices.push_back(mc.start + i);
         // adjust start index to be relative to subset
         if (contrast_updated)
           (*contrast_updated)[ic].start = start;

--- a/src/registration/nonlinear.h
+++ b/src/registration/nonlinear.h
@@ -394,10 +394,7 @@ namespace MR
             is_initialised = true;
           }
 
-          void set_max_iter (const vector<int>& maxiter) {
-            for (size_t i = 0; i < maxiter.size (); ++i)
-              if (maxiter[i] < 0)
-                throw Exception ("the number of iterations must be positive");
+          void set_max_iter (const vector<uint32_t>& maxiter) {
             max_iter = maxiter;
           }
 
@@ -431,10 +428,10 @@ namespace MR
             disp_smoothing = voxel_fwhm;
           }
 
-          void set_lmax (const vector<int>& lmax) {
+          void set_lmax (const vector<uint32_t>& lmax) {
             for (size_t i = 0; i < lmax.size (); ++i)
-              if (lmax[i] < 0 || lmax[i] % 2)
-                throw Exception ("the input nonlinear lmax must be positive and even");
+              if (lmax[i] % 2)
+                throw Exception ("the input nonlinear lmax must be even");
             fod_lmax = lmax;
           }
 
@@ -550,14 +547,14 @@ namespace MR
 
 
           bool is_initialised;
-          vector<int> max_iter;
+          vector<uint32_t> max_iter;
           vector<default_type> scale_factor;
           default_type update_smoothing;
           default_type disp_smoothing;
           default_type gradient_step;
           Eigen::MatrixXd aPSF_directions;
           bool do_reorientation;
-          vector<int> fod_lmax;
+          vector<uint32_t> fod_lmax;
           bool use_cc;
           std::basic_string<char> diagnostics_image_prefix;
 

--- a/src/registration/warp/compose.h
+++ b/src/registration/warp/compose.h
@@ -247,7 +247,7 @@ namespace MR
         WarpType deformation = WarpType::scratch (midway_header);
 
         transform_type linear;
-        vector<int> index(1);
+        vector<uint32_t> index (1);
         if (from == 1) {
           linear = Registration::Warp::parse_linear_transform (warp, "linear1");
           index[0] = 0;
@@ -270,7 +270,7 @@ namespace MR
         transform_type linear1 = Registration::Warp::parse_linear_transform (warp, "linear1");
         transform_type linear2 = Registration::Warp::parse_linear_transform (warp, "linear2");
 
-        vector<int> index(1);
+        vector<uint32_t> index (1);
         if (from == 1) {
           index[0] = 0;
           Adapter::Extract1D<Image<default_type>> im1_to_mid (warp, 4, index);

--- a/testing/binaries/tests/mrconvert
+++ b/testing/binaries/tests/mrconvert
@@ -11,7 +11,7 @@ mrconvert mrconvert/in.mif -strides 1,3,2 -datatype int16 tmp.mgz  && testing_di
 mrconvert mrconvert/in.mif tmp-[].png  && echo -e "1 0 0 0\n0 1 0 0\n0 0 1 0\n" > tmp.txt  && testing_diff_image tmp-[].png $(mrcalc mrconvert/in.mif 0 -max - | mrtransform - -replace tmp.txt -)
 mrconvert unit_warp.mif tmp-[].png -datatype uint8 -force  && echo -e "1 0 0 0\n0 1 0 0\n0 0 1 0\n" > tmp.txt  && testing_diff_image tmp-[].png $(mrcalc unit_warp.mif 0 -max -round - | mrtransform - -replace tmp.txt - | mrconvert - -vox 1,1,1 -)
 mrconvert dwi.mif tmp-[].mif -force && testing_diff_image dwi.mif tmp-[].mif
-mrconvert dwi.mif -coord 3 0:2:end tmp1.mif && mrconvert tmp-[0:2:66].mif tmp2.mif && testing_diff_header -keyval tmp1.mif tmp2.mif && testing_diff_image tmp1.mif tmp2.mif
+mrconvert dwi.mif -coord 3 0:2:end tmp1.mif -force && mrconvert tmp-[0:2:66].mif tmp2.mif && testing_diff_header -keyval tmp1.mif tmp2.mif && testing_diff_image tmp1.mif tmp2.mif
 mrconvert mrcat/voxel[].mih - | testing_diff_header -keyval - mrcat/all_axis0.mif
 mrconvert mrcat/all_axis3.mif tmp-[].mif -force && testing_diff_header -keyval tmp-0.mif mrcat/voxel1.mih && testing_diff_header -keyval tmp-1.mif mrcat/voxel2.mih && testing_diff_header -keyval tmp-2.mif mrcat/voxel3.mih && testing_diff_header -keyval tmp-3.mif mrcat/voxel4.mih && testing_diff_header -keyval tmp-4.mif mrcat/voxel5.mih && testing_diff_header -keyval tmp-5.mif mrcat/voxel6.mih
 mrconvert dwi.mif tmp-[]-[].mif -force && testing_diff_image dwi.mif tmp-[]-[].mif

--- a/testing/cmd/testing_unit_tests_parse_ints.cpp
+++ b/testing/cmd/testing_unit_tests_parse_ints.cpp
@@ -73,8 +73,8 @@ void run ()
 
   for (const auto& t : tests) {
     try {
-      if (parse_ints (t.str) != t.result)
-        failures.push_back ("\"" + std::string (t.str) + "\" to " + str(t.result) + " failed (produced " + str(parse_ints(t.str)) + ")");
+      if (parse_ints<int> (t.str) != t.result)
+        failures.push_back ("\"" + std::string (t.str) + "\" to " + str(t.result) + " failed (produced " + str(parse_ints<int>(t.str)) + ")");
     }
     catch (Exception& e) {
       if (t.result.size())


### PR DESCRIPTION
Work toward addressing #2099. 

Compiles, but I'd like to make an attempt at producing a fixel matrix that exceeds 4 billion entries and see that `fixelfilter` behaves as intended.