### PR TITLE
docs: replace mrresize by mrgrid

### DIFF
--- a/cmd/mrconvert.cpp
+++ b/cmd/mrconvert.cpp
@@ -63,7 +63,7 @@ void usage ()
   + "The -vox option is used to change the size of the voxels in the output "
     "image as reported in the image header; note however that this does not "
     "re-sample the image based on a new voxel size (that is done using the "
-    "mrresize command)."
+    "mrgrid command)."
 
   + "By default, the intensity scaling parameters in the input image header "
     "are passed through to the output image header when writing to an integer "

--- a/docs/fixel_based_analysis/mt_fibre_density_cross-section.rst
+++ b/docs/fixel_based_analysis/mt_fibre_density_cross-section.rst
@@ -64,7 +64,7 @@ There is however no strict requirement for the final set of response functions t
 ^^^^^^^^^^^^^^^^^^^^^^^
 Upsampling DWI data *before* computing FODs increases anatomical contrast and improves downstream template building, registration, tractography and statistics. We recommend upsampling to an isotropic voxel size of 1.25 mm for human brains (if your original resolution is already higher, you can skip this step)::
 
-    for_each * : mrresize IN/dwi_denoised_unringed_preproc_unbiased.mif -vox 1.25 IN/dwi_denoised_unringed_preproc_unbiased_upsampled.mif
+    for_each * : mrgrid IN/dwi_denoised_unringed_preproc_unbiased.mif regrid -vox 1.25 IN/dwi_denoised_unringed_preproc_unbiased_upsampled.mif
 
 
 6. Compute upsampled brain mask images

--- a/docs/fixel_based_analysis/st_fibre_density_cross-section.rst
+++ b/docs/fixel_based_analysis/st_fibre_density_cross-section.rst
@@ -107,7 +107,7 @@ There is however no strict requirement for the (one) final response function to 
 ^^^^^^^^^^^^^^^^^^^^^^^
 Upsampling DWI data *before* computing FODs can increase anatomical contrast and improve downstream template building, registration, tractography and statistics. We recommend upsampling to an isotropic voxel size of 1.25 mm for human brains (if your original resolution is already higher, you can skip this step)::
 
-    for_each * : mrresize IN/dwi_denoised_unringed_preproc_unbiased_normalised.mif -vox 1.25 IN/dwi_denoised_unringed_preproc_unbiased_normalised_upsampled.mif
+    for_each * : mrgrid IN/dwi_denoised_unringed_preproc_unbiased_normalised.mif regrid -vox 1.25 IN/dwi_denoised_unringed_preproc_unbiased_normalised_upsampled.mif
 
 8. Compute upsampled brain mask images
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/quantitative_structural_connectivity/ismrm_hcp_tutorial.rst
+++ b/docs/quantitative_structural_connectivity/ismrm_hcp_tutorial.rst
@@ -161,7 +161,7 @@ image and provide this alternative FOD image to SIFT (this should have
 little influence on the outcome of the algorithm, but will greatly
 reduce memory consumption):
 
-``mrresize WM_FODs.mif FOD_downsampled.mif -scale 0.5 -interp sinc``
+``mrgrid WM_FODs.mif regrid FOD_downsampled.mif -scale 0.5 -interp sinc``
 
 If this still does not adequately reduce RAM usage, you will need to
 reduce the number of input streamlines to a level where your processing

--- a/docs/reference/commands/mrconvert.rst
+++ b/docs/reference/commands/mrconvert.rst
@@ -27,7 +27,7 @@ Note that for both the -coord and -axes options, indexing starts from 0 rather t
 
 Additionally, for the second input to the -coord option and the -axes option, you can use any valid number sequence in the selection, as well as the 'end' keyword (see the main documentation for details); this can be particularly useful to select multiple coordinates.
 
-The -vox option is used to change the size of the voxels in the output image as reported in the image header; note however that this does not re-sample the image based on a new voxel size (that is done using the mrresize command).
+The -vox option is used to change the size of the voxels in the output image as reported in the image header; note however that this does not re-sample the image based on a new voxel size (that is done using the mrgrid command).
 
 By default, the intensity scaling parameters in the input image header are passed through to the output image header when writing to an integer image, and reset to 0,1 (i.e. no scaling) for floating-point and binary images. Note that the -scaling option will therefore have no effect for floating-point or binary output images.
 


### PR DESCRIPTION
There were a few places with leftover `mrresize` examples in the docs as reported in the [forum](https://community.mrtrix.org/t/mrresize/3589/2)