### PR TITLE
dwifslpreproc: Fix for rare usage

### DIFF
--- a/bin/dwifslpreproc
+++ b/bin/dwifslpreproc
@@ -575,7 +575,7 @@ def execute(): #pylint: disable=unused-variable
           app.console('No phase-encoding contrast present in SE-EPI images; will examine again after combining with DWI b=0 images')
           new_se_epi_path = os.path.splitext(se_epi_path)[0] + '_dwibzeros.mif'
           # Don't worry about trying to produce a balanced scheme here
-          run.command('dwiextract dwi.mif - -bzero | mrcat - se_epi.mif ' + new_se_epi_path + ' -axis 3')
+          run.command('dwiextract dwi.mif - -bzero | mrcat - ' + se_epi_path + ' ' + new_se_epi_path + ' -axis 3')
           se_epi_header = image.Header(new_se_epi_path)
           se_epi_pe_scheme_has_contrast = 'pe_scheme' in se_epi_header.keyval()
           if se_epi_pe_scheme_has_contrast:


### PR DESCRIPTION
Fixes case where there is no phase encoding contrast present in the SE_EPI images (and hence they need to be combined with the DWI b=0 data for tuopup to possibly be applicable), and also the SE-EPI volumes are defined on a different image grid to the DWIs.

I thought that this one had already been fixed; not sure if it got reverted in a merge or something. Exceptionally unlikely use case (I only came across it myself due to a partially overwritten dataset).