### PR TITLE
Multithreading: Proposed alteration to functor duplication

### DIFF
--- a/core/thread.h
+++ b/core/thread.h
@@ -22,8 +22,8 @@
 #include <mutex>
 
 #include "debug.h"
-#include "mrtrix.h"
 #include "exception.h"
+#include "mrtrix.h"
 
 /** \defgroup thread_classes Multi-threading
  * \brief functions to provide support for multi-threading
@@ -144,16 +144,43 @@ namespace MR
       };
 
 
+      // TODO Duplicate class instance using __clone__() function if defined;
+      //   copy-constructor if not
+      namespace
+      {
+        template <class T> class __has_clone_function { NOMEMALIGN
+            template <typename C> static inline char test (decltype(C::__clone())) ;
+            template <typename C> static inline long test (...);
+          public:
+            enum { value = sizeof(test<T>(nullptr)) == sizeof(char) };
+        };
+        template <class T>
+        inline typename std::enable_if<__has_clone_function<T>::value, std::unique_ptr<T>>::type __clone (const T& in)
+        {
+          return in.__clone();
+        }
+        template <class T>
+        inline typename std::enable_if<!__has_clone_function<T>::value, std::unique_ptr<T>>::type __clone (const T& in)
+        {
+          std::unique_ptr<T> result (new T (in));
+          return result;
+        }
+      }
+
+
       template <class Functor>
         class __multi_thread : public __thread_base { NOMEMALIGN
           public:
             __multi_thread (Functor& functor, size_t nthreads, const std::string& name = "unnamed") :
-              __thread_base (name), functors ( (nthreads>0 ? nthreads-1 : 0), functor) {
+              __thread_base (name)
+              {
                 DEBUG ("launching " + str (nthreads) + " threads \"" + name + "\"...");
                 using F = typename std::remove_reference<Functor>::type;
                 threads.reserve (nthreads);
-                for (auto& f : functors)
-                  threads.push_back (std::async (std::launch::async, &F::execute, &f));
+                for (size_t i = 0; i != (nthreads>0 ? nthreads-1 : 0); ++i) {
+                  functors.emplace_back (__clone<F> (functor));
+                  threads.push_back (std::async (std::launch::async, &F::execute, functors[i].get()));
+                }
                 threads.push_back (std::async (std::launch::async, &F::execute, &functor));
               }
 
@@ -199,7 +226,7 @@ namespace MR
             }
           protected:
             vector<std::future<void>> threads;
-            vector<typename std::remove_reference<Functor>::type> functors;
+            vector<std::unique_ptr<typename std::remove_reference<Functor>::type>> functors;
 
         };
 


### PR DESCRIPTION
This one needs a little bit of background to justify.

In mucking around with some of the new fancy GLM features on full FBA datasets, I've encountered a couple of things I'd like to resolve:

1. Currently, calculation of properties of the default permutation is done through a [different set of functions](https://github.com/MRtrix3/mrtrix3/blob/3.0.2/core/math/stats/glm.h#L124-L202) to the GLM test class. While it has the advantage of multi-threading within a single permutation, it's a lot of duplicated code.

2. In order to be thread-safe, the GLM test classes allocate all requisite memory for processing each permutation within [the functor itself (which is defined `const`)](https://github.com/MRtrix3/mrtrix3/blob/3.0.2/core/math/stats/glm.h#L243). This results in e.g. `top` reporting memory use being larger than it actually is.
This is necessary with the current code design because the statistical inference commands construct a `std::shared_ptr<GLM::TestBase>`, and this gets passed to the relevant heavy-lifting functions, none of which are templated. 

What I'd prefer is to have a number of instances of the GLM test class equal to the number of working threads, where each instance retains all of the relevant intermediate matrix data as member variables. In addition to preventing re-allocation of memory as per point 2, it should also be possible to, following running the default permutation through the GLM test class, run a virtual function that would return access to whatever statistical properties the command may wish to write to the file system, thus removing the necessity of the code in point 1.

The trap here is that, if you have a pointer to the base class, you can't then just pass that to the multi-threading back-end, as it'll run the copy-constructor of the base class rather than the derived class that's responsible for the actual heavy-lifting.

The generally accepted solution to generating new instances of a derived class from a base class pointer is to define a virtual function that returns a pointer to the new instance, with any derived classes providing custom implementations of such duplication. So what this PR is proposing is that whenever a functor is to be cloned for the sake of running multiple threads, the threading back-end checks for the presence of such a function (which must have an accepted pre-determined name). 

In the absence of this change or something comparable, to achieve what I want to do I'd have to resort to templating the bulk of the permutation testing functions & classes, which seems like a lot of unnecessarily duplicated machine code to me.