### PR TITLE
Container recipes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,100 @@
+ARG MAKE_JOBS="1"
+ARG DEBIAN_FRONTEND="noninteractive"
+
+FROM python:3.8-slim AS base
+FROM buildpack-deps:buster AS base-builder
+
+FROM base-builder AS mrtrix3-builder
+
+# Git commitish from which to build MRtrix3.
+ARG MRTRIX3_GIT_COMMITISH="master"
+# Command-line arguments for `./configure`
+ARG MRTRIX3_CONFIGURE_FLAGS=""
+# Command-line arguments for `./build`
+ARG MRTRIX3_BUILD_FLAGS="-persistent -nopaginate"
+
+RUN apt-get -qq update \
+    && apt-get install -yq --no-install-recommends \
+        libeigen3-dev \
+        libfftw3-dev \
+        libgl1-mesa-dev \
+        libpng-dev \
+        libqt5opengl5-dev \
+        libqt5svg5-dev \
+        libtiff5-dev \
+        qt5-default \
+        zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Clone, build, and install MRtrix3.
+ARG MAKE_JOBS
+WORKDIR /opt/mrtrix3
+RUN git clone -b $MRTRIX3_GIT_COMMITISH --depth 1 https://github.com/MRtrix3/mrtrix3.git . \
+    && ./configure $MRTRIX3_CONFIGURE_FLAGS \
+    && NUMBER_OF_PROCESSORS=$MAKE_JOBS ./build $MRTRIX3_BUILD_FLAGS \
+    && rm -rf tmp
+
+# Download minified ART ACPCdetect (V2.0).
+FROM base-builder as acpcdetect-installer
+WORKDIR /opt/art
+RUN curl -fsSL https://osf.io/73h5s/download \
+    | tar xz --strip-components 1
+
+# Download minified ANTs (2.3.4).
+FROM base-builder as ants-installer
+WORKDIR /opt/ants
+RUN curl -fsSL https://osf.io/3ad69/download \
+    | tar xz --strip-components 1
+
+# Download FreeSurfer files.
+FROM base-builder as freesurfer-installer
+WORKDIR /opt/freesurfer
+RUN curl -fsSLO https://raw.githubusercontent.com/freesurfer/freesurfer/v7.1.1/distribution/FreeSurferColorLUT.txt
+
+# Download minified FSL (6.0.4)
+FROM base-builder as fsl-installer
+WORKDIR /opt/fsl
+RUN curl -fsSL https://osf.io/dv258/download \
+    | tar xz --strip-components 1
+
+# Build final image.
+FROM base AS final
+
+# Install runtime system dependencies.
+RUN apt-get -qq update \
+    && apt-get install -yq --no-install-recommends \
+        dc \
+        less \
+        libfftw3-3 \
+        libgl1-mesa-glx \
+        libgomp1 \
+        liblapack3 \
+        libpng16-16 \
+        libqt5core5a \
+        libqt5gui5 \
+        libqt5network5 \
+        libqt5widgets5 \
+        libquadmath0 \
+        libtiff5 \
+        python3-distutils \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=acpcdetect-installer /opt/art /opt/art
+COPY --from=ants-installer /opt/ants /opt/ants
+COPY --from=freesurfer-installer /opt/freesurfer /opt/freesurfer
+COPY --from=fsl-installer /opt/fsl /opt/fsl
+COPY --from=mrtrix3-builder /opt/mrtrix3 /opt/mrtrix3
+
+ENV ANTSPATH="/opt/ants/bin" \
+    ARTHOME="/opt/art" \
+    FREESURFER_HOME="/opt/freesurfer" \
+    FSLDIR="/opt/fsl" \
+    FSLOUTPUTTYPE="NIFTI_GZ" \
+    FSLMULTIFILEQUIT="TRUE" \
+    FSLTCLSH="/opt/fsl/bin/fsltclsh" \
+    FSLWISH="/opt/fsl/bin/fslwish" \
+    LD_LIBRARY_PATH="/opt/fsl/lib:$LD_LIBRARY_PATH" \
+    PATH="/opt/mrtrix3/bin:/opt/ants/bin:/opt/art/bin:/opt/fsl/bin:$PATH"
+
+WORKDIR /work
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -2,11 +2,17 @@
 
 [![Build Status](https://github.com/MRtrix3/mrtrix3/workflows/checks/badge.svg)](https://github.com/MRtrix3/mrtrix3/actions)
 
-Please visit the [official website for MRtrix](http://www.mrtrix.org) to access the [documentation for MRtrix3](http://mrtrix.readthedocs.org/), including detailed installation instructions.
+*MRtrix3* can be installed / run through multiple avenues:
+- [Direct download](https://www.mrtrix.org/download/) through mechanisms tailored for different OS platforms;
+- Compiled from the source code in this repository, for which [comprehensive instructions](https://mrtrix.readthedocs.io/en/latest/installation/build_from_source.html) are provided in the [online documentation](https://mrtrix.readthedocs.io/en/);
+- Via containerisation technology using Docker or Singularity; see [online documentation page](https://mrtrix.readthedocs.org/en/latest/installation/using_containers.html) for details.
 
 ## Getting help
 
-Support and general discussion is hosted on the [MRtrix3 Community Forum](http://community.mrtrix.org/). Please also look through the Frequently Asked Questions on the [wiki section of the forum](http://community.mrtrix.org/c/wiki). You can address all MRtrix3-related queries there, using your GitHub or Google login to post questions.
+Instructions on software setup and use are provided in the [online documentation](https://mrtrix.readthedocs.org).
+Support and general discussion is hosted on the [*MRtrix3* Community Forum](http://community.mrtrix.org/).
+Please also look through the Frequently Asked Questions on the [wiki section of the forum](http://community.mrtrix.org/c/wiki).
+You can address all *MRtrix3*-related queries there, using your GitHub or Google login to post questions.
 
 ## Quick install
 
@@ -72,4 +78,4 @@ You can build a particular release of MRtrix3 by checking out the corresponding 
     
 ## Contributing
 
-Thank you for your interest in contributing to MRtrix3! Please read on [here](CONTRIBUTING.md) to find out how to report issues, request features and make direct contributions. 
+Thank you for your interest in contributing to *MRtrix3*! Please read on [here](CONTRIBUTING.md) to find out how to report issues, request features and make direct contributions. 

--- a/Singularity
+++ b/Singularity
@@ -65,4 +65,4 @@ Include: apt
     apt-get remove -y build-essential ca-certificates curl git libeigen3-dev libfftw3-dev libgl1-mesa-dev libpng-dev libqt5opengl5-dev libqt5svg5-dev libtiff5-dev qt5-qmake qtbase5-dev-tools wget zlib1g-dev && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 %runscript
-    exec /usr/bin/bash "$@"
+    exec /usr/bin/bash -c "$@"

--- a/Singularity
+++ b/Singularity
@@ -1,0 +1,68 @@
+Bootstrap: debootstrap
+OSVersion: focal
+MirrorURL: http://us.archive.ubuntu.com/ubuntu/
+Include: apt
+
+%environment
+
+# ACPCdetect
+    ARTHOME=/opt/art
+    export ARTHOME
+
+# ANTs
+    ANTSPATH=/opt/ants/bin
+    export ANTSPATH
+
+# FreeSurfer
+    FREESURFER_HOME=/opt/freesurfer
+    export FREESURFER_HOME
+
+# FSL
+    FSLDIR=/opt/fsl
+    FSLOUTPUTTYPE=NIFTI_GZ
+    FSLMULTIFILEQUIT=TRUE
+    FSLTCLSH=/opt/fsl/bin/fsltclsh
+    FSLWISH=/opt/fsl/bin/fslwish
+    export FSLDIR FSLOUTPUTTYPE FSLMULTIFILEQUIT FSLTCLSH FSLWISH
+    
+# All
+    LD_LIBRARY_PATH="/usr/local/cuda/lib64:/usr/local/cuda/bin:/.singularity.d/libs:/usr/lib:/opt/fsl/lib:$LD_LIBRARY_PATH"
+    PATH="/opt/mrtrix3/bin:/opt/ants/bin:/opt/art/bin:/opt/fsl/bin:/usr/local/cuda/bin:$PATH"
+    export LD_LIBRARY_PATH PATH
+
+%post
+# Non-interactive installation of packages
+    export DEBIAN_FRONTEND=noninteractive
+
+# Grab additional repositories
+    sed -i 's/main/main restricted universe multiverse/g' /etc/apt/sources.list
+    apt-get update && apt-get upgrade -y
+
+# Runtime requirements
+    apt-get update && apt-get install -y --no-install-recommends dc less libfftw3-bin liblapack3 libpng16-16 libqt5network5 libqt5widgets5 libtiff5 python3 python3-distutils zlib1g
+
+# Build requirements
+    apt-get update && apt-get install -y --no-install-recommends build-essential ca-certificates curl git libeigen3-dev libfftw3-dev libgl1-mesa-dev libpng-dev libqt5opengl5-dev libqt5svg5-dev libtiff5-dev qt5-qmake qtbase5-dev-tools wget zlib1g-dev
+
+# Neuroimaging software / data dependencies
+    # Download minified ART ACPCdetect (V2.0).
+    mkdir -p /opt/art && curl -fsSL https://osf.io/73h5s/download | tar xz -C /opt/art --strip-components 1
+    # Download minified ANTs (2.3.4).
+    mkdir -p /opt/ants && curl -fsSL https://osf.io/3ad69/download | tar xz -C /opt/ants --strip-components 1
+    # Download FreeSurfer lookup table file (v7.1.1).
+    mkdir -p /opt/freesurfer && curl -fsSL -o /opt/freesurfer/FreeSurferColorLUT.txt https://raw.githubusercontent.com/freesurfer/freesurfer/v7.1.1/distribution/FreeSurferColorLUT.txt
+    # Download minified FSL (6.0.4).
+    mkdir -p /opt/fsl && curl -fsSL https://osf.io/dv258/download | tar xz -C /opt/fsl --strip-components 1
+
+# Use Python3 for anything requesting Python, since Python2 is not installed
+    ln -s /usr/bin/python3 /usr/bin/python
+
+# MRtrix3 setup
+    git clone -b master --depth 1 https://github.com/MRtrix3/mrtrix3.git /opt/mrtrix3
+    cd /opt/mrtrix3 && ./configure && ./build -persistent -nopaginate && rm -rf testing/ tmp/ && cd ../../
+
+# apt cleanup to recover as much space as possible
+    apt-get remove -y build-essential ca-certificates curl git libeigen3-dev libfftw3-dev libgl1-mesa-dev libpng-dev libqt5opengl5-dev libqt5svg5-dev libtiff5-dev qt5-qmake qtbase5-dev-tools wget zlib1g-dev && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+%runscript
+    exec /usr/bin/bash "$@"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -147,6 +147,7 @@ Table of Contents
    installation/build_from_source
    installation/deployment
    installation/hpc_clusters_install
+   installation/using_containers
 
 .. toctree::
    :maxdepth: 1

--- a/docs/installation/using_containers.rst
+++ b/docs/installation/using_containers.rst
@@ -1,0 +1,94 @@
+.. _using_containers:
+
+Running *MRtrix3* using containers
+==================================
+
+From MRtrix version ``3.0.3`` onwards, official Docker and Singularity
+containers are provided for utilising *MRtrix3* commands, enabling use
+of all *MRtrix3* commands (including those that possess dependencies on
+other neuroimaging software packages) without necessitating any software
+installation on the user system.
+
+Using Docker
+------------
+
+Run terminal command
+^^^^^^^^^^^^^^^^^^^^
+
+Non-GUI commands are typically executed as follows::
+
+    docker run --rm -it mrtrix3 <command>
+
+(replacing "``<command>``" with the name of the command to be executed,
+along with any arguments / options to be provided to it)
+
+If an *MRtrix3* image has not been built on the local system, the
+most recent *MRtrix3* Docker image will be automatically downloaded from
+[DockerHub](https://hub.docker.com/r/mrtrix3/mrtrix3).
+
+Run GUI command
+^^^^^^^^^^^^^^^
+
+The following instructions have been shown to work on Linux::
+
+    xhost +local:root
+    docker run --rm -it -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=$DISPLAY mrtrix3 mrview
+    xhost -local:root  # Run this when finished.
+
+Explicitly build image locally
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+As an alternative to downloading the image from DockerHub as described
+above, the following instruction can be run from a location in which the
+*MRtrix3* source code has been cloned::
+
+    docker build --tag mrtrix3 .
+    
+Set `DOCKER_BUILDKIT=1` to build parts of the Docker image in parallel,
+which can speed up build time.
+Use `--build-arg MAKE_JOBS=4` to build *MRtrix3* with 4 processors
+(can substitute this with any number of processors > 0); if omitted,
+*MRtrix3* will be built using a single thread only.
+
+Using Singularity
+-----------------
+
+Build container natively
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following instruction can be run from the location in which the
+*MRtrix3* source code has been cloned::
+
+    singularity build MRtrix3.sif Singularity
+
+Build container from DockerHub
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This command converts the Docker image as stored on DockerHub into a
+Singularity container stored on the user's local system::
+
+    singularity build MRtrix3.sif docker://mrtrix/mrtrix3:<version>
+    
+(Replace "``<version>``" with the specific version tag of *MRtrix3*
+desired)
+
+Run terminal command
+^^^^^^^^^^^^^^^^^^^^
+
+Unlike Docker containers, where an explicit "``docker run``" command must be
+utilised to execute a command within a container, a Singularity image itself
+acts as an executable file that can be invoked directly::
+
+    MRtrix3.sif <command>
+
+(replacing "``<command>``" with the name of the command to be executed,
+along with any arguments / options to be provided to it)
+
+Run GUI command
+^^^^^^^^^^^^^^^
+
+The following usage has been shown to work on Linux::
+
+    singularity exec -B /run MRtrix3.sif mrview
+
+


### PR DESCRIPTION
As discussed in MRtrix3/containers#14.

Plan is to have the primary container building recipes inside the main repository, and for the "`containers`" repository to only be responsible for building the minified dependencies.

1. In order for the recipe file contained within any particular tagged version of *MRtrix3* to be guaranteed to clone that very same version of *MRtrix3* during the build process, the recipe files must be manually updated to reflect the upcoming tag name, similarly to the gymnastics already done with `core/version.h`. The [Wiki instructions](https://github.com/MRtrix3/mrtrix3/wiki/Publishing-a-new-release#merge-to-master) have already been updated accordingly.

2. I have moved some of the contents of `README.md` from the `containers` repo into a new page in the online documentation page. 

3. Reflecting on the contents of `README.md` in *this* repository, there's quite a lot of stripped-down instructions for compilation from source. Not only is it less comprehensive that the online documentation for building from source, but we expect over time that less people will be building from source. It might be worth contemplating removing these instructions altogether and instead relying on selection of which hyperlink to follow based on the desired installation route.

4. It would be preferable to add instructions for running `mrview` via containers on OSX and Windows prior to merge.

5. This is currently targeted for `master`. I don't think there should actually be any problem with either merging this to `master` prior to tagging, or with bundling it up with whatever hotfixes go into the next macro release, though I don't actually recall the result of discussion on the latter. Documentation may not cover all bases if it's included in a macro release, but that can nevertheless be revised on `master` if necessary. Note that #2197 will necessitate the construction of new container dependency downloads, but that targets `3.1.0`, so can be addressed on a separate branch on the `MRtrix3/containers` repo.

6. This PR does not yet address the prospect of automatic building of containers. Given the relative occurrence of updates, such automation is not necessarily a prerequisite for this PR.