### PR TITLE
[BUG] tckgen: Fix absent CST with ACT

### DIFF
--- a/core/interp/base.h
+++ b/core/interp/base.h
@@ -203,6 +203,11 @@ namespace MR
                                     pos[2] <= -0.5 || pos[2] >= bounds[2])));
         }
 
+        template <>
+        bool set_out_of_bounds (const bool& value) {
+          return ((out_of_bounds = value));
+        }
+
         template <class VectorType>
         Eigen::Vector3 intravoxel_offset (const VectorType& pos) {
           if (set_out_of_bounds (pos))

--- a/core/interp/base.h
+++ b/core/interp/base.h
@@ -197,22 +197,17 @@ namespace MR
 
         // Some helper functions
         template <class VectorType>
-        bool is_out_of_bounds (const VectorType& pos) const {
-          if (pos[0] <= -0.5 || pos[0] >= bounds[0] ||
-              pos[1] <= -0.5 || pos[1] >= bounds[1] ||
-              pos[2] <= -0.5 || pos[2] >= bounds[2]) {
-            return true;
-          }
-          return false;
+        bool set_out_of_bounds (const VectorType& pos) {
+          return ((out_of_bounds = (pos[0] <= -0.5 || pos[0] >= bounds[0] ||
+                                    pos[1] <= -0.5 || pos[1] >= bounds[1] ||
+                                    pos[2] <= -0.5 || pos[2] >= bounds[2])));
         }
 
         template <class VectorType>
         Eigen::Vector3 intravoxel_offset (const VectorType& pos) {
-          out_of_bounds = (*this).is_out_of_bounds (pos); // Don't want the equally-named function in image_helpers.h!
-          if (out_of_bounds)
+          if (set_out_of_bounds (pos))
             return Eigen::Vector3 (NaN, NaN, NaN);
-          else
-            return Eigen::Vector3 (pos[0]-std::floor (pos[0]), pos[1]-std::floor (pos[1]), pos[2]-std::floor (pos[2]));
+          return Eigen::Vector3 (pos[0]-std::floor (pos[0]), pos[1]-std::floor (pos[1]), pos[2]-std::floor (pos[2]));
         }
 
     };

--- a/core/interp/base.h
+++ b/core/interp/base.h
@@ -69,6 +69,7 @@ namespace MR
     template <class ImageType> class Base : public ImageType, public Transform
     { MEMALIGN(Base<ImageType>)
       public:
+        using image_type = ImageType;
         using value_type = typename ImageType::value_type;
 
         //! construct an Interp object to obtain interpolated values using the

--- a/core/interp/base.h
+++ b/core/interp/base.h
@@ -203,9 +203,8 @@ namespace MR
                                     pos[2] <= -0.5 || pos[2] >= bounds[2])));
         }
 
