### PR TITLE
tckglobal: Fix erroneous -niter parsing for values bigger that 1.4e9

### DIFF
--- a/cmd/tckglobal.cpp
+++ b/cmd/tckglobal.cpp
@@ -281,7 +281,7 @@ void run ()
     }
   }
 
-  uint64_t niter = get_option_value("niter", (uint64_t)DEFAULT_NITER);
+  uint64_t niter = get_option_value<uint64_t>("niter", DEFAULT_NITER);
   double t0 = get_option_value("t0", DEFAULT_T0);
   double t1 = get_option_value("t1", DEFAULT_T1);
 

--- a/cmd/tckglobal.cpp
+++ b/cmd/tckglobal.cpp
@@ -281,7 +281,12 @@ void run ()
     }
   }
 
-  uint64_t niter = get_option_value("niter", DEFAULT_NITER);
+  uint64_t niter = DEFAULT_NITER;
+  opt = get_options("niter");
+  if (opt.size())
+  {
+    niter = opt[0][0].as_uint();
+  }
   double t0 = get_option_value("t0", DEFAULT_T0);
   double t1 = get_option_value("t1", DEFAULT_T1);
 

--- a/cmd/tckglobal.cpp
+++ b/cmd/tckglobal.cpp
@@ -281,12 +281,7 @@ void run ()
     }
   }
 
-  uint64_t niter = DEFAULT_NITER;
-  opt = get_options("niter");
-  if (opt.size())
-  {
-    niter = opt[0][0].as_uint();
-  }
+  uint64_t niter = get_option_value("niter", (uint64_t)DEFAULT_NITER);
   double t0 = get_option_value("t0", DEFAULT_T0);
   double t1 = get_option_value("t1", DEFAULT_T1);
 


### PR DESCRIPTION
The tckglobal command when run with `-niter 10B` could only run for `1410065408` iterations instead of `10000000000` iterasions. These changes fixed the parsing issue.
