### PR TITLE
Minor command docs updates

### DIFF
--- a/cmd/afdconnectivity.cpp
+++ b/cmd/afdconnectivity.cpp
@@ -16,6 +16,7 @@
 
 #include "command.h"
 #include "memory.h"
+#include "version.h"
 #include "dwi/fmls.h"
 #include "dwi/tractography/file.h"
 #include "dwi/tractography/properties.h"
@@ -56,8 +57,17 @@ void usage ()
     "that is more related to the cross-sectional volume of the tract (and therefore 'connectivity'). "
     "Note that SIFT-ed tract count is a superior measure because it is unaffected by tangential yet unrelated "
     "fibres. However, AFD connectivity may be used as a substitute when Anatomically Constrained Tractography "
-    "is not possible due to uncorrectable EPI distortions, and SIFT may therefore not be as effective.";
+    "is not possible due to uncorrectable EPI distortions, and SIFT may therefore not be as effective."
 
+  + "Longer discussion regarding this command can additionally be found at: "
+    "https://mrtrix.readthedocs.io/en/" MRTRIX_BASE_VERSION "/concepts/afd_connectivity.html "
+    "(as well as in the relevant reference).";
+
+
+  REFERENCES
+  + "Smith, R. E.; Raffelt, D.; Tournier, J.-D.; Connelly, A. " // Internal
+    "Quantitative Streamlines Tractography: Methods and Inter-Subject Normalisation. "
+    "Open Science Framework, https://doi.org/10.31219/osf.io/c67kn.";
 
 
   ARGUMENTS

--- a/cmd/mrtransform.cpp
+++ b/cmd/mrtransform.cpp
@@ -188,7 +188,7 @@ void usage ()
     + Option ("reorient_fod",
         "specify whether to perform FOD reorientation. This is required if the number "
         "of volumes in the 4th dimension corresponds to the number of coefficients in an "
-        "antipodally symmetric spherical harmonic series with lmax >= 2 (i.e. 6, 15, 28, 45, 66 volumes.")
+        "antipodally symmetric spherical harmonic series with lmax >= 2 (i.e. 6, 15, 28, 45, 66 volumes).")
     + Argument ("boolean").type_bool()
 
     + DWI::GradImportOptions()

--- a/cmd/tcksift2.cpp
+++ b/cmd/tcksift2.cpp
@@ -118,7 +118,12 @@ void usage ()
   REFERENCES
     + "Smith, R. E.; Tournier, J.-D.; Calamante, F. & Connelly, A. " // Internal
     "SIFT2: Enabling dense quantitative assessment of brain white matter connectivity using streamlines tractography. "
-    "NeuroImage, 2015, 119, 338-351";
+    "NeuroImage, 2015, 119, 338-351"
+
+    + "* If using the -linear option: \n"
+    "Smith, RE; Raffelt, D; Tournier, J-D; Connelly, A. " // Internal
+    "Quantitative Streamlines Tractography: Methods and Inter-Subject Normalisation. "
+    "Open Science Framework, https://doi.org/10.31219/osf.io/c67kn.";
 
   ARGUMENTS
   + Argument ("in_tracks",   "the input track file").type_tracks_in()

--- a/docs/reference/commands/afdconnectivity.rst
+++ b/docs/reference/commands/afdconnectivity.rst
@@ -31,6 +31,8 @@ For valid comparisons of AFD connectivity across scans, images MUST be intensity
 
 Note that the sum of the AFD is normalised by streamline length to account for subject differences in fibre bundle length. This normalisation results in a measure that is more related to the cross-sectional volume of the tract (and therefore 'connectivity'). Note that SIFT-ed tract count is a superior measure because it is unaffected by tangential yet unrelated fibres. However, AFD connectivity may be used as a substitute when Anatomically Constrained Tractography is not possible due to uncorrectable EPI distortions, and SIFT may therefore not be as effective.
 
+Longer discussion regarding this command can additionally be found at: https://mrtrix.readthedocs.io/en/3.0.2/concepts/afd_connectivity.html (as well as in the relevant reference).
+
 Options
 -------
 
@@ -61,6 +63,8 @@ Standard options
 
 References
 ^^^^^^^^^^
+
+Smith, R. E.; Raffelt, D.; Tournier, J.-D.; Connelly, A. Quantitative Streamlines Tractography: Methods and Inter-Subject Normalisation. Open Science Framework, https://doi.org/10.31219/osf.io/c67kn.
 
 Tournier, J.-D.; Smith, R. E.; Raffelt, D.; Tabbara, R.; Dhollander, T.; Pietsch, M.; Christiaens, D.; Jeurissen, B.; Yeh, C.-H. & Connelly, A. MRtrix3: A fast, flexible and open software framework for medical image processing and visualisation. NeuroImage, 2019, 202, 116137
 

--- a/docs/reference/commands/mrtransform.rst
+++ b/docs/reference/commands/mrtransform.rst
@@ -78,7 +78,7 @@ Fibre orientation distribution handling options
 
 -  **-directions file** directions defining the number and orientation of the apodised point spread functions used in FOD reorientation (Default: 300 directions)
 
--  **-reorient_fod boolean** specify whether to perform FOD reorientation. This is required if the number of volumes in the 4th dimension corresponds to the number of coefficients in an antipodally symmetric spherical harmonic series with lmax >= 2 (i.e. 6, 15, 28, 45, 66 volumes.
+-  **-reorient_fod boolean** specify whether to perform FOD reorientation. This is required if the number of volumes in the 4th dimension corresponds to the number of coefficients in an antipodally symmetric spherical harmonic series with lmax >= 2 (i.e. 6, 15, 28, 45, 66 volumes).
 
 DW gradient table import options
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/reference/commands/tcksift2.rst
+++ b/docs/reference/commands/tcksift2.rst
@@ -107,6 +107,9 @@ References
 
 Smith, R. E.; Tournier, J.-D.; Calamante, F. & Connelly, A. SIFT2: Enabling dense quantitative assessment of brain white matter connectivity using streamlines tractography. NeuroImage, 2015, 119, 338-351
 
+* If using the -linear option:  |br|
+  Smith, RE; Raffelt, D; Tournier, J-D; Connelly, A. Quantitative Streamlines Tractography: Methods and Inter-Subject Normalisation. Open Science Framework, https://doi.org/10.31219/osf.io/c67kn.
+
 Tournier, J.-D.; Smith, R. E.; Raffelt, D.; Tabbara, R.; Dhollander, T.; Pietsch, M.; Christiaens, D.; Jeurissen, B.; Yeh, C.-H. & Connelly, A. MRtrix3: A fast, flexible and open software framework for medical image processing and visualisation. NeuroImage, 2019, 202, 116137
 
 --------------


### PR DESCRIPTION
Adding links to preprint within command help pages that probably should have been done in conjunction with #2201.