### PR TITLE
New command "mask2glass"

### DIFF
--- a/bin/mask2glass
+++ b/bin/mask2glass
@@ -18,20 +18,22 @@
 import warnings
 
 def usage(cmdline): #pylint: disable=unused-variable
-  from mrtrix3 import app #pylint: disable=no-name-in-module, import-outside-toplevel
   cmdline.set_author('Remika Mito (remika.mito@florey.edu.au) and Robert E. Smith (robert.smith@florey.edu.au)')
   cmdline.set_synopsis('Create a glass brain from mask input')
   cmdline.add_description('The output of this command is a glass brain image, which can be viewed '
-                         'using the volume render option in mrview, and used for visualisation purposes to view results in 3D. '
-                         'This script takes either a binary mask image or floating point image (e.g. a mean mask image computed using mrmath) as input.')
+                          'using the volume render option in mrview, and used for visualisation purposes to view results in 3D.')
+  cmdline.add_description('While the name of this script indicates that a binary mask image is required as input, it can '
+                          'also operate on a floating-point image. One way in which this can be exploited is to compute the mean '
+                          'of all subject masks within template space, in which case this script will produce a smoother result '
+                          'than if a binary template mask were to be used as input.')
   cmdline.add_argument('input', help='The input mask image')
   cmdline.add_argument('output', help='The output glass brain image')
-  cmdline.add_argument('-scale', type=float, default=2.0, help='Provide resolution usscaling value; default = 2.0')
+  cmdline.add_argument('-dilate', type=int, default=2, help='Provide number of passes for dilation step; default = 2')
+  cmdline.add_argument('-scale', type=float, default=2.0, help='Provide resolution upscaling value; default = 2.0')
   cmdline.add_argument('-smooth', type=float, default=1.0, help='Provide standard deviation of smoothing (in mm); default = 1.0')
 
 
 def execute(): #pylint: disable=unused-variable
-  from mrtrix3 import MRtrixError #pylint: disable=no-name-in-module, import-outside-toplevel
   from mrtrix3 import app, image, path, run #pylint: disable=no-name-in-module, import-outside-toplevel
 
   app.check_output_path(app.ARGS.output)
@@ -39,15 +41,24 @@ def execute(): #pylint: disable=unused-variable
   # import data to scratch directory
   app.make_scratch_dir()
   run.command('mrconvert ' + path.from_user(app.ARGS.input) + ' ' + path.to_scratch('in.mif'))
-
-  result_stat = image.statistics('in.mif')
-  if result_stat.min < 0 or result_stat.max > 1:
-      app.warn('Input image is not a binary mask and will be thresholded at 0.5')
-
   app.goto_scratch_dir()
 
+  dilate_option = ' -npass ' + str(app.ARGS.dilate)
   scale_option = ' -scale ' + str(app.ARGS.scale)
   smooth_option = ' -stdev ' + str(app.ARGS.smooth)
+  threshold_option = ' -abs 0.5'
+
+  # check whether threshold should be fixed at 0.5 or computed automatically from the data
+  if image.Header('in.mif').datatype() == 'Bit':
+    app.debug('Input image is bitwise; no need to check image intensities')
+  else:
+    app.debug('Input image is not bitwise; checking distribution of image intensities')
+    result_stat = image.statistics('in.mif')
+    if result_stat.min < 0.0 or result_stat.max > 1.0:
+      app.warn('Input image contains values outside of range [0.0, 1.0]; threshold will not be 0.5, but will instead be determined from the image data')
+      threshold_option = ''
+    else:
+      app.debug('Input image values reside within [0.0, 1.0] range; fixed threshold of 0.5 will be used')
 
   # run scaling step
   run.command('mrgrid in.mif regrid upsampled.mif' + scale_option)
@@ -56,10 +67,10 @@ def execute(): #pylint: disable=unused-variable
   run.command('mrfilter upsampled.mif smooth upsampled_smooth.mif' + smooth_option)
 
   # threshold image
-  run.command('mrthreshold upsampled_smooth.mif -abs 0.5 upsampled_smooth_thresh.mif')
+  run.command('mrthreshold upsampled_smooth.mif upsampled_smooth_thresh.mif' + threshold_option)
 
   # dilate image for subtraction
