### PR TITLE
for_each: Tweak error message

### DIFF
--- a/bin/for_each
+++ b/bin/for_each
@@ -273,7 +273,7 @@ def execute(): #pylint: disable=unused-variable
           app.warn('No output from command for input "' + job.sub_in + '" (return code = ' + str(job.returncode) + ')')
         if fail_count > 1:
           sys.stderr.write(app.EXEC_NAME + ':\n')
-    raise MRtrixError(str(fail_count) + ' of ' + str(len(jobs)) + ' jobs did not complete successfully')
+    raise MRtrixError(str(fail_count) + ' of ' + str(len(jobs)) + ' jobs did not complete successfully: ' + str([job.input_text for job in jobs if job.returncode]))
 
   if app.VERBOSITY > 1:
     if any(job.outputtext for job in jobs):


### PR DESCRIPTION
In situations where the output of each failed command is long, it is beneficial for the final error message at the end of the terminal printout to state succinctly which inputs were not successfully processed.

```
[rob@rsmithmetabox mrtrix3]$ for_each 1 2 3 : [[ IN -eq "2" ]]
for_each: [100%] 3/3 jobs completed sequentially (2 errors)
for_each: [WARNING] 2 of 3 jobs did not complete successfully
for_each: [WARNING] Outputs from failed commands:
for_each:
for_each: [WARNING] No output from command for input "1" (return code = 1)
for_each:
for_each: [WARNING] No output from command for input "3" (return code = 1)
for_each:

for_each: [ERROR] 2 of 3 jobs did not complete successfully: ['1', '3']
[rob@rsmithmetabox mrtrix3]$
```