### PR TITLE
dwifslpreproc: Fix eddy_quad susceptibility field

### DIFF
--- a/bin/dwifslpreproc
+++ b/bin/dwifslpreproc
@@ -982,7 +982,7 @@ def execute(): #pylint: disable=unused-variable
       if os.path.isfile('dwi_post_eddy.eddy_residuals'):
         eddyqc_options += ' -g ' + bvecs_path
       if do_topup:
-        eddyqc_options += ' -f ' + fsl.find_image('field_fieldcoef')
+        eddyqc_options += ' -f ' + fsl.find_image('field_map')
       if eddy_mporder:
         eddyqc_options += ' -s slspec.txt'
       if app.VERBOSITY > 2:


### PR DESCRIPTION
Script provides `eddy_quad` with the spline field rather than the image in Hz; as a result `eddy_quad` produces an error like:

```
Traceback (most recent call last):
  File "/software/FSL/fsl6/bin/eddy_quad", line 54, in <module>
    main(args.eddyBase, args.eddyIdx, args.eddyParams, args.mask, args.bvals, args.bvecs, args.output_dir, args.field, args.slspec, args.verbose)
  File "/software/FSL/fsl6/fslpython/envs/fslpython/lib/python3.7/site-packages/eddy_qc/QUAD/quad.py", line 345, in main
    eddyOutput['std_displacement'] = np.std(dispField[data['mask'] != 0.0])
IndexError: boolean index did not match indexed array along dimension 0; dimension is 51 but corresponding boolean dimension is 96
```