### PR TITLE
docs: explicitly state to avoid Qt6 if building from source

### DIFF
--- a/docs/installation/build_from_source.rst
+++ b/docs/installation/build_from_source.rst
@@ -35,7 +35,7 @@ Required dependencies:
    due to `deprecation of Python2 <https://www.python.org/doc/sunset-python-2/>`__);
 -  The `zlib <http://www.zlib.net/>`__ compression library;
 -  `Eigen <http://eigen.tuxfamily.org>`__ version >= 3.2 (>= 3.3 recommended);
--  `Qt <http://www.qt.io/>`__ version >= 5.5 *[GUI components only]*;
+-  `Qt <http://www.qt.io/>`__ version >= 5.5 (but *not* Qt 6) *[GUI components only]*;
 
 and optionally:
 


### PR DESCRIPTION
As discussed recently. 

Support for Qt6 is actively being investigated (#2297), but requires increasing the C++ standard to `c++17`. We'll leave this for `3.1.0`. 