-        template <>
-        bool set_out_of_bounds (const bool& value) {
-          return ((out_of_bounds = value));
+        void set_out_of_bounds (const bool value) {
+          out_of_bounds = value;
         }
 
         template <class VectorType>

--- a/core/interp/masked.h
+++ b/core/interp/masked.h
@@ -1,0 +1,121 @@
+/* Copyright (c) 2008-2020 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Covered Software is provided under this License on an "as is"
+ * basis, without warranty of any kind, either expressed, implied, or
+ * statutory, including, without limitation, warranties that the
+ * Covered Software is free of defects, merchantable, fit for a
+ * particular purpose or non-infringing.
+ * See the Mozilla Public License v. 2.0 for more details.
+ *
+ * For more details, see http://www.mrtrix.org/.
+ */
+
+#ifndef __interp_masked_h__
+#define __interp_masked_h__
+
+#include "datatype.h"
+#include "interp/base.h"
+
+namespace MR
+{
+  namespace Interp
+  {
+
+    //! \addtogroup interp
+    // @{
+
+    //! Implicit masking for interpolator class
+    /*! Wrap a image interpolator in a way that returns false not only if
+     * the position is outside of the field of view of the image, but also
+     * if the image is zero-filled or contains non-finite values at that
+     * location.
+     *
+     * (NaN values are permitted in order to be compatible with 3-vectors
+     * images, i.e. sets of XYZ triplets; but there needs to be at least
+     * one non-NaN value in the voxel)
+     */
+
+    template <class InterpType>
+    class Masked : public InterpType { MEMALIGN(Masked<InterpType>)
+      public:
+        using typename InterpType::value_type;
+
+        Masked (const typename InterpType::image_type& parent,
+                const value_type value_when_out_of_bounds = Base<typename InterpType::image_type>::default_out_of_bounds_value()) :
+            InterpType (parent, value_when_out_of_bounds),
+            mask (Image<bool>::scratch (make_mask_header (parent), "scratch binary mask for masked interpolator"))
+        {
+          typename InterpType::image_type temp (parent);
+          // True if at least one finite & non-zero value
+          for (auto l_voxel = Loop(mask) (temp, mask); l_voxel; ++l_voxel) {
+            bool value = false;
+            for (auto l_inner = Loop(temp, 3) (temp); l_inner; ++l_inner) {
+              if (temp.value()) {
+                value = true;
+                continue;
+              }
+            }
+            mask.value() = value;
+          }
+        }
+
+        //! Set the current position to <b>voxel space</b> position \a pos
+        /* Unlike other interpolators, this involves checking the value of
+         * an internally stored mask, which tracks those voxels that contain
+         * at least one finite & non-zero value.
+         *
+         * See file interp/base.h for details. */
+        template <class VectorType>
+        bool voxel (const VectorType& pos) {
+          InterpType::intravoxel_offset (pos);
+          if (InterpType::out_of_bounds)
+            return false;
+          mask.index(0) = std::round (pos[0]);
+          mask.index(1) = std::round (pos[1]);
+          mask.index(2) = std::round (pos[2]);
+          if (!mask.value())
+            return false;
+          return InterpType::voxel (pos);
+        }
+
+        //! Set the current position to <b>image space</b> position \a pos
+        /*! See file interp/base.h for details. */
+        template <class VectorType>
+        FORCE_INLINE bool image (const VectorType& pos) {
+          return voxel (Transform::voxelsize.inverse() * pos.template cast<default_type>());
+        }
+
+        //! Set the current position to the <b>scanner space</b> position \a pos
+        /*! See file interp/base.h for details. */
+        template <class VectorType>
+        FORCE_INLINE bool scanner (const VectorType& pos) {
+          return voxel (Transform::scanner2voxel * pos.template cast<default_type>());
+        }
+
+      protected:
+        Image<bool> mask;
+
+        static Header make_mask_header (const typename InterpType::image_type& image)
+        {
+          Header H (image);
+          H.ndim() = 3;
+          H.datatype() = DataType::Bit;
+          return H;
+        }
+
+    };
+
+
+
+    //! @}
+
+  }
+}
+
+#endif
+
+

--- a/core/interp/masked.h
+++ b/core/interp/masked.h
@@ -68,7 +68,8 @@ namespace MR
             if (InterpType::image_type::value())
               return InterpType::voxel (pos);
           }
-          return InterpType::set_out_of_bounds (true);
+          InterpType::set_out_of_bounds (true);
+          return true;
         }
 
         //! Set the current position to <b>image space</b> position \a pos

--- a/core/interp/sinc.h
+++ b/core/interp/sinc.h
@@ -92,7 +92,7 @@ namespace MR
         /*! See file interp/base.h for details. */
         template <class VectorType>
         bool voxel (const VectorType& pos) {
-          if ((out_of_bounds = Base<ImageType>::is_out_of_bounds (pos)))
+          if (Base<ImageType>::set_out_of_bounds (pos))
             return false;
           Sinc_x.set (*this, 0, pos[0]);
           Sinc_y.set (*this, 1, pos[1]);

--- a/src/dwi/tractography/ACT/method.h
+++ b/src/dwi/tractography/ACT/method.h
@@ -51,7 +51,12 @@ namespace MR
                 sgm_seed_to_wm (false),
                 act_image (shared.act().voxel) { }
 
-            ACT_Method_additions (const ACT_Method_additions&) = delete;
+            ACT_Method_additions (const ACT_Method_additions& that) :
+                sgm_depth (0),
+                seed_in_sgm (false),
+                sgm_seed_to_wm (false),
+                act_image (that.act_image) { }
+
             ACT_Method_additions() = delete;
 
 

--- a/src/dwi/tractography/ACT/method.h
+++ b/src/dwi/tractography/ACT/method.h
@@ -24,6 +24,7 @@
 #include "dwi/tractography/tracking/types.h"
 
 #include "interp/linear.h"
+#include "interp/masked.h"
 
 
 #define GMWMI_NORMAL_PERTURBATION 0.001
@@ -152,7 +153,7 @@ namespace MR
 
 
           private:
-            Interp::Linear<Image<float>> act_image;
+            Interp::Masked<Interp::Linear<Image<float>>> act_image;
             Tissues tissue_values;
 
         };

