### PR TITLE
Enforce Qt5

### DIFF
--- a/configure
+++ b/configure
@@ -1130,6 +1130,14 @@ def get_qt_version(cmd_list, raise_on_non_zero_exit_code):
   raise raise_on_non_zero_exit_code('Version not Found')
 
 
+
+def check_qt_version(version_string):
+  version = [int(i) for i in version_string.split('.')]
+  if version[0] < 5 or (version[0] == 5 and version[1] < 5):
+    raise VersionError
+
+
+
 moc = ''
 rcc = ''
 qt_cflags = []
@@ -1147,12 +1155,11 @@ if not nogui:
   try:
     moc_version = get_qt_version([ moc, '-v' ], OSError)
     report (moc + ' (version ' + moc_version + ')\n')
-    if int (moc_version.split('.')[0]) < 4:
-      raise VersionError
+    check_qt_version(moc_version)
   except VersionError:
     error (''' Qt moc version is too old!
 
-  The version number reported by the Qt moc command is too old.''' + qt_path_hint + qt_exec_hint ('moc'))
+  The version number reported by the Qt moc command is too old (require >= 5.5).''' + qt_path_hint + qt_exec_hint ('moc'))
   except OSError:
     error (''' Qt moc not found!
 
@@ -1167,12 +1174,11 @@ if not nogui:
   try:
     qmake_version = get_qt_version([ qmake, '-v' ], OSError)
     report (qmake + ' (version ' + qmake_version + ')\n')
-    if int (qmake_version.split('.')[0]) < 4:
-      raise VersionError
+    check_qt_version(qmake_version)
   except VersionError:
     error (''' Qt qmake version is too old!
 
-  The version number reported by the Qt qmake command is too old.''' + qt_path_hint + qt_exec_hint ('qmake'))
+  The version number reported by the Qt qmake command is too old (require >= 5.5).''' + qt_path_hint + qt_exec_hint ('qmake'))
   except OSError:
     error (''' Qt qmake not found!
 
@@ -1190,19 +1196,17 @@ if not nogui:
   try:
     rcc_version = get_qt_version([ rcc, '-v' ], OSError)
     report (rcc + ' (version ' + rcc_version + ')\n')
-    if int (rcc_version.split('.')[0]) < 4:
-      raise VersionError
+    check_qt_version(rcc_version)
   except VersionError:
     error (''' Qt rcc version is too old!
 
-  The version number reported by the Qt rcc command is too old.''' + qt_path_hint + qt_exec_hint ('rcc'))
+  The version number reported by the Qt rcc command is too old (require >= 5.5).''' + qt_path_hint + qt_exec_hint ('rcc'))
   except OSError:
     error (''' Qt rcc not found!
 
   MRtrix3 was unable to locate the Qt command 'rcc'.''' + qt_path_hint)
   except Exception as excp:
     error ('unexpected exception of type ' + type(excp).__name__ + ': ' + str(excp) +  configure_log_hint)
-
 
 
 
@@ -1274,7 +1278,6 @@ int main() { Foo f; }
 
   Use the QMAKE environment variable to set the correct qmake command for use with Qt''')
 
-
       qt_defines = []
       qt_includes = []
       qt_cflags = []
@@ -1343,7 +1346,9 @@ int main() { Foo f; }
       execute ([ cpp[0] ] + ld_flags + [ 'qt_moc.o', 'qt.o', '-o', 'qt' ] + qt_ldflags, \
           LinkError, cwd=qt_dir.name)
 
-      report (execute ([ os.path.join(qt_dir.name, 'qt') ], RunError)[1] + '\n')
+      qt_stdout = execute ([ os.path.join(qt_dir.name, 'qt') ], RunError)[1]
+      report(qt_stdout + '\n')
+      check_qt_version(qt_stdout)
 
 
   except QMakeError:
@@ -1356,6 +1361,8 @@ int main() { Foo f; }
     error ('error compiling Qt application!' + configure_log_hint)
   except RunError:
     error ('error running Qt application!' + configure_log_hint)
