### PR TITLE
mrtransform: Tweak -modulate option help

### DIFF
--- a/cmd/mrtransform.cpp
+++ b/cmd/mrtransform.cpp
@@ -178,7 +178,7 @@ void usage ()
         "fod: modulate FODs during reorientation to preserve the apparent fibre density across fibre bundle widths before and after the transformation. \n"
         "jac: modulate the image intensity with the determinant of the Jacobian of the warp of linear transformation "
         "to preserve the total intensity before and after the transformation.")
-    + Argument ("intensity modulation method").type_choice (modulation_choices)
+    + Argument ("method").type_choice (modulation_choices)
 
     + Option ("directions",
         "directions defining the number and orientation of the apodised point spread functions used in FOD reorientation "

--- a/docs/reference/commands/mrtransform.rst
+++ b/docs/reference/commands/mrtransform.rst
@@ -72,7 +72,7 @@ Non-linear transformation options
 Fibre orientation distribution handling options
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
--  **-modulate intensity modulation method** Valid choices are: fod and jac.  |br|
+-  **-modulate method** Valid choices are: fod and jac.  |br|
    fod: modulate FODs during reorientation to preserve the apparent fibre density across fibre bundle widths before and after the transformation.  |br|
    jac: modulate the image intensity with the determinant of the Jacobian of the warp of linear transformation to preserve the total intensity before and after the transformation.
 


### PR DESCRIPTION
For options that receive multiple command-line inputs, the names of those arguments are space-separated; it is therefore preferable for the description of an option that receives only one command-line input to not have space separators in its name.