-  run.command('maskfilter upsampled_smooth_thresh.mif dilate -npass 2 upsampled_smooth_thresh_dilate.mif')
+  run.command('maskfilter upsampled_smooth_thresh.mif dilate upsampled_smooth_thresh_dilate.mif' + dilate_option)
 
   # create border
   run.command('mrcalc upsampled_smooth_thresh_dilate.mif upsampled_smooth_thresh.mif -subtract out.mif')

--- a/bin/mask2glass
+++ b/bin/mask2glass
@@ -16,38 +16,24 @@
 # For more details, see http://www.mrtrix.org/.
 
 
-#SUPPORTED_OPS = ['mean', 'median', 'sum', 'product', 'rms', 'norm', 'var', 'std', 'min', 'max', 'absmax', 'magmax']
-
-
 def usage(cmdline): #pylint: disable=unused-variable
   from mrtrix3 import app #pylint: disable=no-name-in-module, import-outside-toplevel
   cmdline.set_author('Remika Mito (remika.mito@florey.edu.au) and Robert E. Smith (robert.smith@florey.edu.au)')
   cmdline.set_synopsis('Create a glass brain from mask input')
-  cmdline.add_description('The output of this command is a 4D image, where '
-                          'each volume corresponds to a b-value shell (in order of increasing b-value), and '
-                          'the intensities within each volume correspond to the chosen statistic having been computed from across the DWI volumes belonging to that b-value shell.')
+  #cmdline.add_description('The output of this command is a 4D image, where '
+  #                        'each volume corresponds to a b-value shell (in order of increasing b-value), and '
+  #                        'the intensities within each volume correspond to the chosen statistic having been computed from across the DWI volumes belonging to that b-value shell.')
   cmdline.add_argument('input', help='The input mask image')
-  #cmdline.add_argument('operation**', choices=SUPPORTED_OPS, help='The operation to be applied to each shell; this must be one of the following: ' + ', '.join(SUPPORTED_OPS))
   cmdline.add_argument('output', help='The output glass brain image')
   cmdline.add_argument('-scale', type=int, default=2, help='Provide scaling value. Default: 2')
   cmdline.add_argument('-smooth', type=int, default=1, help='Provide smoothing value. Default: 1')
-  cmdline.add_example_usage('To create glass brain image from mask image',
-                            'mask2glass mask.mif glass.mif')
-  #app.add_dwgrad_import_options(cmdline)
 
 
 def execute(): #pylint: disable=unused-variable
   from mrtrix3 import MRtrixError #pylint: disable=no-name-in-module, import-outside-toplevel
   from mrtrix3 import app, image, path, run #pylint: disable=no-name-in-module, import-outside-toplevel
 
-  # check inputs and outputs
   ### something here to check mask; if not convert to mask?? ###
-  # dwi_header = image.Header(path.from_user(app.ARGS.input, False))
-  # if len(dwi_header.size()) != 4:
-  #   raise MRtrixError('Input image must be a 4D image')
-  # gradimport = app.read_dwgrad_import_options()
-  # if not gradimport and 'dw_scheme' not in dwi_header.keyval():
-  #   raise MRtrixError('No diffusion gradient table provided, and none present in image header')
   app.check_output_path(app.ARGS.output)
 
   # import data to scratch directory
@@ -55,14 +41,14 @@ def execute(): #pylint: disable=unused-variable
   run.command('mrconvert ' + path.from_user(app.ARGS.input) + ' ' + path.to_scratch('in.mif') + ' -datatype bit')
   app.goto_scratch_dir()
 
-  scale_option = '-scale ' + str(app.ARGS.scale)
+  scale_option = ' -scale ' + str(app.ARGS.scale)
   smooth_option = ' -stdev ' + str(app.ARGS.smooth)
 
   # run scaling step
-  run.command('mrgrid ' + 'in.mif ' + 'regrid ' + scale_option + ' upsampled.mif')
+  run.command('mrgrid in.mif regrid upsampled.mif' + scale_option)
 
   # run upsampling step
-  run.command('mrfilter ' + 'upsampled.mif smooth' + smooth_option + ' upsampled_smooth.mif')
+  run.command('mrfilter upsampled.mif smooth upsampled_smooth.mif' + smooth_option)
 
   # threshold image
   run.command('mrthreshold upsampled_smooth.mif -abs 0.5 upsampled_smooth_thresh.mif')
