### PR TITLE
dwi2fod: fix error when volumes not assigned to shells

### DIFF
--- a/src/dwi/sdeconv/msmt_csd.h
+++ b/src/dwi/sdeconv/msmt_csd.h
@@ -134,7 +134,7 @@ namespace MR
 
                 INFO ("initialising multi-tissue CSD for " + str(num_tissues()) + " tissue types, with " + str (nparams) + " parameters");
 
-                Eigen::MatrixXd C (grad.rows(), nparams);
+                Eigen::MatrixXd C = Eigen::MatrixXd::Zero (grad.rows(), nparams);
 
                 vector<size_t> dwilist;
                 for (size_t i = 0; i != size_t(grad.rows()); i++)


### PR DESCRIPTION
This was due to uninitialised rows in the transform matrix when some of the volumes were left out.

This fixes #2129 - see also [discussion on the forum](https://community.mrtrix.org/t/dhollander-response-function-estimation/3895?u=jdtournier).