### PR TITLE
Ensure -force works for fixel directory outputs

### DIFF
--- a/cmd/fixel2sh.cpp
+++ b/cmd/fixel2sh.cpp
@@ -60,10 +60,11 @@ void usage ()
 void run ()
 {
   auto in_data_image = Fixel::open_fixel_data_file<float> (argument[0]);
+  const std::string in_directory = Fixel::filename2directory (argument[0]);
 
-  Header in_index_header = Fixel::find_index_header (Fixel::get_fixel_directory (argument[0]));
-  auto in_index_image =in_index_header.get_image<index_type>();
-  auto in_directions_image = Fixel::find_directions_header (Fixel::get_fixel_directory (argument[0])).get_image<float>().with_direct_io();
+  Header in_index_header = Fixel::find_index_header (in_directory);
+  auto in_index_image = in_index_header.get_image<index_type>();
+  auto in_directions_image = Fixel::find_directions_header (in_directory).get_image<float>().with_direct_io();
 
   size_t lmax = 8;
   auto opt = get_options ("lmax");

--- a/cmd/fixel2tsf.cpp
+++ b/cmd/fixel2tsf.cpp
@@ -75,10 +75,11 @@ void run ()
   if (in_data_image.size(2) != 1)
     throw Exception ("Only a single scalar value for each fixel can be output as a track scalar file, "
                      "therefore the input fixel data file must have dimension Nx1x1");
+  const std::string in_directory = Fixel::filename2directory (argument[0]);
 
-  Header in_index_header = Fixel::find_index_header (Fixel::get_fixel_directory (argument[0]));
+  Header in_index_header = Fixel::find_index_header (in_directory);
   auto in_index_image = in_index_header.get_image<index_type>();
-  auto in_directions_image = Fixel::find_directions_header (Fixel::get_fixel_directory (argument[0])).get_image<float>().with_direct_io();
+  auto in_directions_image = Fixel::find_directions_header (in_directory).get_image<float>().with_direct_io();
 
   DWI::Tractography::Properties properties;
   DWI::Tractography::Reader<float> reader (argument[1], properties);

--- a/cmd/fixel2voxel.cpp
+++ b/cmd/fixel2voxel.cpp
@@ -488,10 +488,11 @@ class None : protected Base
 void run ()
 {
   auto in_data = Fixel::open_fixel_data_file<typename FixelDataType::value_type> (argument[0]);
+  const std::string in_directory = Fixel::filename2directory (argument[0]);
   if (in_data.size(2) != 1)
     throw Exception ("Input fixel data file must have a single scalar value per fixel (i.e. have dimensions Nx1x1)");
 
-  Header in_index_header = Fixel::find_index_header (Fixel::get_fixel_directory (argument[0]));
+  Header in_index_header = Fixel::find_index_header (in_directory);
   auto in_index_image = in_index_header.get_image<typename FixelIndexType::value_type>();
 
   Image<float> in_directions;
@@ -530,8 +531,7 @@ void run ()
   }
 
   if (op == 10 || op == 11)  // dec
-    in_directions = Fixel::find_directions_header (
-                    Fixel::get_fixel_directory (in_data.name())).get_image<float>().with_direct_io();
+    in_directions = Fixel::find_directions_header (in_directory).get_image<float>().with_direct_io();
 
   FixelDataType in_vol;
   auto opt = get_options ("weighted");

--- a/cmd/fixelconvert.cpp
+++ b/cmd/fixelconvert.cpp
@@ -114,7 +114,7 @@ void convert_old2new ()
   const bool output_size = get_options ("out_size").size();
 
   const std::string output_fixel_directory = argument[1];
-  Fixel::check_fixel_directory (output_fixel_directory, true);
+  Fixel::check_fixel_directory_out (output_fixel_directory, true, true);
 
   index_type fixel_count = 0;
   for (auto i = Loop (input) (input); i; ++i)
@@ -148,7 +148,7 @@ void convert_old2new ()
   Image<float> template_directions_image;
   opt = get_options ("template");
   if (opt.size()) {
-    Fixel::check_fixel_directory (opt[0][0]);
+    Fixel::check_fixel_directory_in (opt[0][0]);
     template_index_image = Fixel::find_index_header (opt[0][0]).get_image<index_type>();
     check_dimensions (index_image, template_index_image);
     template_directions_image = Fixel::find_directions_header (opt[0][0]).get_image<float>();

--- a/cmd/fixelcorrespondence.cpp
+++ b/cmd/fixelcorrespondence.cpp
@@ -60,8 +60,9 @@ void run ()
   if (Path::is_dir (input_file))
     throw Exception ("please input the specific fixel data file to be converted (not the fixel directory)");
 
-  auto subject_index = Fixel::find_index_header (Fixel::get_fixel_directory (input_file)).get_image<index_type>();
-  auto subject_directions = Fixel::find_directions_header (Fixel::get_fixel_directory (input_file)).get_image<float>().with_direct_io();
+  const std::string input_directory = Fixel::filename2directory (input_file);
+  auto subject_index = Fixel::find_index_header (input_directory).get_image<index_type>();
+  auto subject_directions = Fixel::find_directions_header (input_directory).get_image<float>().with_direct_io();
 
   if (input_file == subject_directions.name())
     throw Exception ("input fixel data file cannot be the directions file");

--- a/cmd/fixelcrop.cpp
+++ b/cmd/fixelcrop.cpp
@@ -53,7 +53,7 @@ void usage ()
 void run ()
 {
   const auto in_directory = argument[0];
-  Fixel::check_fixel_directory (in_directory);
+  Fixel::check_fixel_directory_in (in_directory);
   Header in_index_header = Fixel::find_index_header (in_directory);
   auto in_index_image = in_index_header.get_image <index_type>();
 
@@ -61,7 +61,7 @@ void run ()
   Fixel::check_fixel_size (in_index_image, mask_image);
 
   const auto out_fixel_directory = argument[2];
-  Fixel::check_fixel_directory (out_fixel_directory, true);
+  Fixel::check_fixel_directory_out (out_fixel_directory, true, true);
 
   Header out_header = Header (in_index_image);
   index_type total_nfixels = Fixel::get_number_of_fixels (in_index_header);

--- a/cmd/fixelfilter.cpp
+++ b/cmd/fixelfilter.cpp
@@ -15,6 +15,8 @@
  */
 
 
+#include <set>
+
 #include "command.h"
 #include "header.h"
 #include "image.h"

--- a/cmd/fixelfilter.cpp
+++ b/cmd/fixelfilter.cpp
@@ -107,7 +107,7 @@ void run()
     output_header = Header (multiple_files[0]);
   } catch (...) {
     try {
-      index_header = Fixel::find_index_header (Fixel::get_fixel_directory (argument[0]));
+      index_header = Fixel::find_index_header (Fixel::filename2directory (argument[0]));
       single_file = Image<float>::open (argument[0]);
       Fixel::check_data_file (single_file);
       output_header = Header (single_file);

--- a/cmd/fod2fixel.cpp
+++ b/cmd/fod2fixel.cpp
@@ -324,7 +324,7 @@ void run ()
       throw Exception ("Cannot use image \"" + str(opt[0][0]) + "\" as mask image; dimensions do not match FOD image");
   }
 
-  Fixel::check_fixel_directory (fixel_directory_path, true, true);
+  Fixel::check_fixel_directory_out (fixel_directory_path, true, true);
 
   FMLS::FODQueueWriter writer (fod_data, mask);
 

--- a/cmd/peaks2fixel.cpp
+++ b/cmd/peaks2fixel.cpp
@@ -93,7 +93,7 @@ void run ()
     INFO ("Peaks have variable amplitudes; will create additional fixel data file \"" + dataname + "\"");
   }
 
-  Fixel::check_fixel_directory (argument[1], true, true);
+  Fixel::check_fixel_directory_out (argument[1], true, true);
 
   // Easiest if we first make the index image
   const std::string index_path = Path::join (argument[1], "index.mif");

--- a/cmd/voxel2fixel.cpp
+++ b/cmd/voxel2fixel.cpp
@@ -51,7 +51,7 @@ void run ()
 {
   auto scalar = Image<float>::open (argument[0]);
   std::string input_fixel_directory = argument[1];
-  Fixel::check_fixel_directory (input_fixel_directory);
+  Fixel::check_fixel_directory_in (input_fixel_directory);
   auto input_fixel_index = Fixel::find_index_header (input_fixel_directory).get_image<index_type>();
   check_dimensions (scalar, input_fixel_index, 0, 3);
 

--- a/core/fixel/helpers.cpp
+++ b/core/fixel/helpers.cpp
@@ -1,0 +1,312 @@
+/* Copyright (c) 2008-2020 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Covered Software is provided under this License on an "as is"
+ * basis, without warranty of any kind, either expressed, implied, or
+ * statutory, including, without limitation, warranties that the
+ * Covered Software is free of defects, merchantable, fit for a
+ * particular purpose or non-infringing.
+ * See the Mozilla Public License v. 2.0 for more details.
+ *
+ * For more details, see http://www.mrtrix.org/.
+ */
+
+#include "fixel/helpers.h"
+
+#include "image_diff.h"
+
+
+namespace MR
+{
+
+
+  namespace Peaks
+  {
+    void check (const Header& in)
+    {
+      if (!in.datatype().is_floating_point())
+        throw Exception ("Image \"" + in.name() + "\" is not a valid peaks image: Does not contain floating-point data");
+      try {
+        check_effective_dimensionality (in, 4);
+      } catch (Exception& e) {
+        throw Exception (e, "Image \"" + in.name() + "\" is not a valid peaks image: Expect 4 dimensions");
+      }
+      if (in.size(3) % 3)
+        throw Exception ("Image \"" + in.name() + "\" is not a valid peaks image: Number of volumes must be a multiple of 3");
+    }
+  }
+
+
+
+  namespace Fixel
+  {
+
+
+
+    bool is_index_filename (const std::string& path)
+    {
+      for (std::initializer_list<const std::string>::iterator it = supported_sparse_formats.begin();
+           it != supported_sparse_formats.end(); ++it) {
+        if (Path::basename (path) == "index" + *it)
+          return true;
+      }
+      return false;
+    }
+
+
+
+    bool is_directions_filename (const std::string& path)
+    {
+      for (std::initializer_list<const std::string>::iterator it = supported_sparse_formats.begin();
+           it != supported_sparse_formats.end(); ++it) {
+        if (Path::basename (path) == "directions" + *it)
+          return true;
+      }
+      return false;
+    }
+
+
+
+    std::string get_fixel_directory (const std::string& fixel_file) {
+      std::string fixel_directory = Path::dirname (fixel_file);
+      // assume the user is running the command from within the fixel directory
+      if (fixel_directory.empty())
+        fixel_directory = Path::cwd();
+      return fixel_directory;
+    }
+
+
+
+    void check_fixel_size (const Header& index_h, const Header& data_h)
+    {
+      check_index_image (index_h);
+      check_data_file (data_h);
+      if (!fixels_match (index_h, data_h))
+        throw InvalidImageException ("Fixel number mismatch between index image " + index_h.name() + " and data image " + data_h.name());
+    }
+
+
+
+    Header find_index_header (const std::string &fixel_directory_path)
+    {
+      Header header;
+
+      for (std::initializer_list<const std::string>::iterator it = supported_sparse_formats.begin();
+           it !=supported_sparse_formats.end(); ++it) {
+        std::string full_path = Path::join (fixel_directory_path, "index" + *it);
+        if (Path::exists(full_path)) {
+          if (header.valid())
+            throw InvalidFixelDirectoryException ("Multiple index images found in directory " + fixel_directory_path);
+          header = Header::open (full_path);
+        }
+      }
+      if (!header.valid())
+        throw InvalidFixelDirectoryException ("Could not find index image in directory " + fixel_directory_path);
+
+      check_index_image (header);
+      return header;
+    }
+
+
+
+    Header find_directions_header (const std::string fixel_directory_path)
+    {
+      Header index_header = Fixel::find_index_header (fixel_directory_path);
+
+      bool directions_found (false);
+      Header header;
+
+      auto dir_walker = Path::Dir (fixel_directory_path);
+      std::string fname;
+      while ((fname = dir_walker.read_name()).size()) {
+        if (is_directions_filename (fname)) {
+          Header tmp_header = Header::open (Path::join (fixel_directory_path, fname));
+          if (is_directions_file (tmp_header)) {
+            if (fixels_match (index_header, tmp_header)) {
+              if (directions_found == true)
+                throw Exception ("multiple directions files found in fixel image directory: " + fixel_directory_path);
+              directions_found = true;
+              header = std::move (tmp_header);
+            } else {
+              WARN ("fixel directions file (" + fname + ") does not contain the same number of elements as fixels in the index file" );
+            }
+          }
+        }
+      }
+
+      if (!directions_found)
+        throw InvalidFixelDirectoryException ("Could not find directions image in directory " + fixel_directory_path);
+
+      return header;
+    }
+
+
+
+    vector<Header> find_data_headers (const std::string &fixel_directory_path,
+                                      const Header &index_header,
+                                      const bool include_directions)
+    {
+      check_index_image (index_header);
+      auto dir_walker = Path::Dir (fixel_directory_path);
+      vector<std::string> file_names;
+      {
+        std::string temp;
+        while ((temp = dir_walker.read_name()).size())
+          file_names.push_back (temp);
+      }
+      std::sort (file_names.begin(), file_names.end());
+
+      vector<Header> data_headers;
+      for (auto fname : file_names) {
+        if (Path::has_suffix (fname, supported_sparse_formats)) {
+          try {
+            auto H = Header::open (Path::join (fixel_directory_path, fname));
+            if (is_data_file (H)) {
+              if (fixels_match (index_header, H)) {
+                if (!is_directions_file (H) || include_directions)
+                  data_headers.emplace_back (std::move (H));
+              } else {
+                WARN ("fixel data file (" + fname + ") does not contain the same number of elements as fixels in the index file");
+              }
+            }
+          } catch (...) {
+            WARN ("unable to open file \"" + fname + "\" as potential fixel data file");
+          }
+        }
+      }
+
+      return data_headers;
+    }
+
+
+
+    void check_fixel_directory_in (const std::string& path)
+    {
+      const std::string path_temp = path.empty() ? Path::cwd() : path;
+      if (!Path::is_dir (path_temp))
+        throw Exception ("Fixel directory (" + str(path_temp) + ") does not exist");
+      try {
+        find_index_header (path_temp);
+        find_directions_header (path_temp);
+      } catch (Exception& e) {
+        throw Exception (e, "Unable to interpret \"" + path + "\" as input fixel directory");
+      }
+    }
+
+
+
+    void check_fixel_directory_out (const std::string& path,
+                                    const bool new_index,
+                                    const bool new_directions)
+    {
+      const std::string path_temp = path.empty() ? Path::cwd() : path;
+
+      if (Path::exists (path_temp)) {
+        if (Path::is_dir (path_temp)) {
+          if (Path::Dir (path_temp).read_name ().size () != 0) { // Existing content in directory
+            if (new_index) {
+              if (App::overwrite_files) {
+                WARN("Contents of existing directory \"" + path + "\" being erased");
+                File::rmdir (path_temp, true);
+                File::mkdir (path_temp);
+              } else {
+                throw Exception("Output fixel directory \"" + path + "\" already exists and is not empty (use -force to override)");
+              }
+            } // If we're not writing index & directions, we don't care if the output directory has pre-existing content
+          } // Empty directory; if core files are not intended to be written by the command, the command is responsible for duplicating index & directions
+        } else { // Exists, but is a file rather than a directory
+          if (App::overwrite_files) {
+            WARN("Existing file \"" + path_temp + "\" being erased ahead of fixel directory creation");
+            File::remove (path_temp);
+            File::mkdir (path_temp);
+          } else {
+            throw Exception ("Target output fixel directory \"" + path + "\" already exists as a file (use -force to override)");
+          }
+        }
+      } else { // Doesn't exist
+        if (!new_index && !new_directions)
+          throw Exception("Output fixel directory \"" + path + "\" does not exist");
+        File::mkdir (path_temp);
+      }
+    }
+
+
+
+    void copy_fixel_file (const std::string& input_file_path, const std::string& output_directory)
+    {
+      check_fixel_directory_out (output_directory, false, false);
+      std::string output_path = Path::join (output_directory, Path::basename (input_file_path));
+      Header input_header = Header::open (input_file_path);
+      auto input_image = input_header.get_image<float>();
+      auto output_image = Image<float>::create (output_path, input_header);
+      threaded_copy (input_image, output_image);
+    }
+
+
+
+    void copy_index_file (const std::string& input_directory, const std::string& output_directory)
+    {
+      Header input_header = Fixel::find_index_header (input_directory);
+      check_fixel_directory_out (output_directory, true, false);
+
+      std::string output_path = Path::join (output_directory, Path::basename (input_header.name()));
+
+      // If the index file already exists check it is the same as the input index file
+      if (Path::exists (output_path) && !App::overwrite_files) {
+        auto input_image = input_header.get_image<index_type>();
+        auto output_image = Image<index_type>::open (output_path);
+
+        if (!images_match_abs (input_image, output_image))
+          throw Exception ("output fixel directory (" + output_directory + ") already contains index file, "
+                           "which is not the same as the expected output. Use -force to override if desired");
+
+      } else {
+        auto output_image = Image<index_type>::create (Path::join (output_directory, Path::basename (input_header.name())), input_header);
+        auto input_image = input_header.get_image<index_type>();
+        threaded_copy (input_image, output_image);
+      }
+    }
+
+
+
+    void copy_directions_file (const std::string& input_directory, const std::string& output_directory)
+    {
+      Header input_header = Fixel::find_directions_header (input_directory);
+      std::string output_path = Path::join (output_directory, Path::basename (input_header.name()));
+
+      // If the index file already exists check it is the same as the input index file
+      if (Path::exists (output_path) && !App::overwrite_files) {
+        auto input_image = input_header.get_image<index_type>();
+        auto output_image = Image<index_type>::open (output_path);
+
+        if (!images_match_abs (input_image, output_image))
+          throw Exception ("output sparse image directory (" + output_directory + ") already contains a directions file, "
+                           "which is not the same as the expected output. Use -force to override if desired");
+
+      } else {
+        copy_fixel_file (input_header.name(), output_directory);
+      }
+
+    }
+
+    void copy_index_and_directions_file (const std::string& input_directory, const std::string &output_directory)
+    {
+      copy_index_file (input_directory, output_directory);
+      copy_directions_file (input_directory, output_directory);
+    }
+
+
+
+    void copy_all_data_files (const std::string &input_directory, const std::string &output_directory)
+    {
+      for (auto& input_header : Fixel::find_data_headers (input_directory, Fixel::find_index_header (input_directory)))
+        copy_fixel_file (input_header.name(), output_directory);
+    }
+
+
+
+  }
+}

--- a/core/fixel/helpers.cpp
+++ b/core/fixel/helpers.cpp
@@ -70,7 +70,7 @@ namespace MR
 
 
 
-    std::string get_fixel_directory (const std::string& fixel_file) {
+    std::string filename2directory (const std::string& fixel_file) {
       std::string fixel_directory = Path::dirname (fixel_file);
       // assume the user is running the command from within the fixel directory
       if (fixel_directory.empty())
@@ -235,18 +235,6 @@ namespace MR
 
 
 
-    void copy_fixel_file (const std::string& input_file_path, const std::string& output_directory)
-    {
-      check_fixel_directory_out (output_directory, false, false);
-      std::string output_path = Path::join (output_directory, Path::basename (input_file_path));
-      Header input_header = Header::open (input_file_path);
-      auto input_image = input_header.get_image<float>();
-      auto output_image = Image<float>::create (output_path, input_header);
-      threaded_copy (input_image, output_image);
-    }
-
-
-
     void copy_index_file (const std::string& input_directory, const std::string& output_directory)
     {
       Header input_header = Fixel::find_index_header (input_directory);
@@ -287,10 +275,12 @@ namespace MR
                            "which is not the same as the expected output. Use -force to override if desired");
 
       } else {
-        copy_fixel_file (input_header.name(), output_directory);
+        copy_data_file (input_header.name(), output_directory);
       }
 
     }
+
+
 
     void copy_index_and_directions_file (const std::string& input_directory, const std::string &output_directory)
     {
@@ -300,10 +290,22 @@ namespace MR
 
 
 
+    void copy_data_file (const std::string& input_file_path, const std::string& output_directory)
+    {
+      check_fixel_directory_out (output_directory, false, false);
+      std::string output_path = Path::join (output_directory, Path::basename (input_file_path));
+      Header input_header = Header::open (input_file_path);
+      auto input_image = input_header.get_image<float>();
+      auto output_image = Image<float>::create (output_path, input_header);
+      threaded_copy (input_image, output_image);
+    }
+
+
+
     void copy_all_data_files (const std::string &input_directory, const std::string &output_directory)
     {
       for (auto& input_header : Fixel::find_data_headers (input_directory, Fixel::find_index_header (input_directory)))
-        copy_fixel_file (input_header.name(), output_directory);
+        copy_data_file (input_header.name(), output_directory);
     }
 
 

--- a/core/fixel/helpers.h
+++ b/core/fixel/helpers.h
@@ -53,8 +53,7 @@ namespace MR
     bool is_index_filename (const std::string& path);
     bool is_directions_filename (const std::string& path);
 
-    // TODO Rename
-    std::string get_fixel_directory (const std::string& fixel_file);
+    std::string filename2directory (const std::string& fixel_file);
 
     void check_fixel_size (const Header& index_h, const Header& data_h);
 
@@ -69,15 +68,14 @@ namespace MR
                                     const bool new_index,
                                     const bool new_directions);
 
-    //! Copy a file from one fixel directory into another.
-    // TODO Check
-    void copy_fixel_file (const std::string& input_file_path, const std::string& output_directory);
     //! Copy the index file from one fixel directory into another
     void copy_index_file (const std::string& input_directory, const std::string& output_directory);
     //! Copy the directions file from one fixel directory into another
     void copy_directions_file (const std::string& input_directory, const std::string& output_directory);
     //! Copy both the index and directions file from one fixel directory into another
     void copy_index_and_directions_file (const std::string& input_directory, const std::string &output_directory);
+    //! Copy a file from one fixel directory into another.
+    void copy_data_file (const std::string& input_file_path, const std::string& output_directory);
     //! Copy all data files in a fixel directory into another directory. Data files do not include the index or directions file.
     void copy_all_data_files (const std::string &input_directory, const std::string &output_directory);
 
@@ -225,7 +223,7 @@ namespace MR
       Fixel::check_data_file (in_data_header);
       auto in_data_image = in_data_header.get_image<ValueType>();
 
-      Header in_index_header = Fixel::find_index_header (Fixel::get_fixel_directory (input_file));
+      Header in_index_header = Fixel::find_index_header (Fixel::filename2directory (input_file));
       if (input_file == in_index_header.name())
         throw Exception ("input fixel data file cannot be the index file");
 

--- a/core/fixel/helpers.h
+++ b/core/fixel/helpers.h
@@ -17,19 +17,17 @@
 #ifndef __fixel_helpers_h__
 #define __fixel_helpers_h__
 
-#include "app.h"
+#include "header.h"
 #include "image.h"
-#include "image_diff.h"
-#include "image_helpers.h"
 #include "algo/loop.h"
-#include "file/utils.h"
 #include "fixel/keys.h"
 #include "fixel/types.h"
-#include "formats/mrtrix_utils.h"
-
 
 namespace MR
 {
+
+
+
   class InvalidFixelDirectoryException : public Exception
   { NOMEMALIGN
     public:
@@ -38,68 +36,85 @@ namespace MR
         : Exception(previous_exception, msg) {}
   };
 
+
+
   namespace Peaks
   {
-    FORCE_INLINE void check (const Header& in)
-    {
-      if (!in.datatype().is_floating_point())
-        throw Exception ("Image \"" + in.name() + "\" is not a valid peaks image: Does not contain floating-point data");
-      try {
-        check_effective_dimensionality (in, 4);
-      } catch (Exception& e) {
-        throw Exception (e, "Image \"" + in.name() + "\" is not a valid peaks image: Expect 4 dimensions");
-      }
-      if (in.size(3) % 3)
-        throw Exception ("Image \"" + in.name() + "\" is not a valid peaks image: Number of volumes must be a multiple of 3");
-    }
+    void check (const Header& in);
   }
+
+
 
   namespace Fixel
   {
-    FORCE_INLINE bool is_index_filename (const std::string& path)
-    {
-      for (std::initializer_list<const std::string>::iterator it = supported_sparse_formats.begin();
-           it != supported_sparse_formats.end(); ++it) {
-        if (Path::basename (path) == "index" + *it)
-          return true;
-      }
-      return false;
-    }
+
+
+
+    bool is_index_filename (const std::string& path);
+    bool is_directions_filename (const std::string& path);
+
+    // TODO Rename
+    std::string get_fixel_directory (const std::string& fixel_file);
+
+    void check_fixel_size (const Header& index_h, const Header& data_h);
+
+    Header find_index_header (const std::string &fixel_directory_path);
+    Header find_directions_header (const std::string fixel_directory_path);
+    vector<Header> find_data_headers (const std::string &fixel_directory_path,
+                                      const Header &index_header,
+                                      const bool include_directions = false);
+
+    void check_fixel_directory_in (const std::string& path);
+    void check_fixel_directory_out (const std::string& path,
+                                    const bool new_index,
+                                    const bool new_directions);
+
+    //! Copy a file from one fixel directory into another.
+    // TODO Check
+    void copy_fixel_file (const std::string& input_file_path, const std::string& output_directory);
+    //! Copy the index file from one fixel directory into another
+    void copy_index_file (const std::string& input_directory, const std::string& output_directory);
+    //! Copy the directions file from one fixel directory into another
+    void copy_directions_file (const std::string& input_directory, const std::string& output_directory);
+    //! Copy both the index and directions file from one fixel directory into another
+    void copy_index_and_directions_file (const std::string& input_directory, const std::string &output_directory);
+    //! Copy all data files in a fixel directory into another directory. Data files do not include the index or directions file.
+    void copy_all_data_files (const std::string &input_directory, const std::string &output_directory);
+
+
 
     template <class HeaderType>
-    FORCE_INLINE bool is_index_image (const HeaderType& in)
+    bool is_index_image (const HeaderType& in)
     {
       return is_index_filename (in.name())
           && in.ndim() == 4
           && in.size(3) == 2;
     }
-
     template <class HeaderType>
-    FORCE_INLINE void check_index_image (const HeaderType& index)
+    void check_index_image (const HeaderType& index)
     {
       if (!is_index_image (index))
         throw InvalidImageException (index.name() + " is not a valid fixel index image. Image must be 4D with 2 volumes in the 4th dimension");
     }
 
+
+
     template <class HeaderType>
-    FORCE_INLINE bool is_data_file (const HeaderType& in)
+    bool is_data_file (const HeaderType& in)
     {
       return in.ndim() == 3 && in.size(2) == 1;
     }
-
-
-    FORCE_INLINE bool is_directions_filename (const std::string& path)
+    template <class HeaderType>
+    void check_data_file (const HeaderType& in)
     {
-      for (std::initializer_list<const std::string>::iterator it = supported_sparse_formats.begin();
-           it != supported_sparse_formats.end(); ++it) {
-        if (Path::basename (path) == "directions" + *it)
-          return true;
-      }
-      return false;
+      if (!is_data_file (in))
+        throw InvalidImageException (in.name() + " is not a valid fixel data file; expected a 3-dimensional image of size n x m x 1");
     }
 
+
+
     template <class HeaderType>
-    FORCE_INLINE bool is_directions_file (const HeaderType& in)
+    bool is_directions_file (const HeaderType& in)
     {
       return is_directions_filename (in.name())
           && in.ndim() == 3
@@ -110,24 +125,11 @@ namespace MR
 
 
 
-    template <class HeaderType>
-    FORCE_INLINE void check_data_file (const HeaderType& in)
-    {
-      if (!is_data_file (in))
-        throw InvalidImageException (in.name() + " is not a valid fixel data file. Expected a 3-dimensional image of size n x m x 1");
-    }
 
-    FORCE_INLINE std::string get_fixel_directory (const std::string& fixel_file) {
-      std::string fixel_directory = Path::dirname (fixel_file);
-      // assume the user is running the command from within the fixel directory
-      if (fixel_directory.empty())
-        fixel_directory = Path::cwd();
-      return fixel_directory;
-    }
 
 
     template <class IndexHeaderType>
-    FORCE_INLINE index_type get_number_of_fixels (IndexHeaderType& index_header) {
+    index_type get_number_of_fixels (IndexHeaderType& index_header) {
       check_index_image (index_header);
       if (index_header.keyval().count (n_fixels_key)) {
         return std::stoul (index_header.keyval().at(n_fixels_key));
@@ -149,8 +151,9 @@ namespace MR
     }
 
 
+
     template <class IndexHeaderType, class DataHeaderType>
-    FORCE_INLINE bool fixels_match (const IndexHeaderType& index_header, const DataHeaderType& data_header)
+    bool fixels_match (const IndexHeaderType& index_header, const DataHeaderType& data_header)
     {
       bool fixels_match (false);
 
@@ -178,144 +181,16 @@ namespace MR
     }
 
 
-    FORCE_INLINE void check_fixel_size (const Header& index_h, const Header& data_h)
-    {
-      check_index_image (index_h);
-      check_data_file (data_h);
-
-      if (!fixels_match (index_h, data_h))
-        throw InvalidImageException ("Fixel number mismatch between index image " + index_h.name() + " and data image " + data_h.name());
-    }
-
-
-    FORCE_INLINE void check_fixel_directory (const std::string &path, bool create_if_missing = false, bool check_if_empty = false)
-    {
-      // handle the use case when a fixel command is run from inside a fixel directory
-      const std::string path_temp = path.empty() ? Path::cwd() : path;
-
-      if (Path::exists (path_temp)) {
-        if (App::overwrite_files) {
-          if (Path::is_dir (path_temp)) {
-            if (Path::Dir (path_temp).read_name ().size () != 0) {
-              WARN("Contents of existing directory \"" + path_temp + "\" being erased");
-              File::rmdir (path_temp, true);
-              File::mkdir (path_temp);
-            }
-          } else { // Exists, is a file rather than a directory, & we have overwrite privileges
-            WARN("Existing file \"" + path_temp + "\" being erased ahead of fixel directory creation");
-            File::remove (path_temp);
-            if (create_if_missing)
-              File::mkdir (path_temp);
-          }
-        } else { // Exists, and we don't have overwrite privileges
-          if (Path::is_dir (path_temp)) {
-            if (check_if_empty && Path::Dir (path_temp).read_name ().size () != 0)
-              throw Exception ("Expected fixel directory \"" + path_temp + "\" to be empty");
-          } else {
-            throw Exception ("Target output fixel directory \"" + path_temp + "\" already exists as a file");
-          }
-        }
-      } else { // Doesn't exist
-        if (create_if_missing)
-          File::mkdir (path_temp);
-        else
-          throw Exception ("Fixel directory (" + str(path_temp) + ") does not exist");
-      }
-    }
-
-
-    FORCE_INLINE Header find_index_header (const std::string &fixel_directory_path)
-    {
-      Header header;
-      check_fixel_directory (fixel_directory_path);
-
-      for (std::initializer_list<const std::string>::iterator it = supported_sparse_formats.begin();
-           it !=supported_sparse_formats.end(); ++it) {
-        std::string full_path = Path::join (fixel_directory_path, "index" + *it);
-        if (Path::exists(full_path)) {
-          if (header.valid())
-            throw InvalidFixelDirectoryException ("Multiple index images found in directory " + fixel_directory_path);
-          header = Header::open (full_path);
-        }
-      }
-      if (!header.valid())
-        throw InvalidFixelDirectoryException ("Could not find index image in directory " + fixel_directory_path);
-
-      check_index_image (header);
-      return header;
-    }
-
-
-    FORCE_INLINE vector<Header> find_data_headers (const std::string &fixel_directory_path, const Header &index_header, const bool include_directions = false)
-    {
-      check_index_image (index_header);
-      auto dir_walker = Path::Dir (fixel_directory_path);
-      vector<std::string> file_names;
-      {
-        std::string temp;
-        while ((temp = dir_walker.read_name()).size())
-          file_names.push_back (temp);
-      }
-      std::sort (file_names.begin(), file_names.end());
-
-      vector<Header> data_headers;
-      for (auto fname : file_names) {
-        if (Path::has_suffix (fname, supported_sparse_formats)) {
-          try {
-            auto H = Header::open (Path::join (fixel_directory_path, fname));
-            if (is_data_file (H)) {
-              if (fixels_match (index_header, H)) {
-                if (!is_directions_file (H) || include_directions)
-                  data_headers.emplace_back (std::move (H));
-              } else {
-                WARN ("fixel data file (" + fname + ") does not contain the same number of elements as fixels in the index file");
-              }
-            }
-          } catch (...) {
-            WARN ("unable to open file \"" + fname + "\" as potential fixel data file");
-          }
-        }
-      }
-
-      return data_headers;
-    }
 
 
 
-    FORCE_INLINE Header find_directions_header (const std::string fixel_directory_path)
-    {
-      bool directions_found (false);
-      Header header;
-      check_fixel_directory (fixel_directory_path);
-      Header index_header = Fixel::find_index_header (fixel_directory_path);
 
-      auto dir_walker = Path::Dir (fixel_directory_path);
-      std::string fname;
-      while ((fname = dir_walker.read_name()).size()) {
-        if (is_directions_filename (fname)) {
-          Header tmp_header = Header::open (Path::join (fixel_directory_path, fname));
-          if (is_directions_file (tmp_header)) {
-            if (fixels_match (index_header, tmp_header)) {
-              if (directions_found == true)
-                throw Exception ("multiple directions files found in fixel image directory: " + fixel_directory_path);
-              directions_found = true;
-              header = std::move (tmp_header);
-            } else {
-              WARN ("fixel directions file (" + fname + ") does not contain the same number of elements as fixels in the index file" );
-            }
-          }
-        }
-      }
 
-      if (!directions_found)
-        throw InvalidFixelDirectoryException ("Could not find directions image in directory " + fixel_directory_path);
 
-      return header;
-    }
 
     //! Generate a header for a sparse data file (Nx1x1) using an index image as a template
     template <class IndexHeaderType>
-    FORCE_INLINE Header data_header_from_index (IndexHeaderType& index) {
+    Header data_header_from_index (IndexHeaderType& index) {
       Header header (index);
       header.ndim() = 3;
       header.size(0) = get_number_of_fixels (index);
@@ -332,76 +207,13 @@ namespace MR
 
     //! Generate a header for a fixel directions data file (Nx3x1) using an index image as a template
     template <class IndexHeaderType>
-    FORCE_INLINE Header directions_header_from_index (IndexHeaderType& index) {
+    Header directions_header_from_index (IndexHeaderType& index) {
       Header header = data_header_from_index (index);
       header.size(1) = 3;
       return header;
     }
 
-    //! Copy a file from one fixel directory into another.
-    FORCE_INLINE void copy_fixel_file (const std::string& input_file_path, const std::string& output_directory) {
-      check_fixel_directory (output_directory, true);
-      std::string output_path = Path::join (output_directory, Path::basename (input_file_path));
-      Header input_header = Header::open (input_file_path);
-      auto input_image = input_header.get_image<float>();
-      auto output_image = Image<float>::create (output_path, input_header);
-      threaded_copy (input_image, output_image);
-    }
 
-    //! Copy the index file from one fixel directory into another
-    FORCE_INLINE void copy_index_file (const std::string& input_directory, const std::string& output_directory) {
-      Header input_header = Fixel::find_index_header (input_directory);
-      check_fixel_directory (output_directory, true);
-
-      std::string output_path = Path::join (output_directory, Path::basename (input_header.name()));
-
-      // If the index file already exists check it is the same as the input index file
-      if (Path::exists (output_path) && !App::overwrite_files) {
-        auto input_image = input_header.get_image<index_type>();
-        auto output_image = Image<index_type>::open (output_path);
-
-        if (!images_match_abs (input_image, output_image))
-          throw Exception ("output sparse image directory (" + output_directory + ") already contains index file, "
-                           "which is not the same as the expected output. Use -force to override if desired");
-
-      } else {
-        auto output_image = Image<index_type>::create (Path::join (output_directory, Path::basename (input_header.name())), input_header);
-        auto input_image = input_header.get_image<index_type>();
-        threaded_copy (input_image, output_image);
-      }
-    }
-
-    //! Copy the directions file from one fixel directory into another.
-    FORCE_INLINE void copy_directions_file (const std::string& input_directory, const std::string& output_directory) {
-      Header input_header = Fixel::find_directions_header (input_directory);
-      std::string output_path = Path::join (output_directory, Path::basename (input_header.name()));
-
-      // If the index file already exists check it is the same as the input index file
-      if (Path::exists (output_path) && !App::overwrite_files) {
-        auto input_image = input_header.get_image<index_type>();
-        auto output_image = Image<index_type>::open (output_path);
-
-        if (!images_match_abs (input_image, output_image))
-          throw Exception ("output sparse image directory (" + output_directory + ") already contains a directions file, "
-                           "which is not the same as the expected output. Use -force to override if desired");
-
-      } else {
-        copy_fixel_file (input_header.name(), output_directory);
-      }
-
-    }
-
-    FORCE_INLINE void copy_index_and_directions_file (const std::string& input_directory, const std::string &output_directory) {
-      copy_index_file (input_directory, output_directory);
-      copy_directions_file (input_directory, output_directory);
-    }
-
-
-    //! Copy all data files in a fixel directory into another directory. Data files do not include the index or directions file.
-    FORCE_INLINE void copy_all_data_files (const std::string &input_directory, const std::string &output_directory) {
-      for (auto& input_header : Fixel::find_data_headers (input_directory, Fixel::find_index_header (input_directory)))
-        copy_fixel_file (input_header.name(), output_directory);
-    }
 
     //! open a data file. checks that a user has not input a fixel directory or index image
     template <class ValueType>
@@ -419,6 +231,9 @@ namespace MR
 
       return in_data_image;
     }
+
+
+
   }
 }
 

--- a/docs/reference/commands/fixelreorient.rst
+++ b/docs/reference/commands/fixelreorient.rst
@@ -16,13 +16,15 @@ Usage
     fixelreorient [ options ]  fixel_in warp fixel_out
 
 -  *fixel_in*: the input fixel directory
--  *warp*: a 4D deformation field used to perform reorientation. Reorientation is performed by applying the Jacobian affine transform in each voxel in the warp, then re-normalising the vector representing the fixel direction
--  *fixel_out*: the output fixel directory. If the the input and output directories are the same, the existing directions file will be replaced (providing the -force option is supplied). If a new directory is supplied then the fixel directions and all other fixel data will be copied to the new directory.
+-  *warp*: a 4D deformation field used to perform reorientation
+-  *fixel_out*: the output fixel directory
 
 Description
 -----------
 
 Reorientation is performed by transforming the vector representing the fixel direction with the Jacobian (local affine transform) computed at each voxel in the warp, then re-normalising the vector.
+
+If the the input and output directories are the same, the existing directions file will be replaced (providing the -force option is supplied). If a new directory is supplied then the fixel directions and all other fixel data will be copied to the new directory.
 
 Options
 -------

--- a/run_tests
+++ b/run_tests
@@ -231,6 +231,7 @@ if [[ ! -z $testsdir && ! -z $datadir ]]; then
   echo -n "Cleaning up temporary files... "
   rm -f $datadir/tmp*.*
   rm -rf $datadir/tmp-*/
+  rm -rf $datadir/tmp_*/
   rm -rf $datadir/*-tmp-*/
   echo OK
 fi

--- a/testing/binaries/tests/fixelconvert
+++ b/testing/binaries/tests/fixelconvert
@@ -1,2 +1,2 @@
-fixelconvert fixel_image tmp.msf -value fixel_image/afd.mif && testing_diff_fixel_old tmp.msf old_fixel.msf 0.001 && rm -f tmp.msf
-fixelconvert old_fixel.msf fixelconvert_tmp && testing_diff_fixel fixelconvert_tmp fixelconvert && rm -rf fixelconvert_tmp
+fixelconvert fixel_image tmp.msf -value fixel_image/afd.mif -force && testing_diff_fixel_old tmp.msf old_fixel.msf 0.001
+fixelconvert old_fixel.msf tmp -force && testing_diff_fixel tmp fixelconvert

--- a/testing/binaries/tests/fixelreorient
+++ b/testing/binaries/tests/fixelreorient
@@ -1,1 +1,1 @@
-fixelreorient fixel_image fod_warp.mif fixelreorient_tmp -force && testing_diff_fixel fixelreorient_tmp fixelreorient -frac 0.001 && rm -rf fixelreorient_tmp
+fixelreorient fixel_image fod_warp.mif fixelreorient_tmp -force && testing_diff_fixel fixelreorient_tmp fixelreorient -frac 0.001

--- a/testing/cmd/testing_diff_fixel.cpp
+++ b/testing/cmd/testing_diff_fixel.cpp
@@ -45,9 +45,9 @@ void usage ()
 void run ()
 {
   std::string fixel_directory1 = argument[0];
-  Fixel::check_fixel_directory (fixel_directory1);
+  Fixel::check_fixel_directory_in (fixel_directory1);
   std::string fixel_directory2 = argument[1];
-  Fixel::check_fixel_directory (fixel_directory2);
+  Fixel::check_fixel_directory_in (fixel_directory2);
 
   if (fixel_directory1 == fixel_directory2)
     throw Exception ("Input fixel directorys are the same");


### PR DESCRIPTION
Only putting as draft request for now as I've committed the code untested; plus there's some chance that a more extensive refactor may be preferable over the proposed change.

I found the structure of this function quite strange. I think it may be in part due to the way that fixel commands provide their command-line interface, e.g. specifying both input & output fixel directories explicitly & separately but allowing them to be the same path. In any other context I'd expect separate functions to be defined for checking input vs. output path specifications. Probably if I were to attack #1043, that one would involve altering command-line interfaces and pipeline documentation, and the code altered here would probably be refactored in the process; but maybe for the sake of a hotfix we should go for easiest solution.

Closes #2164.