### PR TITLE
mrtransform: Prevent erroneous warning

### DIFF
--- a/cmd/mrtransform.cpp
+++ b/cmd/mrtransform.cpp
@@ -443,12 +443,17 @@ void run ()
   }
 
 
-  // Rotate/Flip gradient directions if present
+  // Rotate/Flip direction information if present
   if (linear && input_header.ndim() == 4 && !warp && !fod_reorientation) {
     Eigen::MatrixXd rotation = linear_transform.linear().inverse();
     Eigen::MatrixXd test = rotation.transpose() * rotation;
     test = test.array() / test.diagonal().mean();
-    auto grad = DWI::get_DW_scheme (input_header);
+
+    // Diffusion gradient table
+    Eigen::MatrixXd grad;
+    try {
+      grad = DWI::get_DW_scheme (input_header);
+    } catch (Exception&) {}
     if (grad.rows()) {
       if (replace)
         rotation = linear_transform.linear() * input_header.transform().linear().inverse();
@@ -476,6 +481,7 @@ void run ()
         WARN ("DW gradients not correctly reoriented");
       }
     }
+
     // Also look for key 'directions', and rotate those if present
     auto hit = input_header.keyval().find ("directions");
     if (hit != input_header.keyval().end()) {

--- a/cmd/mrtransform.cpp
+++ b/cmd/mrtransform.cpp
@@ -448,6 +448,8 @@ void run ()
     Eigen::MatrixXd rotation = linear_transform.linear().inverse();
     Eigen::MatrixXd test = rotation.transpose() * rotation;
     test = test.array() / test.diagonal().mean();
+    if (replace)
+      rotation = linear_transform.linear() * input_header.transform().linear().inverse();
 
     // Diffusion gradient table
     Eigen::MatrixXd grad;
@@ -455,8 +457,6 @@ void run ()
       grad = DWI::get_DW_scheme (input_header);
     } catch (Exception&) {}
     if (grad.rows()) {
-      if (replace)
-        rotation = linear_transform.linear() * input_header.transform().linear().inverse();
       try {
         if (input_header.size(3) != (ssize_t) grad.rows()) {
           throw Exception ("DW gradient table of different length ("

--- a/cmd/mrtransform.cpp
+++ b/cmd/mrtransform.cpp
@@ -438,20 +438,18 @@ void run ()
     } else if (is_possible_fod_image) {
       WARN ("Jacobian modulation performed on possible SH series image. Did you mean FOD modulation?");
     }
-
     if (!linear && !warp.valid())
       throw Exception ("Jacobian modulation requires linear or nonlinear transformation");
-
   }
 
 
   // Rotate/Flip gradient directions if present
   if (linear && input_header.ndim() == 4 && !warp && !fod_reorientation) {
+    Eigen::MatrixXd rotation = linear_transform.linear().inverse();
+    Eigen::MatrixXd test = rotation.transpose() * rotation;
+    test = test.array() / test.diagonal().mean();
     auto grad = DWI::get_DW_scheme (input_header);
     if (grad.rows()) {
-      Eigen::MatrixXd rotation = linear_transform.linear().inverse();
-      Eigen::MatrixXd test = rotation.transpose() * rotation;
-      test = test.array() / test.diagonal().mean();
       if (replace)
         rotation = linear_transform.linear() * input_header.transform().linear().inverse();
       try {

--- a/cmd/mrtransform.cpp
+++ b/cmd/mrtransform.cpp
@@ -447,14 +447,21 @@ void run ()
 
   // Rotate/Flip gradient directions if present
   if (linear && input_header.ndim() == 4 && !warp && !fod_reorientation) {
-    Eigen::MatrixXd rotation = linear_transform.linear().inverse();
-    Eigen::MatrixXd test = rotation.transpose() * rotation;
-    test = test.array() / test.diagonal().mean();
-    if (replace)
-      rotation = linear_transform.linear() * input_header.transform().linear().inverse();
-    try {
-      auto grad = DWI::get_DW_scheme (input_header);
-      if (input_header.size(3) == (ssize_t) grad.rows()) {
+    auto grad = DWI::get_DW_scheme (input_header);
+    if (grad.rows()) {
+      Eigen::MatrixXd rotation = linear_transform.linear().inverse();
+      Eigen::MatrixXd test = rotation.transpose() * rotation;
+      test = test.array() / test.diagonal().mean();
+      if (replace)
+        rotation = linear_transform.linear() * input_header.transform().linear().inverse();
+      try {
+        if (input_header.size(3) != (ssize_t) grad.rows()) {
+          throw Exception ("DW gradient table of different length ("
+                           + str(grad.rows())
+                           + ") to number of image volumes ("
+                           + str(input_header.size(3))
+                           + ")");
+        }
         INFO ("DW gradients detected and will be reoriented");
         if (!test.isIdentity (0.001)) {
           WARN ("the input linear transform contains shear or anisotropic scaling and "
@@ -466,10 +473,10 @@ void run ()
         }
         DWI::set_DW_scheme (output_header, grad);
       }
-    }
-    catch (Exception& e) {
-      e.display (2);
-      WARN ("DW gradients not correctly reoriented");
+      catch (Exception& e) {
+        e.display (2);
+        WARN ("DW gradients not correctly reoriented");
+      }
     }
     // Also look for key 'directions', and rotate those if present
     auto hit = input_header.keyval().find ("directions");


### PR DESCRIPTION
If the input image does not contain any diffusion gradient table, and a linear transformation is applied, do not issue a warning about the failure to reorient gradient directions.