### PR TITLE
CI: Try installing "python3-pylint" rather than "pylint3" (Take 2)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -160,7 +160,7 @@ jobs:
     - name: install dependencies
       run: |
          sudo apt-get update
-         sudo apt-get install pylint3 python3-sphinx sphinx-rtd-theme-common python3-recommonmark python3-sphinx-rtd-theme python3-pip
+         sudo apt-get install python3-pylint python3-sphinx sphinx-rtd-theme-common python3-recommonmark python3-sphinx-rtd-theme python3-pip
          pip3 install sphinx-notfound-page
 
 


### PR DESCRIPTION
See if this addresses outdated version of pylint pulled by GitHub runner as commented in #2215.

Opening a second PR in the hope that it triggers the "`secondary-checks`" GitHub Action, for which I've created a dedicated branch protection rule specifically for this PR.