@@ -74,7 +60,9 @@ def execute(): #pylint: disable=unused-variable
   run.command('mrcalc upsampled_smooth_thresh_dilate.mif upsampled_smooth_thresh.mif -subtract out.mif')
 
   # create output image
-  run.command('mrconvert out.mif ' + path.from_user(app.ARGS.output), mrconvert_keyval=path.from_user(app.ARGS.input, False), force=app.FORCE_OVERWRITE)
+  run.command('mrconvert out.mif ' + path.from_user(app.ARGS.output),
+              mrconvert_keyval=path.from_user(app.ARGS.input, False),
+              force=app.FORCE_OVERWRITE)
 
 # Execute the script
 import mrtrix3 #pylint: disable=wrong-import-position

--- a/bin/mask2glass
+++ b/bin/mask2glass
@@ -25,8 +25,8 @@ def usage(cmdline): #pylint: disable=unused-variable
   #                        'the intensities within each volume correspond to the chosen statistic having been computed from across the DWI volumes belonging to that b-value shell.')
   cmdline.add_argument('input', help='The input mask image')
   cmdline.add_argument('output', help='The output glass brain image')
-  cmdline.add_argument('-scale', type=int, default=2, help='Provide scaling value. Default: 2')
-  cmdline.add_argument('-smooth', type=int, default=1, help='Provide smoothing value. Default: 1')
+  cmdline.add_argument('-scale', type=float, default=2.0, help='Provide resolution usscaling value; default = 2.0')
+  cmdline.add_argument('-smooth', type=float, default=1.0, help='Provide standard deviation of smoothing (in mm); default = 1.0')
 
 
 def execute(): #pylint: disable=unused-variable

--- a/bin/mask2glass
+++ b/bin/mask2glass
@@ -16,54 +16,65 @@
 # For more details, see http://www.mrtrix.org/.
 
 
-SUPPORTED_OPS = ['mean', 'median', 'sum', 'product', 'rms', 'norm', 'var', 'std', 'min', 'max', 'absmax', 'magmax']
+#SUPPORTED_OPS = ['mean', 'median', 'sum', 'product', 'rms', 'norm', 'var', 'std', 'min', 'max', 'absmax', 'magmax']
 
 
 def usage(cmdline): #pylint: disable=unused-variable
   from mrtrix3 import app #pylint: disable=no-name-in-module, import-outside-toplevel
-  cmdline.set_author('Daan Christiaens (daan.christiaens@kcl.ac.uk)')
-  cmdline.set_synopsis('Apply an mrmath operation to each b-value shell in a DWI series')
+  cmdline.set_author('Remika Mito (remika.mito@florey.edu.au) and Robert E. Smith (robert.smith@florey.edu.au)')
+  cmdline.set_synopsis('Create a glass brain from mask input')
   cmdline.add_description('The output of this command is a 4D image, where '
                           'each volume corresponds to a b-value shell (in order of increasing b-value), and '
                           'the intensities within each volume correspond to the chosen statistic having been computed from across the DWI volumes belonging to that b-value shell.')
-  cmdline.add_argument('input', help='The input diffusion MRI series')
-  cmdline.add_argument('operation', choices=SUPPORTED_OPS, help='The operation to be applied to each shell; this must be one of the following: ' + ', '.join(SUPPORTED_OPS))
-  cmdline.add_argument('output', help='The output image series')
-  cmdline.add_example_usage('To compute the mean diffusion-weighted signal in each b-value shell',
-                            'dwishellmath dwi.mif mean shellmeans.mif')
-  app.add_dwgrad_import_options(cmdline)
+  cmdline.add_argument('input', help='The input mask image')
+  #cmdline.add_argument('operation**', choices=SUPPORTED_OPS, help='The operation to be applied to each shell; this must be one of the following: ' + ', '.join(SUPPORTED_OPS))
+  cmdline.add_argument('output', help='The output glass brain image')
+  cmdline.add_argument('-scale', type=int, default=2, help='Provide scaling value. Default: 2')
+  cmdline.add_argument('-smooth', type=int, default=1, help='Provide smoothing value. Default: 1')
+  cmdline.add_example_usage('To create glass brain image from mask image',
+                            'mask2glass mask.mif glass.mif')
+  #app.add_dwgrad_import_options(cmdline)
 
 
 def execute(): #pylint: disable=unused-variable
   from mrtrix3 import MRtrixError #pylint: disable=no-name-in-module, import-outside-toplevel
   from mrtrix3 import app, image, path, run #pylint: disable=no-name-in-module, import-outside-toplevel
