### PR TITLE
Inference: Fix for exotic usage

### DIFF
--- a/core/math/stats/glm.cpp
+++ b/core/math/stats/glm.cpp
@@ -419,11 +419,14 @@ namespace MR
                   // Need to reduce the data and design matrices to contain only finite data
                   matrix_type element_data_finite (valid_rows, 1);
                   matrix_type element_design_finite (valid_rows, element_design.cols());
+                  index_array_type variance_groups_finite (variance_groups.size() ? valid_rows : 0);
                   ssize_t output_row = 0;
                   for (ssize_t row = 0; row != data.rows(); ++row) {
                     if (std::isfinite (element_data(row)) && element_design.row (row).allFinite()) {
                       element_data_finite(output_row, 0) = element_data(row);
                       element_design_finite.row (output_row) = element_design.row (row);
+                      if (variance_groups.size())
+                        variance_groups_finite[output_row] = variance_groups[row];
                       ++output_row;
                     }
                   }
@@ -434,7 +437,7 @@ namespace MR
                   if (!std::isfinite (condition_number) || condition_number > 1e5) {
                     zero();
                   } else {
-                    Math::Stats::GLM::all_stats (element_data_finite, element_design_finite, hypotheses, variance_groups,
+                    Math::Stats::GLM::all_stats (element_data_finite, element_design_finite, hypotheses, variance_groups_finite,
                                                  local_betas, local_abs_effect_size, local_std_effect_size, local_stdev);
                   }
                 } else { // Insufficient data to fit model at all


### PR DESCRIPTION
Fixes case where GLM varies between elements (either due to the presence of non-finite values, or the addition of element-wise design matrix columns) *and* variance blocks are defined. Code pre-fix generates an assertion failure, but may proceed if compiled in release mode. But having said that, it's entirely likely that nobody other than myself has even attempted to use this kind of functionality yet.

Intention is for there to be more significant changes to this code in `3.1.0`, but should nevertheless patch this as it currently stands.