### PR TITLE
configure: Add libpng envvars to usage string

### DIFF
--- a/configure
+++ b/configure
@@ -140,6 +140,12 @@ ENVIRONMENT VARIABLES
     TIFF_LINKFLAGS
         Any flags required to link with the TIFF library.
 
+    PNG_CFLAGS
+        Any flags required to compile with the libpng library.
+
+    PNG_LINKFLAGS
+        Any flags required to link with the libpng library.
+
     FFTW_CFLAGS
         Any flags required to compile with the FFTW library.
 


### PR DESCRIPTION
Spawned by [forum thread](https://community.mrtrix.org/t/compiling-mrtrix-with-json-for-modern-c/4918/3).