-  # check inputs and outputs
-  dwi_header = image.Header(path.from_user(app.ARGS.input, False))
-  if len(dwi_header.size()) != 4:
-    raise MRtrixError('Input image must be a 4D image')
-  gradimport = app.read_dwgrad_import_options()
-  if not gradimport and 'dw_scheme' not in dwi_header.keyval():
-    raise MRtrixError('No diffusion gradient table provided, and none present in image header')
-  app.check_output_path(app.ARGS.output)
-  # import data and gradient table
-  app.make_scratch_dir()
-  run.command('mrconvert ' + path.from_user(app.ARGS.input) + ' ' + path.to_scratch('in.mif') + gradimport + ' -strides 0,0,0,1')
-  app.goto_scratch_dir()
-  # run per-shell operations
-  files = []
-  for index, bvalue in enumerate(image.mrinfo('in.mif', 'shell_bvalues').split()):
-    filename = 'shell-{:02d}.mif'.format(index)
-    run.command('dwiextract -shells ' + bvalue + ' in.mif - | mrmath -axis 3 - ' + app.ARGS.operation + ' ' + filename)
-    files.append(filename)
-  if len(files) > 1:
-    # concatenate to output file
-    run.command('mrcat -axis 3 ' + ' '.join(files) + ' out.mif')
-    run.command('mrconvert out.mif ' + path.from_user(app.ARGS.output), mrconvert_keyval=path.from_user(app.ARGS.input, False), force=app.FORCE_OVERWRITE)
-  else:
-    # make a 4D image with one volume
-    app.warn('Only one unique b-value present in DWI data; command mrmath with -axis 3 option may be preferable')
-    run.command('mrconvert ' + files[0] + ' ' + path.from_user(app.ARGS.output) + ' -axes 0,1,2,-1', mrconvert_keyval=path.from_user(app.ARGS.input, False), force=app.FORCE_OVERWRITE)
 
+  # check inputs and outputs
+  ### something here to check mask; if not convert to mask?? ###
+  # dwi_header = image.Header(path.from_user(app.ARGS.input, False))
+  # if len(dwi_header.size()) != 4:
+  #   raise MRtrixError('Input image must be a 4D image')
+  # gradimport = app.read_dwgrad_import_options()
+  # if not gradimport and 'dw_scheme' not in dwi_header.keyval():
+  #   raise MRtrixError('No diffusion gradient table provided, and none present in image header')
+  app.check_output_path(app.ARGS.output)
+
+  # import data to scratch directory
+  app.make_scratch_dir()
+  run.command('mrconvert ' + path.from_user(app.ARGS.input) + ' ' + path.to_scratch('in.mif') + ' -datatype bit')
+  app.goto_scratch_dir()
+
+  scale_option = '-scale ' + str(app.ARGS.scale)
+  smooth_option = ' -stdev ' + str(app.ARGS.smooth)
+
+  # run scaling step
+  run.command('mrgrid ' + 'in.mif ' + 'regrid ' + scale_option + ' upsampled.mif')
+
+  # run upsampling step
+  run.command('mrfilter ' + 'upsampled.mif smooth' + smooth_option + ' upsampled_smooth.mif')
+
+  # threshold image
+  run.command('mrthreshold upsampled_smooth.mif -abs 0.5 upsampled_smooth_thresh.mif')
+
+  # dilate image for subtraction
+  run.command('maskfilter upsampled_smooth_thresh.mif dilate -npass 2 upsampled_smooth_thresh_dilate.mif')
+
+  # create border
+  run.command('mrcalc upsampled_smooth_thresh_dilate.mif upsampled_smooth_thresh.mif -subtract out.mif')
+
+  # create output image
+  run.command('mrconvert out.mif ' + path.from_user(app.ARGS.output), mrconvert_keyval=path.from_user(app.ARGS.input, False), force=app.FORCE_OVERWRITE)
 
 # Execute the script
 import mrtrix3 #pylint: disable=wrong-import-position