+  except VersionError:
+    error ('Qt version is too old! (require >= 5.5)' + configure_log_hint)
   except OSError as e:
     error ('unexpected error: ' + str(e) + configure_log_hint)
   except Exception as excp:

--- a/src/gui/dialog/opengl.cpp
+++ b/src/gui/dialog/opengl.cpp
@@ -52,12 +52,8 @@ namespace MR
         bit_depths->appendChild (new TreeItem ("depth", str (format.depthBufferSize()), bit_depths));
         bit_depths->appendChild (new TreeItem ("stencil", str (format.stencilBufferSize()), bit_depths));
 
-#if QT_VERSION >= 0x050400
         root->appendChild (new TreeItem ("Buffering", format.swapBehavior() == QSurfaceFormat::SingleBuffer ? "single" :
                ( format.swapBehavior() == QSurfaceFormat::DoubleBuffer ? "double" : "triple" ), root));
-#else
-        root->appendChild (new TreeItem ("Buffering", format.doubleBuffer() ? "double" : "single", root));
-#endif
         root->appendChild (new TreeItem ("VSync", format.swapInterval() ? "on" : "off", root));
         root->appendChild (new TreeItem ("Multisample anti-aliasing", format.samples() ? str(format.samples()).c_str() : "off", root));
 

--- a/src/gui/dwi/render_frame.cpp
+++ b/src/gui/dwi/render_frame.cpp
@@ -264,11 +264,9 @@ namespace MR
 
         // need to clear alpha channel when using QOpenGLWidget (Qt >= 5.4)
         // otherwise we get transparent windows...
-#if QT_VERSION >= 0x050400
         gl::ClearColor (0.0, 0.0, 0.0, 1.0);
         gl::ColorMask (false, false, false, true);
         gl::Clear (gl::COLOR_BUFFER_BIT);
-#endif
 
         if (OS > 0) snapshot();
 

--- a/src/gui/mrview/mode/volume.cpp
+++ b/src/gui/mrview/mode/volume.cpp
@@ -475,12 +475,8 @@ namespace MR
             depth_texture.bind();
 
           GL_CHECK_ERROR;
-#if QT_VERSION >= 0x050100
           int m = window().windowHandle()->devicePixelRatio();
           gl::CopyTexImage2D (gl::TEXTURE_2D, 0, gl::DEPTH_COMPONENT, 0, 0, m*projection.width(), m*projection.height(), 0);
-#else
-          gl::CopyTexImage2D (gl::TEXTURE_2D, 0, gl::DEPTH_COMPONENT, 0, 0, projection.width(), projection.height(), 0);
-#endif
 
           GL_CHECK_ERROR;
           gl::Uniform1i (gl::GetUniformLocation (volume_shader, "depth_sampler"), 1);

--- a/src/gui/mrview/tool/connectome/node_list.cpp
+++ b/src/gui/mrview/tool/connectome/node_list.cpp
@@ -90,12 +90,8 @@ namespace MR
       {
         QModelIndex topleft = createIndex (0, 0);
         QModelIndex bottomright = createIndex (rowCount()-1, 0);
-#if QT_VERSION >= 0x050400
         QVector<int> roles (1, Qt::DecorationRole);
         emit dataChanged (topleft, bottomright, roles);
-#else
-         emit dataChanged (topleft, bottomright);
-#endif
       }
 
 

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -59,7 +59,7 @@ namespace MR
 
         template <class Event> inline QPoint position (Event* event) { return event->pos(); }
         template <> inline QPoint position (QWheelEvent* event) {
-#if QT_VERSION >= 0x050E00 // translates to 5.14.0
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
           return event->position().toPoint();
 #else
           return event->pos();
@@ -1597,11 +1597,9 @@ namespace MR
 
         // need to clear alpha channel when using QOpenGLWidget (Qt >= 5.4)
         // otherwise we get transparent windows...
-#if QT_VERSION >= 0x050400
         gl::ColorMask (false, false, false, true);
         gl::Clear (gl::COLOR_BUFFER_BIT);
         glColorMask (true, true, true, true);
-#endif
         GL_CHECK_ERROR;
         GL::assert_context_is_current();
       }
