### PR TITLE
Support for Qt6

### DIFF
--- a/configure
+++ b/configure
@@ -1251,7 +1251,7 @@ int main() { Foo f; }
       filetext = 'CONFIG += c++11'
       if debug:
         filetext += ' debug'
-      filetext += '\nQT += core gui opengl svg network\n'
+      filetext += '\nQT += core gui openglwidgets svg network\n'
       filetext += 'HEADERS += qt.h\nSOURCES += qt.cpp\n'
       if system == "darwin":
         filetext += 'QMAKE_MACOSX_DEPLOYMENT_TARGET = ' + macosx_version + '\n'

--- a/configure
+++ b/configure
@@ -1251,7 +1251,7 @@ int main() { Foo f; }
       filetext = 'CONFIG += c++11'
       if debug:
         filetext += ' debug'
-      filetext += '\nQT += core gui openglwidgets svg network\n'
+      filetext += '\nQT += core gui opengl svg network\n'
       filetext += 'HEADERS += qt.h\nSOURCES += qt.cpp\n'
       if system == "darwin":
         filetext += 'QMAKE_MACOSX_DEPLOYMENT_TARGET = ' + macosx_version + '\n'

--- a/core/algo/loop.h
+++ b/core/algo/loop.h
@@ -194,9 +194,9 @@ namespace MR
         const std::tuple<ImageType&...> vox;
         const ssize_t size0;
         FORCE_INLINE Run (const size_t axis, const std::tuple<ImageType&...>& vox) :
-          axis (axis), vox (vox), size0 (std::get<0>(vox).size(axis)) { apply (set_pos (axis, 0), vox); }
+          axis (axis), vox (vox), size0 (std::get<0>(vox).size(axis)) { MR::apply (set_pos (axis, 0), vox); }
         FORCE_INLINE operator bool() const { return std::get<0>(vox).index(axis) < size0; }
-        FORCE_INLINE void operator++() const { apply (inc_pos (axis), vox); }
+        FORCE_INLINE void operator++() const { MR::apply (inc_pos (axis), vox); }
         FORCE_INLINE void operator++(int) const { operator++(); }
       };
 
@@ -215,9 +215,9 @@ namespace MR
         const std::tuple<ImageType&...> vox;
         const ssize_t size0;
         FORCE_INLINE Run (const std::string& text, const size_t axis, const std::tuple<ImageType&...>& vox) :
-          progress (text, std::get<0>(vox).size(axis)), axis (axis), vox (vox), size0 (std::get<0>(vox).size(axis)) { apply (set_pos (axis, 0), vox); }
+          progress (text, std::get<0>(vox).size(axis)), axis (axis), vox (vox), size0 (std::get<0>(vox).size(axis)) { MR::apply (set_pos (axis, 0), vox); }
         FORCE_INLINE operator bool() const { return std::get<0>(vox).index(axis) < size0; }
-        FORCE_INLINE void operator++() { apply (inc_pos (axis), vox); ++progress; }
+        FORCE_INLINE void operator++() { MR::apply (inc_pos (axis), vox); ++progress; }
         FORCE_INLINE void operator++(int) { operator++(); }
       };
 
