### PR TITLE
dirmerge: don't output a 5th column if single subset

### DIFF
--- a/cmd/dirmerge.cpp
+++ b/cmd/dirmerge.cpp
@@ -210,7 +210,7 @@ void run ()
 
   File::OFStream out (argument[argument.size()-1]);
   for (auto& d : merged)
-    out << MR::printf ("%#20.15f %#20.15f %#20.15f %5d %3d\n",
+    out << MR::printf (num_subsets > 1 ? "%#20.15f %#20.15f %#20.15f %5d %3d\n" : "%#20.15f %#20.15f %#20.15f %5d\n",
         d.d[0], d.d[1], d.d[2],
         int (bvalue[d.b]), int (d.pe+1));
 


### PR DESCRIPTION
This ensures that single-PE schemes generated by `dirmerge` (and hence `gen_scheme`) don't have an unnecessary 5th column if there is only one PE/subset (in which case that 5th column would contains 1's only).