### PR TITLE
mrview: elide ODF file names 

### DIFF
--- a/src/gui/mrview/tool/odf/model.h
+++ b/src/gui/mrview/tool/odf/model.h
@@ -46,7 +46,7 @@ namespace MR
             QVariant data (const QModelIndex& index, int role) const {
               if (!index.isValid()) return {};
               if (role != Qt::DisplayRole) return {};
-              return qstr (shorten (items[index.row()]->image.get_filename(), 35, 0));
+              return qstr (items[index.row()]->image.get_filename());
             }
 
             bool setData (const QModelIndex& index, const QVariant& value, int role) {

--- a/src/gui/mrview/tool/odf/model.h
+++ b/src/gui/mrview/tool/odf/model.h
@@ -45,7 +45,7 @@ namespace MR
 
             QVariant data (const QModelIndex& index, int role) const {
               if (!index.isValid()) return {};
-              if (role != Qt::DisplayRole) return {};
+              if (role != Qt::DisplayRole && role != Qt::ToolTipRole) return {};
               return qstr (items[index.row()]->image.get_filename());
             }
 

--- a/src/gui/mrview/tool/odf/odf.cpp
+++ b/src/gui/mrview/tool/odf/odf.cpp
@@ -94,6 +94,9 @@ namespace MR
             image_list_view->setDragEnabled (true);
             image_list_view->viewport()->setAcceptDrops (true);
             image_list_view->setDropIndicatorShown (true);
+            image_list_view->setGridSize (QSize (200, 56));
+            image_list_view->setResizeMode(QListView::Adjust);
+            image_list_view->setTextElideMode (Qt::ElideLeft);
 
             image_list_model = new ODF_Model (this);
             image_list_view->setModel (image_list_model);


### PR DESCRIPTION
Currently, ODF path and file names are truncated and fixed length:
![image](https://user-images.githubusercontent.com/10046944/122202360-46ec2300-ce9d-11eb-93d0-27f9801e0eaf.png)

Eliding text and responsive widget width (this PR):
<img width="811" alt="Screenshot 2021-06-16 at 12 15 19" src="https://user-images.githubusercontent.com/10046944/122202259-29b75480-ce9d-11eb-853c-4dff83abf666.png">

I tried scrolling full file names (only modify `src/gui/mrview/tool/odf/model.h`):
but the scroll bar is not shown and it's located left on load:
![image](https://user-images.githubusercontent.com/10046944/122202630-861a7400-ce9d-11eb-8785-fa0574d79e46.png) horizontal scroll:
<img width="811" alt="Screenshot 2021-06-16 at 12 17 15" src="https://user-images.githubusercontent.com/10046944/122202287-3176f900-ce9d-11eb-8738-19500d35147d.png">

So I'd go with the sliding option. This is at least a partial fix for #937.

