### PR TITLE
Tweak error message on failed fixel overwrite

### DIFF
--- a/cmd/fixelconvert.cpp
+++ b/cmd/fixelconvert.cpp
@@ -114,7 +114,7 @@ void convert_old2new ()
   const bool output_size = get_options ("out_size").size();
 
   const std::string output_fixel_directory = argument[1];
-  Fixel::check_fixel_directory (output_fixel_directory, true);
+  Fixel::check_fixel_directory (output_fixel_directory, true, true);
 
   index_type fixel_count = 0;
   for (auto i = Loop (input) (input); i; ++i)

--- a/cmd/fixelcrop.cpp
+++ b/cmd/fixelcrop.cpp
@@ -61,7 +61,7 @@ void run ()
   Fixel::check_fixel_size (in_index_image, mask_image);
 
   const auto out_fixel_directory = argument[2];
-  Fixel::check_fixel_directory (out_fixel_directory, true);
+  Fixel::check_fixel_directory (out_fixel_directory, true, true);
 
   Header out_header = Header (in_index_image);
   index_type total_nfixels = Fixel::get_number_of_fixels (in_index_header);

--- a/cmd/fixelfilter.cpp
+++ b/cmd/fixelfilter.cpp
@@ -93,69 +93,73 @@ void run()
                                       "minweight",
                                       "mask" };
 
-  Header index_header;
   Image<float> single_file;
   vector<Header> multiple_files;
-  Header output_header;
-  try {
-    index_header = Fixel::find_index_header (argument[0]);
-    multiple_files = Fixel::find_data_headers (argument[0], index_header);
-    if (multiple_files.empty())
-      throw Exception ("No fixel data files found in directory \"" + argument[0] + "\"");
-    output_header = Header (multiple_files[0]);
-  } catch (...) {
-    try {
-      index_header = Fixel::find_index_header (Fixel::get_fixel_directory (argument[0]));
-      single_file = Image<float>::open (argument[0]);
-      Fixel::check_data_file (single_file);
-      output_header = Header (single_file);
-    } catch (...) {
-      throw Exception ("Could not interpret first argument \"" + argument[0] + "\" as either a fixel data file, or a fixel directory");
-    }
-  }
-
-  if (single_file.valid() && !Fixel::fixels_match (index_header, single_file))
-    throw Exception ("File \"" + argument[0] + "\" is not a valid fixel data file (does not match corresponding index image)");
-
-  auto opt = get_options ("matrix");
-  Fixel::Matrix::Reader matrix (opt[0][0]);
-
-  Image<index_type> index_image = index_header.get_image<index_type>();
-  const size_t nfixels = Fixel::get_number_of_fixels (index_image);
-  if (nfixels != matrix.size())
-    throw Exception ("Number of fixels in input (" + str(nfixels) + ") does not match number of fixels in connectivity matrix (" + str(matrix.size()) + ")");
-
   std::unique_ptr<Fixel::Filter::Base> filter;
