### PR TITLE
Stats commands: Fix -strong option

### DIFF
--- a/cmd/connectomestats.cpp
+++ b/cmd/connectomestats.cpp
@@ -351,7 +351,7 @@ void run()
   // Perform permutation testing
   if (!get_options ("notest").size()) {
 
-    const bool fwe_strong = get_option_value ("strong", false);
+    const bool fwe_strong = get_options ("strong").size();
     if (fwe_strong && num_hypotheses == 1) {
       WARN("Option -strong has no effect when testing a single hypothesis only");
     }

--- a/cmd/fixelcfestats.cpp
+++ b/cmd/fixelcfestats.cpp
@@ -452,7 +452,7 @@ void run()
   // Perform permutation testing
   if (!get_options ("notest").size()) {
 
-    const bool fwe_strong = get_option_value ("strong", false);
+    const bool fwe_strong = get_options("strong").size();
     if (fwe_strong && num_hypotheses == 1) {
       WARN("Option -strong has no effect when testing a single hypothesis only");
     }

--- a/cmd/mrclusterstats.cpp
+++ b/cmd/mrclusterstats.cpp
@@ -368,7 +368,7 @@ void run() {
 
   if (!get_options ("notest").size()) {
 
-    const bool fwe_strong = get_option_value ("strong", false);
+    const bool fwe_strong = get_options ("strong").size();
     if (fwe_strong && num_hypotheses == 1) {
       WARN("Option -strong has no effect when testing a single hypothesis only");
     }

--- a/cmd/vectorstats.cpp
+++ b/cmd/vectorstats.cpp
@@ -247,7 +247,7 @@ void run()
   // Perform permutation testing
   if (!get_options ("notest").size()) {
 
-    const bool fwe_strong = get_option_value ("strong", false);
+    const bool fwe_strong = get_options ("strong").size();
     if (fwe_strong && num_hypotheses == 1) {
       WARN("Option -strong has no effect when testing a single hypothesis only");
     }


### PR DESCRIPTION
Prior change in the implementation of strong FWE control, changing the command-line option from receiving a boolean to being a flag, was not propagated to the point in code at which that option was read. This however now results in an error upon attempting to use that option due to merge of #1794, as it erroneously attempts to convert the next item on the command-line following the `-strong` option to a double.
