### PR TITLE
Fix enable_if_image_type() method

### DIFF
--- a/core/image_helpers.h
+++ b/core/image_helpers.h
@@ -145,7 +145,7 @@ namespace MR
             std::declval<ImageType>().ndim() +
             std::declval<ImageType>().size(0) +
             std::declval<ImageType>().name().size() +
-            std::declval<ImageType>().value() +
+            std::real (typename ImageType::value_type (std::declval<ImageType>().value())) +
             std::declval<ImageType>().index(0)
         ), std::declval<ReturnType>()) type;
     };


### PR DESCRIPTION
Required for the [`save()` method](https://github.com/MRtrix3/mrtrix3/blob/dev/core/image.h#L529-L536) to work correctly (only useful when debugging). 

There's still an issue when using `save()` to dump a temporary file to `.mif` format: for some reason, the data in the file produced is corrupted. I'm not sure what's causing it, but this only happens when going through the [`dump_to_image_file()` method](https://github.com/MRtrix3/mrtrix3/blob/dev/core/image.h#L454-L499). Might be worth looking into at some point... 