### PR TITLE
dwibiascorrect fsl: Revise warning

### DIFF
--- a/lib/mrtrix3/dwibiascorrect/fsl.py
+++ b/lib/mrtrix3/dwibiascorrect/fsl.py
@@ -50,9 +50,9 @@ def execute(): #pylint: disable=unused-variable
 
   fast_cmd = fsl.exe_name('fast')
 
-  app.warn('Use of -fsl option in dwibiascorrect script is discouraged due to its strong dependence ' + \
+  app.warn('Use of fsl algorithm in dwibiascorrect script is discouraged due to its strong dependence ' + \
            'on brain masking (specifically its inability to correct voxels outside of this mask).' + \
-           'Use of the -ants option is recommended for quantitative DWI analyses.')
+           'Use of the ants algorithm is recommended for quantitative DWI analyses.')
 
   # Generate a mean b=0 image
   run.command('dwiextract in.mif - -bzero | mrmath - mean mean_bzero.mif -axis 3')


### PR DESCRIPTION
Terminal warning issued to user was copy&pasted from `3.0_RC3`, but not properly modified to reflect the changes to the `dwibiascorrect` interface introduced in `3.0.0`.

As observed in nipy/nipype#3248 by @effigies.