### PR TITLE
get_option_value(): Restrict usage

### DIFF
--- a/core/app.h
+++ b/core/app.h
@@ -442,8 +442,8 @@ namespace MR
 
 
     //! Returns the option value if set, and the default otherwise.
-    /*! Returns the value of (the first occurence of) option \c name
-     *  or the default value provided as second argument.
+    /*! Only be used for command-line options that do not specify
+     * .allow_multiple(), and that have only one associated Argument.
      *
      * Use:
      * \code
@@ -455,8 +455,18 @@ namespace MR
     inline T get_option_value (const std::string& name, const T default_value)
     {
       auto opt = get_options(name);
-      T r = (opt.size()) ? opt[0][0] : default_value;
-      return r;
+      switch (opt.size()) {
+        case 0: return default_value;
+        case 1:
+          if (opt[0].opt->size() != 1) {
+            assert (false);
+            throw Exception ("Internal error parsing command-line option \"-" + name + "\"");
+          }
+          return T(opt[0][0]);
+        default:
+          assert (false);
+          throw Exception ("Internal error parsing command-line option \"-" + name + "\"");
+      }
     }
 
 

--- a/core/app.h
+++ b/core/app.h
@@ -462,7 +462,7 @@ namespace MR
             assert (false);
             throw Exception ("Internal error parsing command-line option \"-" + name + "\"");
           }
-          return T(opt[0][0]);
+          return opt[0][0];
         default:
           assert (false);
           throw Exception ("Internal error parsing command-line option \"-" + name + "\"");

--- a/core/app.h
+++ b/core/app.h
@@ -458,11 +458,8 @@ namespace MR
       switch (opt.size()) {
         case 0: return default_value;
         case 1:
-          if (opt[0].opt->size() != 1) {
-            assert (false);
-            throw Exception ("Internal error parsing command-line option \"-" + name + "\"");
-          }
-          return opt[0][0];
+          if (opt[0].opt->size() == 1)
+            return opt[0][0];
         default:
           assert (false);
           throw Exception ("Internal error parsing command-line option \"-" + name + "\"");


### PR DESCRIPTION
Came across this while thinking about #1975. While the current `get_option_value()` code is permissive, this theoretically enables erroneous usage of the function by developers. This change constrains usage of the function to only those command-line options for which the usage of this function makes sense.