### PR TITLE
dwifslpreproc: Fix eddy text file outputs (again)

### DIFF
--- a/bin/dwifslpreproc
+++ b/bin/dwifslpreproc
@@ -913,13 +913,13 @@ def execute(): #pylint: disable=unused-variable
       if not eddy_openmp_cmd:
         raise
       with open('eddy_cuda_failure_output.txt', 'wb') as eddy_output_file:
-        eddy_output_file.write(str(exception_cuda))
+        eddy_output_file.write(str(exception_cuda).encode('utf-8', errors='replace'))
       app.console('CUDA version of \'eddy\' was not successful; attempting OpenMP version')
       try:
         eddy_output = run.command(eddy_openmp_cmd + ' ' + eddy_all_options)
       except run.MRtrixCmdError as exception_openmp:
         with open('eddy_openmp_failure_output.txt', 'wb') as eddy_output_file:
-          eddy_output_file.write(str(exception_openmp))
+          eddy_output_file.write(str(exception_openmp).encode('utf-8', errors='replace'))
         # Both have failed; want to combine error messages
         eddy_cuda_header = ('=' * len(eddy_cuda_cmd)) \
                            + '\n' \
@@ -952,8 +952,8 @@ def execute(): #pylint: disable=unused-variable
 
   else:
     eddy_output = run.command(eddy_openmp_cmd + ' ' + eddy_all_options)
-  with open('eddy_output.txt', 'w') as eddy_output_file:
-    eddy_output_file.write(eddy_output.stdout + '\n' + eddy_output.stderr + '\n')
+  with open('eddy_output.txt', 'wb') as eddy_output_file:
+    eddy_output_file.write((eddy_output.stdout + '\n' + eddy_output.stderr + '\n').encode('utf-8', errors='replace'))
   if app.VERBOSITY > 1:
     app.console('Output of eddy command:')
     sys.stderr.write(eddy_output.stdout + '\n' + eddy_output.stderr + '\n')


### PR DESCRIPTION
#2313 can raise an Exception due to expecting bytes data but receiving string data.

I think part of the issue was that I forgot that #2191 is outstanding. While this PR prevents `dwifslpreproc` from erroring, there is a debate to be had w.r.t. the point at which text decoding should take place. Hopefully dropping Python2 support will simplify this discussion somewhat, though I still have to re-familiarise myself with the revised string handling...