### PR TITLE
add two new command lines option in mrview for tractogram

### DIFF
--- a/docs/reference/commands/mrview.rst
+++ b/docs/reference/commands/mrview.rst
@@ -146,7 +146,7 @@ Tractography tool options
 
 -  **-tractography.lighting value** *(multiple uses permitted)* Toggle the use of lighting of tractogram geometry
 
--  **-tractography.colour value** *(multiple uses permitted)* Specify a manual colour for the tractogram, as three comma-separated values
+-  **-tractography.colour R,G,B** *(multiple uses permitted)* Specify a manual colour for the tractogram, as three comma-separated values
 
 -  **-tractography.tsf_load tsf** *(multiple uses permitted)* Load the specified tractography scalar file.
 
@@ -154,7 +154,7 @@ Tractography tool options
 
 -  **-tractography.tsf_thresh ThresholdMin,ThesholdMax** *(multiple uses permitted)* Set thresholds for the tractography scalar file. Requires -tractography.tsf_load already provided.
 
--  **-tractography.tsf_colourmap value** *(multiple uses permitted)* Sets the colourmap of the .tsf file as indexed in the tsf colourmap dropdown menu. Requires -tractography.tsf_load already.
+-  **-tractography.tsf_colourmap index** *(multiple uses permitted)* Sets the colourmap of the .tsf file as indexed in the tsf colourmap dropdown menu. Requires -tractography.tsf_load already.
 
 ODF tool options
 ^^^^^^^^^^^^^^^^

--- a/docs/reference/commands/mrview.rst
+++ b/docs/reference/commands/mrview.rst
@@ -146,11 +146,15 @@ Tractography tool options
 
 -  **-tractography.lighting value** *(multiple uses permitted)* Toggle the use of lighting of tractogram geometry
 
+-  **-tractography.colour value** *(multiple uses permitted)* Specify a manual colour for the tractogram, as three comma-separated values
+
 -  **-tractography.tsf_load tsf** *(multiple uses permitted)* Load the specified tractography scalar file.
 
 -  **-tractography.tsf_range RangeMin,RangeMax** *(multiple uses permitted)* Set range for the tractography scalar file. Requires -tractography.tsf_load already provided.
 
 -  **-tractography.tsf_thresh ThresholdMin,ThesholdMax** *(multiple uses permitted)* Set thresholds for the tractography scalar file. Requires -tractography.tsf_load already provided.
+
+-  **-tractography.tsf_colourmap value** *(multiple uses permitted)* Sets the colourmap of the .tsf file as indexed in the tsf colourmap dropdown menu. Requires -tractography.tsf_load already.
 
 ODF tool options
 ^^^^^^^^^^^^^^^^

--- a/src/gui/mrview/tool/tractography/track_scalar_file.cpp
+++ b/src/gui/mrview/tool/tractography/track_scalar_file.cpp
@@ -446,6 +446,16 @@ namespace MR
             window().updateGL();
           }
         }
+        
+        void TrackScalarFileOptions::set_colourmap (int colourmap_index)
+        {
+          if (tractogram) {
+            tractogram->colourmap = colourmap_index;
+            update_UI();
+            window().updateGL();
+          }
+        }
+
 
       }
     }

--- a/src/gui/mrview/tool/tractography/track_scalar_file.h
+++ b/src/gui/mrview/tool/tractography/track_scalar_file.h
@@ -51,7 +51,7 @@ namespace MR
               void update_UI();
               void set_scaling(default_type min, default_type max);
               void set_threshold(GUI::MRView::Tool::TrackThresholdType dataSource, default_type min, default_type max);
-
+              void set_colourmap (int colourmap_index);
 
             public slots:
               bool open_intensity_track_scalar_file_slot ();
@@ -69,6 +69,7 @@ namespace MR
               void threshold_upper_value_changed ();
               void invert_colourmap_slot ();
               void reset_intensity_slot ();
+            
 
             protected:
               Tractography* tool;

--- a/src/gui/mrview/tool/tractography/tractography.cpp
+++ b/src/gui/mrview/tool/tractography/tractography.cpp
@@ -861,7 +861,7 @@ namespace MR
             + Option ("tractography.tsf_thresh", "Set thresholds for the tractography scalar file. Requires -tractography.tsf_load already provided.").allow_multiple()
             +  Argument ("ThresholdMin,ThesholdMax").type_sequence_float()
             
-            + Option ("tractography.tsf_colourmap", "Sets the colourmap of the .tsf file as indexed in the tsf colourmap dropdown menu. Requires -tractography.tsf_load already ").allow_multiple()
+            + Option ("tractography.tsf_colourmap", "Sets the colourmap of the .tsf file as indexed in the tsf colourmap dropdown menu. Requires -tractography.tsf_load already.").allow_multiple()
             +   Argument ("index").type_integer();
 
         }

--- a/src/gui/mrview/tool/tractography/tractography.cpp
+++ b/src/gui/mrview/tool/tractography/tractography.cpp
@@ -848,15 +848,22 @@ namespace MR
 
             + Option ("tractography.lighting", "Toggle the use of lighting of tractogram geometry").allow_multiple()
             +  Argument ("value").type_bool()
-
+            
+            + Option ("tractography.colour", "Specify a manual colour for the tractogram, as three comma-separated values").allow_multiple()
+            +   Argument ("R,G,B").type_sequence_float()            
+           
             + Option ("tractography.tsf_load", "Load the specified tractography scalar file.").allow_multiple()