--- a/src/dwi/tractography/algorithms/fact.h
+++ b/src/dwi/tractography/algorithms/fact.h
@@ -90,13 +90,10 @@ namespace MR
       bool init() override
       {
         if (!get_data (source)) return false;
-        if (!S.init_dir.allFinite()) {
-          if (!dir.allFinite())
-            dir = random_direction();
-        }
-        else
+        if (S.init_dir.allFinite())
           dir = S.init_dir;
-
+        else
+          dir = random_direction();
         return select_fixel (dir) >= S.threshold;
       }
 

--- a/src/dwi/tractography/algorithms/fact.h
+++ b/src/dwi/tractography/algorithms/fact.h
@@ -97,7 +97,7 @@ namespace MR
         else
           dir = S.init_dir;
 
-        return do_next (dir) >= S.threshold;
+        return select_fixel (dir) >= S.threshold;
       }
 
       term_t next () override
@@ -105,7 +105,7 @@ namespace MR
         if (!get_data (source))
           return EXIT_IMAGE;
 
-        const float max_norm = do_next (dir);
+        const float max_norm = select_fixel (dir);
 
         if (max_norm < S.threshold)
           return MODEL;
@@ -114,11 +114,12 @@ namespace MR
         return CONTINUE;
       }
 
-
-      float get_metric() override
+      float get_metric (const Eigen::Vector3f& position, const Eigen::Vector3f& direction) override
       {
-        Eigen::Vector3f d (dir);
-        return do_next (d);
+        if (!get_data (source, position))
+          return 0.0;
+        Eigen::Vector3f d (direction);
+        return select_fixel (d);
       }
 
 
@@ -126,7 +127,7 @@ namespace MR
       const Shared& S;
       Interp::Masked<Interp::Nearest<Image<float>>> source;
 
-      float do_next (Eigen::Vector3f& d) const
+      float select_fixel (Eigen::Vector3f& d) const
       {
 
         int idx = -1;

--- a/src/dwi/tractography/algorithms/fact.h
+++ b/src/dwi/tractography/algorithms/fact.h
@@ -17,6 +17,7 @@
 #ifndef __dwi_tractography_algorithms_fact_h__
 #define __dwi_tractography_algorithms_fact_h__
 
+#include "interp/masked.h"
 #include "interp/nearest.h"
 
 #include "dwi/tractography/tracking/method.h"
@@ -123,7 +124,7 @@ namespace MR
 
       protected:
       const Shared& S;
-      Interp::Nearest<Image<float>> source;
+      Interp::Masked<Interp::Nearest<Image<float>>> source;
 
       float do_next (Eigen::Vector3f& d) const
       {

--- a/src/dwi/tractography/algorithms/iFOD1.h
+++ b/src/dwi/tractography/algorithms/iFOD1.h
@@ -227,9 +227,11 @@ namespace MR
       }
 
 
-      float get_metric() override
+      float get_metric (const Eigen::Vector3f& position, const Eigen::Vector3f& direction) override
       {
-        return FOD (dir);
+        if (!get_data (source, position))
+          return 0.0;
+        return FOD (direction);
       }
 
 

--- a/src/dwi/tractography/algorithms/iFOD2.h
+++ b/src/dwi/tractography/algorithms/iFOD2.h
@@ -281,9 +281,11 @@ end_init:
             }
 
 
-            float get_metric() override
+            float get_metric (const Eigen::Vector3f& position, const Eigen::Vector3f& direction) override
             {
-              return FOD (dir);
+              if (!get_data (source, position))
+                return 0.0;
+              return FOD (direction);
             }
 
 

--- a/src/dwi/tractography/algorithms/nulldist.h
+++ b/src/dwi/tractography/algorithms/nulldist.h
@@ -76,7 +76,7 @@ namespace MR
         return CONTINUE;
       }
 