--- a/bin/mask2glass
+++ b/bin/mask2glass
@@ -15,8 +15,6 @@
 #
 # For more details, see http://www.mrtrix.org/.
 
-import warnings
-
 def usage(cmdline): #pylint: disable=unused-variable
   cmdline.set_author('Remika Mito (remika.mito@florey.edu.au) and Robert E. Smith (robert.smith@florey.edu.au)')
   cmdline.set_synopsis('Create a glass brain from mask input')

--- a/bin/mask2glass
+++ b/bin/mask2glass
@@ -52,16 +52,16 @@ def execute(): #pylint: disable=unused-variable
   else:
     app.debug('Input image is not bitwise; checking distribution of image intensities')
     result_stat = image.statistics('in.mif')
-    if result_stat.min < 0.0 or result_stat.max > 1.0:
+    if not (result_stat.min == 0.0 and result_stat.max == 1.0):
       app.warn('Input image contains values outside of range [0.0, 1.0]; threshold will not be 0.5, but will instead be determined from the image data')
       threshold_option = ''
     else:
       app.debug('Input image values reside within [0.0, 1.0] range; fixed threshold of 0.5 will be used')
 
-  # run scaling step
+  # run upscaling step
   run.command('mrgrid in.mif regrid upsampled.mif' + scale_option)
 
-  # run upsampling step
+  # run smoothing step
   run.command('mrfilter upsampled.mif smooth upsampled_smooth.mif' + smooth_option)
 
   # threshold image
@@ -71,7 +71,7 @@ def execute(): #pylint: disable=unused-variable
   run.command('maskfilter upsampled_smooth_thresh.mif dilate upsampled_smooth_thresh_dilate.mif' + dilate_option)
 
   # create border
