### PR TITLE
fod2fixel: Order fixels by FD

### DIFF
--- a/src/dwi/fmls.cpp
+++ b/src/dwi/fmls.cpp
@@ -92,6 +92,12 @@ namespace MR {
 
 
 
+      bool order_by_fd (const FOD_lobe& a, const FOD_lobe& b) { return (a.get_integral() > b.get_integral()); }
+
+
+
+
+
 
       IntegrationWeights::IntegrationWeights (const DWI::Directions::Set& dirs) :
           data (dirs.size())
@@ -301,6 +307,8 @@ namespace MR {
             }
           }
         }
+
+        std::sort (out.begin(), out.end(), order_by_fd);
 
         if (create_lookup_table) {
 

--- a/src/dwi/fmls.cpp
+++ b/src/dwi/fmls.cpp
@@ -92,13 +92,6 @@ namespace MR {
 
 
 
-      bool order_by_fd (const FOD_lobe& a, const FOD_lobe& b) { return (a.get_integral() > b.get_integral()); }
-
-
-
-
-
-
       IntegrationWeights::IntegrationWeights (const DWI::Directions::Set& dirs) :
           data (dirs.size())
       {
@@ -308,7 +301,7 @@ namespace MR {
           }
         }
 
-        std::sort (out.begin(), out.end(), order_by_fd);
+        std::sort (out.begin(), out.end(), [] (const FOD_lobe& a, const FOD_lobe& b) { return (a.get_integral() > b.get_integral()); } );
 
         if (create_lookup_table) {
 

--- a/src/dwi/fmls.h
+++ b/src/dwi/fmls.h
@@ -160,9 +160,6 @@ namespace MR
       };
 
 
-      bool order_by_fd (const FOD_lobe&, const FOD_lobe&);
-
-
 
       class FOD_lobes : public vector<FOD_lobe> { MEMALIGN(FOD_lobes)
         public:

--- a/src/dwi/fmls.h
+++ b/src/dwi/fmls.h
@@ -160,6 +160,9 @@ namespace MR
       };
 
 
+      bool order_by_fd (const FOD_lobe&, const FOD_lobe&);
+
+
 
       class FOD_lobes : public vector<FOD_lobe> { MEMALIGN(FOD_lobes)
         public:


### PR DESCRIPTION
As recently re-raised on [forum](https://community.mrtrix.org/t/fixel2voxel-how-to-extract-primary-secondary-and-tertiary-voxel-based-fd-maps/4394).

Here's the output of `fod2fixel` then `fixel2voxel none` on FD from the test data:

Old code:
![screenshot0003](https://user-images.githubusercontent.com/5637955/105145857-6469ca80-5b53-11eb-98d7-a99185e67256.png)

New code:
![screenshot0002](https://user-images.githubusercontent.com/5637955/105145867-6895e800-5b53-11eb-8f93-8ea8f5bbfb60.png)

Kinda hard to see, but there are some voxels in the top image that get brighter going from left to right, whereas in the lower image FD always decreases from left to right.