### PR TITLE
mrview show rgb values

### DIFF
--- a/src/gui/mrview/gui_image.cpp
+++ b/src/gui/mrview/gui_image.cpp
@@ -631,6 +631,61 @@ namespace MR
         return interp.value();
       }
 
+      Eigen::VectorXcf Image::trilinear_values (const Eigen::Vector3f& scanner_point, const size_t axis) const
+      {
+        auto interp = Interp::make_linear (image);
+        if (!interp.scanner (scanner_point)) {
+          Eigen::VectorXcf val (image.ndim() - 2);
+          val.fill(cfloat(NAN, NAN));
+          return val;
+        }
+        return interp.row(axis);
+      }
+
+      Eigen::VectorXcf Image::nearest_neighbour_values (const Eigen::Vector3f& scanner_point, const size_t axis) const
+      {
+        auto interp = Interp::make_nearest (image);
+        if (!interp.scanner (scanner_point)) {
+          Eigen::VectorXcf val (image.ndim() - 2);
+          val.fill(cfloat(NAN, NAN));
+          return val;
+        }
+        return interp.row(axis);
+      }
+
+      std::string Image::describe_value (const Eigen::Vector3f& focus) const
+      {
+        std::string value_str (interpolate() ? "interp" : "voxel");
+        if (colourmap == 8 && header().ndim() > 3 && header().size(3) > 1) { // show RGB values
+          Eigen::VectorXcf values;
+          if (interpolate())
+            values = trilinear_values (focus);
+          else
+            values = nearest_neighbour_values (focus);
+          value_str += " values: ";
+          for (ssize_t n = 0; (n + image.index(3)) < values.rows() && n < 3; n++) {
+            if (n > 0) value_str += ", ";
+            value_str += "rgb"[n]; value_str += ": ";
+            ssize_t v = n + image.index(3);
+            if (std::isfinite (abs (values[v])))
+              value_str += str(values[v]);
+            else
+              value_str += "?";
+          }
+        } else { // show single value
+          cfloat value;
+          value_str += " value: ";
+          if (interpolate())
+            value = trilinear_value (focus);
+          else
+            value = nearest_neighbour_value (focus);
+          if (std::isfinite (abs (value)))
+            value_str += str(value);
+          else
+            value_str += "?";
+        }
+        return value_str;
+      }
 
 
       void Image::reset_windowing (const int plane, const bool axis_locked)

--- a/src/gui/mrview/gui_image.h
+++ b/src/gui/mrview/gui_image.h
@@ -87,9 +87,12 @@ namespace MR
 
           cfloat trilinear_value (const Eigen::Vector3f&) const;
           cfloat nearest_neighbour_value (const Eigen::Vector3f&) const;
+          Eigen::VectorXcf trilinear_values (const Eigen::Vector3f&, const size_t axis=3) const;
+          Eigen::VectorXcf nearest_neighbour_values (const Eigen::Vector3f&, const size_t axis=3) const;
 
           const transform_type& transform() const { return image.transform(); }
           const vector<std::string>& comments() const { return _comments; }
+          std::string describe_value (const Eigen::Vector3f& focus) const;
 
           void reset_windowing (const int, const bool);
 

--- a/src/gui/mrview/mode/base.cpp
+++ b/src/gui/mrview/mode/base.cpp
@@ -80,21 +80,7 @@ namespace MR
 
               projection.render_text (printf ("position: [ %.4g %.4g %.4g ] mm", focus() [0], focus() [1], focus() [2]), LeftEdge | BottomEdge);
               projection.render_text (vox_str, LeftEdge | BottomEdge, 1);
-              std::string value_str;
-              cfloat value;
-              if (image()->interpolate()) {
-                value_str = "interp value: ";
-                value = image()->trilinear_value (window().focus());
-              } else {
-                value_str = "voxel value: ";
-                value = image()->nearest_neighbour_value (window().focus());
-              }
-              if (std::isfinite (abs (value)))
-                value_str += str(value);
-              else
-                value_str += "?";
-
-              projection.render_text (value_str, LeftEdge | BottomEdge, 2);
+              projection.render_text (image()->describe_value(window().focus()), LeftEdge | BottomEdge, 2);
 
               // Draw additional labels from tools
               QList<QAction*> tools = window().tools()->actions();

--- a/src/gui/mrview/tool/overlay.cpp
+++ b/src/gui/mrview/tool/overlay.cpp
@@ -343,18 +343,7 @@ namespace MR
             Image* image = dynamic_cast<Image*>(image_list_model->items[i].get());
             if (image && image->show) {
               std::string value_str = Path::basename(image->get_filename()) + " ";
-              cfloat value;
-              if (image->interpolate()) {
-                value_str += "interp value: ";
-                value = image->trilinear_value (window().focus());
-              } else {
-                value_str += "voxel value: ";
-                value = image->nearest_neighbour_value (window().focus());
-              }
-              if (std::isnan(abs(value)))
-                value_str += "?";
-              else
-                value_str += str(value);
+              value_str += image->describe_value (window().focus());
               transform.render_text (value_str, position, start_line_num + num_of_new_lines);
               num_of_new_lines += 1;
             }


### PR DESCRIPTION
In RGB-mode, this adds info for the volumes used for RGB rendering to mrview's main image and overlay:

![image](https://user-images.githubusercontent.com/10046944/105222726-296b9500-5b5b-11eb-896b-f64b5bcf6f66.png)

