### PR TITLE
Remove copy_ptr and fix handling of masks when more than 3D

### DIFF
--- a/cmd/dwi2tensor.cpp
+++ b/cmd/dwi2tensor.cpp
@@ -111,7 +111,7 @@ template <class MASKType, class B0Type, class DKTType, class PredictType>
 class Processor { MEMALIGN(Processor)
   public:
     Processor (const Eigen::MatrixXd& b, const bool ols, const int iter,
-        MASKType* mask_image, B0Type* b0_image, DKTType* dkt_image, PredictType* predict_image) :
+        const MASKType& mask_image, const B0Type& b0_image, const DKTType& dkt_image, const PredictType& predict_image) :
       mask_image (mask_image),
       b0_image (b0_image),
       dkt_image (dkt_image),
@@ -128,9 +128,9 @@ class Processor { MEMALIGN(Processor)
     template <class DWIType, class DTType>
       void operator() (DWIType& dwi_image, DTType& dt_image)
       {
-        if (mask_image) {
-          assign_pos_of (dwi_image, 0, 3).to (*mask_image);
-          if (!mask_image->value())
+        if (mask_image.valid()) {
+          assign_pos_of (dwi_image, 0, 3).to (mask_image);
+          if (!mask_image.value())
             return;
         }
 
@@ -157,34 +157,34 @@ class Processor { MEMALIGN(Processor)
           dt_image.value() = p[dt_image.index(3)];
         }
 
-        if (b0_image) {
-          assign_pos_of (dwi_image, 0, 3).to (*b0_image);
-          b0_image->value() = exp(p[6]);
+        if (b0_image.valid()) {
+          assign_pos_of (dwi_image, 0, 3).to (b0_image);
+          b0_image.value() = exp(p[6]);
         }
 
-        if (dkt_image) {
-          assign_pos_of (dwi_image, 0, 3).to (*dkt_image);
+        if (dkt_image.valid()) {
+          assign_pos_of (dwi_image, 0, 3).to (dkt_image);
           double adc_sq = (p[0]+p[1]+p[2])*(p[0]+p[1]+p[2])/9.0;
-          for (auto l = Loop(3)(*dkt_image); l; ++l) {
-            dkt_image->value() = p[dkt_image->index(3)+7]/adc_sq;
+          for (auto l = Loop(3)(dkt_image); l; ++l) {
+            dkt_image.value() = p[dkt_image.index(3)+7]/adc_sq;
           }
         }
 
-        if (predict_image) {
-          assign_pos_of (dwi_image, 0, 3).to (*predict_image);
+        if (predict_image.valid()) {
+          assign_pos_of (dwi_image, 0, 3).to (predict_image);
           dwi = (b*p).array().exp();
-          for (auto l = Loop(3)(*predict_image); l; ++l) {
-            predict_image->value() = dwi[predict_image->index(3)];
+          for (auto l = Loop(3)(predict_image); l; ++l) {
+            predict_image.value() = dwi[predict_image.index(3)];
           }
         }
 
       }
 
   private:
-    copy_ptr<MASKType> mask_image;
-    copy_ptr<B0Type> b0_image;
-    copy_ptr<DKTType> dkt_image;
-    copy_ptr<PredictType> predict_image;
+    MASKType mask_image;
+    B0Type b0_image;
+    DKTType dkt_image;
+    PredictType predict_image;
     Eigen::VectorXd dwi;
     Eigen::VectorXd p;
     Eigen::VectorXd w;
@@ -196,7 +196,7 @@ class Processor { MEMALIGN(Processor)
 };
 
 template <class MASKType, class B0Type, class DKTType, class PredictType>
-inline Processor<MASKType, B0Type, DKTType, PredictType> processor (const Eigen::MatrixXd& b, const bool ols, const int iter, MASKType* mask_image, B0Type* b0_image, DKTType* dkt_image, PredictType* predict_image) {
+inline Processor<MASKType, B0Type, DKTType, PredictType> processor (const Eigen::MatrixXd& b, const bool ols, const int iter, const MASKType& mask_image, const B0Type& b0_image, const DKTType& dkt_image, const PredictType& predict_image) {
   return { b, ols, iter, mask_image, b0_image, dkt_image, predict_image };
 }
 
@@ -205,11 +205,11 @@ void run ()
   auto dwi = Header::open (argument[0]).get_image<value_type>();
   auto grad = DWI::get_DW_scheme (dwi);
 
-  Image<bool>* mask = nullptr;
+  Image<bool> mask;
   auto opt = get_options ("mask");
   if (opt.size()) {
-    mask = new Image<bool> (Image<bool>::open (opt[0][0]));
-    check_dimensions (dwi, *mask, 0, 3);
+    mask = Image<bool>::open (opt[0][0]);
+    check_dimensions (dwi, mask, 0, 3);
   }
 
   bool ols = get_options ("ols").size();
@@ -223,27 +223,27 @@ void run ()
   DWI::stash_DW_scheme (header, grad);
   PhaseEncoding::clear_scheme (header);
 
-  Image<value_type>* predict = nullptr;
+  Image<value_type> predict;
   opt = get_options ("predicted_signal");
   if (opt.size())
-    predict = new Image<value_type> (Image<value_type>::create (opt[0][0], header));
+    predict = Image<value_type>::create (opt[0][0], header);
 
   header.size(3) = 6;
   auto dt = Image<value_type>::create (argument[1], header);
 
-  Image<value_type>* b0 = nullptr;
+  Image<value_type> b0;
   opt = get_options ("b0");
   if (opt.size()) {
     header.ndim() = 3;
-    b0 = new Image<value_type> (Image<value_type>::create (opt[0][0], header));
+    b0 = Image<value_type>::create (opt[0][0], header);
   }
 
-  Image<value_type>* dkt = nullptr;
+  Image<value_type> dkt;
   opt = get_options ("dkt");
   if (opt.size()) {
     header.ndim() = 4;
     header.size(3) = 15;
-    dkt = new Image<value_type> (Image<value_type>::create (opt[0][0], header));
+    dkt = Image<value_type>::create (opt[0][0], header);
   }
 
   Eigen::MatrixXd b = -DWI::grad2bmatrix<double> (grad, opt.size()>0);

--- a/cmd/dwidenoise.cpp
+++ b/cmd/dwidenoise.cpp
@@ -143,7 +143,7 @@ public:
   {
     // Process voxels in mask only
     if (mask.valid()) {
-      assign_pos_of (dwi).to (mask);
+      assign_pos_of (dwi, 0, 3).to (mask);
       if (!mask.value())
         return;
     }
@@ -196,7 +196,7 @@ public:
 
     // store noise map if requested:
     if (noise.valid()) {
-      assign_pos_of(dwi).to(noise);
+      assign_pos_of(dwi, 0, 3).to(noise);
       noise.value() = real_type (std::sqrt(sigma2));
     }
   }

--- a/cmd/sh2peaks.cpp
+++ b/cmd/sh2peaks.cpp
@@ -135,7 +135,7 @@ class DataLoader { MEMALIGN(DataLoader)
         item.pos[2] = sh.index(2);
 
         if (mask.valid())
-          assign_pos_of(sh).to(mask);
+          assign_pos_of(sh, 0, 3).to(mask);
         if (mask.valid() && !mask.value()) {
           for (auto l = Loop(3) (sh); l; ++l)
             item.data[sh.index(3)] = NaN;

--- a/cmd/sh2peaks.cpp
+++ b/cmd/sh2peaks.cpp
@@ -134,12 +134,11 @@ class DataLoader { MEMALIGN(DataLoader)
         item.pos[1] = sh.index(1);
         item.pos[2] = sh.index(2);
 
-        if (mask.valid()) {
+        if (mask.valid())
           assign_pos_of(sh).to(mask);
-          if (!mask.value()) {
-            for (auto l = Loop(3) (sh); l; ++l)
-              item.data[sh.index(3)] = NaN;
-          }
+        if (mask.valid() && !mask.value()) {
+          for (auto l = Loop(3) (sh); l; ++l)
+            item.data[sh.index(3)] = NaN;
         } else {
           // iterates over SH coefficients
           for (auto l = Loop(3) (sh); l; ++l)


### PR DESCRIPTION
This was originally intended to fix #2148, but now includes other similar fixes elsewhere. 
