### PR TITLE
tensor2metric: avoid crash when supplying input with wrong size

### DIFF
--- a/cmd/tensor2metric.cpp
+++ b/cmd/tensor2metric.cpp
@@ -145,7 +145,7 @@ class Processor { MEMALIGN(Processor)
 
       /* input dt */
       Eigen::Matrix<double, 6, 1> dt;
-      for (auto l = Loop (3) (dt_img); l; ++l)
+      for (dt_img.index(3) = 0; dt_img.index(3) < 6; ++dt_img.index(3))
         dt[dt_img.index(3)] = dt_img.value();
 
       /* output adc */

--- a/cmd/tensor2metric.cpp
+++ b/cmd/tensor2metric.cpp
@@ -275,6 +275,9 @@ void run ()
 {
   auto dt_img = Image<value_type>::open (argument[0]);
   Header header (dt_img);
+  if (header.ndim() != 4 || header.size(3) !=6) {
+    throw Exception("input tensor image is not a valid tensor.");
+  }
 
   auto mask_img = Image<bool>();
   auto opt = get_options ("mask");


### PR DESCRIPTION
Tensor2metric was segfaulting with multiple users on the forum when provided DWIs instead of tensors. On my own system the command even became unresponsive... This change checks if the input consists of 6 volumes and thus can be considered a tensor.