### PR TITLE
mrview Overlay: Fix segfault on bad image load

### DIFF
--- a/core/file/nifti_utils.cpp
+++ b/core/file/nifti_utils.cpp
@@ -695,7 +695,8 @@ namespace MR
             std::unique_ptr<ImageIO::Default> handler (new ImageIO::Default (H));
             handler->files.push_back (File::Entry (H.name(), ( single_file ? data_offset : 0 )));
             return std::move (handler);
-          } catch (...) {
+          } catch (Exception& e) {
+            e.display();
             return std::unique_ptr<ImageIO::Base>();
           }
         }

--- a/src/gui/mrview/tool/overlay.cpp
+++ b/src/gui/mrview/tool/overlay.cpp
@@ -196,9 +196,13 @@ namespace MR
           if (overlay_names.empty())
             return;
           vector<std::unique_ptr<MR::Header>> list;
-          for (size_t n = 0; n < overlay_names.size(); ++n)
-            list.push_back (make_unique<MR::Header> (MR::Header::open (overlay_names[n])));
-
+          for (size_t n = 0; n < overlay_names.size(); ++n) {
+            try {
+              list.push_back (make_unique<MR::Header> (MR::Header::open (overlay_names[n])));
+            } catch (Exception& e) {
+              e.display();
+            }
+          }
           add_images (list);
         }
 


### PR DESCRIPTION
Fixes #2344.

On loading one image in `mrview`, then attempting to load within the Overlay tool a `.img` file that does not have a corresponding `.hdr` file:

<details>
<summary>master:</summary>

```
[rob@BRI-Pub-122 diffusion]$ gdb --args mrview fa.mif 
GNU gdb (Ubuntu 9.2-0ubuntu1~20.04) 9.2
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from mrview...
(gdb) r
Starting program: /home/rob/src/mrtrix3/bin/mrview fa.mif
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
[New Thread 0x7ffff09cd700 (LWP 3222)]
[New Thread 0x7fffeaf74700 (LWP 3223)]
[New Thread 0x7fffea773700 (LWP 3224)]
[New Thread 0x7fffe9e52700 (LWP 3225)]
[New Thread 0x7fffd99f7700 (LWP 3229)]
[New Thread 0x7fffd3fff700 (LWP 3230)]
[New Thread 0x7fffd37fe700 (LWP 3231)]
[New Thread 0x7fffd2ffd700 (LWP 3233)]
[New Thread 0x7fffd27fc700 (LWP 3234)]
[Thread 0x7fffd99f7700 (LWP 3229) exited]
[Thread 0x7fffd2ffd700 (LWP 3233) exited]
[Thread 0x7fffd27fc700 (LWP 3234) exited]
Qt has caught an exception thrown from an event handler. Throwing
exceptions from an event handler is not supported in Qt.
You must not let any exception whatsoever propagate through Qt code.
If that is not possible, in Qt 5 you must at least reimplement
QCoreApplication::notify() and catch all exceptions there.

[Thread 0x7ffff09cd700 (LWP 3222) exited]
mrview: [ERROR] unknown format for image "/home/rob/MRI_data/SIFT2/diffusion/fa.img"
mrview: [ERROR] error opening image "/home/rob/MRI_data/SIFT2/diffusion/fa.img"

Thread 1 "mrview" received signal SIGSEGV, Segmentation fault.
0x00007ffff5ee3ede in QGuiApplication::font() () from /lib/x86_64-linux-gnu/libQt5Gui.so.5
(gdb) bt
#0  0x00007ffff5ee3ede in QGuiApplication::font() () from /lib/x86_64-linux-gnu/libQt5Gui.so.5
#1  0x00007ffff5fa47d5 in QFont::QFont() () from /lib/x86_64-linux-gnu/libQt5Gui.so.5
#2  0x00007ffff65468a1 in QWidgetPrivate::QWidgetPrivate(int) () from /lib/x86_64-linux-gnu/libQt5Widgets.so.5
#3  0x00007ffff6759fde in QMessageBox::QMessageBox(QMessageBox::Icon, QString const&, QString const&, QFlags<QMessageBox::StandardButton>, QWidget*, QFlags<Qt::WindowType>) () from /lib/x86_64-linux-gnu/libQt5Widgets.so.5
#4  0x000000000060b4f0 in MR::GUI::Dialog::(anonymous namespace)::report (E=...) at src/gui/dialog/report_exception.cpp:32
#5  0x000000000060b3fe in MR::GUI::Dialog::display_exception (E=..., log_level=0) at src/gui/dialog/report_exception.cpp:53
#6  0x000000000057c6a2 in MR::Exception::display (this=0x1a21410, log_level=0) at ./core/exception.h:91
#7  0x0000000000970db9 in main (cmdline_argc=2, cmdline_argv=0x7fffffffe128) at ./core/command.h:104
(gdb) q
A debugging session is active.

	Inferior 1 [process 3211] will be killed.

Quit anyway? (y or n) y
```

</details>

<details>
<summary>With f48e438a:</summary>

```
[rob@BRI-Pub-122 diffusion]$ gdb --args mrview fa.mif 
GNU gdb (Ubuntu 9.2-0ubuntu1~20.04) 9.2
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from mrview...
r
(gdb) r
Starting program: /home/rob/src/mrtrix3/bin/mrview fa.mif
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
[New Thread 0x7ffff09cd700 (LWP 3934)]
[New Thread 0x7fffeaf74700 (LWP 3935)]
[New Thread 0x7fffea773700 (LWP 3936)]
[New Thread 0x7fffe9e52700 (LWP 3937)]
[New Thread 0x7fffd9dd5700 (LWP 3939)]
[New Thread 0x7fffd3fff700 (LWP 3941)]
[New Thread 0x7fffd37fe700 (LWP 3942)]
[Thread 0x7fffd9dd5700 (LWP 3939) exited]
mrview: [ERROR] cannot stat file "/home/rob/MRI_data/SIFT2/diffusion/fa.hdr": No such file or directory
mrview: [ERROR] cannot stat file "/home/rob/MRI_data/SIFT2/diffusion/fa.hdr": No such file or directory
mrview: [ERROR] unknown format for image "/home/rob/MRI_data/SIFT2/diffusion/fa.img"
mrview: [ERROR] error opening image "/home/rob/MRI_data/SIFT2/diffusion/fa.img"
[Thread 0x7ffff09cd700 (LWP 3934) exited]
[Thread 0x7fffe9e52700 (LWP 3937) exited]
[Thread 0x7fffd3fff700 (LWP 3941) exited]
[Thread 0x7fffea773700 (LWP 3936) exited]
[Thread 0x7fffeaf74700 (LWP 3935) exited]
[Thread 0x7ffff25a8b00 (LWP 3930) exited]
[Inferior 1 (process 3930) exited normally]
(gdb) q
```

</details>

Note that in addition to the Exception handling for the Overlay tool, there's also display of the Exception resulting from the NIfTI format handler trying and failing to open an image.