### PR TITLE
mrview: accept drop events

### DIFF
--- a/src/gui/mrview/tool/fixel/fixel.cpp
+++ b/src/gui/mrview/tool/fixel/fixel.cpp
@@ -378,6 +378,7 @@ namespace MR
             catch (Exception& e) {
               e.display();
             }
+            event->acceptProposedAction();
           }
         }
 

--- a/src/gui/mrview/tool/overlay.cpp
+++ b/src/gui/mrview/tool/overlay.cpp
@@ -237,6 +237,7 @@ namespace MR
             }
             if (list.size())
               add_images (list);
+            event->acceptProposedAction();
           }
         }
 

--- a/src/gui/mrview/tool/roi_editor/roi.cpp
+++ b/src/gui/mrview/tool/roi_editor/roi.cpp
@@ -331,6 +331,7 @@ namespace MR
                 load (list);
                 in_insert_mode = false;
             }
+            event->acceptProposedAction();
           }
         }
 

--- a/src/gui/mrview/tool/tractography/tractography.cpp
+++ b/src/gui/mrview/tool/tractography/tractography.cpp
@@ -403,6 +403,7 @@ namespace MR
             catch (Exception& e) {
               e.display();
             }
+            event->acceptProposedAction();
           }
         }
 

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -168,6 +168,7 @@ namespace MR
           }
           if (list.size())
             main->add_images (list);
+          event->acceptProposedAction();
         }
       }
 


### PR DESCRIPTION
File drop into mrview works currently but the gesture appears to be rejected. This change accepts the drop gesture for opening new main images and for fixels, overlays, rois, tractograms.