### PR TITLE
minimal set of changes to pass pylint 2.11.1 tests

### DIFF
--- a/bin/blend
+++ b/bin/blend
@@ -15,6 +15,9 @@
 #
 # For more details, see http://www.mrtrix.org/.
 
+# note: deal with these warnings properly when we drop support for Python 2:
+# pylint: disable=consider-using-f-string
+
 import os
 import sys
 

--- a/bin/convert_bruker
+++ b/bin/convert_bruker
@@ -15,6 +15,9 @@
 #
 # For more details, see http://www.mrtrix.org/.
 
+# note: deal with these warnings properly when we drop support for Python 2:
+# pylint: disable=unspecified-encoding
+
 import sys, os.path
 
 if len (sys.argv) != 3:

--- a/bin/dwicat
+++ b/bin/dwicat
@@ -15,6 +15,9 @@
 #
 # For more details, see http://www.mrtrix.org/.
 
+# note: deal with these warnings properly when we drop support for Python 2:
+# pylint: disable=unspecified-encoding
+
 
 
 import json, shutil

--- a/bin/dwifslpreproc
+++ b/bin/dwifslpreproc
@@ -17,6 +17,9 @@
 
 # Script for performing DWI pre-processing using FSL 5.0 (onwards) tools eddy / topup / applytopup
 
+# note: deal with these warnings properly when we drop support for Python 2:
+# pylint: disable=unspecified-encoding
+
 
 
 import itertools, json, math, os, shutil, sys

--- a/bin/dwigradcheck
+++ b/bin/dwigradcheck
@@ -15,6 +15,9 @@
 #
 # For more details, see http://www.mrtrix.org/.
 
+# note: deal with these warnings properly when we drop support for Python 2:
+# pylint: disable=unspecified-encoding,consider-using-f-string
+
 import copy, numbers, os, shutil, sys
 
 

--- a/bin/dwishellmath
+++ b/bin/dwishellmath
@@ -15,6 +15,9 @@
 #
 # For more details, see http://www.mrtrix.org/.
 
+# note: deal with these warnings properly when we drop support for Python 2:
+# pylint: disable=consider-using-f-string
+
 
 SUPPORTED_OPS = ['mean', 'median', 'sum', 'product', 'rms', 'norm', 'var', 'std', 'min', 'max', 'absmax', 'magmax']
 

--- a/bin/for_each
+++ b/bin/for_each
@@ -106,7 +106,6 @@ KEYLIST = [ 'IN', 'NAME', 'PRE', 'UNI' ]
 def execute(): #pylint: disable=unused-variable
   from mrtrix3 import ANSI, MRtrixError #pylint: disable=no-name-in-module, import-outside-toplevel
   from mrtrix3 import app, run #pylint: disable=no-name-in-module, import-outside-toplevel
-  global CMDSPLIT
 
   inputs = app.ARGS.inputs
   app.debug('All inputs: ' + str(inputs))
@@ -215,7 +214,6 @@ def execute(): #pylint: disable=unused-variable
   progress = app.ProgressBar(progress_string(), len(jobs))
 
   def execute_parallel():
-    global shared #pylint: disable=invalid-name
     while not shared.stop:
       my_job = shared.next(jobs)
       if not my_job:

--- a/bin/labelsgmfix
+++ b/bin/labelsgmfix
@@ -24,6 +24,9 @@
 #   derived from FIRST.
 
 
+# note: deal with these warnings properly when we drop support for Python 2:
+# pylint: disable=unspecified-encoding
+
 
 import math, os
 

--- a/bin/mrtrix_cleanup
+++ b/bin/mrtrix_cleanup
@@ -15,6 +15,9 @@
 #
 # For more details, see http://www.mrtrix.org/.
 
+# note: deal with these warnings properly when we drop support for Python 2:
+# pylint: disable=unspecified-encoding
+
 
 import math, os, re, shutil
 

--- a/bin/population_template
+++ b/bin/population_template
@@ -17,6 +17,9 @@
 
 # Generates an unbiased group-average template via image registration of images to a midway space.
 
+# note: deal with these warnings properly when we drop support for Python 2:
+# pylint: disable=unspecified-encoding,consider-using-f-string
+
 import json, math, os, re, shutil, sys
 
 DEFAULT_RIGID_SCALES  = [0.3,0.4,0.6,0.8,1.0,1.0]
