### PR TITLE
mrview: fix glitch in handling of clip plane selection

### DIFF
--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -1857,7 +1857,7 @@ namespace MR
 
       void Window::register_camera_interactor (Tool::CameraInteractor* agent)
       {
-        if (camera_interactor)
+        if (camera_interactor && camera_interactor != agent)
           camera_interactor->deactivate();
         camera_interactor = agent;
       }


### PR DESCRIPTION
What it says in the title. This one has been giving me the irrits for a while, I finally decided it had to be sorted out... 

Issue manifests when adding a clip plane, then hitting the 'invert' button: this deselects the clip plane and you can't then select it again. Only way around it is to untick it and tick it again, which seems to sort this out temporarily. Other way to trigger this is to add two clip planes, then try to select both or something... 