### PR TITLE
dwifslpreproc: Handle non-ascii data in eddy error outputs

### DIFF
--- a/bin/dwifslpreproc
+++ b/bin/dwifslpreproc
@@ -912,13 +912,13 @@ def execute(): #pylint: disable=unused-variable
     except run.MRtrixCmdError as exception_cuda:
       if not eddy_openmp_cmd:
         raise
-      with open('eddy_cuda_failure_output.txt', 'w') as eddy_output_file:
+      with open('eddy_cuda_failure_output.txt', 'wb') as eddy_output_file:
         eddy_output_file.write(str(exception_cuda))
       app.console('CUDA version of \'eddy\' was not successful; attempting OpenMP version')
       try:
         eddy_output = run.command(eddy_openmp_cmd + ' ' + eddy_all_options)
       except run.MRtrixCmdError as exception_openmp:
-        with open('eddy_openmp_failure_output.txt', 'w') as eddy_output_file:
+        with open('eddy_openmp_failure_output.txt', 'wb') as eddy_output_file:
           eddy_output_file.write(str(exception_openmp))
         # Both have failed; want to combine error messages
         eddy_cuda_header = ('=' * len(eddy_cuda_cmd)) \

--- a/core/formats/tiff.cpp
+++ b/core/formats/tiff.cpp
@@ -35,13 +35,13 @@ namespace MR
       if (! (Path::has_suffix (H.name(), ".tiff") ||
             Path::has_suffix (H.name(), ".tif") ||
             Path::has_suffix (H.name(), ".TIFF") ||
-            Path::has_suffix (H.name(), ".TIF"))) 
+            Path::has_suffix (H.name(), ".TIF")))
         return std::unique_ptr<ImageIO::Base>();
 
       File::TIFF tif (H.name());
 
-      uint32 width(0), height(0);
-      uint16 bpp(0), sampleformat(0), samplesperpixel(0), config (0);
+      uint32_t width(0), height(0);
+      uint16_t bpp(0), sampleformat(0), samplesperpixel(0), config (0);
       size_t ndir = 0;
 
       do {
@@ -57,7 +57,7 @@ namespace MR
 
       H.ndim() = samplesperpixel > 1 ? 4 : 3;
 
-      H.size(0) = width; 
+      H.size(0) = width;
       H.stride(0) = 2;
 
       H.size(1) = height;
@@ -73,7 +73,7 @@ namespace MR
 
       H.datatype() = DataType::Undefined;
       switch (bpp) {
-        case 8: 
+        case 8:
           switch (sampleformat) {
             case 1: H.datatype() = DataType::UInt8; break;
             case 2: H.datatype() = DataType::Int8; break;
@@ -114,7 +114,7 @@ namespace MR
       if (Path::has_suffix (H.name(), ".tiff") ||
           Path::has_suffix (H.name(), ".tif") ||
           Path::has_suffix (H.name(), ".TIFF") ||
-          Path::has_suffix (H.name(), ".TIF")) 
+          Path::has_suffix (H.name(), ".TIF"))
         throw Exception ("TIFF format not supported for output");
 
       return false;

--- a/core/image_io/tiff.cpp
+++ b/core/image_io/tiff.cpp
@@ -36,7 +36,7 @@ namespace MR
       for (auto& entry : files) {
         File::TIFF tif (entry.name);
 
-        uint16 config (0);
+        uint16_t config (0);
         tif.read_and_check (TIFFTAG_PLANARCONFIG, config);
 
         size_t scanline_size = tif.scanline_size();


### PR DESCRIPTION
The FSL `eddy` commands sometimes contain a small block of binary data at the end of their outputs. If, when attempting to write those data to a text file in the scratch directory, an encoding operation occurs, such data may yield a `UnicodeEncodeError`. This commit changes the output text files to be opened in binary mode, so such an encoding should no longer be applied.

(Note that `__str__()` is [defined](https://github.com/MRtrix3/mrtrix3/blob/3.0.2/lib/mrtrix3/run.py#L192-L193) for `MRtrixCmdError` as a straight concatenation of `stdout` and `stderr` contents, so there shouldn't be any `ascii` conversion happening there)
