### PR TITLE
DICOM: fix formatting error in dictionary

### DIFF
--- a/core/file/dicom/dict.cpp
+++ b/core/file/dicom/dict.cpp
@@ -2481,8 +2481,8 @@ namespace MR {
         dict[0x04000561UL] =  "SQOriginalAttributesSequence";
         dict[0x04000562UL] =  "DTAttributeModificationDateTime";
         dict[0x04000563UL] =  "LOModifyingSystem";
-        dict[0x04000564UL] =  "LOSourceOfPreviousValuesReasonForTheAttributeModif";
-        dict[0x04000565UL] =  "icationCS";
+        dict[0x04000564UL] =  "LOSourceOfPreviousValues";
+        dict[0x04000565UL] =  "CSReasonForTheAttributeModification";
         dict[0x20000010UL] =  "ISNumberOfCopies";
         dict[0x2000001EUL] =  "SQPrinterConfigurationSequence";
         dict[0x20000020UL] =  "CSPrintPriority";


### PR DESCRIPTION
Fixes a minor error in the DICOM dictionary, probably caused by a glitch in the initial automated import from the DICOM specs.