-      float get_metric() override { return uniform(rng); }
+      float get_metric (const Eigen::Vector3f&, const Eigen::Vector3f&) override { return uniform(rng); }
 
 
       protected:
@@ -156,7 +156,7 @@ namespace MR
         sample_idx = S.num_samples;
       }
 
-      float get_metric() override { return uniform(rng); }
+      float get_metric (const Eigen::Vector3f&, const Eigen::Vector3f&) override { return uniform(rng); }
 
 
       protected:

--- a/src/dwi/tractography/algorithms/sd_stream.h
+++ b/src/dwi/tractography/algorithms/sd_stream.h
@@ -134,9 +134,11 @@ class SDStream : public MethodBase { MEMALIGN(SDStream)
     }
 
 
-    float get_metric() override
+    float get_metric (const Eigen::Vector3f& position, const Eigen::Vector3f& direction) override
     {
-      return FOD (dir);
+      if (!get_data (source, position))
+        return 0.0;
+      return FOD (direction);
     }
 
 

--- a/src/dwi/tractography/algorithms/seedtest.h
+++ b/src/dwi/tractography/algorithms/seedtest.h
@@ -55,7 +55,7 @@ class Seedtest : public MethodBase { MEMALIGN(Seedtest)
 
   bool init() override { return true; }
   term_t next () override { return EXIT_IMAGE; }
-  float get_metric() override { return 1.0f; }
+  float get_metric (const Eigen::Vector3f& position, const Eigen::Vector3f& direction) override { return 1.0f; }
 
 
   protected:

--- a/src/dwi/tractography/algorithms/tensor_det.h
+++ b/src/dwi/tractography/algorithms/tensor_det.h
@@ -99,7 +99,13 @@ namespace MR
       {
         if (!get_data (source))
           return false;
-        return do_init();
+        if (!do_init())
+          return false;
+        if (S.init_dir.allFinite())
+          return true;
+        if (S.init_dir.dot (dir) < 0.0)
+          dir = -dir;
+        return true;
       }
 
 
@@ -107,7 +113,7 @@ namespace MR
       term_t next () override
       {
         if (!get_data (source))
-          return Tracking::EXIT_IMAGE;
+          return EXIT_IMAGE;
         return do_next();
       }
 

--- a/src/dwi/tractography/algorithms/tensor_det.h
+++ b/src/dwi/tractography/algorithms/tensor_det.h
@@ -112,8 +112,10 @@ namespace MR
       }
 
 
-      float get_metric() override
+      float get_metric (const Eigen::Vector3f& position, const Eigen::Vector3f& direction) override
       {
+        if (!get_data (source, position))
+          return 0.0;
         dwi2tensor (dt, S.binv, values);
         return tensor2FA (dt);
       }

--- a/src/dwi/tractography/algorithms/tensor_prob.h
+++ b/src/dwi/tractography/algorithms/tensor_prob.h
@@ -59,12 +59,12 @@ namespace MR
             Tensor_Prob (const Shared& shared) :
               Tensor_Det (shared),
               S (shared),
-              source (Bootstrap<Image<float>,WildBootstrap> (S.source, WildBootstrap (S.Hat)), S.source) { }
+              source (Bootstrap<Image<float>,WildBootstrap> (S.source, WildBootstrap (S.Hat))) { }
 
             Tensor_Prob (const Tensor_Prob& F) :
               Tensor_Det (F.S),
               S (F.S),
-              source (Bootstrap<Image<float>,WildBootstrap> (S.source, WildBootstrap (S.Hat)), S.source) { }
+              source (Bootstrap<Image<float>,WildBootstrap> (S.source, WildBootstrap (S.Hat))) { }
 
 
 
