### PR TITLE
dwifslpreproc: For EddyQC, don't invoke Python3 interpreter

### DIFF
--- a/bin/dwifslpreproc
+++ b/bin/dwifslpreproc
@@ -970,8 +970,7 @@ def execute(): #pylint: disable=unused-variable
 
   # Run eddy qc tool QUAD if installed and one of -eddyqc_text or -eddyqc_all is specified
   if eddyqc_path:
-    eddyqc_exe = find_executable('eddy_quad')
-    if eddyqc_exe:
+    if find_executable('eddy_quad'):
       eddyqc_options = ' -idx eddy_indices.txt -par eddy_config.txt -m eddy_mask.nii -b bvals'
       if os.path.isfile('dwi_post_eddy.eddy_residuals'):
         eddyqc_options += ' -g ' + bvecs_path
@@ -983,9 +982,10 @@ def execute(): #pylint: disable=unused-variable
         eddyqc_options += ' -v'
       try:
         run.command('eddy_quad dwi_post_eddy' + eddyqc_options)
-      except run.MRtrixCmdError as exception_eddyquad:
+      except run.MRtrixCmdError as exception:
         with open('eddy_quad_failure_output.txt', 'w') as eddy_quad_output_file:
-          eddy_quad_output_file.write(str(exception_eddyquad))
+          eddy_quad_output_file.write(str(exception))
+        app.debug(str(exception))
         app.warn('Error running automated EddyQC tool \'eddy_quad\'; QC data written to "' + eddyqc_path + '" will be files from "eddy" only')
         # Delete the directory if the script only made it partway through
         try:

--- a/bin/dwifslpreproc
+++ b/bin/dwifslpreproc
@@ -983,20 +983,15 @@ def execute(): #pylint: disable=unused-variable
         eddyqc_options += ' -v'
       try:
         run.command('eddy_quad dwi_post_eddy' + eddyqc_options)
-      except run.MRtrixCmdError as exception_default:
-        with open('eddy_quad_default_failure_output.txt', 'w') as eddy_quad_output_file:
-          eddy_quad_output_file.write(str(exception_default))
+      except run.MRtrixCmdError as exception_eddyquad:
+        with open('eddy_quad_failure_output.txt', 'w') as eddy_quad_output_file:
+          eddy_quad_output_file.write(str(exception_eddyquad))
+        app.warn('Error running automated EddyQC tool \'eddy_quad\'; QC data written to "' + eddyqc_path + '" will be files from "eddy" only')
+        # Delete the directory if the script only made it partway through
         try:
-          run.command('python3 ' + eddyqc_exe + ' dwi_post_eddy' + eddyqc_options)
-        except run.MRtrixCmdError as exception_python3:
-          with open('eddy_quad_python3_failure_output.txt', 'w') as eddy_quad_output_file:
-            eddy_quad_output_file.write(str(exception_python3))
-          app.warn('Error running automated EddyQC tool \'eddy_quad\'; QC data written to "' + eddyqc_path + '" will be files from "eddy" only')
-          # Delete the directory if the script only made it partway through
-          try:
-            shutil.rmtree('dwi_post_eddy.qc')
-          except OSError:
-            pass
+          shutil.rmtree('dwi_post_eddy.qc')
+        except OSError:
+          pass
     else:
       app.console('Command \'eddy_quad\' not found in PATH; skipping')
 

--- a/bin/dwifslpreproc
+++ b/bin/dwifslpreproc
@@ -970,15 +970,9 @@ def execute(): #pylint: disable=unused-variable
 
   # Run eddy qc tool QUAD if installed and one of -eddyqc_text or -eddyqc_all is specified
   if eddyqc_path:
-    eddyqc_cmd = find_executable('eddy_quad')
-    if eddyqc_cmd:
-      # The eddy_quad script is not compatible with Python 2; try to explicitly invoke Python 3
-      if sys.version_info[0] == 2:
-        if find_executable('python3'):
-          eddyqc_cmd = 'python3 ' + eddyqc_cmd
-      else:
-        eddyqc_cmd = 'eddy_quad'
-      eddyqc_options = '-idx eddy_indices.txt -par eddy_config.txt -m eddy_mask.nii -b bvals'
+    eddyqc_exe = find_executable('eddy_quad')
+    if eddyqc_exe:
+      eddyqc_options = ' -idx eddy_indices.txt -par eddy_config.txt -m eddy_mask.nii -b bvals'
       if os.path.isfile('dwi_post_eddy.eddy_residuals'):
         eddyqc_options += ' -g ' + bvecs_path
       if do_topup:
@@ -988,17 +982,23 @@ def execute(): #pylint: disable=unused-variable
       if app.VERBOSITY > 2:
         eddyqc_options += ' -v'
       try:
-        run.command(eddyqc_cmd + ' dwi_post_eddy ' + eddyqc_options)
-      except run.MRtrixCmdError as exception:
-        app.warn('Error running automated eddy qc tool QUAD; data will not be provided')
-        app.debug(str(exception))
-        # Delete the directory if the script only made it partway through
+        run.command('eddy_quad dwi_post_eddy' + eddyqc_options)
+      except run.MRtrixCmdError as exception_default:
+        with open('eddy_quad_default_failure_output.txt', 'w') as eddy_quad_output_file:
+          eddy_quad_output_file.write(str(exception_default))
         try:
-          shutil.rmtree('dwi_post_eddy.qc')
-        except OSError:
-          pass
+          run.command('python3 ' + eddyqc_exe + ' dwi_post_eddy' + eddyqc_options)
+        except run.MRtrixCmdError as exception_python3:
+          with open('eddy_quad_python3_failure_output.txt', 'w') as eddy_quad_output_file:
+            eddy_quad_output_file.write(str(exception_python3))
+          app.warn('Error running automated EddyQC tool \'eddy_quad\'; QC data written to "' + eddyqc_path + '" will be files from "eddy" only')
+          # Delete the directory if the script only made it partway through
+          try:
+            shutil.rmtree('dwi_post_eddy.qc')
+          except OSError:
+            pass
     else:
-      app.console('Command \'eddy_quad\' not found in PATH; not running automated eddy qc tool QUAD')
+      app.console('Command \'eddy_quad\' not found in PATH; skipping')
 
 
   # Have to retain these images until after eddyQC is run


### PR DESCRIPTION
This I think makes sense as a solution.

I don't know for certain, but what I think has happened is that prior to integration in FSL6, `eddy_quad` required Python3, whereas now in FSL6 it gets an FSLPython shebang and so needs to be executed as-is.

This approach should succeed on first attempt for anyone with FSL6 installed, whereas for any systems that happen to have FSL5 combined with an EddyQC installation from source it'll still make a second attempt by explicitly invoking the Python3 compiler.