### PR TITLE
run_tests: allow different location for MRtrix executables

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
 [submodule "testing/data"]
 	path = testing/binaries/data
 	url = https://github.com/MRtrix3/test_data
+	ignore = dirty
 [submodule "testing/script_data"]
 	path = testing/scripts/data
 	url = https://github.com/MRtrix3/script_test_data.git
+	ignore = dirty

--- a/run_tests
+++ b/run_tests
@@ -15,6 +15,14 @@
 #
 # For more details, see http://www.mrtrix.org/.
 
+
+
+# when testing a binary release, you can use the MRTRIX_BINDIR environment
+# variable to point to the location of the executables you want to test. You'll
+# need to ensure the same commit/tag is checked out on this repo for the
+# results to be valid.
+
+
 if test "$#" -ne 1; then
   echo "Script must be provided with single input argument: \"binaries\", \"scripts\", \"units\", or the name of a specific test to be run."
   exit 1
@@ -151,6 +159,16 @@ cat >> $LOGFILE <<EOD
 PATH is set to $PATH
 EOD
 
+if [[ -z "$MRTRIX_BINDIR" ]]; then
+  MRTRIX_BINDIR="$(pwd)/bin"
+else
+  MRTRIX_BINDIR="${MRTRIX_BINDIR}"
+fi
+cat >> $LOGFILE <<EOD
+
+Testing executables in: $MRTRIX_BINDIR
+EOD
+
 
 for testitem in $testlist; do
 
@@ -173,7 +191,7 @@ EOD
     [[ -n "$cmd" ]] || continue
     echo -n '# command: '$cmd >> $LOGFILE
     (
-      export PATH="$(pwd)/testing/bin:$(pwd)/bin:$PATH";
+      export PATH="$(pwd)/testing/bin:${MRTRIX_BINDIR}:$PATH";
       cd $datadir
       eval $cmd
     ) > .__tmp.log 2>&1


### PR DESCRIPTION
This is to allow binary packages to be tested. To use, make sure you
have a clone of the MRtrix3 repo checked out, and the binary package you
want to test is installed. Then set the MRTRIX_BINDIR environment
variable to point to the location of the executables to be tested, and
invoke run_tests. For example:
```
MRTRIX_BINDIR=~/miniconda3/bin/ ./run_tests binaries
```
