### PR TITLE
Revert container recipes to pull master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM buildpack-deps:buster AS base-builder
 FROM base-builder AS mrtrix3-builder
 
 # Git commitish from which to build MRtrix3.
-ARG MRTRIX3_GIT_COMMITISH="3.0.3"
+ARG MRTRIX3_GIT_COMMITISH="master"
 # Command-line arguments for `./configure`
 ARG MRTRIX3_CONFIGURE_FLAGS=""
 # Command-line arguments for `./build`

--- a/Singularity
+++ b/Singularity
@@ -58,7 +58,7 @@ Include: apt
     ln -s /usr/bin/python3 /usr/bin/python
 
 # MRtrix3 setup
-    git clone -b 3.0.3 --depth 1 https://github.com/MRtrix3/mrtrix3.git /opt/mrtrix3
+    git clone -b master --depth 1 https://github.com/MRtrix3/mrtrix3.git /opt/mrtrix3
     cd /opt/mrtrix3 && ./configure && ./build -persistent -nopaginate && rm -rf testing/ tmp/ && cd ../../
 
 # apt cleanup to recover as much space as possible


### PR DESCRIPTION
As per comment in #2356.

The theory here is that:

- If someone checks out the code in `3.0.3`, and then builds a container using one of the recipe files, during the building of that container it should download and compile the *MRtrix3* code specifically at tag `3.0.3`, regardless of how `master` may have changed after that point;

- If someone checks out the code in `master`, and then builds a container using one of the recipe files, during the building of that container it should download and compile whatever the *MRtrix3* `master` branch is pointing to at that point in time, regardless of what tags may or may not have been added.
   (Better would be if, during container build, it would check out the *MRtrix3* code at the commit hash corresponding to the code version of the recipe that is dictating the build process; but I have not yet thought about how such could be achieved).