### PR TITLE
Docs: afdconnectivity: Link to preprint

### DIFF
--- a/docs/concepts/afd_connectivity.rst
+++ b/docs/concepts/afd_connectivity.rst
@@ -1,11 +1,20 @@
 Motivation for ``afdconnectivity``
 ==================================
 
+.. NOTE::
+
+    A `preprint <https://osf.io/c67kn/>`_ has now been uploaded, which
+    expands on the concepts within this page with figures and greater detail,
+    and includes explanation of the newer SIFT2 method available in command
+    :ref:`tcksift2`. Readers may find it more informative and up-to-date than
+    the content of this documentation page.
 
 Due to the interest in the :ref:`afdconnectivity` command, I thought I'd
 explain the reasoning behind the approach, the rationale behind the
-improvements made in commit 40ccdb62, and the argument for why we
-recommend the use of :ref:`sift` as an alternative if possible.
+improvements made in commit 
+`40ccdb62 <https://github.com/MRtrix3/mrtrix3/commit/40ccdb6290ccac81252747d5be71a77af56e8dc6>`_, 
+and the argument for why we recommend the use of :ref:`sift` as an
+alternative if possible.
 
 The ``afdconnectivity`` command was originally written as a 'hack' for a
 colleague who wanted to obtain quantitative measures of 'connectivity'


### PR DESCRIPTION
It was always my intention that the explanations provided in the "quantitative structural connectivity" manuscript would supersede the contents of this documentation page. Once the manuscript is properly published we can discuss how the software documentation may or may not change; but for now I think it's worth throwing a hyperlink to the preprint in there, since for anyone interested in such concepts it's going to be a better reference than that text-only documentation page.