### PR TITLE
vectorstats: Permit numerical matrix data as input

### DIFF
--- a/cmd/vectorstats.cpp
+++ b/cmd/vectorstats.cpp
@@ -115,16 +115,40 @@ class SubjectVectorImport : public SubjectDataImportBase
 void run()
 {
 
+  // Unlike other statistical inference commands, don't delay actual
+  //   loading of input data: feasible for the input itself to be
+  //   a text file containing raw numerical matrix data, rather than
+  //   a list of files
   CohortDataImport importer;
-  importer.initialise<SubjectVectorImport> (argument[0]);
-  const size_t num_inputs = importer.size();
-  CONSOLE ("Number of subjects: " + str(num_inputs));
-  const size_t num_elements = importer[0]->size();
-  CONSOLE ("Number of elements: " + str(num_elements));
-  for (size_t i = 0; i != importer.size(); ++i) {
-    if (importer[i]->size() != num_elements)
-      throw Exception ("Subject file \"" + importer[i]->name() + "\" contains incorrect number of elements (" + str(importer[i]) + "; expected " + str(num_elements) + ")");
+  matrix_type data;
+  size_t num_inputs = 0, num_elements = 0;
+  try {
+    importer.initialise<SubjectVectorImport> (argument[0]);
+    num_inputs = importer.size();
+    num_elements = importer[0]->size();
+    for (size_t i = 0; i != importer.size(); ++i) {
+      if (importer[i]->size() != num_elements)
+        throw Exception ("Subject file \"" + importer[i]->name() + "\" contains incorrect number of elements (" + str(importer[i]) + "; expected " + str(num_elements) + ")");
+    }
+    data.resize (num_inputs, num_elements);
+    for (size_t subject = 0; subject != num_inputs; subject++)
+      (*importer[subject]) (data.row(subject));
+  } catch (Exception& e_asfilelist) {
+    try {
+      data = load_matrix (argument[0]);
+      num_inputs = data.rows();
+      num_elements = data.cols();
+    } catch (Exception& e_asmatrix) {
+      Exception e ("Unable to load input data from file \"" + argument[0] + '"');
+      e.push_back ("Error when interpreted as containing list of file names: ");
+      e.push_back (e_asfilelist);
+      e.push_back ("Error when interpreted as numerical matrix data: ");
+      e.push_back (e_asmatrix);
+      throw e;
+    }
   }
+  CONSOLE ("Number of subjects: " + str(num_inputs));
+  CONSOLE ("Number of elements: " + str(num_elements));
 
   // Load design matrix
   const matrix_type design = load_matrix (argument[1]);
@@ -167,11 +191,6 @@ void run()
   CONSOLE ("Number of hypotheses: " + str(num_hypotheses));
 
   const std::string output_prefix = argument[3];
-
-  // Load input data
-  matrix_type data (num_inputs, num_elements);
-  for (size_t subject = 0; subject != num_inputs; subject++)
-    (*importer[subject]) (data.row(subject));
 
   const bool nans_in_data = !data.allFinite();
   if (nans_in_data) {

--- a/core/math/stats/import.h
+++ b/core/math/stats/import.h
@@ -100,6 +100,7 @@ namespace MR
            */
           vector_type operator() (const size_t index) const;
 
+          operator bool() const { return bool(files.size()); }
           size_t size() const { return files.size(); }
 
           std::shared_ptr<SubjectDataImportBase> operator[] (const size_t i) const
@@ -174,7 +175,7 @@ namespace MR
         if (load_from_dir.empty())
           throw e_nosuccess;
 
-        ProgressBar progress ("Importing data from files listed in \""
+        ProgressBar progress ("Configuring data import from files listed in \""
                               + Path::basename (listpath)
                               + "\" as found relative to directory \""
                               + load_from_dir + "\"");
@@ -184,7 +185,7 @@ namespace MR
             std::shared_ptr<SubjectDataImport> subject (new SubjectDataImport (Path::join (load_from_dir, line)));
             files.emplace_back (subject);
           } catch (Exception& e) {
-            throw Exception (e, "Input data not successfully loaded: \"" + line + "\"");
+            throw Exception (e, "Input data not successfully configured for load: \"" + line + "\"");
           }
           ++progress;
         }


### PR DESCRIPTION
For some experiments, it may be preferable for the primary input to the `vectorstats` command to be the raw data in matrix form, rather than a list of files (each of which contains numerical vector data) (which is consistent with the interface of other statistical inference commands). This change attempts data import based on the user-specified argument using both approaches.

Draft pull request as I am awaiting generation of data for which the change is intended.