@@ -239,21 +239,21 @@ namespace MR
         FORCE_INLINE Run (const size_t axis_from, const size_t axis_to, const std::tuple<ImageType&...>& vox) :
           from (axis_from), to (axis_to ? axis_to : std::get<0>(vox).ndim()), vox (vox), size0 (std::get<0>(vox).size(from)), ok (true) {
             for (size_t n = from; n < to; ++n)
-              apply (set_pos (n, 0), vox);
+              MR::apply (set_pos (n, 0), vox);
           }
         FORCE_INLINE operator bool() const { return ok; }
         FORCE_INLINE void operator++() {
-          apply (inc_pos (from), vox);
+          MR::apply (inc_pos (from), vox);
           if (std::get<0>(vox).index(from) < size0)
             return;
 
-          apply (set_pos (from, 0), vox);
+          MR::apply (set_pos (from, 0), vox);
           size_t axis = from+1;
           while (axis < to) {
-            apply (inc_pos (axis), vox);
+            MR::apply (inc_pos (axis), vox);
             if (std::get<0>(vox).index(axis) < std::get<0>(vox).size(axis))
               return;
-            apply (set_pos (axis, 0), vox);
+            MR::apply (set_pos (axis, 0), vox);
             ++axis;
           }
           ok = false;
@@ -311,21 +311,21 @@ namespace MR
         FORCE_INLINE Run (const std::initializer_list<size_t> axes, const std::tuple<ImageType&...>& vox) :
           axes (axes), vox (vox), from (*axes.begin()), size0 (std::get<0>(vox).size(from)), ok (true) {
             for (auto axis : axes)
-              apply (set_pos (axis, 0), vox);
+              MR::apply (set_pos (axis, 0), vox);
           }
         FORCE_INLINE operator bool() const { return ok; }
         FORCE_INLINE void operator++() {
-          apply (inc_pos (from), vox);
+          MR::apply (inc_pos (from), vox);
           if (std::get<0>(vox).index(from) < size0)
             return;
 
-          apply (set_pos (from, 0), vox);
+          MR::apply (set_pos (from, 0), vox);
           auto axis = axes.begin()+1;
           while (axis != axes.end()) {
-            apply (inc_pos (*axis), vox);
+            MR::apply (inc_pos (*axis), vox);
             if (std::get<0>(vox).index(*axis) < std::get<0>(vox).size(*axis))
               return;
-            apply (set_pos (*axis, 0), vox);
+            MR::apply (set_pos (*axis, 0), vox);
             ++axis;
           }
           ok = false;
@@ -370,18 +370,18 @@ namespace MR
         FORCE_INLINE Run (const vector<size_t>& axes, const std::tuple<ImageType&...>& vox) :
           axes (axes), vox (vox), from (axes[0]), size0 (std::get<0>(vox).size(from)), ok (true) {
             for (auto axis : axes)
-              apply (set_pos (axis, 0), vox);
+              MR::apply (set_pos (axis, 0), vox);
           }
         FORCE_INLINE operator bool() const { return ok; }
         FORCE_INLINE void operator++() {
-          apply (inc_pos (from), vox);
+          MR::apply (inc_pos (from), vox);
           if (std::get<0>(vox).index(from) < size0)
             return;
 
           auto axis = axes.cbegin()+1;
           while (axis != axes.cend()) {
-            apply (set_pos (*(axis-1), 0), vox);
-            apply (inc_pos (*axis), vox);
+            MR::apply (set_pos (*(axis-1), 0), vox);
+            MR::apply (inc_pos (*axis), vox);
             if (std::get<0>(vox).index(*axis) < std::get<0>(vox).size(*axis))
               return;
             ++axis;

--- a/core/algo/loop.h
+++ b/core/algo/loop.h
@@ -21,6 +21,7 @@
 #include "progressbar.h"
 #include "stride.h"
 #include "image_helpers.h"
+using MR::apply;
 
 namespace MR
 {
@@ -194,9 +195,9 @@ namespace MR
         const std::tuple<ImageType&...> vox;
         const ssize_t size0;
         FORCE_INLINE Run (const size_t axis, const std::tuple<ImageType&...>& vox) :
-          axis (axis), vox (vox), size0 (std::get<0>(vox).size(axis)) { MR::apply (set_pos (axis, 0), vox); }
+          axis (axis), vox (vox), size0 (std::get<0>(vox).size(axis)) { apply (set_pos (axis, 0), vox); }
         FORCE_INLINE operator bool() const { return std::get<0>(vox).index(axis) < size0; }
-        FORCE_INLINE void operator++() const { MR::apply (inc_pos (axis), vox); }
+        FORCE_INLINE void operator++() const { apply (inc_pos (axis), vox); }
         FORCE_INLINE void operator++(int) const { operator++(); }
       };
 
@@ -215,9 +216,9 @@ namespace MR
         const std::tuple<ImageType&...> vox;
         const ssize_t size0;
         FORCE_INLINE Run (const std::string& text, const size_t axis, const std::tuple<ImageType&...>& vox) :
-          progress (text, std::get<0>(vox).size(axis)), axis (axis), vox (vox), size0 (std::get<0>(vox).size(axis)) { MR::apply (set_pos (axis, 0), vox); }
+          progress (text, std::get<0>(vox).size(axis)), axis (axis), vox (vox), size0 (std::get<0>(vox).size(axis)) { apply (set_pos (axis, 0), vox); }
         FORCE_INLINE operator bool() const { return std::get<0>(vox).index(axis) < size0; }
-        FORCE_INLINE void operator++() { MR::apply (inc_pos (axis), vox); ++progress; }
+        FORCE_INLINE void operator++() { apply (inc_pos (axis), vox); ++progress; }
         FORCE_INLINE void operator++(int) { operator++(); }
       };
 
@@ -239,21 +240,21 @@ namespace MR
         FORCE_INLINE Run (const size_t axis_from, const size_t axis_to, const std::tuple<ImageType&...>& vox) :
           from (axis_from), to (axis_to ? axis_to : std::get<0>(vox).ndim()), vox (vox), size0 (std::get<0>(vox).size(from)), ok (true) {
             for (size_t n = from; n < to; ++n)
-              MR::apply (set_pos (n, 0), vox);
+              apply (set_pos (n, 0), vox);
           }
         FORCE_INLINE operator bool() const { return ok; }
         FORCE_INLINE void operator++() {
-          MR::apply (inc_pos (from), vox);
+          apply (inc_pos (from), vox);
           if (std::get<0>(vox).index(from) < size0)
             return;
 
-          MR::apply (set_pos (from, 0), vox);
+          apply (set_pos (from, 0), vox);
           size_t axis = from+1;
           while (axis < to) {
-            MR::apply (inc_pos (axis), vox);
+            apply (inc_pos (axis), vox);
             if (std::get<0>(vox).index(axis) < std::get<0>(vox).size(axis))
               return;
-            MR::apply (set_pos (axis, 0), vox);
+            apply (set_pos (axis, 0), vox);
             ++axis;
           }
           ok = false;
@@ -311,21 +312,21 @@ namespace MR
         FORCE_INLINE Run (const std::initializer_list<size_t> axes, const std::tuple<ImageType&...>& vox) :
           axes (axes), vox (vox), from (*axes.begin()), size0 (std::get<0>(vox).size(from)), ok (true) {
             for (auto axis : axes)
-              MR::apply (set_pos (axis, 0), vox);
+              apply (set_pos (axis, 0), vox);
           }
         FORCE_INLINE operator bool() const { return ok; }
         FORCE_INLINE void operator++() {
-          MR::apply (inc_pos (from), vox);
+          apply (inc_pos (from), vox);
           if (std::get<0>(vox).index(from) < size0)
             return;
 
-          MR::apply (set_pos (from, 0), vox);
+          apply (set_pos (from, 0), vox);
           auto axis = axes.begin()+1;
           while (axis != axes.end()) {
-            MR::apply (inc_pos (*axis), vox);
+            apply (inc_pos (*axis), vox);
             if (std::get<0>(vox).index(*axis) < std::get<0>(vox).size(*axis))
               return;
-            MR::apply (set_pos (*axis, 0), vox);
+            apply (set_pos (*axis, 0), vox);
             ++axis;
           }
           ok = false;
@@ -370,18 +371,18 @@ namespace MR
         FORCE_INLINE Run (const vector<size_t>& axes, const std::tuple<ImageType&...>& vox) :
           axes (axes), vox (vox), from (axes[0]), size0 (std::get<0>(vox).size(from)), ok (true) {
             for (auto axis : axes)
-              MR::apply (set_pos (axis, 0), vox);
+              apply (set_pos (axis, 0), vox);
           }
         FORCE_INLINE operator bool() const { return ok; }
         FORCE_INLINE void operator++() {
-          MR::apply (inc_pos (from), vox);
+          apply (inc_pos (from), vox);
           if (std::get<0>(vox).index(from) < size0)
             return;
 
           auto axis = axes.cbegin()+1;
           while (axis != axes.cend()) {
-            MR::apply (set_pos (*(axis-1), 0), vox);
-            MR::apply (inc_pos (*axis), vox);
+            apply (set_pos (*(axis-1), 0), vox);
+            apply (inc_pos (*axis), vox);
             if (std::get<0>(vox).index(*axis) < std::get<0>(vox).size(*axis))
               return;
             ++axis;

--- a/core/algo/loop.h
+++ b/core/algo/loop.h
@@ -21,7 +21,6 @@
 #include "progressbar.h"
 #include "stride.h"
 #include "image_helpers.h"
-using MR::apply;
 
 namespace MR
 {
@@ -195,9 +194,9 @@ namespace MR
         const std::tuple<ImageType&...> vox;
         const ssize_t size0;
         FORCE_INLINE Run (const size_t axis, const std::tuple<ImageType&...>& vox) :
-          axis (axis), vox (vox), size0 (std::get<0>(vox).size(axis)) { apply (set_pos (axis, 0), vox); }
+          axis (axis), vox (vox), size0 (std::get<0>(vox).size(axis)) { MR::apply (set_pos (axis, 0), vox); }
         FORCE_INLINE operator bool() const { return std::get<0>(vox).index(axis) < size0; }
-        FORCE_INLINE void operator++() const { apply (inc_pos (axis), vox); }
+        FORCE_INLINE void operator++() const { MR::apply (inc_pos (axis), vox); }
         FORCE_INLINE void operator++(int) const { operator++(); }
       };
 
@@ -216,9 +215,9 @@ namespace MR
         const std::tuple<ImageType&...> vox;
         const ssize_t size0;
         FORCE_INLINE Run (const std::string& text, const size_t axis, const std::tuple<ImageType&...>& vox) :
-          progress (text, std::get<0>(vox).size(axis)), axis (axis), vox (vox), size0 (std::get<0>(vox).size(axis)) { apply (set_pos (axis, 0), vox); }
+          progress (text, std::get<0>(vox).size(axis)), axis (axis), vox (vox), size0 (std::get<0>(vox).size(axis)) { MR::apply (set_pos (axis, 0), vox); }
         FORCE_INLINE operator bool() const { return std::get<0>(vox).index(axis) < size0; }
-        FORCE_INLINE void operator++() { apply (inc_pos (axis), vox); ++progress; }
+        FORCE_INLINE void operator++() { MR::apply (inc_pos (axis), vox); ++progress; }
         FORCE_INLINE void operator++(int) { operator++(); }
       };
 
@@ -240,21 +239,21 @@ namespace MR
         FORCE_INLINE Run (const size_t axis_from, const size_t axis_to, const std::tuple<ImageType&...>& vox) :
           from (axis_from), to (axis_to ? axis_to : std::get<0>(vox).ndim()), vox (vox), size0 (std::get<0>(vox).size(from)), ok (true) {
             for (size_t n = from; n < to; ++n)
-              apply (set_pos (n, 0), vox);
+              MR::apply (set_pos (n, 0), vox);
           }
         FORCE_INLINE operator bool() const { return ok; }
         FORCE_INLINE void operator++() {
-          apply (inc_pos (from), vox);
+          MR::apply (inc_pos (from), vox);
           if (std::get<0>(vox).index(from) < size0)
             return;
 
-          apply (set_pos (from, 0), vox);
+          MR::apply (set_pos (from, 0), vox);
           size_t axis = from+1;
           while (axis < to) {
-            apply (inc_pos (axis), vox);
+            MR::apply (inc_pos (axis), vox);
             if (std::get<0>(vox).index(axis) < std::get<0>(vox).size(axis))
               return;
-            apply (set_pos (axis, 0), vox);
+            MR::apply (set_pos (axis, 0), vox);
             ++axis;
           }
           ok = false;
@@ -312,21 +311,21 @@ namespace MR
         FORCE_INLINE Run (const std::initializer_list<size_t> axes, const std::tuple<ImageType&...>& vox) :
           axes (axes), vox (vox), from (*axes.begin()), size0 (std::get<0>(vox).size(from)), ok (true) {
             for (auto axis : axes)
-              apply (set_pos (axis, 0), vox);
+              MR::apply (set_pos (axis, 0), vox);
           }
         FORCE_INLINE operator bool() const { return ok; }
         FORCE_INLINE void operator++() {
-          apply (inc_pos (from), vox);
+          MR::apply (inc_pos (from), vox);
           if (std::get<0>(vox).index(from) < size0)
             return;
 
-          apply (set_pos (from, 0), vox);
+          MR::apply (set_pos (from, 0), vox);
           auto axis = axes.begin()+1;
           while (axis != axes.end()) {
-            apply (inc_pos (*axis), vox);
+            MR::apply (inc_pos (*axis), vox);
             if (std::get<0>(vox).index(*axis) < std::get<0>(vox).size(*axis))
               return;
-            apply (set_pos (*axis, 0), vox);
+            MR::apply (set_pos (*axis, 0), vox);
             ++axis;
           }
           ok = false;
@@ -371,18 +370,18 @@ namespace MR
         FORCE_INLINE Run (const vector<size_t>& axes, const std::tuple<ImageType&...>& vox) :
           axes (axes), vox (vox), from (axes[0]), size0 (std::get<0>(vox).size(from)), ok (true) {
             for (auto axis : axes)
-              apply (set_pos (axis, 0), vox);
+              MR::apply (set_pos (axis, 0), vox);
           }
         FORCE_INLINE operator bool() const { return ok; }
         FORCE_INLINE void operator++() {
-          apply (inc_pos (from), vox);
+          MR::apply (inc_pos (from), vox);
           if (std::get<0>(vox).index(from) < size0)
             return;
 
           auto axis = axes.cbegin()+1;
           while (axis != axes.cend()) {
-            apply (set_pos (*(axis-1), 0), vox);
-            apply (inc_pos (*axis), vox);
+            MR::apply (set_pos (*(axis-1), 0), vox);
+            MR::apply (inc_pos (*axis), vox);
             if (std::get<0>(vox).index(*axis) < std::get<0>(vox).size(*axis))
               return;
             ++axis;
@@ -476,5 +475,3 @@ namespace MR
 }
 
 #endif
-
-

--- a/core/image_helpers.h
+++ b/core/image_helpers.h
@@ -20,6 +20,7 @@
 #include "datatype.h"
 #include "apply.h"
 #include "debug.h"
+using MR::apply;
 
 namespace MR
 {
@@ -66,7 +67,7 @@ namespace MR
         const size_t axis;
         const ssize_t index;
         template <class ImageType>
-          FORCE_INLINE void operator() (ImageType& x) { MR::apply (__assign<DestImageType...> (axis, index), x); }
+          FORCE_INLINE void operator() (ImageType& x) { apply (__assign<DestImageType...> (axis, index), x); }
       };
 
     template <class... DestImageType>
@@ -82,7 +83,7 @@ namespace MR
         __max_axis (size_t& axis) : axis (axis) { }
         size_t& axis;
         template <class ImageType>
-          FORCE_INLINE void operator() (ImageType& x) { MR::apply (__max_axis<DestImageType...> (axis), x); }
+          FORCE_INLINE void operator() (ImageType& x) { apply (__max_axis<DestImageType...> (axis), x); }
       };
 
     template <class ImageType>
@@ -90,9 +91,9 @@ namespace MR
         template <class... DestImageType>
           FORCE_INLINE void to (DestImageType&... dest) const {
             size_t last_axis = to_axis;
-            MR::apply (__max_axis<DestImageType...> (last_axis), std::tie (ref, dest...));
+            apply (__max_axis<DestImageType...> (last_axis), std::tie (ref, dest...));
             for (size_t n = from_axis; n < last_axis; ++n)
-              MR::apply (__assign<DestImageType...> (n, __get_index (ref, n)), std::tie (dest...));
+              apply (__assign<DestImageType...> (n, __get_index (ref, n)), std::tie (dest...));
           }
         const ImageType& ref;
         const size_t from_axis, to_axis;
@@ -104,7 +105,7 @@ namespace MR
         template <class... DestImageType>
           FORCE_INLINE void to (DestImageType&... dest) const {
             for (auto a : axes)
-              MR::apply (__assign<DestImageType...> (a, __get_index (ref, a)), std::tie (dest...));
+              apply (__assign<DestImageType...> (a, __get_index (ref, a)), std::tie (dest...));
           }
         const ImageType& ref;
         const vector<IntType> axes;

--- a/core/image_helpers.h
+++ b/core/image_helpers.h
@@ -66,7 +66,7 @@ namespace MR
         const size_t axis;
         const ssize_t index;
         template <class ImageType>
-          FORCE_INLINE void operator() (ImageType& x) { apply (__assign<DestImageType...> (axis, index), x); }
+          FORCE_INLINE void operator() (ImageType& x) { MR::apply (__assign<DestImageType...> (axis, index), x); }
       };
 
     template <class... DestImageType>
@@ -82,7 +82,7 @@ namespace MR
         __max_axis (size_t& axis) : axis (axis) { }
         size_t& axis;
         template <class ImageType>
-          FORCE_INLINE void operator() (ImageType& x) { apply (__max_axis<DestImageType...> (axis), x); }
+          FORCE_INLINE void operator() (ImageType& x) { MR::apply (__max_axis<DestImageType...> (axis), x); }
       };
 
     template <class ImageType>
@@ -90,9 +90,9 @@ namespace MR
         template <class... DestImageType>
           FORCE_INLINE void to (DestImageType&... dest) const {
             size_t last_axis = to_axis;
-            apply (__max_axis<DestImageType...> (last_axis), std::tie (ref, dest...));
+            MR::apply (__max_axis<DestImageType...> (last_axis), std::tie (ref, dest...));
             for (size_t n = from_axis; n < last_axis; ++n)
-              apply (__assign<DestImageType...> (n, __get_index (ref, n)), std::tie (dest...));
+              MR::apply (__assign<DestImageType...> (n, __get_index (ref, n)), std::tie (dest...));
           }
         const ImageType& ref;
         const size_t from_axis, to_axis;
@@ -104,7 +104,7 @@ namespace MR
         template <class... DestImageType>
           FORCE_INLINE void to (DestImageType&... dest) const {
             for (auto a : axes)
-              apply (__assign<DestImageType...> (a, __get_index (ref, a)), std::tie (dest...));
+              MR::apply (__assign<DestImageType...> (a, __get_index (ref, a)), std::tie (dest...));
           }
         const ImageType& ref;
         const vector<IntType> axes;

--- a/core/image_helpers.h
+++ b/core/image_helpers.h
@@ -20,7 +20,6 @@
 #include "datatype.h"
 #include "apply.h"
 #include "debug.h"
-using MR::apply;
 
 namespace MR
 {
@@ -67,7 +66,7 @@ namespace MR
         const size_t axis;
         const ssize_t index;
         template <class ImageType>
-          FORCE_INLINE void operator() (ImageType& x) { apply (__assign<DestImageType...> (axis, index), x); }
+          FORCE_INLINE void operator() (ImageType& x) { MR::apply (__assign<DestImageType...> (axis, index), x); }
       };
 
     template <class... DestImageType>
@@ -83,7 +82,7 @@ namespace MR
         __max_axis (size_t& axis) : axis (axis) { }
         size_t& axis;
         template <class ImageType>
-          FORCE_INLINE void operator() (ImageType& x) { apply (__max_axis<DestImageType...> (axis), x); }
+          FORCE_INLINE void operator() (ImageType& x) { MR::apply (__max_axis<DestImageType...> (axis), x); }
       };
 
     template <class ImageType>
@@ -91,9 +90,9 @@ namespace MR
         template <class... DestImageType>
           FORCE_INLINE void to (DestImageType&... dest) const {
             size_t last_axis = to_axis;
-            apply (__max_axis<DestImageType...> (last_axis), std::tie (ref, dest...));
+            MR::apply (__max_axis<DestImageType...> (last_axis), std::tie (ref, dest...));
             for (size_t n = from_axis; n < last_axis; ++n)
-              apply (__assign<DestImageType...> (n, __get_index (ref, n)), std::tie (dest...));
+              MR::apply (__assign<DestImageType...> (n, __get_index (ref, n)), std::tie (dest...));
           }
         const ImageType& ref;
         const size_t from_axis, to_axis;
@@ -105,7 +104,7 @@ namespace MR
         template <class... DestImageType>
           FORCE_INLINE void to (DestImageType&... dest) const {
             for (auto a : axes)
-              apply (__assign<DestImageType...> (a, __get_index (ref, a)), std::tie (dest...));
+              MR::apply (__assign<DestImageType...> (a, __get_index (ref, a)), std::tie (dest...));
           }
         const ImageType& ref;
         const vector<IntType> axes;
@@ -658,8 +657,3 @@ namespace MR
 }
 
 #endif
-
-
-
-
-

--- a/src/gui/color_button.cpp
+++ b/src/gui/color_button.cpp
@@ -74,7 +74,7 @@ QSize QColorButton::sizeHint() const
 {
   QStyleOptionButton option;
   option.initFrom (this);
-  return (style()->sizeFromContents(QStyle::CT_PushButton, &option, option.fontMetrics.size (0, "MM"), this).expandedTo(QApplication::globalStrut()));
+  return (style()->sizeFromContents(QStyle::CT_PushButton, &option, option.fontMetrics.size (0, "MM"), this).expandedTo(QSize(0,0)));
 }
 
 void QColorButton::chooseColor()

--- a/src/gui/dwi/render_frame.cpp
+++ b/src/gui/dwi/render_frame.cpp
@@ -16,7 +16,7 @@
 
 #include <fstream>
 
-#include <QGLWidget>
+#include <QOpenGLWidget>
 
 #include "app.h"
 #include "gui/dwi/render_frame.h"
@@ -61,7 +61,7 @@ namespace MR
         glfont (get_font (parent)), projection (this, glfont),
         orientation (DefaultOrientation),
         focus (0.0, 0.0, 0.0), OS (0), OS_x (0), OS_y (0),
-        renderer ((QGLWidget*)this)
+        renderer ((QOpenGLWidget*)this)
       {
         setMinimumSize (128, 128);
         lighting = new GL::Lighting (this);
@@ -311,7 +311,7 @@ namespace MR
             orientation = rot * orientation;
             update();
           }
-          else if (event->buttons() == Qt::MidButton) {
+          else if (event->buttons() == Qt::MiddleButton) {
             focus += projection.screen_to_model_direction (QPoint (dx, -dy), focus);
             update();
           }

--- a/src/gui/dwi/render_frame.cpp
+++ b/src/gui/dwi/render_frame.cpp
@@ -295,8 +295,8 @@ namespace MR
 
       void RenderFrame::mouseMoveEvent (QMouseEvent* event)
       {
-        int dx = event->position().x() - last_pos.x();
-        int dy = event->position().y() - last_pos.y();
+        int dx = event->x() - last_pos.x();
+        int dy = event->y() - last_pos.y();
         last_pos = event->pos();
         if (dx == 0 && dy == 0) return;
 

--- a/src/gui/dwi/render_frame.cpp
+++ b/src/gui/dwi/render_frame.cpp
@@ -295,8 +295,8 @@ namespace MR
 
       void RenderFrame::mouseMoveEvent (QMouseEvent* event)
       {
-        int dx = event->x() - last_pos.x();
-        int dy = event->y() - last_pos.y();
+        int dx = event->position().x() - last_pos.x();
+        int dy = event->position().y() - last_pos.y();
         last_pos = event->pos();
         if (dx == 0 && dy == 0) return;
 
@@ -398,4 +398,3 @@ namespace MR
     }
   }
 }
-

--- a/src/gui/dwi/renderer.cpp
+++ b/src/gui/dwi/renderer.cpp
@@ -33,7 +33,7 @@ namespace MR
 
 
 
-      Renderer::Renderer (QGLWidget* widget) :
+      Renderer::Renderer (QOpenGLWidget* widget) :
           mode (mode_t::SH),
           reverse_ID (0),
           origin_ID (0),

--- a/src/gui/dwi/renderer.h
+++ b/src/gui/dwi/renderer.h
@@ -17,7 +17,7 @@
 #ifndef __gui_dwi_renderer_h__
 #define __gui_dwi_renderer_h__
 
-#include <QGLWidget>
+#include <QOpenGLWidget>
 #include <Eigen/Eigenvalues>
 
 #include "gui/gui.h"
@@ -54,7 +54,7 @@ namespace MR
 
           enum class mode_t { SH, TENSOR, DIXEL };
 
-          Renderer (QGLWidget*);
+          Renderer (QOpenGLWidget*);
 
           bool ready () const { return shader; }
 
@@ -229,7 +229,7 @@ namespace MR
           } dixel;
 
         private:
-          QGLWidget* context_;
+          QOpenGLWidget* context_;
 
 
       };

--- a/src/gui/mrview/adjust_button.cpp
+++ b/src/gui/mrview/adjust_button.cpp
@@ -67,7 +67,7 @@ namespace MR
           if (event->type() == QEvent::MouseButtonPress) {
             QMouseEvent* mevent = static_cast<QMouseEvent*> (event);
             if (mevent->button() == mevent->buttons()) {
-              previous_y = deadzone_y = mevent->position().y();
+              previous_y = deadzone_y = mevent->y();
               deadzone_value = value();
             }
           }
@@ -80,18 +80,18 @@ namespace MR
           else if (event->type() == QEvent::MouseMove) {
             QMouseEvent* mevent = static_cast<QMouseEvent*> (event);
             if (mevent->buttons() != Qt::NoButton) {
-              if (abs (mevent->position().y() - deadzone_y) < ADJUST_BUTTON_DEADZONE_SIZE) {
+              if (abs (mevent->y() - deadzone_y) < ADJUST_BUTTON_DEADZONE_SIZE) {
                 if (value() != deadzone_value) {
                   setValue (deadzone_value);
                   emit valueChanged();
                   emit valueChanged(value());
                 }
-              } else if (mevent->position().y() != previous_y) {
-                setValue (value() - rate * (mevent->position().y() - previous_y));
+              } else if (mevent->y() != previous_y) {
+                setValue (value() - rate * (mevent->y() - previous_y));
                 emit valueChanged();
                 emit valueChanged(value());
               }
-              previous_y = mevent->position().y();
+              previous_y = mevent->y();
               return true;
             }
           }

--- a/src/gui/mrview/adjust_button.cpp
+++ b/src/gui/mrview/adjust_button.cpp
@@ -67,7 +67,7 @@ namespace MR
           if (event->type() == QEvent::MouseButtonPress) {
             QMouseEvent* mevent = static_cast<QMouseEvent*> (event);
             if (mevent->button() == mevent->buttons()) {
-              previous_y = deadzone_y = mevent->y();
+              previous_y = deadzone_y = mevent->position().y();
               deadzone_value = value();
             }
           }
@@ -80,18 +80,18 @@ namespace MR
           else if (event->type() == QEvent::MouseMove) {
             QMouseEvent* mevent = static_cast<QMouseEvent*> (event);
             if (mevent->buttons() != Qt::NoButton) {
-              if (abs (mevent->y() - deadzone_y) < ADJUST_BUTTON_DEADZONE_SIZE) {
+              if (abs (mevent->position().y() - deadzone_y) < ADJUST_BUTTON_DEADZONE_SIZE) {
                 if (value() != deadzone_value) {
                   setValue (deadzone_value);
                   emit valueChanged();
                   emit valueChanged(value());
                 }
-              } else if (mevent->y() != previous_y) {
-                setValue (value() - rate * (mevent->y() - previous_y));
+              } else if (mevent->position().y() != previous_y) {
+                setValue (value() - rate * (mevent->position().y() - previous_y));
                 emit valueChanged();
                 emit valueChanged(value());
               }
-              previous_y = mevent->y();
+              previous_y = mevent->position().y();
               return true;
             }
           }
@@ -102,4 +102,3 @@ namespace MR
     }
   }
 }
-

--- a/src/gui/mrview/tool/odf/item.cpp
+++ b/src/gui/mrview/tool/odf/item.cpp
@@ -20,8 +20,6 @@
 #include "dwi/gradient.h"
 #include "math/SH.h"
 
-using MR::make_unique;
-
 namespace MR
 {
   namespace GUI
@@ -119,7 +117,7 @@ namespace MR
           const vector<size_t>& volumes = (*shells)[index].get_volumes();
           for (size_t row = 0; row != volumes.size(); ++row)
             shell_dirs.row (row) = grad.row (volumes[row]).head<3>().cast<float>();
-          auto new_dirs = make_unique<MR::DWI::Directions::Set> (shell_dirs);
+          auto new_dirs = MR::make_unique<MR::DWI::Directions::Set> (shell_dirs);
           std::swap (dirs, new_dirs);
           shell_index = index;
           dir_type = DixelPlugin::dir_t::DW_SCHEME;
@@ -128,13 +126,13 @@ namespace MR
         void ODF_Item::DixelPlugin::set_header() {
           if (!header_dirs.rows())
             throw Exception ("No direction scheme defined in header");
-          auto new_dirs = make_unique<MR::DWI::Directions::Set> (header_dirs);
+          auto new_dirs = MR::make_unique<MR::DWI::Directions::Set> (header_dirs);
           std::swap (dirs, new_dirs);
           dir_type = DixelPlugin::dir_t::HEADER;
         }
 
         void ODF_Item::DixelPlugin::set_internal (const size_t n) {
-          auto new_dirs = make_unique<MR::DWI::Directions::Set> (n);
+          auto new_dirs = MR::make_unique<MR::DWI::Directions::Set> (n);
           std::swap (dirs, new_dirs);
           dir_type = DixelPlugin::dir_t::INTERNAL;
         }
@@ -147,7 +145,7 @@ namespace MR
 
         void ODF_Item::DixelPlugin::set_from_file (const std::string& path)
         {
-          auto new_dirs = make_unique<MR::DWI::Directions::Set> (path);
+          auto new_dirs = MR::make_unique<MR::DWI::Directions::Set> (path);
           std::swap (dirs, new_dirs);
           dir_type = DixelPlugin::dir_t::FILE;
         }
@@ -174,8 +172,3 @@ namespace MR
     }
   }
 }
