### PR TITLE
Release 3.0.3 (take 2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM buildpack-deps:buster AS base-builder
 FROM base-builder AS mrtrix3-builder
 
 # Git commitish from which to build MRtrix3.
-ARG MRTRIX3_GIT_COMMITISH="master"
+ARG MRTRIX3_GIT_COMMITISH="3.0.3"
 # Command-line arguments for `./configure`
 ARG MRTRIX3_CONFIGURE_FLAGS=""
 # Command-line arguments for `./build`

--- a/Singularity
+++ b/Singularity
@@ -58,7 +58,7 @@ Include: apt
     ln -s /usr/bin/python3 /usr/bin/python
 
 # MRtrix3 setup
-    git clone -b master --depth 1 https://github.com/MRtrix3/mrtrix3.git /opt/mrtrix3
+    git clone -b 3.0.3 --depth 1 https://github.com/MRtrix3/mrtrix3.git /opt/mrtrix3
     cd /opt/mrtrix3 && ./configure && ./build -persistent -nopaginate && rm -rf testing/ tmp/ && cd ../../
 
 # apt cleanup to recover as much space as possible

--- a/core/version.h
+++ b/core/version.h
@@ -9,7 +9,7 @@
 //   git tag -s 3.3.0
 //   git push --follow-tags
 
-#define MRTRIX_BASE_VERSION "3.0.2"
+#define MRTRIX_BASE_VERSION "3.0.3"
 
 #endif
 

--- a/docs/reference/commands/afdconnectivity.rst
+++ b/docs/reference/commands/afdconnectivity.rst
@@ -31,7 +31,7 @@ For valid comparisons of AFD connectivity across scans, images MUST be intensity
 
 Note that the sum of the AFD is normalised by streamline length to account for subject differences in fibre bundle length. This normalisation results in a measure that is more related to the cross-sectional volume of the tract (and therefore 'connectivity'). Note that SIFT-ed tract count is a superior measure because it is unaffected by tangential yet unrelated fibres. However, AFD connectivity may be used as a substitute when Anatomically Constrained Tractography is not possible due to uncorrectable EPI distortions, and SIFT may therefore not be as effective.
 
-Longer discussion regarding this command can additionally be found at: https://mrtrix.readthedocs.io/en/3.0.2/concepts/afd_connectivity.html (as well as in the relevant reference).
+Longer discussion regarding this command can additionally be found at: https://mrtrix.readthedocs.io/en/3.0.3/concepts/afd_connectivity.html (as well as in the relevant reference).
 
 Options
 -------

--- a/docs/reference/commands/amp2sh.rst
+++ b/docs/reference/commands/amp2sh.rst
@@ -26,7 +26,7 @@ The spherical harmonic decomposition is calculated by least-squares linear fitti
 The directions can be defined either as a DW gradient scheme (for example to compute the SH representation of the DW signal), a set of [az el] pairs as output by the dirgen command, or a set of [ x y z ] directions in Cartesian coordinates. The DW gradient scheme or direction set can be supplied within the input image header or using the -gradient or -directions option. Note that if a direction set and DW gradient scheme can be found, the direction set will be used by default.
 
 The spherical harmonic coefficients are stored according the conventions described the main documentation, which can be found at the following link:  |br|
-https://mrtrix.readthedocs.io/en/3.0.2/concepts/spherical_harmonics.html
+https://mrtrix.readthedocs.io/en/3.0.3/concepts/spherical_harmonics.html
 
 Options
 -------

--- a/docs/reference/commands/dwi2fod.rst
+++ b/docs/reference/commands/dwi2fod.rst
@@ -23,7 +23,7 @@ Description
 -----------
 
 The spherical harmonic coefficients are stored according the conventions described the main documentation, which can be found at the following link:  |br|
-https://mrtrix.readthedocs.io/en/3.0.2/concepts/spherical_harmonics.html
+https://mrtrix.readthedocs.io/en/3.0.3/concepts/spherical_harmonics.html
 
 Example usages
 --------------

--- a/docs/reference/commands/fixel2sh.rst
+++ b/docs/reference/commands/fixel2sh.rst
@@ -24,7 +24,7 @@ Description
 This command generates spherical harmonic data from fixels that can be visualised using the ODF tool in MRview. The output ODF lobes are scaled according to the values in the input fixel image.
 
 The spherical harmonic coefficients are stored according the conventions described the main documentation, which can be found at the following link:  |br|
-https://mrtrix.readthedocs.io/en/3.0.2/concepts/spherical_harmonics.html
+https://mrtrix.readthedocs.io/en/3.0.3/concepts/spherical_harmonics.html
 
 Options
 -------

--- a/docs/reference/commands/sh2amp.rst
+++ b/docs/reference/commands/sh2amp.rst
@@ -35,7 +35,7 @@ If a full DW encoding is provided, the number of shells needs to match those fou
 If the input image contains multiple shells (its size along the 5th dimension is greater than one), the program will expect the direction set to contain multiple shells, which can only be provided as a full DW encodings (the last two options in the list above).
 
 The spherical harmonic coefficients are stored according the conventions described the main documentation, which can be found at the following link:  |br|
-https://mrtrix.readthedocs.io/en/3.0.2/concepts/spherical_harmonics.html
+https://mrtrix.readthedocs.io/en/3.0.3/concepts/spherical_harmonics.html
 
 Options
 -------

--- a/docs/reference/commands/sh2peaks.rst
+++ b/docs/reference/commands/sh2peaks.rst
@@ -24,7 +24,7 @@ Description
 Peaks of the spherical harmonic function in each voxel are located by commencing a Newton search along each of a set of pre-specified directions
 
 The spherical harmonic coefficients are stored according the conventions described the main documentation, which can be found at the following link:  |br|
-https://mrtrix.readthedocs.io/en/3.0.2/concepts/spherical_harmonics.html
+https://mrtrix.readthedocs.io/en/3.0.3/concepts/spherical_harmonics.html
 
 Options
 -------

--- a/docs/reference/commands/sh2power.rst
+++ b/docs/reference/commands/sh2power.rst
@@ -24,7 +24,7 @@ Description
 This command computes the sum of squared SH coefficients, which equals the mean-squared amplitude of the spherical function it represents.
 
 The spherical harmonic coefficients are stored according the conventions described the main documentation, which can be found at the following link:  |br|
-https://mrtrix.readthedocs.io/en/3.0.2/concepts/spherical_harmonics.html
+https://mrtrix.readthedocs.io/en/3.0.3/concepts/spherical_harmonics.html
 
 Options
 -------

--- a/docs/reference/commands/sh2response.rst
+++ b/docs/reference/commands/sh2response.rst
@@ -24,7 +24,7 @@ Description
 -----------
 
 The spherical harmonic coefficients are stored according the conventions described the main documentation, which can be found at the following link:  |br|
-https://mrtrix.readthedocs.io/en/3.0.2/concepts/spherical_harmonics.html
+https://mrtrix.readthedocs.io/en/3.0.3/concepts/spherical_harmonics.html
 
 Options
 -------

--- a/docs/reference/commands/shbasis.rst
+++ b/docs/reference/commands/shbasis.rst
@@ -27,7 +27,7 @@ This command provides a mechanism for testing the basis used in storage of image
 Note that the "force_*" conversion choices should only be used in cases where this command has previously been unable to automatically determine the SH basis from the image data, but the user themselves are confident of the SH basis of the data.
 
 The spherical harmonic coefficients are stored according the conventions described the main documentation, which can be found at the following link:  |br|
-https://mrtrix.readthedocs.io/en/3.0.2/concepts/spherical_harmonics.html
+https://mrtrix.readthedocs.io/en/3.0.3/concepts/spherical_harmonics.html
 
 Options
 -------

--- a/docs/reference/commands/shconv.rst
+++ b/docs/reference/commands/shconv.rst
@@ -28,10 +28,10 @@ If multiple pairs of inputs are provided, their contributions will be summed int
 If the responses are multi-shell (with one line of coefficients per shell), the output will be a 5-dimensional image, with the SH coefficients of the signal in each shell stored at different indices along the 5th dimension.
 
 The spherical harmonic coefficients are stored according the conventions described the main documentation, which can be found at the following link:  |br|
-https://mrtrix.readthedocs.io/en/3.0.2/concepts/spherical_harmonics.html
+https://mrtrix.readthedocs.io/en/3.0.3/concepts/spherical_harmonics.html
 
 The spherical harmonic coefficients are stored according the conventions described the main documentation, which can be found at the following link:  |br|
-https://mrtrix.readthedocs.io/en/3.0.2/concepts/spherical_harmonics.html
+https://mrtrix.readthedocs.io/en/3.0.3/concepts/spherical_harmonics.html
 
 Options
 -------


### PR DESCRIPTION
Replacement of #2355.

f89e89c4 replaces e14597c6 by including requisite change to container recipes.

NOT TO BE MERGED; is only to be used for a final CI run.