### PR TITLE
dirorder: Fix segfault

### DIFF
--- a/cmd/dirorder.cpp
+++ b/cmd/dirorder.cpp
@@ -90,11 +90,13 @@ vector<size_t> optimise (const Eigen::MatrixXd& directions, const size_t first_v
 
 value_type calc_cost (const Eigen::MatrixXd& directions, const vector<size_t>& order)
 {
-  value_type cost = value_type(0);
   const size_t start = Math::SH::NforL (2);
+  if (directions.rows() <= start)
+    return value_type(0);
   Eigen::MatrixXd subset (start, 3);
   for (size_t i = 0; i != start; ++i)
     subset.row(i) = directions.row(order[i]);
+  value_type cost = value_type(0);
   for (size_t N = start+1; N < size_t(directions.rows()); ++N) {
     // Don't include condition numbers where precisely the number of coefficients
     //   for that spherical harmonic degree are included, as these tend to
@@ -115,10 +117,19 @@ void run ()
 {
   auto directions = DWI::Directions::load_cartesian (argument[0]);
 
+  size_t last_candidate_first_volume = directions.rows();
+  if (directions.rows() <= Math::SH::NforL (2)) {
+    WARN ("Very few directions in input ("
+          + str(directions.rows())
+          + "); selection of first direction cannot be optimised"
+          + " (first direction in input will be first direction in output)");
+    last_candidate_first_volume = 1;
+  }
+
   value_type min_cost = std::numeric_limits<value_type>::infinity();
   vector<size_t> best_order;
   ProgressBar progress ("Determining best reordering", directions.rows());
-  for (size_t first_volume = 0; first_volume != size_t(directions.rows()); ++first_volume) {
+  for (size_t first_volume = 0; first_volume != last_candidate_first_volume; ++first_volume) {
     const vector<size_t> order = optimise (directions, first_volume);
     const value_type cost = calc_cost (directions, order);
     if (cost < min_cost) {

--- a/cmd/dirorder.cpp
+++ b/cmd/dirorder.cpp
@@ -91,7 +91,7 @@ vector<size_t> optimise (const Eigen::MatrixXd& directions, const size_t first_v
 value_type calc_cost (const Eigen::MatrixXd& directions, const vector<size_t>& order)
 {
   const size_t start = Math::SH::NforL (2);
-  if (directions.rows() <= start)
+  if (size_t(directions.rows()) <= start)
     return value_type(0);
   Eigen::MatrixXd subset (start, 3);
   for (size_t i = 0; i != start; ++i)
@@ -118,7 +118,7 @@ void run ()
   auto directions = DWI::Directions::load_cartesian (argument[0]);
 
   size_t last_candidate_first_volume = directions.rows();
-  if (directions.rows() <= Math::SH::NforL (2)) {
+  if (size_t(directions.rows()) <= Math::SH::NforL (2)) {
     WARN ("Very few directions in input ("
           + str(directions.rows())
           + "); selection of first direction cannot be optimised"


### PR DESCRIPTION
Downstream of #1800, which introduced the functionality of determining the optimal reordering of directions for all possible selections of first volume, and choosing the optimal reordering from that set. Algorithm produces a segmentation fault if fewer than six input directions. This change forces the first volume in the input to be the first volume in the output in such scenarios (as there is no objective criterion by which to determine which direction is best to use first in this scenario).

Closes #2271.