-  run.command('mrcalc upsampled_smooth_thresh_dilate.mif upsampled_smooth_thresh.mif -subtract out.mif')
+  run.command('mrcalc upsampled_smooth_thresh_dilate.mif upsampled_smooth_thresh.mif -xor out.mif -datatype bit')
 
   # create output image
   run.command('mrconvert out.mif ' + path.from_user(app.ARGS.output),

--- a/bin/mask2glass
+++ b/bin/mask2glass
@@ -15,14 +15,15 @@
 #
 # For more details, see http://www.mrtrix.org/.
 
+import warnings
 
 def usage(cmdline): #pylint: disable=unused-variable
   from mrtrix3 import app #pylint: disable=no-name-in-module, import-outside-toplevel
   cmdline.set_author('Remika Mito (remika.mito@florey.edu.au) and Robert E. Smith (robert.smith@florey.edu.au)')
   cmdline.set_synopsis('Create a glass brain from mask input')
-  #cmdline.add_description('The output of this command is a 4D image, where '
-  #                        'each volume corresponds to a b-value shell (in order of increasing b-value), and '
-  #                        'the intensities within each volume correspond to the chosen statistic having been computed from across the DWI volumes belonging to that b-value shell.')
+  cmdline.add_description('The output of this command is a glass brain image, which can be viewed '
+                         'using the volume render option in mrview, and used for visualisation purposes to view results in 3D. '
+                         'This script takes either a binary mask image or floating point image (e.g. a mean mask image computed using mrmath) as input.')
   cmdline.add_argument('input', help='The input mask image')
   cmdline.add_argument('output', help='The output glass brain image')
   cmdline.add_argument('-scale', type=float, default=2.0, help='Provide resolution usscaling value; default = 2.0')
@@ -33,12 +34,16 @@ def execute(): #pylint: disable=unused-variable
   from mrtrix3 import MRtrixError #pylint: disable=no-name-in-module, import-outside-toplevel
   from mrtrix3 import app, image, path, run #pylint: disable=no-name-in-module, import-outside-toplevel
 
-  ### something here to check mask; if not convert to mask?? ###
   app.check_output_path(app.ARGS.output)
 
   # import data to scratch directory
   app.make_scratch_dir()
-  run.command('mrconvert ' + path.from_user(app.ARGS.input) + ' ' + path.to_scratch('in.mif') + ' -datatype bit')
+  run.command('mrconvert ' + path.from_user(app.ARGS.input) + ' ' + path.to_scratch('in.mif'))
+
+  result_stat = image.statistics('in.mif')
+  if result_stat.min < 0 or result_stat.max > 1:
+      app.warn('Input image is not a binary mask and will be thresholded at 0.5')
+
   app.goto_scratch_dir()
 
   scale_option = ' -scale ' + str(app.ARGS.scale)

--- a/bin/mask2glass
+++ b/bin/mask2glass
@@ -1,0 +1,70 @@
+#!/usr/bin/python3
+
+# Copyright (c) 2008-2021 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
+
+SUPPORTED_OPS = ['mean', 'median', 'sum', 'product', 'rms', 'norm', 'var', 'std', 'min', 'max', 'absmax', 'magmax']
+
+
+def usage(cmdline): #pylint: disable=unused-variable
+  from mrtrix3 import app #pylint: disable=no-name-in-module, import-outside-toplevel
+  cmdline.set_author('Daan Christiaens (daan.christiaens@kcl.ac.uk)')
+  cmdline.set_synopsis('Apply an mrmath operation to each b-value shell in a DWI series')
+  cmdline.add_description('The output of this command is a 4D image, where '
+                          'each volume corresponds to a b-value shell (in order of increasing b-value), and '
+                          'the intensities within each volume correspond to the chosen statistic having been computed from across the DWI volumes belonging to that b-value shell.')
+  cmdline.add_argument('input', help='The input diffusion MRI series')
+  cmdline.add_argument('operation', choices=SUPPORTED_OPS, help='The operation to be applied to each shell; this must be one of the following: ' + ', '.join(SUPPORTED_OPS))
+  cmdline.add_argument('output', help='The output image series')
+  cmdline.add_example_usage('To compute the mean diffusion-weighted signal in each b-value shell',
+                            'dwishellmath dwi.mif mean shellmeans.mif')
+  app.add_dwgrad_import_options(cmdline)
+
+
+def execute(): #pylint: disable=unused-variable
+  from mrtrix3 import MRtrixError #pylint: disable=no-name-in-module, import-outside-toplevel
+  from mrtrix3 import app, image, path, run #pylint: disable=no-name-in-module, import-outside-toplevel
+  # check inputs and outputs
+  dwi_header = image.Header(path.from_user(app.ARGS.input, False))
+  if len(dwi_header.size()) != 4:
+    raise MRtrixError('Input image must be a 4D image')
+  gradimport = app.read_dwgrad_import_options()
+  if not gradimport and 'dw_scheme' not in dwi_header.keyval():
+    raise MRtrixError('No diffusion gradient table provided, and none present in image header')
+  app.check_output_path(app.ARGS.output)
+  # import data and gradient table
+  app.make_scratch_dir()
+  run.command('mrconvert ' + path.from_user(app.ARGS.input) + ' ' + path.to_scratch('in.mif') + gradimport + ' -strides 0,0,0,1')
+  app.goto_scratch_dir()
+  # run per-shell operations
+  files = []
+  for index, bvalue in enumerate(image.mrinfo('in.mif', 'shell_bvalues').split()):
+    filename = 'shell-{:02d}.mif'.format(index)
+    run.command('dwiextract -shells ' + bvalue + ' in.mif - | mrmath -axis 3 - ' + app.ARGS.operation + ' ' + filename)
+    files.append(filename)
+  if len(files) > 1:
+    # concatenate to output file
+    run.command('mrcat -axis 3 ' + ' '.join(files) + ' out.mif')
+    run.command('mrconvert out.mif ' + path.from_user(app.ARGS.output), mrconvert_keyval=path.from_user(app.ARGS.input, False), force=app.FORCE_OVERWRITE)
+  else:
+    # make a 4D image with one volume
+    app.warn('Only one unique b-value present in DWI data; command mrmath with -axis 3 option may be preferable')
+    run.command('mrconvert ' + files[0] + ' ' + path.from_user(app.ARGS.output) + ' -axes 0,1,2,-1', mrconvert_keyval=path.from_user(app.ARGS.input, False), force=app.FORCE_OVERWRITE)
+
+
+# Execute the script
+import mrtrix3 #pylint: disable=wrong-import-position
+mrtrix3.execute() #pylint: disable=no-member

--- a/docs/reference/commands/mask2glass.rst
+++ b/docs/reference/commands/mask2glass.rst
@@ -1,0 +1,90 @@
+.. _mask2glass:
+
+mask2glass
+==========
+
+Synopsis
+--------
+
+Create a glass brain from mask input
+
+Usage
+-----
+
+::
+
+    mask2glass input output [ options ]
+
+-  *input*: The input mask image
+-  *output*: The output glass brain image
+
+Description
+-----------
+
+The output of this command is a glass brain image, which can be viewed using the volume render option in mrview, and used for visualisation purposes to view results in 3D.
+
+While the name of this script indicates that a binary mask image is required as input, it can also operate on a floating-point image. One way in which this can be exploited is to compute the mean of all subject masks within template space, in which case this script will produce a smoother result than if a binary template mask were to be used as input.
+
+Options
+-------
+
+- **-dilate** Provide number of passes for dilation step; default = 2
+
+- **-scale** Provide resolution upscaling value; default = 2.0
+
+- **-smooth** Provide standard deviation of smoothing (in mm); default = 1.0
+
+Additional standard options for Python scripts
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- **-nocleanup** do not delete intermediate files during script execution, and do not delete scratch directory at script completion.
+
+- **-scratch /path/to/scratch/** manually specify the path in which to generate the scratch directory.
+
+- **-continue <ScratchDir> <LastFile>** continue the script from a previous execution; must provide the scratch directory path, and the name of the last successfully-generated file.
+
+Standard options
+^^^^^^^^^^^^^^^^
+
+- **-info** display information messages.
+
+- **-quiet** do not display information messages or progress status. Alternatively, this can be achieved by setting the MRTRIX_QUIET environment variable to a non-empty string.
+
+- **-debug** display debugging messages.
+
+- **-force** force overwrite of output files.
+
+- **-nthreads number** use this number of threads in multi-threaded applications (set to 0 to disable multi-threading).
+
+- **-config key value**  *(multiple uses permitted)* temporarily set the value of an MRtrix config file entry.
+
+- **-help** display this information page and exit.
+
+- **-version** display version information and exit.
+
+References
+^^^^^^^^^^
+
+Tournier, J.-D.; Smith, R. E.; Raffelt, D.; Tabbara, R.; Dhollander, T.; Pietsch, M.; Christiaens, D.; Jeurissen, B.; Yeh, C.-H. & Connelly, A. MRtrix3: A fast, flexible and open software framework for medical image processing and visualisation. NeuroImage, 2019, 202, 116137
+
+--------------
+
+
+
+**Author:** Remika Mito (remika.mito@florey.edu.au) and Robert E. Smith (robert.smith@florey.edu.au)
+
+**Copyright:** Copyright (c) 2008-2021 the MRtrix3 contributors.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Covered Software is provided under this License on an "as is"
+basis, without warranty of any kind, either expressed, implied, or
+statutory, including, without limitation, warranties that the
+Covered Software is free of defects, merchantable, fit for a
+particular purpose or non-infringing.
+See the Mozilla Public License v. 2.0 for more details.
+
+For more details, see http://www.mrtrix.org/.
+

--- a/docs/reference/commands_list.rst
+++ b/docs/reference/commands_list.rst
@@ -62,6 +62,7 @@ List of MRtrix3 commands
     commands/labelconvert
     commands/labelsgmfix
     commands/labelstats
+    commands/mask2glass
     commands/maskdump
     commands/maskfilter
     commands/mesh2voxel
@@ -192,6 +193,7 @@ List of MRtrix3 commands
     |cpp.png|, :ref:`labelconvert`, "Convert a connectome node image from one lookup table to another"
     |python.png|, :ref:`labelsgmfix`, "In a FreeSurfer parcellation image, replace the sub-cortical grey matter structure delineations using FSL FIRST"
     |cpp.png|, :ref:`labelstats`, "Compute statistics of parcels within a label image"
+    |python.png|, :ref:`mask2glass`, "Create a glass brain from mask input"
     |cpp.png|, :ref:`maskdump`, "Print out the locations of all non-zero voxels in a mask image"
     |cpp.png|, :ref:`maskfilter`, "Perform filtering operations on 3D / 4D mask images"
     |cpp.png|, :ref:`mesh2voxel`, "Convert a mesh surface to a partial volume estimation image"


### PR DESCRIPTION
New command "mask2glass" written, which automatically generates a "glass brain" image for visualisation purposes, using a mask image as input. This visualisation technique has been used in publications using fixel-based analysis, and has been requested from members to apply to their own independent research.  