-
-
-
-
-

--- a/src/gui/mrview/tool/odf/item.cpp
+++ b/src/gui/mrview/tool/odf/item.cpp
@@ -117,7 +117,7 @@ namespace MR
           const vector<size_t>& volumes = (*shells)[index].get_volumes();
           for (size_t row = 0; row != volumes.size(); ++row)
             shell_dirs.row (row) = grad.row (volumes[row]).head<3>().cast<float>();
-          auto new_dirs = make_unique<MR::DWI::Directions::Set> (shell_dirs);
+          auto new_dirs = MR::make_unique<MR::DWI::Directions::Set> (shell_dirs);
           std::swap (dirs, new_dirs);
           shell_index = index;
           dir_type = DixelPlugin::dir_t::DW_SCHEME;
@@ -126,13 +126,13 @@ namespace MR
         void ODF_Item::DixelPlugin::set_header() {
           if (!header_dirs.rows())
             throw Exception ("No direction scheme defined in header");
-          auto new_dirs = make_unique<MR::DWI::Directions::Set> (header_dirs);
+          auto new_dirs = MR::make_unique<MR::DWI::Directions::Set> (header_dirs);
           std::swap (dirs, new_dirs);
           dir_type = DixelPlugin::dir_t::HEADER;
         }
 
         void ODF_Item::DixelPlugin::set_internal (const size_t n) {
-          auto new_dirs = make_unique<MR::DWI::Directions::Set> (n);
+          auto new_dirs = MR::make_unique<MR::DWI::Directions::Set> (n);
           std::swap (dirs, new_dirs);
           dir_type = DixelPlugin::dir_t::INTERNAL;
         }
