### PR TITLE
CI: Test scripts w. no external dependencies

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -37,6 +37,9 @@ jobs:
 
     - name: binary tests
       run: ./run_tests binaries || { cat testing_binaries.log; false; }
+      
+    - name: script tests
+      run: ./run_tests scripts_nodep || { cat testing_scripts_nodep.log; false; }
 
 
 
@@ -98,6 +101,9 @@ jobs:
 
     - name: binary tests
       run: ./run_tests binaries || { cat testing_binaries.log; false; }
+      
+    - name: script tests
+      run: ./run_tests scripts_nodep || { cat testing_scripts_nodep; false; }
 
     - name: check command documentation
       run: ./docs/generate_user_docs.sh && git diff --exit-code docs/
@@ -143,6 +149,10 @@ jobs:
     - name: binary tests
       shell: cmd
       run: msys64\msys2_shell.cmd -c "./run_tests binaries || { cat testing_binaries.log; false; }"
+      
+    - name: script tests
+      shell: cmd
+      run: msys64\msys2_shell.cmd -c "./run_tests scripts_nodep || { cat testing_scripts_nodep.log; false; }"
 
 
 

--- a/run_tests
+++ b/run_tests
@@ -15,14 +15,19 @@
 #
 # For more details, see http://www.mrtrix.org/.
 
+
+# Scripts to be blacklisted from testing due to external software dependencies
+SCRIPTS_EXTDEP="5ttgen dwibiascorrect dwifslpreproc labelsgmfix"
+
+
 if test "$#" -ne 1; then
-  echo "Script must be provided with single input argument: \"binaries\", \"scripts\", \"units\", or the name of a specific test to be run."
+  echo "Script must be provided with single input argument: \"binaries\", \"scripts\", \"scripts_nodep\", \"units\", or the name of a specific test to be run."
   exit 1
 fi
 
 
 if [ -d testing/data/ ]; then
-  echo -n "Deleting old testing data directory testing/data/"
+  echo -n "Deleting old testing data directory testing/data/ ... "
   rm -rf testing/data/
   echo OK
 fi
@@ -42,6 +47,11 @@ case $1 in
     datadir="testing/scripts/data/"
     testsdir="testing/scripts/tests/"
     teststring="scripts"
+    ;;
+  scripts_nodep)
+    datadir="testing/scripts/data/"
+    testsdir="testing/scripts/tests/"
+    teststring="scripts (no external dependencies)"
     ;;
   units)
     testsdir="testing/tests/"
@@ -105,6 +115,16 @@ if [ ! -z $testsdir ]; then
   if [ -z "$testlist" ]; then
     echo ERROR!
     exit 1
+  fi
+  if [ $1 == "scripts_nodep" ]; then
+    blacklist="("$(echo $SCRIPTS_EXTDEP | tr ' ' '|')")"
+    revisedtestlist=""
+    for item in $testlist; do
+      if [[ ! $item =~ $blacklist ]]; then
+        revisedtestlist="$revisedtestlist $item"
+      fi
+    done
+    testlist=$revisedtestlist
   fi
   echo OK
   cat >> $LOGFILE <<EOD


### PR DESCRIPTION
Adds "`scripts_nodep`" input to `run_tests` script, which executes only tests for those Python scripts absent from the blacklist identifying those scripts with external software dependencies.

Related to #2134, but seeking to integrate more regular testing of as many scripts as possible; testing of those scripts *with* external dependencies could potentially be done only for merges to `master`. Will find out from the checks on this PR how much additional runtime is required.