### PR TITLE
MGH/MGZ: Fix Colortable V2 write

### DIFF
--- a/core/file/mgh.h
+++ b/core/file/mgh.h
@@ -393,14 +393,16 @@ namespace MR
               throw Exception ("Error reading colour table from file \"" + H.name() + "\": No entries");
             std::string table;
             const int32_t filename_length = fetch<int32_t> (in);
-            std::string filename (filename_length + 1, '\0');
+            std::string filename (filename_length, '\0');
             in.read (const_cast<char*> (filename.data()), filename_length);
             for (int32_t structure = 0; structure != nentries; ++structure) {
               const int32_t structurename_length = fetch<int32_t> (in);
               if (structurename_length < 0)
                 throw Exception ("Error reading colour table from file \"" + H.name() + "\": Negative structure name length");
-              std::string structurename (structurename_length + 1, '\0');
+              std::string structurename (structurename_length, '\0');
               in.read (const_cast<char*> (structurename.data()), structurename_length);
+              while (structurename.size() && !structurename.back())
+                structurename.pop_back();
               const int32_t r = fetch<int32_t> (in);
               const int32_t g = fetch<int32_t> (in);
               const int32_t b = fetch<int32_t> (in);
@@ -420,7 +422,7 @@ namespace MR
               throw Exception ("Error reading colour table from file \"" + H.name() + "\": No entries");
             vector<std::string> table;
             const int32_t filename_length = fetch<int32_t> (in);
-            std::string filename (filename_length + 1, '\0');
+            std::string filename (filename_length, '\0');
             in.read (const_cast<char*> (filename.data()), filename_length);
             const int32_t num_entries_to_read = fetch<int32_t> (in);
             for (int32_t i = 0; i != num_entries_to_read; ++i) {
@@ -434,8 +436,10 @@ namespace MR
               const int32_t structurename_length = fetch<int32_t> (in);
               if (structurename_length < 0)
                 throw Exception ("Error reading colour table from file \"" + H.name() + "\": Negative structure name length");
-              std::string structurename (structurename_length + 1, '\0');
+              std::string structurename (structurename_length, '\0');
               in.read (const_cast<char*> (structurename.data()), structurename_length);
+              while (structurename.size() && !structurename.back())
+                structurename.pop_back();
               const int32_t r = fetch<int32_t> (in);
               const int32_t g = fetch<int32_t> (in);
               const int32_t b = fetch<int32_t> (in);
@@ -474,6 +478,8 @@ namespace MR
                     || id == MGH_TAG_OLD_USEREALRAS
                     || id == MGH_TAG_OLD_COLORTABLE)
                 size = 0;
+              else if (id <= 0)
+                throw Exception ("Invalid tag (" + str(id) + ") in MGH format \"other data\"");
               else
                 size = fetch<int64_t> (in);
               std::string content (size+1, '\0');
@@ -818,7 +824,7 @@ namespace MR
             const std::string filename = "INTERNAL";
             store<int32_t> (filename.size()+1, out);
             out.write (filename.c_str(), filename.size()+1);
-            for (auto line : lines) {
+            for (const auto& line : lines) {
               const auto entries = split (line, ",", true);
               if (entries.size() != 5)
                 throw Exception ("Error writing colour table to file: Line has " + str(entries.size()) + " fields, expected 5");
@@ -836,6 +842,7 @@ namespace MR
 
           auto write_colourtable_V2 = [] (const std::string& table, Output& out)
           {
+            store<int32_t> (MGH_TAG_OLD_COLORTABLE, out);
             store<int32_t> (-2, out);
             // Need to find out the maximum node index
             const auto lines = split_lines (table);
@@ -847,13 +854,13 @@ namespace MR
               const int32_t index = to<int32_t> (entries[0]);
               max_index = std::max (max_index, index);
             }
-            store<int32_t> (max_index, out);
+            store<int32_t> (max_index+1, out);
             const std::string filename = "INTERNAL";
             store<int32_t> (filename.size()+1, out);
             out.write (filename.c_str(), filename.size()+1);
             // Actual number of entries in the table
             store<int32_t> (lines.size(), out);
-            for (auto line : lines) {
+            for (const auto& line : lines) {
               const auto entries = split (line, ",", true);
               // Index,Name,Red,Green,Blue,Transparency
               store<int32_t> (to<int32_t> (entries[0]), out);
@@ -954,8 +961,8 @@ namespace MR
           //   tag ID.
           for (const auto& tag : tags) {
             store<int32_t> (tag.id, out);
-            store<int64_t> (tag.content.size(), out);
-            out.write (tag.content.c_str(), tag.content.size());
+            store<int64_t> (tag.content.size()+1, out);
+            out.write (tag.content.c_str(), tag.content.size()+1);
           }
           if (auto_align_matrix)
             write_matrix (*auto_align_matrix, out);
@@ -981,12 +988,10 @@ namespace MR
               default: WARN ("Malformed colour table in header (incorrect number of columns); not written to output image"); break;
             }
           }
-          if (cmdline_tags.size()) {
-            for (auto tag : cmdline_tags) {
-              store<int32_t> (tag.id, out);
-              store<int64_t> (tag.content.size()+1, out);
-              out.write (tag.content.c_str(), tag.content.size()+1);
-            }
+          for (const auto& tag : cmdline_tags) {
+            store<int32_t> (tag.id, out);
+            store<int64_t> (tag.content.size()+1, out);
+            out.write (tag.content.c_str(), tag.content.size()+1);
           }
         }
 


### PR DESCRIPTION
If a MGH / MGZ file that internally contains a version 2 colourfile is read by *MRtrix3*, and then *MRtrix3* writes out a new MGH / MGZ that contains the header key-value data corresponding to the colourfile loaded in the first step (`MGH_TAG_OLD_COLORTABLE`), the resulting output file cannot be read by either FreeSurfer or *MRtrix3*. This is because until now I had never actually come across an MGH / MGZ file that contained such information, and therefore could not verify my load / save functions; the format is undocumented, so I had essentially incorrectly duplicated the FreeSurfer C code.

Full evidence below shows two MGH files generated from the original FreeSurfer MGZ: one with *MRtrix3* `master` code and one with the changes in this PR; all three of these files are then read by FreeSurfer's `mri_info`, *MRtrix3* `master` code, and with the changes in this PR. Long story short, FreeSurfer reads the colourtable fine after it's been in and out of *MRtrix3*'s handling, and *MRtrix3* will generate a more meaningful error message if it encounters an erroneous image file.

-----

```
$ ~/src/master/bin/mrconvert aparc+aseg.mgz master.mgh
$ mrconvert aparc+aseg.mgz fixed.mgh
```

#### File aparc+aseg.mgz
```
$ mri_info aparc+aseg.mgz
reading colortable from MGH file...
colortable with 14176 entries read (originally /opt/freesurfer/FreeSurferColorLUT.txt)
Volume information for aparc+aseg.mgz
          type: MGH
    dimensions: 256 x 256 x 256
   voxel sizes: 1.000000, 1.000000, 1.000000
          type: INT (1)
           fov: 256.000
           dof: 1
        xstart: -128.0, xend: 128.0
        ystart: -128.0, yend: 128.0
        zstart: -128.0, zend: 128.0
            TR: 0.00 msec, TE: 0.00 msec, TI: 0.00 msec, flip angle: 0.00 degrees
       nframes: 1
       PhEncDir: UNKNOWN
       FieldStrength: 0.000000
ras xform present
    xform info: x_r =  -1.0000, y_r =   0.0000, z_r =   0.0000, c_r =    -0.6956
              : x_a =   0.0000, y_a =   0.0000, z_a =   1.0000, c_a =    13.0225
              : x_s =   0.0000, y_s =  -1.0000, z_s =   0.0000, c_s =   -33.3578

talairach xfm : /home/rob/src/MRtrix3_connectome/mrtrix3_connectome.py-tmp-W1V3AA/freesurfer/mri/transforms/talairach.xfm
Orientation   : LIA
Primary Slice Direction: coronal

voxel to ras transform:
               -1.0000   0.0000   0.0000   127.3044
                0.0000   0.0000   1.0000  -114.9775
                0.0000  -1.0000   0.0000    94.6422
                0.0000   0.0000   0.0000     1.0000

voxel-to-ras determinant -1

ras to voxel transform:
               -1.0000  -0.0000  -0.0000   127.3044
               -0.0000  -0.0000  -1.0000    94.6422
               -0.0000   1.0000  -0.0000   114.9775
               -0.0000  -0.0000  -0.0000     1.0000
  0  Unknown                           0   0   0    0
  1  Left-Cerebral-Exterior           70 130 180    0
...
14174  wm_rh_S_temporal_sup            223 220  60    0
14175  wm_rh_S_temporal_transverse     221  60  60    0
```

```
$ ~/src/master/bin/mrinfo aparc+aseg.mgz
************************************************
Image name:          "aparc+aseg.mgz"
************************************************
  Dimensions:        256 x 256 x 256
  Voxel size:        1 x 1 x 1
  Data strides:      [ -1 3 -2 ]
  Format:            MGZ (compressed MGH)
  Data type:         signed 32 bit integer (big endian)
  Intensity scaling: offset = 0, multiplier = 1
  Transform:                    1           0          -0      -127.7
                               -0           1          -0        -115
                               -0           0           1      -160.4
  MGH_TAG_FIELDSTRENGTH: 0
  MGH_TAG_MGH_XFORM: /home/rob/src/MRtrix3_connectome/mrtrix3_connectome.py-tmp-W1V3AA/freesurfer/mri/transforms/talairach.xfm
  MGH_TAG_MRI_FRAME: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,,0,0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0,0,0
  MGH_TAG_OLD_COLORTABLE: 0,Unknown,0,0,0,255
  [1378 entries]     1,Left-Cerebral-Exterior,70,130,180,255
                     ...
                     14174,wm_rh_S_temporal_sup,223,220,60,255
                     14175,wm_rh_S_temporal_transverse,221,60,60,255
  MGH_TAG_PEDIR:     UNKNOWN
  MGH_TE:            0
  MGH_TI:            0
  MGH_TR:            0
  MGH_flip:          0
  command_history:   ProgramName: mri_convert  ProgramArguments: mri_convert /home/rob/src/MRtrix3_connectome/mrtrix3_connectome.py-tmp-W1V3AA/T1.nii /home/rob/src/MRtrix3_connectome/mrtrix3_connectome.py-tmp-W1V3AA/freesurfer/mri/orig/001.mgz  ProgramVersion: 7.1.1  TimeStamp: 2020/10/29-00:09:23-GMT  BuildTime: Jul 23 2020 11:55:54  BuildStamp: freesurfer-linux-centos7_x86_64-7.1.1-20200723-8b40551  User: rob  Machine: bri-priv-237  Platform: Linux  PlatformVersion: 5.8.8-arch1-1  CompilerName: GCC  CompilerVersion: 4.8.5
                     ProgramName: mri_convert  ProgramArguments: mri_convert /home/rob/src/MRtrix3_connectome/mrtrix3_connectome.py-tmp-W1V3AA/freesurfer/mri/rawavg.mgz /home/rob/src/MRtrix3_connectome/mrtrix3_connectome.py-tmp-W1V3AA/freesurfer/mri/orig.mgz --conform  ProgramVersion: 7.1.1  TimeStamp: 2020/10/29-00:09:27-GMT  BuildTime: Jul 23 2020 11:55:54  BuildStamp: freesurfer-linux-centos7_x86_64-7.1.1-20200723-8b40551  User: rob  Machine: bri-priv-237  Platform: Linux  PlatformVersion: 5.8.8-arch1-1  CompilerName: GCC  CompilerVersion: 4.8.5
                     ProgramName: mri_ca_normalize  ProgramArguments: mri_ca_normalize -c ctrl_pts.mgz -mask brainmask.mgz nu.mgz /opt/freesurfer/average/RB_all_2020-01-02.gca transforms/talairach.lta norm.mgz  ProgramVersion: 7.1.1  TimeStamp: 2020/10/29-00:25:19-GMT  BuildTime: Jul 23 2020 11:55:54  BuildStamp: freesurfer-linux-centos7_x86_64-7.1.1-20200723-8b40551  User: rob  Machine: bri-priv-237  Platform: Linux  PlatformVersion: 5.8.8-arch1-1  CompilerName: GCC  CompilerVersion: 4.8.5
                     ProgramName: mri_ca_label  ProgramArguments: mri_ca_label -relabel_unlikely 9 .3 -prior 0.5 -align norm.mgz transforms/talairach.m3z /opt/freesurfer/average/RB_all_2020-01-02.gca aseg.auto_noCCseg.mgz  ProgramVersion: 7.1.1  TimeStamp: 2020/10/29-01:28:30-GMT  BuildTime: Jul 23 2020 11:55:54  BuildStamp: freesurfer-linux-centos7_x86_64-7.1.1-20200723-8b40551  User: rob  Machine: bri-priv-237  Platform: Linux  PlatformVersion: 5.8.8-arch1-1  CompilerName: GCC  CompilerVersion: 4.8.5
```

```
$ mrinfo aparc+aseg.mgz
************************************************
Image name:          "aparc+aseg.mgz"
************************************************
  Dimensions:        256 x 256 x 256
  Voxel size:        1 x 1 x 1
  Data strides:      [ -1 3 -2 ]
  Format:            MGZ (compressed MGH)
  Data type:         signed 32 bit integer (big endian)
  Intensity scaling: offset = 0, multiplier = 1
  Transform:                    1           0          -0      -127.7
                               -0           1          -0        -115
                               -0           0           1      -160.4
  MGH_TAG_FIELDSTRENGTH: 0
  MGH_TAG_MGH_XFORM: /home/rob/src/MRtrix3_connectome/mrtrix3_connectome.py-tmp-W1V3AA/freesurfer/mri/transforms/talairach.xfm
  MGH_TAG_MRI_FRAME: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,,0,0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0,0,0
  MGH_TAG_OLD_COLORTABLE: 0,Unknown,0,0,0,255
  [1378 entries]     1,Left-Cerebral-Exterior,70,130,180,255
                     ...
                     14174,wm_rh_S_temporal_sup,223,220,60,255
                     14175,wm_rh_S_temporal_transverse,221,60,60,255
  MGH_TAG_PEDIR:     UNKNOWN
  MGH_TE:            0
  MGH_TI:            0
  MGH_TR:            0
  MGH_flip:          0
  command_history:   ProgramName: mri_convert  ProgramArguments: mri_convert /home/rob/src/MRtrix3_connectome/mrtrix3_connectome.py-tmp-W1V3AA/T1.nii /home/rob/src/MRtrix3_connectome/mrtrix3_connectome.py-tmp-W1V3AA/freesurfer/mri/orig/001.mgz  ProgramVersion: 7.1.1  TimeStamp: 2020/10/29-00:09:23-GMT  BuildTime: Jul 23 2020 11:55:54  BuildStamp: freesurfer-linux-centos7_x86_64-7.1.1-20200723-8b40551  User: rob  Machine: bri-priv-237  Platform: Linux  PlatformVersion: 5.8.8-arch1-1  CompilerName: GCC  CompilerVersion: 4.8.5
                     ProgramName: mri_convert  ProgramArguments: mri_convert /home/rob/src/MRtrix3_connectome/mrtrix3_connectome.py-tmp-W1V3AA/freesurfer/mri/rawavg.mgz /home/rob/src/MRtrix3_connectome/mrtrix3_connectome.py-tmp-W1V3AA/freesurfer/mri/orig.mgz --conform  ProgramVersion: 7.1.1  TimeStamp: 2020/10/29-00:09:27-GMT  BuildTime: Jul 23 2020 11:55:54  BuildStamp: freesurfer-linux-centos7_x86_64-7.1.1-20200723-8b40551  User: rob  Machine: bri-priv-237  Platform: Linux  PlatformVersion: 5.8.8-arch1-1  CompilerName: GCC  CompilerVersion: 4.8.5
                     ProgramName: mri_ca_normalize  ProgramArguments: mri_ca_normalize -c ctrl_pts.mgz -mask brainmask.mgz nu.mgz /opt/freesurfer/average/RB_all_2020-01-02.gca transforms/talairach.lta norm.mgz  ProgramVersion: 7.1.1  TimeStamp: 2020/10/29-00:25:19-GMT  BuildTime: Jul 23 2020 11:55:54  BuildStamp: freesurfer-linux-centos7_x86_64-7.1.1-20200723-8b40551  User: rob  Machine: bri-priv-237  Platform: Linux  PlatformVersion: 5.8.8-arch1-1  CompilerName: GCC  CompilerVersion: 4.8.5
                     ProgramName: mri_ca_label  ProgramArguments: mri_ca_label -relabel_unlikely 9 .3 -prior 0.5 -align norm.mgz transforms/talairach.m3z /opt/freesurfer/average/RB_all_2020-01-02.gca aseg.auto_noCCseg.mgz  ProgramVersion: 7.1.1  TimeStamp: 2020/10/29-01:28:30-GMT  BuildTime: Jul 23 2020 11:55:54  BuildStamp: freesurfer-linux-centos7_x86_64-7.1.1-20200723-8b40551  User: rob  Machine: bri-priv-237  Platform: Linux  PlatformVersion: 5.8.8-arch1-1  CompilerName: GCC  CompilerVersion: 4.8.5
```

#### File master.mgh

```
$ mri_info master.mgh
znzTAGskip: tag=-2, failed to calloc 9 bytes!

Cannot allocate memory
```

```
$ ~/src/master/bin/mrinfo master.mgh
terminate called after throwing an instance of 'std::bad_alloc'
  what():  std::bad_alloc
Aborted (core dumped)
```

```
$ mrinfo master.mgh
mrinfo: [ERROR] Invalid tag (-2) in MGH format "other data"
mrinfo: [ERROR] error opening image "from_mrtrix3_master.mgh"
```

#### File fixed.mgh

```
$ mri_info fixed.mgh
reading colortable from MGH file...
colortable with 14176 entries read (originally INTERNAL)
Volume information for from_mrtrix3_fixed.mgh
          type: MGH
    dimensions: 256 x 256 x 256
   voxel sizes: 1.000000, 1.000000, 1.000000
          type: INT (1)
           fov: 256.000
           dof: 0
        xstart: -128.0, xend: 128.0
        ystart: -128.0, yend: 128.0
        zstart: -128.0, zend: 128.0
            TR: 0.00 msec, TE: 0.00 msec, TI: 0.00 msec, flip angle: 0.00 degrees
       nframes: 1
       PhEncDir: UNKNOWN
       FieldStrength: 0.000000
ras xform present
    xform info: x_r =  -1.0000, y_r =   0.0000, z_r =   0.0000, c_r =    -0.6956
              : x_a =   0.0000, y_a =   0.0000, z_a =   1.0000, c_a =    13.0225
              : x_s =   0.0000, y_s =  -1.0000, z_s =   0.0000, c_s =   -33.3578

talairach xfm : /home/rob/src/MRtrix3_connectome/mrtrix3_connectome.py-tmp-W1V3AA/freesurfer/mri/transforms/talairach.xfm
Orientation   : LIA
Primary Slice Direction: coronal

voxel to ras transform:
               -1.0000   0.0000   0.0000   127.3044
                0.0000   0.0000   1.0000  -114.9775
                0.0000  -1.0000   0.0000    94.6422
                0.0000   0.0000   0.0000     1.0000

voxel-to-ras determinant -1

ras to voxel transform:
               -1.0000  -0.0000  -0.0000   127.3044
               -0.0000  -0.0000  -1.0000    94.6422
               -0.0000   1.0000  -0.0000   114.9775
               -0.0000  -0.0000  -0.0000     1.0000
  0  Unknown                           0   0   0    0
  1  Left-Cerebral-Exterior           70 130 180    0
...
14174  wm_rh_S_temporal_sup            223 220  60    0
14175  wm_rh_S_temporal_transverse     221  60  60    0
```

```
$ ~/src/master/bin/mrinfo fixed.mgh
************************************************
Image name:          "from_mrtrix3_fixed.mgh"
************************************************
  Dimensions:        256 x 256 x 256
  Voxel size:        1 x 1 x 1
  Data strides:      [ -1 3 -2 ]
  Format:            MGH
  Data type:         signed 32 bit integer (big endian)
  Intensity scaling: offset = 0, multiplier = 1
  Transform:                    1           0          -0      -127.7
                               -0           1          -0        -115
                               -0           0           1      -160.4
  MGH_TAG_FIELDSTRENGTH: 0
  MGH_TAG_MGH_XFORM: /home/rob/src/MRtrix3_connectome/mrtrix3_connectome.py-tmp-W1V3AA/freesurfer/mri/transforms/talairach.xfm
  MGH_TAG_MRI_FRAME: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,,0,0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0,0,0
  MGH_TAG_OLD_COLORTABLE: 0,Unknown,0,0,0,255
  [1378 entries]     1,Left-Cerebral-Exterior,70,130,180,255
                     ...
                     14174,wm_rh_S_temporal_sup,223,220,60,255
                     14175,wm_rh_S_temporal_transverse,221,60,60,255
  MGH_TAG_PEDIR:     UNKNOWN
  MGH_TE:            0
  MGH_TI:            0
  MGH_TR:            0
  MGH_flip:          0
  command_history:   ProgramName: mri_convert  ProgramArguments: mri_convert /home/rob/src/MRtrix3_connectome/mrtrix3_connectome.py-tmp-W1V3AA/T1.nii /home/rob/src/MRtrix3_connectome/mrtrix3_connectome.py-tmp-W1V3AA/freesurfer/mri/orig/001.mgz  ProgramVersion: 7.1.1  TimeStamp: 2020/10/29-00:09:23-GMT  BuildTime: Jul 23 2020 11:55:54  BuildStamp: freesurfer-linux-centos7_x86_64-7.1.1-20200723-8b40551  User: rob  Machine: bri-priv-237  Platform: Linux  PlatformVersion: 5.8.8-arch1-1  CompilerName: GCC  CompilerVersion: 4.8.5
                     ProgramName: mri_convert  ProgramArguments: mri_convert /home/rob/src/MRtrix3_connectome/mrtrix3_connectome.py-tmp-W1V3AA/freesurfer/mri/rawavg.mgz /home/rob/src/MRtrix3_connectome/mrtrix3_connectome.py-tmp-W1V3AA/freesurfer/mri/orig.mgz --conform  ProgramVersion: 7.1.1  TimeStamp: 2020/10/29-00:09:27-GMT  BuildTime: Jul 23 2020 11:55:54  BuildStamp: freesurfer-linux-centos7_x86_64-7.1.1-20200723-8b40551  User: rob  Machine: bri-priv-237  Platform: Linux  PlatformVersion: 5.8.8-arch1-1  CompilerName: GCC  CompilerVersion: 4.8.5
                     ProgramName: mri_ca_normalize  ProgramArguments: mri_ca_normalize -c ctrl_pts.mgz -mask brainmask.mgz nu.mgz /opt/freesurfer/average/RB_all_2020-01-02.gca transforms/talairach.lta norm.mgz  ProgramVersion: 7.1.1  TimeStamp: 2020/10/29-00:25:19-GMT  BuildTime: Jul 23 2020 11:55:54  BuildStamp: freesurfer-linux-centos7_x86_64-7.1.1-20200723-8b40551  User: rob  Machine: bri-priv-237  Platform: Linux  PlatformVersion: 5.8.8-arch1-1  CompilerName: GCC  CompilerVersion: 4.8.5
                     ProgramName: mri_ca_label  ProgramArguments: mri_ca_label -relabel_unlikely 9 .3 -prior 0.5 -align norm.mgz transforms/talairach.m3z /opt/freesurfer/average/RB_all_2020-01-02.gca aseg.auto_noCCseg.mgz  ProgramVersion: 7.1.1  TimeStamp: 2020/10/29-01:28:30-GMT  BuildTime: Jul 23 2020 11:55:54  BuildStamp: freesurfer-linux-centos7_x86_64-7.1.1-20200723-8b40551  User: rob  Machine: bri-priv-237  Platform: Linux  PlatformVersion: 5.8.8-arch1-1  CompilerName: GCC  CompilerVersion: 4.8.5
                     mrconvert 'aparc+aseg.mgz' from_mrtrix3_fixed.mgh  (version=3.0.2-38-g3da505fe-dirty)
```

```
$ mrinfo fixed.mgh
************************************************
Image name:          "from_mrtrix3_fixed.mgh"
************************************************
  Dimensions:        256 x 256 x 256
  Voxel size:        1 x 1 x 1
  Data strides:      [ -1 3 -2 ]
  Format:            MGH
  Data type:         signed 32 bit integer (big endian)
  Intensity scaling: offset = 0, multiplier = 1
  Transform:                    1           0          -0      -127.7
                               -0           1          -0        -115
                               -0           0           1      -160.4
  MGH_TAG_FIELDSTRENGTH: 0
  MGH_TAG_MGH_XFORM: /home/rob/src/MRtrix3_connectome/mrtrix3_connectome.py-tmp-W1V3AA/freesurfer/mri/transforms/talairach.xfm
  MGH_TAG_MRI_FRAME: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,,0,0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0,0,0
  MGH_TAG_OLD_COLORTABLE: 0,Unknown,0,0,0,255
  [1378 entries]     1,Left-Cerebral-Exterior,70,130,180,255
                     ...
                     14174,wm_rh_S_temporal_sup,223,220,60,255
                     14175,wm_rh_S_temporal_transverse,221,60,60,255
  MGH_TAG_PEDIR:     UNKNOWN
  MGH_TE:            0
  MGH_TI:            0
  MGH_TR:            0
  MGH_flip:          0
  command_history:   ProgramName: mri_convert  ProgramArguments: mri_convert /home/rob/src/MRtrix3_connectome/mrtrix3_connectome.py-tmp-W1V3AA/T1.nii /home/rob/src/MRtrix3_connectome/mrtrix3_connectome.py-tmp-W1V3AA/freesurfer/mri/orig/001.mgz  ProgramVersion: 7.1.1  TimeStamp: 2020/10/29-00:09:23-GMT  BuildTime: Jul 23 2020 11:55:54  BuildStamp: freesurfer-linux-centos7_x86_64-7.1.1-20200723-8b40551  User: rob  Machine: bri-priv-237  Platform: Linux  PlatformVersion: 5.8.8-arch1-1  CompilerName: GCC  CompilerVersion: 4.8.5
                     ProgramName: mri_convert  ProgramArguments: mri_convert /home/rob/src/MRtrix3_connectome/mrtrix3_connectome.py-tmp-W1V3AA/freesurfer/mri/rawavg.mgz /home/rob/src/MRtrix3_connectome/mrtrix3_connectome.py-tmp-W1V3AA/freesurfer/mri/orig.mgz --conform  ProgramVersion: 7.1.1  TimeStamp: 2020/10/29-00:09:27-GMT  BuildTime: Jul 23 2020 11:55:54  BuildStamp: freesurfer-linux-centos7_x86_64-7.1.1-20200723-8b40551  User: rob  Machine: bri-priv-237  Platform: Linux  PlatformVersion: 5.8.8-arch1-1  CompilerName: GCC  CompilerVersion: 4.8.5
                     ProgramName: mri_ca_normalize  ProgramArguments: mri_ca_normalize -c ctrl_pts.mgz -mask brainmask.mgz nu.mgz /opt/freesurfer/average/RB_all_2020-01-02.gca transforms/talairach.lta norm.mgz  ProgramVersion: 7.1.1  TimeStamp: 2020/10/29-00:25:19-GMT  BuildTime: Jul 23 2020 11:55:54  BuildStamp: freesurfer-linux-centos7_x86_64-7.1.1-20200723-8b40551  User: rob  Machine: bri-priv-237  Platform: Linux  PlatformVersion: 5.8.8-arch1-1  CompilerName: GCC  CompilerVersion: 4.8.5
                     ProgramName: mri_ca_label  ProgramArguments: mri_ca_label -relabel_unlikely 9 .3 -prior 0.5 -align norm.mgz transforms/talairach.m3z /opt/freesurfer/average/RB_all_2020-01-02.gca aseg.auto_noCCseg.mgz  ProgramVersion: 7.1.1  TimeStamp: 2020/10/29-01:28:30-GMT  BuildTime: Jul 23 2020 11:55:54  BuildStamp: freesurfer-linux-centos7_x86_64-7.1.1-20200723-8b40551  User: rob  Machine: bri-priv-237  Platform: Linux  PlatformVersion: 5.8.8-arch1-1  CompilerName: GCC  CompilerVersion: 4.8.5
                     mrconvert 'aparc+aseg.mgz' from_mrtrix3_fixed.mgh  (version=3.0.2-38-g3da505fe-dirty)
```


