### PR TITLE
New envvar MRTRIX_LOGLEVEL

### DIFF
--- a/core/app.cpp
+++ b/core/app.cpp
@@ -93,10 +93,20 @@ namespace MR
     std::string command_history_string;
     vector<ParsedArgument> argument;
     vector<ParsedOption> option;
+
     //ENVVAR name: MRTRIX_QUIET
     //ENVVAR Do not display information messages or progress status. This has
-    //ENVVAR the same effect as the ``-quiet`` command-line option.
-    int log_level = getenv("MRTRIX_QUIET") ? 0 : 1;
+    //ENVVAR the same effect as the ``-quiet`` command-line option. If set,
+    //ENVVAR supersedes the MRTRIX_LOGLEVEL environment variable.
+
+    //ENVVAR name: MRTRIX_LOGLEVEL
+    //ENVVAR Set the default terminal verbosity. Default terminal verbosity
+    //ENVVAR is 1. This has the same effect as the ``-quiet`` (0),
+    //ENVVAR ``-info`` (2) or ``-debug`` (3) comand-line options.
+    int log_level = getenv("MRTRIX_QUIET") ?
+                    0 :
+                    (getenv("MRTRIX_LOGLEVEL") ? to<int>(getenv("MRTRIX_LOGLEVEL")) : 1);
+
     int exit_error_code = 0;
     bool fail_on_warn = false;
     bool terminal_use_colour = true;

--- a/docs/reference/environment_variables.rst
+++ b/docs/reference/environment_variables.rst
@@ -32,6 +32,12 @@ List of MRtrix3 environment variables
      ``/etc`` folder is problematic, or to allow different versions of
      the software to have different configurations, etc.
 
+.. envvar:: MRTRIX_LOGLEVEL
+
+     Set the default terminal verbosity. Default terminal verbosity
+     is 1. This has the same effect as the ``-quiet`` (0),
+     ``-info`` (2) or ``-debug`` (3) comand-line options.
+
 .. envvar:: MRTRIX_NOSIGNALS
 
      If this variable is set to any value, disable MRtrix3's custom
@@ -50,7 +56,8 @@ List of MRtrix3 environment variables
 .. envvar:: MRTRIX_QUIET
 
      Do not display information messages or progress status. This has
-     the same effect as the ``-quiet`` command-line option.
+     the same effect as the ``-quiet`` command-line option. If set,
+     supersedes the MRTRIX_LOGLEVEL environment variable.
 
 .. envvar:: MRTRIX_RNG_SEED
 

--- a/lib/mrtrix3/app.py
+++ b/lib/mrtrix3/app.py
@@ -14,7 +14,6 @@
 # For more details, see http://www.mrtrix.org/.
 
 import argparse, inspect, math, os, random, shlex, shutil, signal, string, subprocess, sys, textwrap, time
-import mrtrix3
 from mrtrix3 import ANSI, CONFIG, MRtrixError, setup_ansi
 from mrtrix3 import utils # Needed at global level
 from ._version import __version__

--- a/lib/mrtrix3/app.py
+++ b/lib/mrtrix3/app.py
@@ -43,7 +43,7 @@ EXEC_NAME = os.path.basename(sys.argv[0])
 FORCE_OVERWRITE = False #pylint: disable=unused-variable
 NUM_THREADS = None #pylint: disable=unused-variable
 SCRATCH_DIR = ''
-VERBOSITY = 0 if 'MRTRIX_QUIET' in mrtrix3.CONFIG else 1
+VERBOSITY = 0 if 'MRTRIX_QUIET' in os.environ else int(os.environ.get('MRTRIX_LOGLEVEL', '1'))
 WORKING_DIR = os.getcwd()
 
 
@@ -187,7 +187,7 @@ def _execute(module): #pylint: disable=unused-variable
       pass
     run.shared.set_continue(ARGS.cont[1])
 
-  run.shared.verbosity = VERBOSITY
+  run.shared.set_verbosity(VERBOSITY)
   run.shared.set_num_threads(NUM_THREADS)
 
   CMDLINE.print_citation_warning()
@@ -486,6 +486,8 @@ class ProgressBar(object): #pylint: disable=unused-variable
     self.wrapoff = '' if self.newline else ProgressBar.WRAPOFF
     self.wrapon = '' if self.newline else ProgressBar.WRAPON
     VERBOSITY = run.shared.verbosity = VERBOSITY - 1 if VERBOSITY else 0
+    if not self.orig_verbosity:
+      return
     if self.isatty:
       sys.stderr.write(self.wrapoff + EXEC_NAME + ': ' + ANSI.execute + '[' + ('{0:>3}%'.format(self.value) if self.multiplier else ProgressBar.BUSY[0]) + ']' + ANSI.clear + ' ' + ANSI.console + self._get_message() + '... ' + ANSI.clear + ANSI.lineclear + self.wrapon + self.newline)
     else:
@@ -523,6 +525,9 @@ class ProgressBar(object): #pylint: disable=unused-variable
       self.message = msg
     if self.multiplier:
       self.value = 100
+    VERBOSITY = run.shared.verbosity = self.orig_verbosity
+    if not self.orig_verbosity:
+      return
     if self.isatty:
       sys.stderr.write('\r' + EXEC_NAME + ': ' + ANSI.execute + '[' + ('100%' if self.multiplier else 'done') + ']' + ANSI.clear + ' ' + ANSI.console + self._get_message() + ANSI.clear + ANSI.lineclear + '\n')
     else:
