### PR TITLE
GLM: Fix all_stats() segfault

### DIFF
--- a/core/math/stats/glm.cpp
+++ b/core/math/stats/glm.cpp
@@ -471,7 +471,7 @@ namespace MR
                 local_stdev = matrix_type::Zero (num_vgs, 1);
                 for (size_t ih = 0; ih != hypotheses.size(); ++ih) {
                   if (hypotheses[ih].is_F())
-                    local_abs_effect_size (1, ih) = local_std_effect_size (1, ih) = NaN;
+                    local_abs_effect_size (0, ih) = local_std_effect_size (0, ih) = NaN;
                 }
               }
           };


### PR DESCRIPTION
As reported in #2289.

Fixes segmentation fault in case where:

1. Either:
    1. Input data contain non-finite values (regardless of whether or not those data are or are not within the statistical inference processing mask);
    2. Element-wise design matrix columns are added via `-column` option;
2. At least one F-test is performed.

Fairly obvious blunder even without explaining the surrounding code.