@@ -1753,15 +1751,11 @@ namespace MR
       void Window::wheelEventGL (QWheelEvent* event)
       {
         assert (mode);
-#if QT_VERSION >= 0x050500
         QPoint delta;
         if (event->source() == Qt::MouseEventNotSynthesized)
           delta = event->angleDelta();
         else
           delta = 30 * event->pixelDelta();
-#else
-        QPoint delta = event->orientation() == Qt::Vertical ? QPoint (0, event->delta()) : QPoint (event->delta(), 0);
-#endif
         if (delta.isNull())
           return;
 

--- a/src/gui/opengl/font.cpp
+++ b/src/gui/opengl/font.cpp
@@ -60,19 +60,19 @@ namespace MR
         DEBUG ("loading font into OpenGL texture...");
 
         font_height = metric.height() + 2;
-        #if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
+#if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
         const float max_font_width = metric.width("MM") + 2;
-        #else
+#else
         const float max_font_width = metric.horizontalAdvance("MM") + 2;
-        #endif
+#endif
 
         int tex_width = 0;
         for (int c = first_char; c <= last_char; ++c)
-          #if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
+#if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
           tex_width += metric.width (c) + 2;
-          #else
+#else
           tex_width += metric.horizontalAdvance (c) + 2;
-          #endif
+#endif
 
         QImage pixmap (max_font_width, font_height, QImage::Format_ARGB32);
         const GLubyte* pix_data = pixmap.bits();
@@ -91,11 +91,11 @@ namespace MR
         for (int c = first_char; c <= last_char; ++c) {
           pixmap.fill (0);
           painter.drawText (1, metric.ascent() + 1, QString(c));
-          #if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
+#if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
           font_width[c] = metric.width (c);
-          #else
+#else
           font_width[c] = metric.horizontalAdvance (c);
-          #endif
+#endif
           const int current_font_width = font_width[c] + 2;
 
           if (with_shadow) {

--- a/src/gui/opengl/gl.cpp
+++ b/src/gui/opengl/gl.cpp
@@ -53,12 +53,8 @@ namespace MR
         //CONF improve display quality).
 
         GL::Format f;
-#if QT_VERSION >= 0x050400
         f.setSwapBehavior (GL::Format::DoubleBuffer);
         f.setRenderableType (GL::Format::OpenGL);
-#else
-        f.setDoubleBuffer (true);
-#endif
 
         if (File::Config::get_bool ("NeedOpenGLCoreProfile", true)) {
           f.setVersion (3,3);

--- a/src/gui/opengl/gl.h
+++ b/src/gui/opengl/gl.h
@@ -21,20 +21,12 @@
 #include "debug.h"
 
 #include <QtGlobal>
-#if QT_VERSION >= 0x050000
 #include <QtWidgets>
-#else
-#include <QtGui>
-#endif
 #include <QGLWidget>
 #include "gui/opengl/gl_core_3_3.h"
 
-// necessary to avoid conflict with Qt4's macros:
-#ifdef Complex
-# undef Complex
-#endif
-#ifdef foreach
-# undef foreach
+#if QT_VERSION < QT_VERSION_CHECK(5, 5, 0)
+#error "MRtrix3 requires Qt version 5.5 or later"
 #endif
 
 // uncomment to trace texture/VAO/VBO/FBO operations:
@@ -65,20 +57,8 @@ namespace MR
 
 
 
-#if QT_VERSION >= 0x050400
-
       using Area = QOpenGLWidget;
       using Format = QSurfaceFormat;
-
-#else
-      class Area : public QGLWidget { NOMEMALIGN
-        public:
-          using QGLWidget::QGLWidget;
-          QImage grabFramebuffer () { return QGLWidget::grabFrameBuffer(); }
-      };
-
-      using Format = QGLFormat;
-#endif
 
       void init ();
       void set_default_context ();
@@ -107,7 +87,6 @@ namespace MR
 
       namespace Context
       {
-#if QT_VERSION >= 0x050400
         inline std::pair<QOpenGLContext*,QSurface*> current() {
           QOpenGLContext* context = QOpenGLContext::currentContext();
           QSurface* surface = context ? context->surface() : nullptr;
@@ -131,12 +110,6 @@ namespace MR
           if (previous_context.first)
             previous_context.first->makeCurrent (previous_context.second);
         }
-#else
-        inline std::pair<int,int> current() { return { 0, 0 }; }
-        inline std::pair<int,int> get (QWidget*) { return { 0, 0 }; }
-        inline std::pair<int,int> makeCurrent (QWidget*) { return { 0, 0 }; }
-        inline void restore (std::pair<int,int>) { }
-#endif
 
         struct Grab { NOMEMALIGN
           decltype (current()) previous_context;
@@ -355,11 +328,7 @@ namespace MR
           void unbind () const {
             check_context();
             GL_DEBUG ("binding default OpenGL framebuffer");
-#if QT_VERSION >= 0x050400
             gl::BindFramebuffer (gl::FRAMEBUFFER, QOpenGLContext::currentContext()->defaultFramebufferObject());
-#else
-            gl::BindFramebuffer (gl::FRAMEBUFFER, 0);
-#endif
           }
 
 

--- a/src/gui/projection.h
+++ b/src/gui/projection.h
@@ -182,16 +182,10 @@ namespace MR
           set_viewport (frame);
         }
 
-#if QT_VERSION >= 0x050100
         void set_viewport (const QWidget& frame) const {
           int m = frame.window()->devicePixelRatio();
           gl::Viewport (m*viewport[0], m*viewport[1], m*viewport[2], m*viewport[3]);
         }
-#else
-        void set_viewport (const QWidget&) const {
-          gl::Viewport (viewport[0], viewport[1], viewport[2], viewport[3]);
-        }
-#endif
 
         void render_crosshairs (const Eigen::Vector3f& focus) const { crosshair->render (focus, *this); }
 
@@ -206,11 +200,11 @@ namespace MR
 
         void render_text_align (int x, int y, const std::string& text, int halign = 0, int valign = 0) const {
           QString s (qstr(text));
-          #if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
+#if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
           int w = font.metric.width (s);
-          #else
+#else
           int w = font.metric.horizontalAdvance (s);
-          #endif
+#endif
           int h = font.metric.height();
           if (halign == 0) x -= w/2;
           else if (halign > 0) x -= w;
@@ -225,13 +219,13 @@ namespace MR
             inset = font.metric.height() / 2;
           if (x < inset)
             x = inset;
-          #if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
+#if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
           if (x + font.metric.width (s) + inset > width())
             x = width() - font.metric.width (s) - inset;
-          #else
+#else
           if (x + font.metric.horizontalAdvance (s) + inset > width())
             x = width() - font.metric.horizontalAdvance (s) - inset;
-          #endif
+#endif
 
           if (y < inset)
             y = inset;
@@ -244,15 +238,15 @@ namespace MR
           QString s (qstr(text));
           int x, y;
 
-          #if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
+#if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
           if (position & RightEdge) x = width() - font.metric.height() / 2 - font.metric.width (s);
           else if (position & LeftEdge) x = font.metric.height() / 2;
           else x = (width() - font.metric.width (s)) / 2;
-          #else
+#else
           if (position & RightEdge) x = width() - font.metric.height() / 2 - font.metric.horizontalAdvance (s);
           else if (position & LeftEdge) x = font.metric.height() / 2;
           else x = (width() - font.metric.horizontalAdvance (s)) / 2;
-          #endif
+#endif
 
           if (position & TopEdge) y = height() - 1.5 * font.metric.height() - line * font.metric.lineSpacing();
           else if (position & BottomEdge) y = font.metric.height() / 2 + line * font.metric.lineSpacing();


### PR DESCRIPTION
Second half of #2142: where the first half (#2153) only alters documentation on `master`, this goes to `dev`, and involves removing support for anything prior to 5.5 and performing corresponding checks.