### PR TITLE
labelconvert: Error if -spine used but absent from LUT

### DIFF
--- a/cmd/labelconvert.cpp
+++ b/cmd/labelconvert.cpp
@@ -129,32 +129,31 @@ void run ()
   auto opt = get_options ("spine");
   if (opt.size()) {
 
-    if (duplicates) {
-      WARN ("Could not add spine node: \"" + SPINE_NODE_NAME + "\" appears multiple times in output LUT");
+    if (duplicates)
+      throw Exception ("Cannot add spine node: \"" + SPINE_NODE_NAME + "\" appears multiple times in output LUT");
+    if (!spine_index)
+      throw Exception ("Cannot add spine node: \"" + SPINE_NODE_NAME + "\" not present in output LUT");
+
+    auto in_spine = Image<bool>::open (opt[0][0]);
+    if (dimensions_match (in_spine, out)) {
+
+      for (auto l = Loop (in_spine) (in_spine, out); l; ++l) {
+        if (in_spine.value())
+          out.value() = spine_index;
+      }
+
     } else {
 
-      auto in_spine = Image<bool>::open (opt[0][0]);
-      if (dimensions_match (in_spine, out)) {
+      WARN ("Spine node is being created from the mask image provided using -spine option using nearest-neighbour interpolation;");
+      WARN ("recommend using the parcellation image as the basis for this mask so that interpolation is not required");
 
-        for (auto l = Loop (in_spine) (in_spine, out); l; ++l) {
-          if (in_spine.value())
-            out.value() = spine_index;
-        }
-
-      } else {
-
-        WARN ("Spine node is being created from the mask image provided using -spine option using nearest-neighbour interpolation;");
-        WARN ("recommend using the parcellation image as the basis for this mask so that interpolation is not required");
-
-        Transform transform (out);
-        Interp::Nearest<decltype(in_spine)> nearest (in_spine);
-        for (auto l = Loop (out) (out); l; ++l) {
-          Eigen::Vector3 p (out.index (0), out.index (1), out.index (2));
-          p = transform.voxel2scanner * p;
-          if (nearest.scanner (p) && nearest.value())
-            out.value() = spine_index;
-        }
-
+      Transform transform (out);
+      Interp::Nearest<decltype(in_spine)> nearest (in_spine);
+      for (auto l = Loop (out) (out); l; ++l) {
+        Eigen::Vector3 p (out.index (0), out.index (1), out.index (2));
+        p = transform.voxel2scanner * p;
+        if (nearest.scanner (p) && nearest.value())
+          out.value() = spine_index;
       }
 
     }


### PR DESCRIPTION
As reported on [forum](https://community.mrtrix.org/t/tracks-passing-through-brainstem-counted-for-connectome/427/4).

Even if this isn't the actual source of confusion for the user, it nevertheless makes sense that if the command-line option is not going to achieve its purpose properly due to not having a target parcel index, the command should not be executing.

I've also promoted the case where "`Spinal_column`" is specified *multiple times* in the output parcellation from a warning to an error.