### PR TITLE
Documentation (Fixels and Dixels): double negative typo

### DIFF
--- a/docs/concepts/fixels_dixels.rst
+++ b/docs/concepts/fixels_dixels.rst
@@ -45,7 +45,7 @@ voxel, can be considered as estimating fixels. However in the past,
 researchers have resorted either to lengthy descriptive labels in an
 attempt to express the nature of the data being manipulated, or have
 adopted existing terms, which can lead to confusion with the original sense of
-the terms. Furthermore, these labels are not applied inconsistently
+the terms. Furthermore, these labels are not applied consistently
 between publications; we hope that the term 'fixel', being unambiguous with
 other interpretations of "fibre bundle" or "fascicle" or other examples,
 will slowly become the standard term for describing these data.


### PR DESCRIPTION
Tiny fix affecting [Fixel docs page ](https://mrtrix.readthedocs.io/en/latest/concepts/fixels_dixels.html)

Based on previous versions of this file I'm assuming this double negative snuck in by accident. Could also be rewritten as _"are ~not~ applied inconsistently"_

Sidenote, I figured it would be overkill to open an issue about this, but do let me know if that would have been preferred. The contributing [guidelines](https://github.com/MRtrix3/mrtrix3/blob/master/CONTRIBUTING.md) are somewhat vague when it comes to documentation, and since the `doc` branch hasn't been updated in two years, I went with `master` as base.