-            +  Argument ("tsf").type_file_in()
+            +  Argument ("tsf").type_file_in()  
 
             + Option ("tractography.tsf_range", "Set range for the tractography scalar file. Requires -tractography.tsf_load already provided.").allow_multiple()
             +  Argument ("RangeMin,RangeMax").type_sequence_float()
 
             + Option ("tractography.tsf_thresh", "Set thresholds for the tractography scalar file. Requires -tractography.tsf_load already provided.").allow_multiple()
-            +  Argument ("ThresholdMin,ThesholdMax").type_sequence_float();
+            +  Argument ("ThresholdMin,ThesholdMax").type_sequence_float()
+            
+            + Option ("tractography.tsf_colourmap", "Sets the colourmap of the .tsf file as indexed in the tsf colourmap dropdown menu. Requires -tractography.tsf_load already ").allow_multiple()
+            +   Argument ("index").type_integer();
+
         }
 
         /*
@@ -871,10 +878,7 @@ namespace MR
             window().updateGL();
           }
         }
-
-
-
-
+        
 
         bool Tractography::process_commandline_option (const MR::App::ParsedOption& opt)
         {
@@ -949,10 +953,79 @@ namespace MR
           }
 
 
+	if (opt.opt->is ("tractography.tsf_colourmap"))
+          {
+            try {
+              int n = opt[0];
+              if (n < 0 || !ColourMap::maps[n].name)
+                throw Exception ("invalid overlay colourmap index \"" + std::string (opt[0]) + "\" for -tractography.tsf_colourmap option"); 
+		// help needed here !
+		// scalar_file_options->set_track_colormap(n) ?
+            }
+	    catch (Exception& e) { e.display(); }
+	    
+	    if (process_commandline_option_tsf_check_tracto_loaded()) {
+                // get list of selected tractograms:
+                QModelIndexList indices = tractogram_list_view->selectionModel()->selectedIndexes();
+                if (indices.size() != 1)
+                  throw Exception ("-tractography.tsf_colourmap option requires one tractogram to be selected");
+                // get pointer to tractogram:
+                Tractogram* tractogram = tractogram_list_model->get_tractogram (indices[0]);
+                // check tractogram has a scalar file attached and prepare the scalar_file_options object:
+                if (tractogram->get_color_type() == TrackColourType::ScalarFile){
+                  scalar_file_options->set_tractogram (tractogram);
+                  // invoke member function (which needs to be added - see below):
+                  scalar_file_options->set_colourmap (opt[0]);
+               }
+
+             }
+          }
+          
+          
+           if (opt.opt->is ("tractography.colour")) {
+            try {
+            
+              auto values = parse_floats (opt[0]);
+              if (values.size() != 3)
+                throw Exception ("must provide exactly three comma-separated values to the -overlay.colour option");
+              const float max_value = std::max ({ values[0], values[1], values[2] });
+              if (std::min ({ values[0], values[1], values[2] }) < 0.0 || max_value > 255)
+                throw Exception ("values provided to -tractogram.colour must be either between 0.0 and 1.0, or between 0 and 255");
+              const float multiplier = max_value <= 1.0 ? 255.0 : 1.0;
+              QColor colour (int(values[0] * multiplier), int(values[1]*multiplier), int(values[2]*multiplier));               
+                           
+              QModelIndexList indices = tractogram_list_view->selectionModel()->selectedIndexes(); 
+              
+              if (indices.size() != 1)
+                  throw Exception ("-tractography.colour option requires one tractogram to be selected");
+              // get pointer to tractogram:
+              Tractogram* tractogram = tractogram_list_model->get_tractogram (indices[0]);
+                
+              //input need to be a float *  
+              float colour_input[3];
+                
+               colour_input[0]=values[0]/255;
+               colour_input[1]=values[1]/255;
+               colour_input[2]=values[2]/255;
+                
+               // set the color
+               tractogram->set_color_type (TrackColourType::Manual);
+               tractogram->set_colour(colour_input);
+                
+               // update_color_type_gui
+               colour_combobox->setCurrentIndex (3);                
+               colour_button->setEnabled (true);
+               colour_button->setColor (QColor (colour_input[0]*255.0f, colour_input[1]*255.0f, colour_input[2]*255.0f));
+              
+            
+            }
+            catch (Exception& e) { e.display(); }
+            return true;
+          }
+          
 
           if (opt.opt-> is ("tractography.geometry")) {
-            try {
-              const TrackGeometryType geom_type = geometry_index2type (geometry_string2index (opt[0]));
+            try {             const TrackGeometryType geom_type = geometry_index2type (geometry_string2index (opt[0]));
               QModelIndexList indices = tractogram_list_view->selectionModel()->selectedIndexes();
               if (indices.size()) {
                 for (int i = 0; i < indices.size(); ++i)


### PR DESCRIPTION
The pull request introduce two minor modifications of the command line of mrview related to the following discussion:

https://community.mrtrix.org/t/help-for-changing-the-colormap-of-tsf-file-in-command-line/4433
https://community.mrtrix.org/t/adding-command-line-option-to-mrview-to-set-tractography-colors/2453

1) tractography.tsf_colourmap  (allow to load a tsf file for each tractogram ) 
2) tractography.colour  (allow to specify the  rgb value of the tractogram )

tractography.tsf_colourmap  is working but the gui has not been updated
tractography.colour is half -working : if you load a second tractogram with a different color , the previous color is reset to the new one which make the option not so usefull. 

The code is more a hack than a clean version. I would be interested in knowing the fix for my issue with tractography.colour
