### PR TITLE
Write binary vtkPolyDataFiles

### DIFF
--- a/cmd/tckconvert.cpp
+++ b/cmd/tckconvert.cpp
@@ -94,9 +94,9 @@ void usage ()
     + Option ("radius", "radius of the streamlines")
     +   Argument("radius").type_float(0.0f)
 
-    + OptionGroup ("Options VTK writer")
+    + OptionGroup ("Options specific to VTK writer")
 
-    + Option ("binary", "write a binary VTK file");
+    + Option ("ascii", "write an ASCII VTK file (binary by default)");
 
 }
 
@@ -108,15 +108,15 @@ void usage ()
 
 class VTKWriter: public WriterInterface<float> { MEMALIGN(VTKWriter)
   public:
-    VTKWriter(const std::string& file, bool write_binary = false) : VTKout (file, std::ios::binary ), write_binary(write_binary){
+    VTKWriter(const std::string& file, bool write_ascii = false) : VTKout (file, std::ios::binary ), write_ascii(write_ascii){
       // create and write header of VTK output file:
       VTKout <<
-        "# vtk DataFile Version 4.2\n"
+        "# vtk DataFile Version 3.0\n"
         "Data values for Tracks\n";
-      if ( write_binary ) {
-          VTKout << "BINARY\n";
-      } else {
+      if ( write_ascii ) {
           VTKout << "ASCII\n";
+      } else {
+          VTKout << "BINARY\n";
       }
       VTKout << "DATASET POLYDATA\n"
         "POINTS ";
@@ -130,15 +130,15 @@ class VTKWriter: public WriterInterface<float> { MEMALIGN(VTKWriter)
       size_t start_index = current_index;
       current_index += tck.size();
       track_list.push_back (std::pair<size_t,size_t> (start_index, current_index));
-      if ( write_binary ) {
+      if ( write_ascii ) {
+          for (const auto &pos : tck) {
+              VTKout << pos[0] << " " << pos[1] << " " << pos[2] << "\n";
+          }
+      } else {
           float p[3];
           for (const auto& pos : tck) {
               for (auto i = 0; i < 3; ++i) Raw::store_BE(pos[i], p, i);
               VTKout.write((char*)p, 3 * sizeof(float));
-          }
-      } else {
-          for (const auto& pos : tck) {
-              VTKout << pos[0] << " " << pos[1] << " " << pos[2] << "\n";
           }
       }
       return true;
@@ -147,13 +147,18 @@ class VTKWriter: public WriterInterface<float> { MEMALIGN(VTKWriter)
     ~VTKWriter() {
       try {
         // write out list of tracks:
-        if ( write_binary ) {
+        if ( write_ascii == false ) {
             // Need to include an extra new line when writing binary
             VTKout << "\n";
         }
         VTKout << "LINES " << track_list.size() << " " << track_list.size() + current_index << "\n";
         for (const auto& track : track_list) {
-            if ( write_binary ) {
+            if ( write_ascii ) {
+                VTKout << track.second - track.first << " " << track.first;
+                for (size_t i = track.first + 1; i < track.second; ++i)
+                    VTKout << " " << i;
+                VTKout << "\n";
+            } else {
                 int32_t buffer;
                 buffer = ByteOrder::BE<int32_t> (track.second - track.first);
                 VTKout.write((char*) &buffer, 1 * sizeof(int32_t));
@@ -165,14 +170,9 @@ class VTKWriter: public WriterInterface<float> { MEMALIGN(VTKWriter)
                     buffer = ByteOrder::BE<int32_t> (i);
                     VTKout.write((char*)&buffer, 1* sizeof(int32_t));
                 }
-            } else {
-              VTKout << track.second - track.first << " " << track.first;
-              for (size_t i = track.first + 1; i < track.second; ++i)
-                VTKout << " " << i;
-              VTKout << "\n";
             }
         };
-      if ( write_binary ) {
+      if ( write_ascii == false ) {
           // Need to include an extra new line when writing binary
           VTKout << "\n";
       }
@@ -192,7 +192,7 @@ class VTKWriter: public WriterInterface<float> { MEMALIGN(VTKWriter)
 
   private:
     File::OFStream VTKout;
-    bool write_binary;
+    const bool write_ascii;
     size_t offset_num_points;
     vector<std::pair<size_t,size_t>> track_list;
     size_t current_index = 0;
@@ -744,8 +744,8 @@ void run ()
     writer.reset( new Writer<float>(argument[1], properties) );
   }
   else if (Path::has_suffix(argument[1], ".vtk")) {
-      auto write_binary = get_options("binary").size();
-    writer.reset( new VTKWriter(argument[1], write_binary));
+      auto write_ascii = get_options("ascii").size();
+    writer.reset( new VTKWriter(argument[1], write_ascii));
   }
   else if (Path::has_suffix(argument[1], ".ply")) {
     auto increment = get_options("increment").size() ? get_options("increment")[0][0].as_int() : 1;

--- a/docs/reference/commands/tckconvert.rst
+++ b/docs/reference/commands/tckconvert.rst
@@ -57,10 +57,10 @@ Options for both PLY and RIB writer
 
 -  **-radius radius** radius of the streamlines
 
-Options VTK writer
-^^^^^^^^^^^^^^^^^^
+Options specific to VTK writer
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
--  **-binary** write a binary VTK file
+-  **-ascii** write an ASCII VTK file (binary by default)
 
 Standard options
 ^^^^^^^^^^^^^^^^

--- a/docs/reference/commands/tckconvert.rst
+++ b/docs/reference/commands/tckconvert.rst
@@ -57,6 +57,11 @@ Options for both PLY and RIB writer
 
 -  **-radius radius** radius of the streamlines
 
+Options VTK writer
+^^^^^^^^^^^^^^^^^^
+
+-  **-binary** write a binary VTK file
+
 Standard options
 ^^^^^^^^^^^^^^^^
 

--- a/testing/binaries/tests/tckconvert
+++ b/testing/binaries/tests/tckconvert
@@ -7,3 +7,9 @@ tckedit tracks.tck -number 10 tmp.tck -nthread 0 && tckconvert tmp.tck tmp-[].tx
 tckconvert tckconvert/out2-[2:9].txt tmp.tck -force && testing_diff_tck tmp.tck tckconvert/out3.tck
 echo 1 2 3 > tmp.txt && tckconvert -force -quiet tmp.txt tmp.tck && tckconvert -quiet -force tmp.tck tmp.rib && [ $(wc -l < tmp.rib ) == 4 ]
 tckconvert -force -quiet tckconvert/empty.vtk tmp.tck
+
+# convert tck -> vtk -> txt and compare to tck -> txt
+tckconvert tracks.tck tmp.vtk -force -quiet && tckconvert tmp.vtk tmp-vtk-streamlines-[].txt -force && cat tmp-vtk-streamlines-*.txt > tmp-vtk-all.txt && tckconvert tracks.tck tmp-mrtrix-streamlines-[].txt -force -quiet && cat tmp-mrtrix-streamlines-*.txt > tmp-mrtrix-all.txt && testing_diff_matrix tmp-vtk-all.txt tmp-mrtrix-all.txt
+
+# convert tck -> vtk -> txt and compare to tck -> vtk -> tck -> txt
+tckconvert tracks.tck tmp.vtk -force -quiet && tckconvert tmp.vtk tmp-roundtrip.tck -force && tckconvert tmp-roundtrip.tck tmp-roundtrip-streamlines-[].txt -force && cat tmp-roundtrip-streamlines-*.txt > tmp-roundtrip-all.txt && tckconvert tracks.tck tmp-mrtrix-streamlines-[].txt -force -quiet && cat tmp-mrtrix-streamlines-*.txt > tmp-mrtrix-all.txt && testing_diff_matrix tmp-roundtrip-all.txt tmp-mrtrix-all.txt

--- a/testing/binaries/tests/tckconvert
+++ b/testing/binaries/tests/tckconvert
@@ -1,7 +1,8 @@
-tckconvert tracks.tck tmp.vtk -force && awk '/POINTS/{s=1;next}/LINES/{s=0}s' tmp.vtk > tmppoints1.txt && awk '/POINTS/{s=1;next}/LINES/{s=0}s' tckconvert/out0.vtk > tmppoints2.txt && testing_diff_matrix tmppoints1.txt tmppoints2.txt -abs 1e-4
-tckconvert tracks.tck tmp.vtk -force && awk '/LINES/,0' tmp.vtk > tmplines1.txt && awk '/LINES/,0' tckconvert/out0.vtk > tmplines2.txt && diff tmplines1.txt tmplines2.txt
-tckconvert tracks.tck -scanner2voxel dwi.mif tmp.vtk -force && awk '/POINTS/{s=1;next}/LINES/{s=0}s' tmp.vtk > tmppoints1.txt && awk '/POINTS/{s=1;next}/LINES/{s=0}s' tckconvert/out1.vtk > tmppoints2.txt && testing_diff_matrix tmppoints1.txt tmppoints2.txt -abs 1e-4
-tckconvert tracks.tck -scanner2voxel dwi.mif tmp.vtk -force && awk '/LINES/,0' tmp.vtk > tmplines1.txt && awk '/LINES/,0' tckconvert/out1.vtk > tmplines2.txt && diff tmplines1.txt tmplines2.txt
+tckconvert -ascii tracks.tck tmp.vtk -force && awk '/POINTS/{s=1;next}/LINES/{s=0}s' tmp.vtk > tmppoints1.txt && awk '/POINTS/{s=1;next}/LINES/{s=0}s' tckconvert/out0.vtk > tmppoints2.txt && testing_diff_matrix tmppoints1.txt tmppoints2.txt -abs 1e-4
+tckconvert tracks.tck tmp.vtk -force
+tckconvert -ascii tracks.tck tmp.vtk -force && awk '/LINES/,0' tmp.vtk > tmplines1.txt && awk '/LINES/,0' tckconvert/out0.vtk > tmplines2.txt && diff tmplines1.txt tmplines2.txt
+tckconvert -ascii tracks.tck -scanner2voxel dwi.mif tmp.vtk -force && awk '/POINTS/{s=1;next}/LINES/{s=0}s' tmp.vtk > tmppoints1.txt && awk '/POINTS/{s=1;next}/LINES/{s=0}s' tckconvert/out1.vtk > tmppoints2.txt && testing_diff_matrix tmppoints1.txt tmppoints2.txt -abs 1e-4
+tckconvert -ascii tracks.tck -scanner2voxel dwi.mif tmp.vtk -force && awk '/LINES/,0' tmp.vtk > tmplines1.txt && awk '/LINES/,0' tckconvert/out1.vtk > tmplines2.txt && diff tmplines1.txt tmplines2.txt
 tckedit tracks.tck -number 10 tmp.tck -nthread 0 && tckconvert tmp.tck tmp-[].txt && cat tmp-*.txt > tmp-all.txt && testing_diff_matrix tmp-all.txt tckconvert/out2-all.txt -abs 1e-4
 tckconvert tckconvert/out2-[2:9].txt tmp.tck -force && testing_diff_tck tmp.tck tckconvert/out3.tck
 echo 1 2 3 > tmp.txt && tckconvert -force -quiet tmp.txt tmp.tck && tckconvert -quiet -force tmp.tck tmp.rib && [ $(wc -l < tmp.rib ) == 4 ]


### PR DESCRIPTION
This change enhances the functionality of `tckconvert` by enabling writing `vtkPolyData` files (`.vtk`) in a binary format.  In addition to being faster because floats do not need to be converted to ASCII, the files are smaller.

This PR does not have a corresponding test at this moment.

To use the new format:

`tckconvert -binary streamlines.tck streamlines.vtk`

Writing the new VTK XML format (`.vtp`) is preferred and may be the subject of a future PR.

@jdtournier @Lestropie 