@@ -477,7 +480,7 @@ def parse_input_files(in_files, mask_files, contrasts, f_agg_weight=None, whites
   inputs = []
   def paths_to_file_uids(paths, prefix, postfix):
     """ strip pre and postfix from filename, replace whitespace characters """
-    uid_path = dict()
+    uid_path = {}
     uids = []
     for path in paths:
       uid = re.sub(re.escape(postfix)+'$', '', re.sub('^'+re.escape(prefix), '', os.path.split(path)[1]))

--- a/build
+++ b/build
@@ -17,6 +17,9 @@
 
 # pylint: disable=redefined-outer-name,invalid-name
 
+# note: deal with these warnings properly when we drop support for Python 2:
+# pylint: disable=unspecified-encoding,consider-using-dict-items,unused-variable,consider-using-f-string
+
 usage_string = '''
 USAGE
 
@@ -193,7 +196,6 @@ def colorize(s):
 
 
 def pipe_errors_to_less_handler():
-  global error_stream
   if error_stream:
     with tempfile.NamedTemporaryFile() as tf:
       tf.write (colorize(error_stream).encode (errors='ignore'))
@@ -533,7 +535,8 @@ cpp = cpp_flags = ld = ld_flags = ld_lib = ld_lib_flags = eigen_cflags = qt_cfla
 
 try:
   log ('reading configuration from "' + config_file + '"...' + os.linesep)
-  exec (codecs.open (config_file, mode='r', encoding='utf-8').read()) # pylint: disable=exec-used
+  with codecs.open (config_file, mode='r', encoding='utf-8') as f:
+    exec (f.read()) # pylint: disable=exec-used
 except IOError:
   fail ('''no configuration file found!
 please run "./configure" prior to invoking this script
@@ -685,7 +688,6 @@ class TargetException (Exception):
 
 class Entry(object):
   def __init__ (self, name):
-    global todo
     name = os.path.normpath (name)
     if name in todo:
       return
@@ -990,7 +992,6 @@ def is_GUI_target (current_file):
 
 
 def list_headers (current_file):
-  global headers, file_flags
   current_file = os.path.normpath (current_file)
 
   if current_file not in headers.keys():
@@ -1039,7 +1040,6 @@ def list_headers (current_file):
 
 
 def list_cmd_deps (file_cc):
-  global object_deps, file_flags
   file_cc = os.path.normpath (file_cc)
 
   if file_cc not in object_deps.keys():
@@ -1078,7 +1078,7 @@ def list_lib_deps ():
 
 
 def build_next ():
-  global todo, lock, stop, main_cindex
+  global stop, main_cindex
   total_count = len(todo)
   cindex = 0
   formatstr = '({:>'+str(len(str(total_count)))+'}/'+str(total_count)+') [{}] {}'

--- a/configure
+++ b/configure
@@ -17,6 +17,9 @@
 
 # pylint: disable=invalid-name
 
+# note: deal with these warnings properly when we drop support for Python 2:
+# pylint: disable=unspecified-encoding,consider-using-dict-items,unused-variable,consider-iterating-dictionary
+
 usage_string = '''
 USAGE
 
@@ -235,21 +238,19 @@ config_report = ''
 
 
 def log (message):
-  global logfile
   logfile.write (message.encode (errors='ignore'))
   if verbose:
     sys.stdout.write (message)
     sys.stdout.flush()
 
 def report (message):
-  global config_report, logfile
+  global config_report
   config_report += message
   sys.stdout.write (message)
   sys.stdout.flush()
   logfile.write (('\nREPORT: ' + message.rstrip() + '\n').encode (errors='ignore'))
 
 def error (message):
-  global logfile
   logfile.write (('\nERROR: ' + message.rstrip() + '\n\n').encode (errors='ignore'))
   sys.stdout.write ('\nERROR: ' + message.rstrip() + '\n\n')
   sys.stdout.flush()
@@ -335,8 +336,8 @@ class TempFile(object):
   def __exit__(self, exception_type, value, traceback):
     try:
       os.unlink (self.name)
-    except OSError as excp:
-      log ('error deleting temporary file "' + self.name + '": ' + excp.strerror)
+    except OSError as excp_local:
+      log ('error deleting temporary file "' + self.name + '": ' + excp_local.strerror)
 
 
 
@@ -350,8 +351,8 @@ class DeleteAfter(object):
   def __exit__(self, exception_type, value, traceback):
     try:
       os.unlink (self.name)
-    except OSError as excp:
-      log ('error deleting temporary file "' + self.name + '": ' + excp.strerror)
+    except OSError as excp_local:
+      log ('error deleting temporary file "' + self.name + '": ' + excp_local.strerror)
 
 
 class TempDir(object):
@@ -371,8 +372,8 @@ class TempDir(object):
           os.unlink (fullpath)
       os.rmdir (self.name)
 
-    except OSError as excp:
-      log ('error deleting temporary folder "' + self.name + '": ' + excp.strerror)
+    except OSError as excp_local:
+      log ('error deleting temporary folder "' + self.name + '": ' + excp_local.strerror)
 
 
 
@@ -509,11 +510,11 @@ def execute (cmd, exception, raise_on_non_zero_exit_code = True, cwd = None):
       log ('STDERR:\n' + stderr + '\n')
     log ('>>\n\n')
 
-  except OSError as e:
-    log ('error invoking command "' + cmd[0] + '": ' + e.strerror + '\n>>\n\n')
+  except OSError as excp_local:
+    log ('error invoking command "' + cmd[0] + '": ' + excp_local.strerror + '\n>>\n\n')
     raise exception
-  except Exception as excp:
-    error ('unexpected exception of type ' + type(excp).__name__ + ': ' + str(excp) +  configure_log_hint)
+  except Exception as excp_local:
+    error ('unexpected exception of type ' + type(excp_local).__name__ + ': ' + str(excp_local) +  configure_log_hint)
   else:
     if raise_on_non_zero_exit_code and process.returncode != 0:
       raise exception (stderr)
@@ -524,7 +525,6 @@ def execute (cmd, exception, raise_on_non_zero_exit_code = True, cwd = None):
 
 
 def compile (source, compiler_flags, linker_flags): # pylint: disable=redefined-builtin
-  global cpp, ld
   with TempFile ('.cpp') as srcfile:
     log ('\nCOMPILE ' + srcfile.name + ':\n---\n' + source + '\n---\n')
     srcfile.fid.write (source)
@@ -655,8 +655,8 @@ def compile_check (full_name, name, cflags, ldflags, code, cflags_env=None, cfla
     error ('''runtime error!
 
    Unable to configure ''' + name + configure_log_hint)
-  except Exception as excp:
-    error ('unexpected exception of type ' + type(excp).__name__ + ': ' + str(excp) +  configure_log_hint)
+  except Exception as excp_local:
+    error ('unexpected exception of type ' + type(excp_local).__name__ + ': ' + str(excp_local) +  configure_log_hint)
 
 
 
@@ -1286,18 +1286,19 @@ int main() { Foo f; }
       for qt_makefile in [ 'Makefile', 'Makefile.Release' ]:
         try:
           log ("reading Qt parameters from file '" + qt_makefile + "'... ")
-          for line in open (os.path.join (qt_dir.name, qt_makefile)):
-            line = line.strip()
-            if line.startswith ('DEFINES'):
-              qt_defines = shlex.split (line[line.find('=')+1:].strip())
-            elif line.startswith ('CXXFLAGS'):
-              qt_cflags = shlex.split (line[line.find('=')+1:].strip())
-            elif line.startswith ('INCPATH'):
-              qt_includes = shlex.split (line[line.find('=')+1:].strip())
-            elif line.startswith ('LIBS'):
-              qt_libs = shlex.split (line[line.find('=')+1:].strip())
-            elif line.startswith ('LFLAGS'):
-              qt_ldflags = shlex.split (line[line.find('=')+1:].strip())
+          with open (os.path.join (qt_dir.name, qt_makefile)) as f:
+            for line in f:
+              line = line.strip()
+              if line.startswith ('DEFINES'):
+                qt_defines = shlex.split (line[line.find('=')+1:].strip())
+              elif line.startswith ('CXXFLAGS'):
+                qt_cflags = shlex.split (line[line.find('=')+1:].strip())
+              elif line.startswith ('INCPATH'):
+                qt_includes = shlex.split (line[line.find('=')+1:].strip())
+              elif line.startswith ('LIBS'):
+                qt_libs = shlex.split (line[line.find('=')+1:].strip())
+              elif line.startswith ('LFLAGS'):
+                qt_ldflags = shlex.split (line[line.find('=')+1:].strip())
           if qt_defines or qt_cflags or qt_includes or qt_libs or qt_ldflags:
             log ('ok\n')
             log ('  qt_defines: ' + str(qt_defines) + '\n')

--- a/lib/mrtrix3/_5ttgen/hsvs.py
+++ b/lib/mrtrix3/_5ttgen/hsvs.py
@@ -13,6 +13,9 @@
 #
 # For more details, see http://www.mrtrix.org/.
 
+# note: deal with these warnings properly when we drop support for Python 2:
+# pylint: disable=unspecified-encoding
+
 
 
 import glob, os, re

--- a/lib/mrtrix3/__init__.py
+++ b/lib/mrtrix3/__init__.py
@@ -13,6 +13,9 @@
 #
 # For more details, see http://www.mrtrix.org/.
 
+# note: deal with these warnings properly when we drop support for Python 2:
+# pylint: disable=unspecified-encoding
+
 import inspect, os, sys
 from collections import namedtuple
 try:
@@ -78,7 +81,7 @@ for config_path in [ os.environ.get ('MRTRIX_CONFIGFILE', os.path.join(os.path.s
 
 # Set up terminal special characters now, since they may be dependent on the config file
 def setup_ansi():
-  global ANSI, CONFIG
+  global ANSI
   if sys.stderr.isatty() and not ('TerminalColor' in CONFIG and CONFIG['TerminalColor'].lower() in ['no', 'false', '0']):
     ANSI = ANSICodes('\033[0K', '\033[0m', '\033[03;32m', '\033[03;34m', '\033[01;31m', '\033[03;36m', '\033[00;31m') #pylint: disable=unused-variable
 setup_ansi()

--- a/lib/mrtrix3/app.py
+++ b/lib/mrtrix3/app.py
@@ -13,6 +13,9 @@
 #
 # For more details, see http://www.mrtrix.org/.
 
+# note: deal with these warnings properly when we drop support for Python 2:
+# pylint: disable=unspecified-encoding,consider-using-f-string
+
 import argparse, inspect, math, os, random, shlex, shutil, signal, string, subprocess, sys, textwrap, time
 from mrtrix3 import ANSI, CONFIG, MRtrixError, setup_ansi
 from mrtrix3 import utils # Needed at global level
@@ -108,7 +111,7 @@ else:
 # , rather than executing this function directly
 def _execute(module): #pylint: disable=unused-variable
   from mrtrix3 import run #pylint: disable=import-outside-toplevel
-  global ARGS, CMDLINE, CONTINUE_OPTION, DO_CLEANUP, EXEC_NAME, FORCE_OVERWRITE, NUM_THREADS, SCRATCH_DIR, VERBOSITY, WORKING_DIR
+  global ARGS, CMDLINE, CONTINUE_OPTION, DO_CLEANUP, FORCE_OVERWRITE, NUM_THREADS, SCRATCH_DIR, VERBOSITY
 
   # Set up signal handlers
   for sig in _SIGNALS:
@@ -268,7 +271,6 @@ def _execute(module): #pylint: disable=unused-variable
 
 
 def check_output_path(item): #pylint: disable=unused-variable
-  global ARGS, FORCE_OVERWRITE, WORKING_DIR
   if not item:
     return
   abspath = os.path.abspath(os.path.join(WORKING_DIR, item))
@@ -287,7 +289,7 @@ def check_output_path(item): #pylint: disable=unused-variable
 
 def make_scratch_dir(): #pylint: disable=unused-variable
   from mrtrix3 import run #pylint: disable=import-outside-toplevel
-  global ARGS, CONTINUE_OPTION, EXEC_NAME, SCRATCH_DIR, WORKING_DIR
+  global SCRATCH_DIR
   if CONTINUE_OPTION:
     debug('Skipping scratch directory creation due to use of -continue option')
     return
@@ -309,7 +311,8 @@ def make_scratch_dir(): #pylint: disable=unused-variable
     outfile.write(WORKING_DIR + '\n')
   with open(os.path.join(SCRATCH_DIR, 'command.txt'), 'w') as outfile:
     outfile.write(' '.join(sys.argv) + '\n')
-  open(os.path.join(SCRATCH_DIR, 'log.txt'), 'w').close()
+  with open(os.path.join(SCRATCH_DIR, 'log.txt'), 'w'):
+    pass
   # Also use this scratch directory for any piped images within run.command() calls,
   #   and for keeping a log of executed commands / functions
   run.shared.set_scratch_dir(SCRATCH_DIR)
@@ -317,7 +320,6 @@ def make_scratch_dir(): #pylint: disable=unused-variable
 
 
 def goto_scratch_dir(): #pylint: disable=unused-variable
-  global SCRATCH_DIR
   if not SCRATCH_DIR:
     raise Exception('No scratch directory location set')
   if VERBOSITY:
@@ -331,7 +333,6 @@ def goto_scratch_dir(): #pylint: disable=unused-variable
 #   all intermediates, the resource will be retained; if not, it will be deleted (in particular
 #   to dynamically free up storage space used by the script).
 def cleanup(items): #pylint: disable=unused-variable
-  global DO_CLEANUP, VERBOSITY
   if not DO_CLEANUP:
     return
   if isinstance(items, list):
@@ -376,12 +377,10 @@ def cleanup(items): #pylint: disable=unused-variable
 
 # A set of functions and variables for printing various information at the command-line.
 def console(text): #pylint: disable=unused-variable
-  global VERBOSITY
   if VERBOSITY:
     sys.stderr.write(EXEC_NAME + ': ' + ANSI.console + text + ANSI.clear + '\n')
 
 def debug(text): #pylint: disable=unused-variable
-  global EXEC_NAME, VERBOSITY
   if VERBOSITY <= 2:
     return
   outer_frames = inspect.getouterframes(inspect.currentframe())
@@ -446,7 +445,6 @@ def var(*variables): #pylint: disable=unused-variable
     del calling_frame
 
 def warn(text): #pylint: disable=unused-variable
-  global EXEC_NAME
   sys.stderr.write(EXEC_NAME + ': ' + ANSI.warn + '[WARNING] ' + text + ANSI.clear + '\n')
 
 
@@ -468,7 +466,7 @@ class ProgressBar(object): #pylint: disable=unused-variable
 
   def __init__(self, msg, target=0):
     from mrtrix3 import run #pylint: disable=import-outside-toplevel
-    global EXEC_NAME, VERBOSITY
+    global VERBOSITY
     if not (isinstance(msg, utils.STRING_TYPES) or callable(msg)):
       raise TypeError('app.ProgressBar must be constructed using either a string or a function')
     self.counter = 0
@@ -518,7 +516,7 @@ class ProgressBar(object): #pylint: disable=unused-variable
 
   def done(self, msg=None):
     from mrtrix3 import run #pylint: disable=import-outside-toplevel
-    global EXEC_NAME, VERBOSITY
+    global VERBOSITY
     self.iscomplete = True
     if msg is not None:
       self.message = msg
@@ -538,7 +536,6 @@ class ProgressBar(object): #pylint: disable=unused-variable
 
 
   def _update(self):
-    global EXEC_NAME
     assert not self.iscomplete
     if not self.orig_verbosity:
       return
@@ -570,7 +567,6 @@ class Parser(argparse.ArgumentParser):
 
   # pylint: disable=protected-access
   def __init__(self, *args_in, **kwargs_in):
-    global _DEFAULT_COPYRIGHT
     self._author = None
     self._citation_list = [ ]
     self._copyright = _DEFAULT_COPYRIGHT
@@ -658,7 +654,6 @@ class Parser(argparse.ArgumentParser):
   def print_citation_warning(self):
     # If a subparser has been invoked, the subparser's function should instead be called,
     #   since it might have had additional citations appended
-    global ARGS
     if self._subparsers:
       subparser = getattr(ARGS, self._subparsers._group_actions[0].dest)
       for alg in self._subparsers._group_actions[0].choices:
@@ -675,7 +670,7 @@ class Parser(argparse.ArgumentParser):
       console('')
 
   # Overloads argparse.ArgumentParser function to give a better error message on failed parsing
-  def error(self, text):
+  def error(self, message):
     for entry in sys.argv:
       if '-help'.startswith(entry):
         self.print_help()
@@ -689,7 +684,7 @@ class Parser(argparse.ArgumentParser):
         if alg == sys.argv[1]:
           usage = self._subparsers._group_actions[0].choices[alg].format_usage()
           continue
-    sys.stderr.write('\nError: %s\n' % text)
+    sys.stderr.write('\nError: %s\n' % message)
     sys.stderr.write('Usage: ' + usage + '\n')
     sys.stderr.write('       (Run ' + self.prog + ' -help for more information)\n\n')
     sys.stderr.flush()
@@ -820,7 +815,7 @@ class Parser(argparse.ArgumentParser):
         elif option.nargs:
           if isinstance(option.nargs, int):
             group_text += (' ' + option.dest.upper())*option.nargs
-          elif option.nargs == '+' or option.nargs == '*':
+          elif option.nargs in ('+', '*'):
             group_text += ' <space-separated list>'
           elif option.nargs == '?':
             group_text += ' <optional value>'
@@ -1116,7 +1111,6 @@ def add_dwgrad_import_options(cmdline): #pylint: disable=unused-variable
   cmdline.flag_mutually_exclusive_options( [ 'grad', 'fslgrad' ] )
 def read_dwgrad_import_options(): #pylint: disable=unused-variable
   from mrtrix3 import path #pylint: disable=import-outside-toplevel
-  global ARGS
   assert ARGS
   if ARGS.grad:
     return ' -grad ' + path.from_user(ARGS.grad)
@@ -1131,7 +1125,6 @@ def add_dwgrad_export_options(cmdline): #pylint: disable=unused-variable
   cmdline.flag_mutually_exclusive_options( [ 'export_grad_mrtrix', 'export_grad_fsl' ] )
 def read_dwgrad_export_options(): #pylint: disable=unused-variable
   from mrtrix3 import path #pylint: disable=import-outside-toplevel
-  global ARGS
   assert ARGS
   if ARGS.export_grad_mrtrix:
     check_output_path(path.from_user(ARGS.export_grad_mrtrix, False))
@@ -1150,7 +1143,7 @@ def read_dwgrad_export_options(): #pylint: disable=unused-variable
 # Handler function for dealing with system signals
 def handler(signum, _frame):
   from mrtrix3 import run #pylint: disable=import-outside-toplevel
-  global _SIGNALS, EXEC_NAME, SCRATCH_DIR, WORKING_DIR
+  global SCRATCH_DIR
   # Terminate any child processes in the run module
   try:
     run.shared.terminate(signum)

--- a/lib/mrtrix3/dwi2response/dhollander.py
+++ b/lib/mrtrix3/dwi2response/dhollander.py
@@ -13,6 +13,9 @@
 #
 # For more details, see http://www.mrtrix.org/.
 
+# note: deal with these warnings properly when we drop support for Python 2:
+# pylint: disable=unspecified-encoding,consider-using-f-string
+
 import math, shutil
 from mrtrix3 import CONFIG, MRtrixError
 from mrtrix3 import app, image, path, run

--- a/lib/mrtrix3/dwi2response/tax.py
+++ b/lib/mrtrix3/dwi2response/tax.py
@@ -13,6 +13,9 @@
 #
 # For more details, see http://www.mrtrix.org/.
 
+# note: deal with these warnings properly when we drop support for Python 2:
+# pylint: disable=unspecified-encoding,consider-using-f-string
+
 import math, os, shutil
 from mrtrix3 import MRtrixError
 from mrtrix3 import app, image, matrix, path, run

--- a/lib/mrtrix3/dwi2response/tournier.py
+++ b/lib/mrtrix3/dwi2response/tournier.py
@@ -13,6 +13,9 @@
 #
 # For more details, see http://www.mrtrix.org/.
 
+# note: deal with these warnings properly when we drop support for Python 2:
+# pylint: disable=unspecified-encoding,consider-using-f-string
+
 import os, shutil
 from mrtrix3 import MRtrixError
 from mrtrix3 import app, image, matrix, path, run

--- a/lib/mrtrix3/dwibiascorrect/ants.py
+++ b/lib/mrtrix3/dwibiascorrect/ants.py
@@ -13,6 +13,9 @@
 #
 # For more details, see http://www.mrtrix.org/.
 
+# note: deal with these warnings properly when we drop support for Python 2:
+# pylint: disable=consider-using-f-string
+
 from distutils.spawn import find_executable
 from mrtrix3 import MRtrixError
 from mrtrix3 import app, path, run

--- a/lib/mrtrix3/image.py
+++ b/lib/mrtrix3/image.py
@@ -18,6 +18,9 @@
 #   data, rather than trying to duplicate support for all possible image formats natively
 #   in Python.
 
+# note: deal with these warnings properly when we drop support for Python 2:
+# pylint: disable=unspecified-encoding
+
 
 import json, math, os, subprocess
 from collections import namedtuple
@@ -242,7 +245,7 @@ def statistics(image_path, **kwargs): #pylint: disable=unused-variable
   try:
     from subprocess import DEVNULL #pylint: disable=import-outside-toplevel
   except ImportError:
-    DEVNULL = open(os.devnull, 'wb')
+    DEVNULL = open(os.devnull, 'wb') #pylint: disable=consider-using-with
   proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=DEVNULL) #pylint: disable=consider-using-with
   stdout = proc.communicate()[0]
   if proc.returncode:

--- a/lib/mrtrix3/path.py
+++ b/lib/mrtrix3/path.py
@@ -15,6 +15,9 @@
 
 # Collection of convenience functions for manipulating filesystem paths
 
+# note: deal with these warnings properly when we drop support for Python 2:
+# pylint: disable=unspecified-encoding,redundant-u-string-prefix,consider-using-f-string
+
 
 
 import ctypes, errno, inspect, os, random, string, subprocess, time
@@ -97,7 +100,8 @@ def make_temporary(suffix): #pylint: disable=unused-variable
       if is_directory:
         os.makedirs(temp_path)
       else:
-        open(temp_path, 'a').close()
+        with open(temp_path, 'a'):
+          pass
       app.debug(temp_path)
       return temp_path
     except OSError as exception:

--- a/lib/mrtrix3/phaseencoding.py
+++ b/lib/mrtrix3/phaseencoding.py
@@ -15,6 +15,8 @@
 
 # Functions relating to handling phase encoding information
 
+# note: deal with these warnings properly when we drop support for Python 2:
+# pylint: disable=unspecified-encoding,consider-using-f-string
 
 
 from mrtrix3 import COMMAND_HISTORY_STRING, MRtrixError

--- a/lib/mrtrix3/run.py
+++ b/lib/mrtrix3/run.py
@@ -13,6 +13,9 @@
 #
 # For more details, see http://www.mrtrix.org/.
 
+# note: deal with these warnings properly when we drop support for Python 2:
+# pylint: disable=unspecified-encoding
+
 import collections, itertools, os, shlex, signal, string, subprocess, sys, tempfile, threading
 from distutils.spawn import find_executable
 from mrtrix3 import ANSI, BIN_PATH, COMMAND_HISTORY_STRING, EXE_LIST, MRtrixBaseError, MRtrixError
@@ -224,7 +227,6 @@ CommandReturn = collections.namedtuple('CommandReturn', 'stdout stderr')
 
 def command(cmd, **kwargs): #pylint: disable=unused-variable
   from mrtrix3 import app, path #pylint: disable=import-outside-toplevel
-  global shared #pylint: disable=invalid-name
 
   def quote_nonpipe(item):
     return item if item == '|' else path.quote(item)

--- a/lib/mrtrix3/utils.py
+++ b/lib/mrtrix3/utils.py
@@ -112,7 +112,7 @@ def load_keyval(filename, **kwargs): #pylint: disable=unused-variable
         if len(line) < 2:
           continue
         name, var = line.rstrip().partition(":")[::2]
-        if name in res.keys():
+        if name in res:
           res[name].append(var.split())
         else:
           res[name] = var.split()

--- a/update_copyright
+++ b/update_copyright
@@ -15,6 +15,9 @@
 #
 # For more details, see http://www.mrtrix.org/.
 
+# note: deal with these warnings properly when we drop support for Python 2:
+# pylint: disable=unspecified-encoding
+
 import datetime, os
 from collections import namedtuple
 


### PR DESCRIPTION
Follows on from discussion on #2392. Pushing to a new branch / pull request to preserve the changes originally submitted by @maxpietsch, many of which may be appropriate for `dev`. 

This PR disables a lot of warnings to allow compatibility with Python 2. These will be re-enabled on `dev` with a view to dropping Python 2 support in future releases. Minor fixes have been applied where that could be done safely without affecting Python 2 compatibility, and where the changes would be expected to carry over to `dev` anyway.

Most of the changes boil down to disabling the warnings at the file level, along with a note to deal with them in `dev`. The rationale is to help identify these when merging to `dev` - it's otherwise difficult to work out which warnings need to be addressed and which are expected to remain disabled, when these warnings are added in the global `disable` line in the `pylint.rc`, or on a line-by-line basis. Hopefully it'll simplify the merge to `dev`, which I don't anticipate will be straightforward...
