### PR TITLE
fod2fixel: Wipe transform / spacing info from fixel data files

### DIFF
--- a/cmd/fod2fixel.cpp
+++ b/cmd/fod2fixel.cpp
@@ -203,6 +203,8 @@ void Segmented_FOD_receiver::commit ()
   fixel_data_header.ndim() = 3;
   fixel_data_header.size(0) = fixel_count;
   fixel_data_header.size(2) = 1;
+  fixel_data_header.transform().setIdentity();
+  fixel_data_header.spacing(0) = fixel_data_header.spacing(1) = fixel_data_header.spacing(2) = 1.0;
   fixel_data_header.datatype() = DataType::Float32;
   fixel_data_header.datatype().set_byte_order_native();
 


### PR DESCRIPTION
As raised on [forum](https://community.mrtrix.org/t/a-warning-in-the-fixel-pipeline/4531).

I had in 61bfc64d prevented non-identity transform / voxel spacing info from being written to fixel data files, but only in the helper function `data_header_from_index()`, whereas `fod2fixel` does this same process manually.