-  switch (int(argument[1])) {
-    case 0:
-    {
-      const float value = get_option_value ("threshold_value", float(DEFAULT_FIXEL_CONNECT_VALUE_THRESHOLD));
-      const float connect = get_option_value ("threshold_connectivity", float(DEFAULT_FIXEL_CONNECT_CONNECTIVITY_THRESHOLD));
-      filter.reset (new Fixel::Filter::Connect (matrix, value, connect));
-      output_header.datatype() = DataType::UInt32;
-      output_header.datatype().set_byte_order_native();
-      option_list.erase ("threshold_value");
-      option_list.erase ("threshold_connectivity");
-    }
-      break;
-    case 1:
-    {
-      const float fwhm = get_option_value ("fwhm", float(DEFAULT_FIXEL_SMOOTHING_FWHM));
-      const float threshold = get_option_value ("minweight", float(DEFAULT_FIXEL_SMOOTHING_MINWEIGHT));
-      opt = get_options ("mask");
-      if (opt.size()) {
-        Image<bool> mask_image = Image<bool>::open (opt[0][0]);
-        filter.reset (new Fixel::Filter::Smooth (index_image, matrix, mask_image, fwhm, threshold));
-      } else {
-        filter.reset (new Fixel::Filter::Smooth (index_image, matrix, fwhm, threshold));
+
+  {
+    Header index_header;
+    Header output_header;
+    try {
+      index_header = Fixel::find_index_header (argument[0]);
+      multiple_files = Fixel::find_data_headers (argument[0], index_header);
+      if (multiple_files.empty())
+        throw Exception ("No fixel data files found in directory \"" + argument[0] + "\"");
+      output_header = Header (multiple_files[0]);
+    } catch (...) {
+      try {
+        index_header = Fixel::find_index_header (Fixel::get_fixel_directory (argument[0]));
+        single_file = Image<float>::open (argument[0]);
+        Fixel::check_data_file (single_file);
+        output_header = Header (single_file);
+      } catch (...) {
+        throw Exception ("Could not interpret first argument \"" + argument[0] + "\" as either a fixel data file, or a fixel directory");
       }
-      option_list.erase ("fwhm");
-      option_list.erase ("minweight");
-      option_list.erase ("mask");
     }
-      break;
-    default:
-      assert (0);
+
+    if (single_file.valid() && !Fixel::fixels_match (index_header, single_file))
+      throw Exception ("File \"" + argument[0] + "\" is not a valid fixel data file (does not match corresponding index image)");
+
+    auto opt = get_options ("matrix");
+    Fixel::Matrix::Reader matrix (opt[0][0]);
+
+    Image<index_type> index_image = index_header.get_image<index_type>();
+    const size_t nfixels = Fixel::get_number_of_fixels (index_image);
+    if (nfixels != matrix.size())
+      throw Exception ("Number of fixels in input (" + str(nfixels) + ") does not match number of fixels in connectivity matrix (" + str(matrix.size()) + ")");
+
+    switch (int(argument[1])) {
+      case 0:
+      {
+        const float value = get_option_value ("threshold_value", float(DEFAULT_FIXEL_CONNECT_VALUE_THRESHOLD));
+        const float connect = get_option_value ("threshold_connectivity", float(DEFAULT_FIXEL_CONNECT_CONNECTIVITY_THRESHOLD));
+        filter.reset (new Fixel::Filter::Connect (matrix, value, connect));
+        output_header.datatype() = DataType::UInt32;
+        output_header.datatype().set_byte_order_native();
+        option_list.erase ("threshold_value");
+        option_list.erase ("threshold_connectivity");
+      }
+        break;
+      case 1:
+      {
+        const float fwhm = get_option_value ("fwhm", float(DEFAULT_FIXEL_SMOOTHING_FWHM));
+        const float threshold = get_option_value ("minweight", float(DEFAULT_FIXEL_SMOOTHING_MINWEIGHT));
+        opt = get_options ("mask");
+        if (opt.size()) {
+          Image<bool> mask_image = Image<bool>::open (opt[0][0]);
+          filter.reset (new Fixel::Filter::Smooth (index_image, matrix, mask_image, fwhm, threshold));
+        } else {
+          filter.reset (new Fixel::Filter::Smooth (index_image, matrix, fwhm, threshold));
+        }
+        option_list.erase ("fwhm");
+        option_list.erase ("minweight");
+        option_list.erase ("mask");
+      }
+        break;
+      default:
+        assert (0);
+    }
+
   }
 
   for (const auto& i : option_list) {

--- a/core/fixel/helpers.h
+++ b/core/fixel/helpers.h
@@ -206,7 +206,7 @@ namespace MR
       if (check_if_empty && Path::Dir (path_temp).read_name ().size () != 0)
         throw Exception ("Output fixel directory \"" + path_temp + "\" is not empty"
                          + (App::overwrite_files ?
-                            " (-force option does not work on directories; need to erase manually)" :
+                            " (-force option cannot safely be applied on directories; please erase manually instead)" :
                             ""));
     }
 

--- a/core/fixel/helpers.h
+++ b/core/fixel/helpers.h
@@ -343,14 +343,15 @@ namespace MR
       std::string output_path = Path::join (output_directory, Path::basename (input_header.name()));
 
       // If the index file already exists check it is the same as the input index file
-      if (Path::exists (output_path) && !App::overwrite_files) {
+      if (Path::exists (output_path)) {
         auto input_image = input_header.get_image<index_type>();
         auto output_image = Image<index_type>::open (output_path);
-
         if (!images_match_abs (input_image, output_image))
-          throw Exception ("output sparse image directory (" + output_directory + ") already contains index file, "
-                           "which is not the same as the expected output. Use -force to override if desired");
-
+          throw Exception ("output fixel directory \"" + output_directory + "\" already contains index file, "
+                           + "which is not the same as the expected output"
+                           + (App::overwrite_files ?
+                              " (-force option cannot safely be applied on directories; please erase manually instead)" :
+                              ""));
       } else {
         auto output_image = Image<index_type>::create (Path::join (output_directory, Path::basename (input_header.name())), input_header);
         auto input_image = input_header.get_image<index_type>();
@@ -363,15 +364,16 @@ namespace MR
       Header input_header = Fixel::find_directions_header (input_directory);
       std::string output_path = Path::join (output_directory, Path::basename (input_header.name()));
 
-      // If the index file already exists check it is the same as the input index file
-      if (Path::exists (output_path) && !App::overwrite_files) {
+      // If the directions file already exists check it is the same as the input directions file
+      if (Path::exists (output_path)) {
         auto input_image = input_header.get_image<index_type>();
         auto output_image = Image<index_type>::open (output_path);
-
         if (!images_match_abs (input_image, output_image))
-          throw Exception ("output sparse image directory (" + output_directory + ") already contains a directions file, "
-                           "which is not the same as the expected output. Use -force to override if desired");
-
+          throw Exception ("output fixel directory \"" + output_directory + "\" already contains directions file, "
+                           + "which is not the same as the expected output"
+                           + (App::overwrite_files ?
+                              " (-force option cannot safely be applied on directories; please erase manually instead)" :
+                              ""));
       } else {
         copy_fixel_file (input_header.name(), output_directory);
       }

--- a/core/fixel/helpers.h
+++ b/core/fixel/helpers.h
@@ -366,8 +366,8 @@ namespace MR
 
       // If the directions file already exists check it is the same as the input directions file
       if (Path::exists (output_path)) {
-        auto input_image = input_header.get_image<index_type>();
-        auto output_image = Image<index_type>::open (output_path);
+        auto input_image = input_header.get_image<float>();
+        auto output_image = Image<float>::open (output_path);
         if (!images_match_abs (input_image, output_image))
           throw Exception ("output fixel directory \"" + output_directory + "\" already contains directions file, "
                            + "which is not the same as the expected output"

--- a/core/fixel/helpers.h
+++ b/core/fixel/helpers.h
@@ -17,6 +17,7 @@
 #ifndef __fixel_helpers_h__
 #define __fixel_helpers_h__
 
+#include "app.h"
 #include "image.h"
 #include "image_diff.h"
 #include "image_helpers.h"
@@ -203,7 +204,10 @@ namespace MR
         throw Exception (str(path_temp) + " is not a directory");
 
       if (check_if_empty && Path::Dir (path_temp).read_name ().size () != 0)
-        throw Exception ("Expected fixel directory " + path_temp + " to be empty.");
+        throw Exception ("Output fixel directory \"" + path_temp + "\" is not empty"
+                         + (App::overwrite_files ?
+                            " (-force option does not work on directories; need to erase manually)" :
+                            ""));
     }
 
 

--- a/core/fixel/helpers.h
+++ b/core/fixel/helpers.h
@@ -375,7 +375,9 @@ namespace MR
                               " (-force option cannot safely be applied on directories; please erase manually instead)" :
                               ""));
       } else {
-        copy_fixel_file (input_header.name(), output_directory);
+        auto output_image = Image<float>::create (Path::join (output_directory, Path::basename (input_header.name())), input_header);
+        auto input_image = input_header.get_image<float>();
+        threaded_copy (input_image, output_image);
       }
 
     }

--- a/core/image_diff.h
+++ b/core/image_diff.h
@@ -159,7 +159,8 @@ namespace MR
    template <class ImageType1, class ImageType2>
      inline bool images_match_abs (ImageType1& in1, ImageType2& in2, const double tol = 0.0)
      {
-       headers_match (in1, in2);
+       if (!headers_match (in1, in2))
+         return false;
        for (auto i = Loop (in1)(in1, in2); i; ++i)
          if (abs (cdouble (in1.value()) - cdouble (in2.value())) > tol)
            return false;

--- a/run_tests
+++ b/run_tests
@@ -180,10 +180,7 @@ for testitem in $testlist; do
 EOD
 
   echo -n 'running "'${testitem}'"... '
-  rm -f $datadir/tmp*.*
-  rm -rf $datadir/tmp-*/
-  rm -rf $datadir/tmp_*/
-  rm -rf $datadir/*-tmp-*/
+  rm -rf $datadir/tmp*
   ((ntests=0))
   ((success=0))
   while IFS='' read -r cmd || [[ -n "$cmd" ]]; do

--- a/run_tests
+++ b/run_tests
@@ -180,7 +180,7 @@ for testitem in $testlist; do
 EOD
 
   echo -n 'running "'${testitem}'"... '
-  rm -rf $datadir/tmp*
+  rm -rf $datadir/tmp* $datadir/*-tmp-*
   ((ntests=0))
   ((success=0))
   while IFS='' read -r cmd || [[ -n "$cmd" ]]; do
@@ -226,9 +226,7 @@ done
 
 if [[ ! -z $testsdir && ! -z $datadir ]]; then
   echo -n "Cleaning up temporary files... "
-  rm -f $datadir/tmp*.*
-  rm -rf $datadir/tmp-*/
-  rm -rf $datadir/*-tmp-*/
+  rm -rf $datadir/tmp* $datadir/*-tmp-*/
   echo OK
 fi
 
@@ -237,5 +235,3 @@ if [ ${a_test_has_failed} = true ];
 then
   exit 1
 fi
-
-

--- a/testing/binaries/tests/fixelconvert
+++ b/testing/binaries/tests/fixelconvert
@@ -1,2 +1,2 @@
-fixelconvert fixel_image tmp.msf -value fixel_image/afd.mif && testing_diff_fixel_old tmp.msf old_fixel.msf 0.001 && rm -f tmp.msf
-fixelconvert old_fixel.msf fixelconvert_tmp && testing_diff_fixel fixelconvert_tmp fixelconvert && rm -rf fixelconvert_tmp
+fixelconvert fixel_image tmp.msf -value fixel_image/afd.mif && testing_diff_fixel_old tmp.msf old_fixel.msf 0.001
+fixelconvert old_fixel.msf tmp && testing_diff_fixel tmp fixelconvert

--- a/testing/binaries/tests/fixelcorrespondence
+++ b/testing/binaries/tests/fixelcorrespondence
@@ -1,1 +1,1 @@
-fixelcorrespondence fixel_image/afd.mif fixel_image_template fixelcorrespondence_tmp afd.mif && testing_diff_fixel fixelcorrespondence_tmp fixelcorrespondence -frac 0.001 && rm -rf fixelcorrespondence_tmp
+fixelcorrespondence fixel_image/afd.mif fixel_image_template tmp afd.mif && testing_diff_fixel tmp fixelcorrespondence -frac 0.001

--- a/testing/binaries/tests/fixelcrop
+++ b/testing/binaries/tests/fixelcrop
@@ -1,1 +1,1 @@
-mrthreshold fixel_image/afd.mif -abs 0.08 - | fixelcrop fixel_image - fixelcrop_tmp && testing_diff_fixel fixelcrop_tmp fixelcrop -frac 0.001 && rm -rf fixelcrop_tmp
+mrthreshold fixel_image/afd.mif -abs 0.08 - | fixelcrop fixel_image - tmp && testing_diff_fixel tmp fixelcrop -frac 0.001

--- a/testing/binaries/tests/fixelreorient
+++ b/testing/binaries/tests/fixelreorient
@@ -1,1 +1,1 @@
-fixelreorient fixel_image fod_warp.mif fixelreorient_tmp -force && testing_diff_fixel fixelreorient_tmp fixelreorient -frac 0.001 && rm -rf fixelreorient_tmp
+fixelreorient fixel_image fod_warp.mif tmp -force && testing_diff_fixel tmp fixelreorient -frac 0.001

--- a/testing/binaries/tests/tckconvert
+++ b/testing/binaries/tests/tckconvert
@@ -1,7 +1,7 @@
-tckconvert tracks.tck tmp.vtk -force && awk '/POINTS/{s=1;next}/LINES/{s=0}s' tmp.vtk >tmppoints1.txt && awk '/POINTS/{s=1;next}/LINES/{s=0}s' tckconvert/out0.vtk >tmppoints2.txt && testing_diff_matrix tmppoints1.txt tmppoints2.txt -abs 1e-4
-tckconvert tracks.tck tmp.vtk -force && awk '/LINES/,0' tmp.vtk >tmplines1.txt && awk '/LINES/,0' tckconvert/out0.vtk >tmplines2.txt && diff tmplines1.txt tmplines2.txt
-tckconvert tracks.tck -scanner2voxel dwi.mif tmp.vtk -force && awk '/POINTS/{s=1;next}/LINES/{s=0}s' tmp.vtk >tmppoints1.txt && awk '/POINTS/{s=1;next}/LINES/{s=0}s' tckconvert/out1.vtk >tmppoints2.txt && testing_diff_matrix tmppoints1.txt tmppoints2.txt -abs 1e-4
-tckconvert tracks.tck -scanner2voxel dwi.mif tmp.vtk -force && awk '/LINES/,0' tmp.vtk >tmplines1.txt && awk '/LINES/,0' tckconvert/out1.vtk >tmplines2.txt && diff tmplines1.txt tmplines2.txt
+tckconvert tracks.tck tmp.vtk -force && awk '/POINTS/{s=1;next}/LINES/{s=0}s' tmp.vtk > tmppoints1.txt && awk '/POINTS/{s=1;next}/LINES/{s=0}s' tckconvert/out0.vtk > tmppoints2.txt && testing_diff_matrix tmppoints1.txt tmppoints2.txt -abs 1e-4
+tckconvert tracks.tck tmp.vtk -force && awk '/LINES/,0' tmp.vtk > tmplines1.txt && awk '/LINES/,0' tckconvert/out0.vtk > tmplines2.txt && diff tmplines1.txt tmplines2.txt
+tckconvert tracks.tck -scanner2voxel dwi.mif tmp.vtk -force && awk '/POINTS/{s=1;next}/LINES/{s=0}s' tmp.vtk > tmppoints1.txt && awk '/POINTS/{s=1;next}/LINES/{s=0}s' tckconvert/out1.vtk > tmppoints2.txt && testing_diff_matrix tmppoints1.txt tmppoints2.txt -abs 1e-4
+tckconvert tracks.tck -scanner2voxel dwi.mif tmp.vtk -force && awk '/LINES/,0' tmp.vtk > tmplines1.txt && awk '/LINES/,0' tckconvert/out1.vtk > tmplines2.txt && diff tmplines1.txt tmplines2.txt
 tckedit tracks.tck -number 10 tmp.tck -nthread 0 && tckconvert tmp.tck tmp-[].txt && cat tmp-*.txt > tmp-all.txt && testing_diff_matrix tmp-all.txt tckconvert/out2-all.txt -abs 1e-4
 tckconvert tckconvert/out2-[2:9].txt tmp.tck -force && testing_diff_tck tmp.tck tckconvert/out3.tck
 echo 1 2 3 > tmp.txt && tckconvert -force -quiet tmp.txt tmp.tck && tckconvert -quiet -force tmp.tck tmp.rib && [ $(wc -l < tmp.rib ) == 4 ]

--- a/testing/binaries/tests/voxel2fixel
+++ b/testing/binaries/tests/voxel2fixel
@@ -1,1 +1,1 @@
-voxel2fixel dwi_mean.mif fixel_image voxel2fixel_tmp dwi_mean.mif -force && testing_diff_fixel voxel2fixel voxel2fixel_tmp -frac 1e-4 && rm -rf voxel2fixel_tmp
+voxel2fixel dwi_mean.mif fixel_image tmp dwi_mean.mif -force && testing_diff_fixel voxel2fixel tmp -frac 1e-4

--- a/testing/binaries/tests/warp2metric
+++ b/testing/binaries/tests/warp2metric
@@ -1,3 +1,3 @@
 warp2metric fod_warp.mif -jdet - | testing_diff_image - warp2metric/jdet.mif -frac 0.001
 warp2metric fod_warp.mif -jmat - | testing_diff_image - warp2metric/jmat.mif -frac 0.001
-warp2metric fod_warp.mif -fc fixel_image warp2metric_tmp fc.mif -force && testing_diff_fixel warp2metric_tmp warp2metric/fc -frac 0.001 && rm -rf warp2metric_tmp
+warp2metric fod_warp.mif -fc fixel_image tmp fc.mif -force && testing_diff_fixel tmp warp2metric/fc -frac 0.001


### PR DESCRIPTION
Argument "`bool check_if_empty`" of function "`Fixel::check_fixel_directory()`" was only set to `true` for commands `fod2fixel` and `peaks2fixel`. Everything else is currently set up to be permissive of existing & non-empty output fixel directories. I have decided that `fixelconvert` and `fixelcrop` should also not be permissive of such. Other commands cannot enforce this requirement due to allowing the same directory to be defined for both input & output.