### PR TITLE
GLM: Change check for rank deficiency

### DIFF
--- a/core/math/stats/glm.cpp
+++ b/core/math/stats/glm.cpp
@@ -79,8 +79,7 @@ namespace MR
 
         void check_design (const matrix_type& design, const bool extra_factors)
         {
-          Eigen::ColPivHouseholderQR<matrix_type> decomp;
-          decomp.setThreshold (1e-5);
+          Eigen::FullPivHouseholderQR<matrix_type> decomp;
           decomp = decomp.compute (design);
           if (decomp.rank() < design.cols()) {
             if (extra_factors) {


### PR DESCRIPTION
Change inspired by [forum thread](https://community.mrtrix.org/t/fba-rank-deficient-matrix/4162).

My suspicion is that I added a threshold to the QR decomposition in order to catch near-deficient cases, but then later on added the condition number check. With the latter in place, I think it makes more sense to have an up-front check for genuine deficiency only, and near-deficiency should be exposed in the condition number check (as per my response in that thread).

Open to alternatives from those with better linear algebra than mine though.