@@ -118,8 +118,7 @@ namespace MR
 
             class Interp : public Interpolator<Bootstrap<Image<float>,WildBootstrap>>::type { MEMALIGN(Interp)
               public:
-                Interp (const Bootstrap<Image<float>,WildBootstrap>& bootstrap_vox,
-                        const Image<float>& vox) :
+                Interp (const Bootstrap<Image<float>,WildBootstrap>& bootstrap_vox) :
                     Interpolator<Bootstrap<Image<float>,WildBootstrap> >::type (bootstrap_vox)
                 {
                   for (size_t i = 0; i < 8; ++i)

--- a/src/dwi/tractography/algorithms/tensor_prob.h
+++ b/src/dwi/tractography/algorithms/tensor_prob.h
@@ -120,7 +120,7 @@ namespace MR
               public:
                 Interp (const Bootstrap<Image<float>,WildBootstrap>& bootstrap_vox,
                         const Image<float>& vox) :
-                    Interpolator<Bootstrap<Image<float>,WildBootstrap> >::type (bootstrap_vox, vox)
+                    Interpolator<Bootstrap<Image<float>,WildBootstrap> >::type (bootstrap_vox)
                 {
                   for (size_t i = 0; i < 8; ++i)
                     raw_signals.push_back (Eigen::VectorXf (size(3)));
@@ -129,15 +129,13 @@ namespace MR
                 vector<Eigen::VectorXf> raw_signals;
 
                 bool get (const Eigen::Vector3f& pos, Eigen::VectorXf& data) {
-                  scanner (pos);
-                  if (out_of_bounds) {
+                  if (!scanner (pos)) {
                     data.fill (NaN);
                     return false;
                   }
 
                   data.setZero();
 
-                  // Modified to be consistent with the new Interp::Linear implementation
                   size_t i = 0;
                   for (ssize_t z = 0; z < 2; ++z) {
                     index(2) = clamp (P[2]+z, size(2));

--- a/src/dwi/tractography/algorithms/tensor_prob.h
+++ b/src/dwi/tractography/algorithms/tensor_prob.h
@@ -59,12 +59,12 @@ namespace MR
             Tensor_Prob (const Shared& shared) :
               Tensor_Det (shared),
               S (shared),
-              source (Bootstrap<Image<float>,WildBootstrap> (S.source, WildBootstrap (S.Hat))) { }
+              source (Bootstrap<Image<float>,WildBootstrap> (S.source, WildBootstrap (S.Hat)), S.source) { }
 
             Tensor_Prob (const Tensor_Prob& F) :
               Tensor_Det (F.S),
               S (F.S),
-              source (Bootstrap<Image<float>,WildBootstrap> (S.source, WildBootstrap (S.Hat))) { }
+              source (Bootstrap<Image<float>,WildBootstrap> (S.source, WildBootstrap (S.Hat)), S.source) { }
 
 
 
@@ -118,11 +118,13 @@ namespace MR
 
             class Interp : public Interpolator<Bootstrap<Image<float>,WildBootstrap>>::type { MEMALIGN(Interp)
               public:
-                Interp (const Bootstrap<Image<float>,WildBootstrap>& bootstrap_vox) :
-                  Interpolator<Bootstrap<Image<float>,WildBootstrap> >::type (bootstrap_vox) {
-                    for (size_t i = 0; i < 8; ++i)
-                      raw_signals.push_back (Eigen::VectorXf (size(3)));
-                  }
+                Interp (const Bootstrap<Image<float>,WildBootstrap>& bootstrap_vox,
+                        const Image<float>& vox) :
+                    Interpolator<Bootstrap<Image<float>,WildBootstrap> >::type (bootstrap_vox, vox)
+                {
+                  for (size_t i = 0; i < 8; ++i)
+                    raw_signals.push_back (Eigen::VectorXf (size(3)));
+                }
 
                 vector<Eigen::VectorXf> raw_signals;
 

--- a/src/dwi/tractography/tracking/exec.h
+++ b/src/dwi/tractography/tracking/exec.h
@@ -116,6 +116,12 @@ namespace MR
               track_excluded (false),
               include_visitation (S.properties.include, S.properties.ordered_include) { }
 
+            Exec (const Exec& that) :
+              S (that.S),
+              method (that.method),
+              track_excluded (false),
+              include_visitation (S.properties.include, S.properties.ordered_include) { }
+
 
             bool operator() (GeneratedTrack& item) {
               if (!seed_track (item))
@@ -447,17 +453,13 @@ namespace MR
 
             void truncate_exit_sgm (vector<Eigen::Vector3f>& tck)
             {
-              Interpolator<Image<float>>::type source (S.source);
-
               const size_t sgm_start = tck.size() - method.act().sgm_depth;
               assert (sgm_start >= 0 && sgm_start < tck.size());
               size_t best_termination = tck.size() - 1;
               float min_value = std::numeric_limits<float>::infinity();
               for (size_t i = sgm_start; i != tck.size(); ++i) {
-                method.pos = tck[i];
-                method.get_data (source);
-                method.dir = (tck[i] - tck[i-1]).normalized();
-                const float this_value = method.get_metric();
+                const Eigen::Vector3f direction = (tck[i] - tck[i-1]).normalized();
+                const float this_value = method.get_metric (tck[i], direction);
                 if (this_value < min_value) {
                   min_value = this_value;
                   best_termination = i;

--- a/src/dwi/tractography/tracking/method.h
+++ b/src/dwi/tractography/tracking/method.h
@@ -51,7 +51,7 @@ namespace MR
               pos (0.0, 0.0, 0.0),
               dir (0.0, 0.0, 1.0),
               S (that.S),
-              act_method_additions (S.is_act() ? new ACT::ACT_Method_additions (S) : nullptr),
+              act_method_additions (S.is_act() ? new ACT::ACT_Method_additions (that.act()) : nullptr),
               uniform (that.uniform),
               values (that.values.size()) { }
 
@@ -72,10 +72,9 @@ namespace MR
               return get_data (source, pos);
             }
 
-
             virtual bool init() = 0;
             virtual term_t next() = 0;
-            virtual float get_metric() = 0;
+            virtual float get_metric (const Eigen::Vector3f& position, const Eigen::Vector3f& direction) = 0;
 
             virtual void reverse_track() { if (act_method_additions) act().reverse_track(); }
             virtual void truncate_track (GeneratedTrack& tck, const size_t length_to_revert_from, const size_t revert_step);

--- a/src/dwi/tractography/tracking/types.h
+++ b/src/dwi/tractography/tracking/types.h
@@ -20,6 +20,7 @@
 
 #include "image.h"
 #include "interp/linear.h"
+#include "interp/masked.h"
 
 
 
@@ -49,7 +50,7 @@ namespace MR
         template <class ImageType>
           class Interpolator { MEMALIGN(Interpolator<ImageType>)
             public:
-              using type = Interp::Linear<ImageType>;
+              using type = Interp::Masked<Interp::Linear<ImageType>>;
           };
 
 

--- a/testing/binaries/tests/tckgen
+++ b/testing/binaries/tests/tckgen
@@ -11,4 +11,4 @@ tckgen SIFT_phantom/fods.mif -algo sd_stream -seed_image SIFT_phantom/mask.mif -
 tckgen SIFT_phantom/dwi.mif -algo tensor_prob -seed_image SIFT_phantom/mask.mif -mask SIFT_phantom/mask.mif -minlength 4 -select 100 tmp.tck -force
 tckgen SIFT_phantom/fods.mif -algo ifod1 -seed_image SIFT_phantom/mask.mif -act SIFT_phantom/5tt.mif -backtrack -select 100 tmp.tck -force
 tckgen dwi.mif -algo tensor_det -seed_grid_per_voxel mrcrop/mask.mif 3 -nthread 0 tmp.tck -force && testing_diff_tck tmp.tck tckgen/tensor_det.tck
-tckgen dwi.mif -algo tensor_det -seed_grid_per_voxel mrcrop/mask.mif 3 tmp.tck -force && testing_diff_tck tmp.tck tckgen/tensor_det.tck -unordered
+tckgen dwi.mif -algo tensor_det -seed_grid_per_voxel mrcrop/mask.mif 3 tmp.tck -force && testing_diff_tck tmp.tck tckgen/tensor_det.tck -unordered && testing_diff_tck tckgen/tensor_det.tck tmp.tck -unordered


### PR DESCRIPTION
As originally reported directly by @cbajada, then posted on [forum](https://community.mrtrix.org/t/unwanted-results-using-act-tractography-with-hcp-data/2419), but I neglected to list on GitHub and hence a fix was erroneously omitted from `3.0.0`.

I second-guessed myself a bit as to how exactly I wanted to go about this, as there were a few different options, but I won't bother boring with the full details unless there are questions or concerns.

One outstanding issue is that I'm going to have to modify the test data. Can't have the transition from >=50% WM, <50% GM to <50% WM, >=50% GM align perfectly with the voxel transition from present FOD to absent FOD, as this change now means that there's no valid DWI data just inside of the GM.