### PR TITLE
mrview: add -orientation cmdline option

### DIFF
--- a/docs/reference/commands/mrview.rst
+++ b/docs/reference/commands/mrview.rst
@@ -48,6 +48,8 @@ View options
 
 -  **-target x,y,z** Set the target location for the viewing window (the scanner coordinate that will appear at the centre of the viewing window
 
+-  **-orientation w,x,y,z** Set the orientation of the camera for the viewing window, in the form of a quaternion representing the rotation away from the z-axis. This should be provided as a list of 4 comma-separated floating point values (this will be automatically normalised).
+
 -  **-voxel x,y,z** *(multiple uses permitted)* Set the position of the crosshairs in voxel coordinates, relative the image currently displayed. The new position should be supplied as a comma-separated list of floating-point values.
 
 -  **-volume idx** *(multiple uses permitted)* Set the volume index for the image displayed, as a comma-separated list of integers.

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -1948,6 +1948,17 @@ namespace MR
             return;
           }
 
+          if (opt.opt->is ("orientation")) {
+            if (image()) {
+              vector<default_type> pos = parse_floats (opt[0]);
+              if (pos.size() != 4)
+                throw Exception ("-orientation option expects a comma-separated list of 4 floating-point values");
+              set_orientation ({ float(pos[0]), float(pos[1]), float(pos[2]), float(pos[3]) });
+              glarea->update();
+            }
+            return;
+          }
+
           if (opt.opt->is ("voxel")) {
             if (image()) {
               vector<default_type> pos = parse_floats (opt[0]);
@@ -2173,6 +2184,9 @@ namespace MR
           + Option ("target", "Set the target location for the viewing window (the scanner coordinate "
               "that will appear at the centre of the viewing window")
           +   Argument ("x,y,z").type_sequence_float()
+
+          + Option ("orientation", "Set the orientation of the camera for the viewing window, in the form of a quaternion representing the rotation away from the z-axis. This should be provided as a list of 4 comma-separated floating point values (this will be automatically normalised).")
+          +   Argument ("w,x,y,z").type_sequence_float()
 
           + Option ("voxel", "Set the position of the crosshairs in voxel coordinates, "
               "relative the image currently displayed. The new position should be supplied "


### PR DESCRIPTION
As the name implies... Requested by @bjeurissen. 

Not ideal in that the orientation needs to be provided as a comma-separated 4-vector, which isn't massively intuitive. In due course, we'd want to add options to manipulate the orientation more meaningfully, akin to [Matlab's campan, camzoom, camorbit, etc functions](https://uk.mathworks.com/help/matlab/referencelist.html?type=function&category=views). But this would be in addition to this particular option, so I reckon we can merge this now anyway.