@@ -531,11 +536,13 @@ class ProgressBar(object): #pylint: disable=unused-variable
       else:
         sys.stderr.write('=' * (int(self.value/2) - int(self.old_value/2)) + ']\n')
     sys.stderr.flush()
-    VERBOSITY = run.shared.verbosity = self.orig_verbosity
+
 
   def _update(self):
     global EXEC_NAME
     assert not self.iscomplete
+    if not self.orig_verbosity:
+      return
     if self.isatty:
       sys.stderr.write(self.wrapoff + '\r' + EXEC_NAME + ': ' + ANSI.execute + '[' + ('{0:>3}%'.format(self.value) if self.multiplier else ProgressBar.BUSY[self.counter%6]) + ']' + ANSI.clear + ' ' + ANSI.console + self._get_message() + '... ' + ANSI.clear + ANSI.lineclear + self.wrapon + self.newline)
     else:

--- a/lib/mrtrix3/image.py
+++ b/lib/mrtrix3/image.py
@@ -240,7 +240,12 @@ def statistics(image_path, **kwargs): #pylint: disable=unused-variable
   if app.VERBOSITY > 1:
     app.console('Command: \'' + ' '.join(command) + '\' (piping data to local storage)')
 
-  proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=None)
+  try:
+    from subprocess import DEVNULL
+  except ImportError:
+    import os
+    DEVNULL = open(os.devnull, 'wb')
+  proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=DEVNULL)
   stdout = proc.communicate()[0]
   if proc.returncode:
     raise MRtrixError('Error trying to calculate statistics from image \'' + image_path + '\'')

--- a/lib/mrtrix3/image.py
+++ b/lib/mrtrix3/image.py
@@ -241,9 +241,8 @@ def statistics(image_path, **kwargs): #pylint: disable=unused-variable
     app.console('Command: \'' + ' '.join(command) + '\' (piping data to local storage)')
 
   try:
-    from subprocess import DEVNULL
+    from subprocess import DEVNULL #pylint: disable=import-outside-toplevel
   except ImportError:
-    import os
     DEVNULL = open(os.devnull, 'wb')
   proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=DEVNULL)
   stdout = proc.communicate()[0]

--- a/lib/mrtrix3/run.py
+++ b/lib/mrtrix3/run.py
@@ -55,6 +55,14 @@ class Shared(object):
     if self.env.get('SGE_ROOT') and self.env.get('JOB_ID'):
       del self.env['SGE_ROOT']
 
+    # If environment variable is set, should apply to invoked script,
+    #   but not to any underlying invoked commands
+    try:
+      self.env.pop('MRTRIX_QUIET')
+    except KeyError:
+      pass
+    self.env['MRTRIX_LOGLEVEL'] = 1
+
     # Flagged by calling the set_continue() function;
     #   run.command() and run.function() calls will be skipped until one of the inputs to
     #   these functions matches the given string
@@ -71,7 +79,7 @@ class Shared(object):
     self.process_lists = [ ]
 
     self._scratch_dir = None
-    self.verbosity = 0
+    self.verbosity = 1
 
   # Acquire a unique index
   # This ensures that if command() is executed in parallel using different threads, they will
@@ -144,6 +152,14 @@ class Shared(object):
   def set_scratch_dir(self, path):
     self.env['MRTRIX_TMPFILE_DIR'] = path
     self._scratch_dir = path
+
+  # Controls verbosity of invoked MRtrix3 commands, as well as whether or not the
+  #   stderr outputs of invoked commands are propagated to the terminal instantly or
+  #   instead written to a temporary file for read on completion
+  def set_verbosity(self, verbosity):
+    assert isinstance(verbosity, int)
+    self.verbosity = verbosity
+    self.env['MRTRIX_LOGLEVEL'] = str(max(1, verbosity-1))
 
   # Terminate any and all running processes, and delete any associated temporary files
   def terminate(self, signum): #pylint: disable=unused-variable
@@ -330,9 +346,6 @@ def command(cmd, **kwargs): #pylint: disable=unused-variable
         line[0] = version_match(line[0])
         if shared.get_num_threads() is not None:
           line.extend( [ '-nthreads', str(shared.get_num_threads()) ] )
-        # Get MRtrix3 binaries to output additional INFO-level information if script running in debug mode
-        if shared.verbosity == 3 and not any(entry in line for entry in ['-info', '-debug']):
-          line.append('-info')
         if force:
           line.append('-force')
       else:


### PR DESCRIPTION
This environment variable modulates the terminal verbosity of commands in the same fashion as the -quiet / -info / -debug command-line options.
The contents of this environment variable are utilised by the Python API to affect the verbosity of any *MRtrix3* commands that it invokes, rather than explicitly adding the -info flag to the execution string when relevant.
The `MRTRIX_QUIET` environment variable remains, and supersedes `MRTRIX_LOGLEVEL`.
Additional fixes include Python commands now correctly honouring `MRTRIX_QUIET`, and progress bars in Python scripts no longer being erroneously displayed when the log level is zero.
Fixes #2268.

Assigned to `3.0.4` initially, but can be promoted to `3.0.3` pending team discussion.