### PR TITLE
CONTRIBUTING.md: Revise text RE: target branch for docs changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,9 +145,13 @@ to be provided in subsequent sections of this document.
 
    -  If only making changes to the *MRtrix3* *documentation*, then the
       appropriate base branch will depend upon the nature of the changes
-      being proposed and the urgency of the update. In this scenario,
-      please generate an [Issue](https://github.com/MRtrix3/mrtrix3/issues)
-      to facilitate communication with the core development team.
+      being proposed and the urgency of the update. If providing a minor
+      correction to spelling / grammar, then a direct merge to `master`
+      is appropriate. If however your changes are sufficiently complex that
+      they would require verification that the formatting of the online
+      documentation is correct, then this will require coordination with
+      the *MRtrix3* core development team; in this case, please generate an
+      [Issue](https://github.com/MRtrix3/mrtrix3/issues) to facilitate such.
 
 1. Generate one or more Git commits that apply your proposed changes to
    the repository.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,13 +145,17 @@ to be provided in subsequent sections of this document.
 
    -  If only making changes to the *MRtrix3* *documentation*, then the
       appropriate base branch will depend upon the nature of the changes
-      being proposed and the urgency of the update. If providing a minor
-      correction to spelling / grammar, then a direct merge to `master`
-      is appropriate. If however your changes are sufficiently complex that
-      they would require verification that the formatting of the online
-      documentation is correct, then this will require coordination with
-      the *MRtrix3* core development team; in this case, please generate an
-      [Issue](https://github.com/MRtrix3/mrtrix3/issues) to facilitate such.
+      being proposed and the urgency of the update. For instance, if providing
+      a minor correction to spelling / grammar, or fixing an erroneous
+      hyperlink, then a direct merge to `master` is likely appropriate.
+      Conversely, if the changes are non-trivial, and it makes more sense for
+      the changes to be made as part of an *MRtrix3* update rather than
+      immediately, then `dev` may be the more appropriate base branch. If
+      the answer to this question in the context of your proposed changes is
+      unclear to you, then please generate an [Issue](https://github.com/MRtrix3/mrtrix3/issues)
+      to facilitate direct discussion with the *MRtrix3* core development
+      team (ideally before commencing the implementation of changes, as
+      incorrect selection can sometimes be laborious to resolve later).
 
 1. Generate one or more Git commits that apply your proposed changes to
    the repository.


### PR DESCRIPTION
Based on feedback in #2398.

@fionaEyoung: Would this text have been more appropriate in your opinion? Eager to remove barriers to contribution as much as possible.

@jdtournier: I figure the main barrier is not `dev` vs. `master` target so much as whether we need to check formatting; in which case we probably need to merge `master` into `docs` at our end, merge the external PR into `docs`, then it's our obligation to fix then merge `docs` into `master` or `dev`. Unless it's easy to configure docs building from external forks?