### PR TITLE
NIfTI: Fix verification of rigid transform

### DIFF
--- a/core/file/nifti_utils.cpp
+++ b/core/file/nifti_utils.cpp
@@ -513,7 +513,7 @@ namespace MR
           Eigen::Quaterniond Q (R);
 
           if (Q.w() < 0.0)
-            Q.vec() = -Q.vec();
+            Q.coeffs() *= -1.0;
 
           if (R.isApprox (Q.matrix(), 1e-6)) {
             Raw::store<code_type> (NIFTI_XFORM_SCANNER_ANAT, &NH.qform_code, is_BE);


### PR DESCRIPTION
@jdtournier: This removes the warning for me on a dataset where the error was appearing.

I was just printing out variable contents and noted that the 3x3 matrix produced from Q was identical to R until the `Q.w` check resulted in negating the vector, which changed the matrix (some elements unchanged, others changed by maybe 1e-3).

I always lose my understanding of quaternions as soon as I'm finished dealing with whatever code uses them, plus there's the confound of NIfTI peculiarities, so I'm handing this one off to you if it needs to be resolved in a different way.