@@ -145,7 +145,7 @@ namespace MR
 
         void ODF_Item::DixelPlugin::set_from_file (const std::string& path)
         {
-          auto new_dirs = make_unique<MR::DWI::Directions::Set> (path);
+          auto new_dirs = MR::make_unique<MR::DWI::Directions::Set> (path);
           std::swap (dirs, new_dirs);
           dir_type = DixelPlugin::dir_t::FILE;
         }

--- a/src/gui/mrview/tool/odf/item.cpp
+++ b/src/gui/mrview/tool/odf/item.cpp
@@ -20,6 +20,8 @@
 #include "dwi/gradient.h"
 #include "math/SH.h"
 
+using MR::make_unique;
+
 namespace MR
 {
   namespace GUI
@@ -117,7 +119,7 @@ namespace MR
           const vector<size_t>& volumes = (*shells)[index].get_volumes();
           for (size_t row = 0; row != volumes.size(); ++row)
             shell_dirs.row (row) = grad.row (volumes[row]).head<3>().cast<float>();
-          auto new_dirs = MR::make_unique<MR::DWI::Directions::Set> (shell_dirs);
+          auto new_dirs = make_unique<MR::DWI::Directions::Set> (shell_dirs);
           std::swap (dirs, new_dirs);
           shell_index = index;
           dir_type = DixelPlugin::dir_t::DW_SCHEME;
@@ -126,13 +128,13 @@ namespace MR
         void ODF_Item::DixelPlugin::set_header() {
           if (!header_dirs.rows())
             throw Exception ("No direction scheme defined in header");
-          auto new_dirs = MR::make_unique<MR::DWI::Directions::Set> (header_dirs);
+          auto new_dirs = make_unique<MR::DWI::Directions::Set> (header_dirs);
           std::swap (dirs, new_dirs);
           dir_type = DixelPlugin::dir_t::HEADER;
         }
 
         void ODF_Item::DixelPlugin::set_internal (const size_t n) {
-          auto new_dirs = MR::make_unique<MR::DWI::Directions::Set> (n);
+          auto new_dirs = make_unique<MR::DWI::Directions::Set> (n);
           std::swap (dirs, new_dirs);
           dir_type = DixelPlugin::dir_t::INTERNAL;
         }
@@ -145,7 +147,7 @@ namespace MR
 
         void ODF_Item::DixelPlugin::set_from_file (const std::string& path)
         {
-          auto new_dirs = MR::make_unique<MR::DWI::Directions::Set> (path);
+          auto new_dirs = make_unique<MR::DWI::Directions::Set> (path);
           std::swap (dirs, new_dirs);
           dir_type = DixelPlugin::dir_t::FILE;
         }

--- a/src/gui/mrview/tool/odf/odf.cpp
+++ b/src/gui/mrview/tool/odf/odf.cpp
@@ -226,7 +226,7 @@ namespace MR
             connect (lighting, SIGNAL (changed()), this, SLOT (updateGL()));
 
 
-            renderer = new DWI::Renderer ((QGLWidget*)Window::main->glarea);
+            renderer = new DWI::Renderer ((QOpenGLWidget*)Window::main->glarea);
             renderer->initGL();
             colour_button->setColor (renderer->get_colour());
 

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -1677,7 +1677,7 @@ namespace MR
 
         int group = get_mouse_mode();
 
-        if (buttons_ == Qt::MidButton)
+        if (buttons_ == Qt::MiddleButton)
           mouse_action = Pan;
         else if (group == 1) {
           if (buttons_ == Qt::LeftButton) {

--- a/src/gui/opengl/font.cpp
+++ b/src/gui/opengl/font.cpp
@@ -71,7 +71,7 @@ namespace MR
           #if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
           tex_width += metric.width (c) + 2;
           #else
-          tex_width += metric.horizontalAdvance (c) + 2;
+          tex_width += metric.horizontalAdvance (QChar(c)) + 2;
           #endif
 
         QImage pixmap (max_font_width, font_height, QImage::Format_ARGB32);
@@ -90,11 +90,11 @@ namespace MR
         int current_x = 0;
         for (int c = first_char; c <= last_char; ++c) {
           pixmap.fill (0);
-          painter.drawText (1, metric.ascent() + 1, QString(c));
+          painter.drawText (1, metric.ascent() + 1, QString(QChar(c)));
           #if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
           font_width[c] = metric.width (c);
           #else
-          font_width[c] = metric.horizontalAdvance (c);
+          font_width[c] = metric.horizontalAdvance (QChar(c));
           #endif
           const int current_font_width = font_width[c] + 2;
 

--- a/src/gui/opengl/gl.h
+++ b/src/gui/opengl/gl.h
@@ -21,7 +21,7 @@
 #include "debug.h"
 
 #include <QtGlobal>
-#include <QtGui>
+#include <QtWidgets>
 #include <QOpenGLWidget>
 #include "gui/opengl/gl_core_3_3.h"
 

--- a/src/gui/opengl/gl.h
+++ b/src/gui/opengl/gl.h
@@ -21,16 +21,8 @@
 #include "debug.h"
 
 #include <QtGlobal>
-#if QT_VERSION >= 0x050000
-#include <QtWidgets>
-#else
 #include <QtGui>
-#endif
-#if QT_VERSION >= 0x050400
 #include <QOpenGLWidget>
-#else
-#include <QGLWidget>
-#endif
 #include "gui/opengl/gl_core_3_3.h"
 
 // necessary to avoid conflict with Qt4's macros:
@@ -69,20 +61,8 @@ namespace MR
 
 
 
-#if QT_VERSION >= 0x050400
-
       using Area = QOpenGLWidget;
       using Format = QSurfaceFormat;
-
-#else
-      class Area : public QGLWidget { NOMEMALIGN
-        public:
-          using QGLWidget::QGLWidget;
-          QImage grabFramebuffer () { return QGLWidget::grabFrameBuffer(); }
-      };
-
-      using Format = QGLFormat;
-#endif
 
       void init ();
       void set_default_context ();
@@ -111,7 +91,6 @@ namespace MR
 
       namespace Context
       {
-#if QT_VERSION >= 0x050400
         inline std::pair<QOpenGLContext*,QSurface*> current() {
           QOpenGLContext* context = QOpenGLContext::currentContext();
           QSurface* surface = context ? context->surface() : nullptr;
@@ -135,12 +114,6 @@ namespace MR
           if (previous_context.first)
             previous_context.first->makeCurrent (previous_context.second);
         }
-#else
-        inline std::pair<int,int> current() { return { 0, 0 }; }
-        inline std::pair<int,int> get (QWidget*) { return { 0, 0 }; }
-        inline std::pair<int,int> makeCurrent (QWidget*) { return { 0, 0 }; }
-        inline void restore (std::pair<int,int>) { }
-#endif
 
         struct Grab { NOMEMALIGN
           decltype (current()) previous_context;
@@ -359,14 +332,8 @@ namespace MR
           void unbind () const {
             check_context();
             GL_DEBUG ("binding default OpenGL framebuffer");
-#if QT_VERSION >= 0x050400
             gl::BindFramebuffer (gl::FRAMEBUFFER, QOpenGLContext::currentContext()->defaultFramebufferObject());
-#else
-            gl::BindFramebuffer (gl::FRAMEBUFFER, 0);
-#endif
           }
-
-
           void attach_color (Texture& tex, size_t attachment) const {
             assert (tex);
             bind();

--- a/src/gui/opengl/gl.h
+++ b/src/gui/opengl/gl.h
@@ -26,7 +26,7 @@
 #else
 #include <QtGui>
 #endif
-#include <QGLWidget>
+#include <QOpenGLWidget>
 #include "gui/opengl/gl_core_3_3.h"
 
 // necessary to avoid conflict with Qt4's macros:
@@ -71,10 +71,10 @@ namespace MR
       using Format = QSurfaceFormat;
 
 #else
-      class Area : public QGLWidget { NOMEMALIGN
+      class Area : public QOpenGLWidget { NOMEMALIGN
         public:
-          using QGLWidget::QGLWidget;
-          QImage grabFramebuffer () { return QGLWidget::grabFrameBuffer(); }
+          //using QOpenGLWidget::QOpenGLWidget;
+          QImage grabFramebuffer () { return QOpenGLWidget::grabFrameBuffer(); }
       };
 
       using Format = QGLFormat;

--- a/src/gui/opengl/gl.h
+++ b/src/gui/opengl/gl.h
@@ -26,7 +26,11 @@
 #else
 #include <QtGui>
 #endif
+#if QT_VERSION >= 0x050400
 #include <QOpenGLWidget>
+#else
+#include <QGLWidget>
+#endif
 #include "gui/opengl/gl_core_3_3.h"
 
 // necessary to avoid conflict with Qt4's macros:
@@ -71,10 +75,10 @@ namespace MR
       using Format = QSurfaceFormat;
 
 #else
-      class Area : public QOpenGLWidget { NOMEMALIGN
+      class Area : public QGLWidget { NOMEMALIGN
         public:
-          //using QOpenGLWidget::QOpenGLWidget;
-          QImage grabFramebuffer () { return QOpenGLWidget::grabFrameBuffer(); }
+          using QGLWidget::QGLWidget;
+          QImage grabFramebuffer () { return QGLWidget::grabFrameBuffer(); }
       };
 
       using Format = QGLFormat;


### PR DESCRIPTION
Not sure if this should go to master.

Today homebrew upgraded my qt installation to qt6, so I tried rebuilding mrtrix3 against it, which did not work out-of-the-box.

I believe that all of the changes here are backward compatible with Qt5. Most of the things I had to change were things that were already deprecated in Qt5.

I tested this on:
* MacOS Big Sur (arm64) with Qt 6.0.2
* Ubuntu 20.04.2 LTS (x86_64) with Qt 5.12.8

One caveat is the ``configure`` script:
- for Qt6 it needs to add module ``openglwidgets`` to the project file (as in this branch)
- for Qt5 it needs to add module ``opengl`` to the project file (as in master)
but we detect the Qt-version by building a binary using this project file...

What would be the preferred solution here?