### PR TITLE
resize filter, adapter and reslice adapter: more explicit nearest interpolation and oversample handling

### DIFF
--- a/core/adapter/reslice.h
+++ b/core/adapter/reslice.h
@@ -23,6 +23,7 @@
 #include "transform.h"
 #include "types.h"
 #include "interp/base.h"
+#include "interp/nearest.h"
 
 namespace MR
 {
@@ -129,22 +130,33 @@ namespace MR
               using namespace Eigen;
               assert (ndim() >= 3);
 
-              if (oversample.size()) {
+              const bool is_nearest = std::is_same<typename Interp::Nearest<ImageType>, decltype(interp)>::value;
+
+              if (oversample.size()) { // oversample explicitly set
                 assert (oversample.size() == 3);
                 if (oversample[0] < 1 || oversample[1] < 1 || oversample[2] < 1)
                   throw Exception ("oversample factors must be greater than zero");
-                OS[0] = oversample[0];
-                OS[1] = oversample[1];
-                OS[2] = oversample[2];
+                if (is_nearest && (oversample[0] != 1 || oversample[1] != 1 || oversample[2] != 1)) {
+                  WARN("oversampling factors ignored for nearest neighbour interpolation");
+                  OS[0] = OS[1] = OS[2] = 1;
+                }
+                else {
+                  OS[0] = oversample[0]; OS[1] = oversample[1]; OS[2] = oversample[2];
+                }
               }
-              else {
-                Vector3 y = direct_transform * Vector3 (0.0, 0.0, 0.0);
-                Vector3 x0 = direct_transform * Vector3 (1.0, 0.0, 0.0);
-                OS[0] = std::ceil ((1.0-std::numeric_limits<default_type>::epsilon()) * (y-x0).norm());
-                x0 = direct_transform * Vector3 (0.0, 1.0, 0.0);
-                OS[1] = std::ceil ((1.0-std::numeric_limits<default_type>::epsilon()) * (y-x0).norm());
-                x0 = direct_transform * Vector3 (0.0, 0.0, 1.0);
-                OS[2] = std::ceil ((1.0-std::numeric_limits<default_type>::epsilon()) * (y-x0).norm());
+              else { // oversample is default
+                if (is_nearest) {
+                  OS[0] = OS[1] = OS[2] = 1;
+                }
+                else {
+                  Vector3 y = direct_transform * Vector3 (0.0, 0.0, 0.0);
+                  Vector3 x0 = direct_transform * Vector3 (1.0, 0.0, 0.0);
+                  OS[0] = std::ceil ((1.0-std::numeric_limits<default_type>::epsilon()) * (y-x0).norm());
+                  x0 = direct_transform * Vector3 (0.0, 1.0, 0.0);
+                  OS[1] = std::ceil ((1.0-std::numeric_limits<default_type>::epsilon()) * (y-x0).norm());
+                  x0 = direct_transform * Vector3 (0.0, 0.0, 1.0);
+                  OS[2] = std::ceil ((1.0-std::numeric_limits<default_type>::epsilon()) * (y-x0).norm());
+                }
               }
 
               if (OS[0] * OS[1] * OS[2] > 1) {

--- a/core/filter/resize.h
+++ b/core/filter/resize.h
@@ -137,8 +137,6 @@ namespace MR
 
         void set_interp_type (int type) {
           interp_type = type;
-          if (interp_type == 0) // nearest
-            set_oversample (vector<uint32_t> (3, 1));
         }
 
         void set_transform (const transform_type& trafo) {
@@ -156,8 +154,8 @@ namespace MR
              *out_of_bounds_value : Interp::Base<InputImageType>::default_out_of_bounds_value();
             switch (interp_type) {
             case 0:
-              // Prevent use of oversampling when using nearest-neighbour interpolation
-              reslice <Interp::Nearest> (input, output, transformation, {1, 1, 1}, oob);
+              // Use of oversampling is prevented in reslice adapter
+              reslice <Interp::Nearest> (input, output, transformation, oversampling, oob);
               break;
             case 1:
               reslice <Interp::Linear> (input, output, transformation, oversampling, oob);

--- a/core/filter/resize.h
+++ b/core/filter/resize.h
@@ -124,17 +124,6 @@ namespace MR
         }
 
         void set_oversample (vector<uint32_t> oversample) {
-          // Prevent use of oversampling when using nearest-neighbour interpolation
-          if (interp_type == 0) { // nearest
-            for (auto s : oversample) {
-              if (s != 1) {
-                WARN("oversampling is ignored for nearest neighbour interpolation");
-                break;
-              }
-            }
-            oversampling = {1, 1, 1};
-            return;
-          }
           if (oversample.size() == 1)
             oversample.resize (3, oversample[0]);
           else if (oversample.size() != 3 and oversample.size() != 0)
@@ -148,7 +137,6 @@ namespace MR
 
         void set_interp_type (int type) {
           interp_type = type;
-          // Prevent use of oversampling when using nearest-neighbour interpolation
           if (interp_type == 0) // nearest
             set_oversample (vector<uint32_t> (3, 1));
         }
@@ -168,7 +156,8 @@ namespace MR
              *out_of_bounds_value : Interp::Base<InputImageType>::default_out_of_bounds_value();
             switch (interp_type) {
             case 0:
-              reslice <Interp::Nearest> (input, output, transformation, oversampling, oob);
+              // Prevent use of oversampling when using nearest-neighbour interpolation
+              reslice <Interp::Nearest> (input, output, transformation, {1, 1, 1}, oob);
               break;
             case 1:
               reslice <Interp::Linear> (input, output, transformation, oversampling, oob);

--- a/core/filter/resize.h
+++ b/core/filter/resize.h
@@ -124,6 +124,17 @@ namespace MR
         }
 
         void set_oversample (vector<uint32_t> oversample) {
+          // Prevent use of oversampling when using nearest-neighbour interpolation
+          if (interp_type == 0) { // nearest
+            for (auto s : oversample) {
+              if (s != 1) {
+                WARN("oversampling is ignored for nearest neighbour interpolation");
+                break;
+              }
+            }
+            oversampling = {1, 1, 1};
+            return;
+          }
           if (oversample.size() == 1)
             oversample.resize (3, oversample[0]);
           else if (oversample.size() != 3 and oversample.size() != 0)
@@ -137,6 +148,7 @@ namespace MR
 
         void set_interp_type (int type) {
           interp_type = type;
+          // Prevent use of oversampling when using nearest-neighbour interpolation
           if (interp_type == 0) // nearest
             set_oversample (vector<uint32_t> (3, 1));
         }
@@ -156,8 +168,7 @@ namespace MR
              *out_of_bounds_value : Interp::Base<InputImageType>::default_out_of_bounds_value();
             switch (interp_type) {
             case 0:
-              // Prevent use of oversampling when using nearest-neighbour interpolation
-              reslice <Interp::Nearest> (input, output, transformation, {1, 1, 1}, oob);
+              reslice <Interp::Nearest> (input, output, transformation, oversampling, oob);
               break;
             case 1:
               reslice <Interp::Linear> (input, output, transformation, oversampling, oob);


### PR DESCRIPTION
modification to fix for #2158: warn in the reslice adapter used in the resize filter in mrgrid if the user provides oversample != 1 when nearest neighbour interpolation is requested.

```
mrgrid int.mif -voxel 8 -interp nearest regrid - -oversample 2 | mrview -
mrgrid: [WARNING] oversampling factors ignored for nearest neighbour interpolation


mrgrid int.mif -voxel 8 -interp nearest regrid - | mrview -
```