### PR TITLE
dwifslpreproc: strip DW encoding from padding slice

### DIFF
--- a/bin/dwifslpreproc
+++ b/bin/dwifslpreproc
@@ -768,7 +768,7 @@ def execute(): #pylint: disable=unused-variable
           app.cleanup(se_epi_path)
           se_epi_path = new_se_epi_path
           new_dwi_path = os.path.splitext(dwi_path)[0] + '_pad' + str(axis) + '.mif'
-          run.command('mrconvert ' + dwi_path + ' -coord ' + str(axis) + ' ' + str(axis_size-1) + ' - | mrcat ' + dwi_path + ' - ' + new_dwi_path + ' -axis ' + str(axis))
+          run.command('mrconvert ' + dwi_path + ' -coord ' + str(axis) + ' ' + str(axis_size-1) + ' -clear dw_scheme - | mrcat ' + dwi_path + ' - ' + new_dwi_path + ' -axis ' + str(axis))
           app.cleanup(dwi_path)
           dwi_path = new_dwi_path
           dwi_post_eddy_crop_option += ' -coord ' + str(axis) + ' 0:' + str(axis_size-1)


### PR DESCRIPTION
As discussed on the forum: https://community.mrtrix.org/t/dwifslpreproc-error-somewhere-after-the-topup-process/5248/4

This is to avoid potential mismatch with the original DWI series in the subsequent mrcat call, which can result in the DW scheme being labelled as 'variable' and removed altogether. This will fix that specific issue in `dwifslpreproc`, and should be merged to `master` ASAP given there's now been several reports of this particular problem.

In due course, we'll need to discuss what the correct behaviour ought to be here. It doesn't seem right for a slight mismatch to lead to an actual loss of information. I would also be keen to find a _general_ solution, rather than just patch up this specific use case. I think that'll need a separate discussion though...