### PR TITLE
Avoid invalid memory access when ROI is malformed in tck header

### DIFF
--- a/src/dwi/tractography/file_base.cpp
+++ b/src/dwi/tractography/file_base.cpp
@@ -36,6 +36,8 @@ namespace MR {
           if (key == "roi" || key == "prior_roi") {
             try {
               vector<std::string> V (split (kv.value(), " \t", true, 2));
+              if (V.size() < 2)
+                V.push_back (std::string());
               properties.prior_rois.insert (std::pair<std::string,std::string> (V[0], V[1]));
             }
             catch (...) {

--- a/src/dwi/tractography/file_base.cpp
+++ b/src/dwi/tractography/file_base.cpp
@@ -36,8 +36,8 @@ namespace MR {
           if (key == "roi" || key == "prior_roi") {
             try {
               vector<std::string> V (split (kv.value(), " \t", true, 2));
-              if (V.size() < 2)
-                V.push_back (std::string());
+              if (V.size() != 2)
+                throw 1;
               properties.prior_rois.insert (std::pair<std::string,std::string> (V[0], V[1]));
             }
             catch (...) {


### PR DESCRIPTION
As [discussed on the forum](https://community.mrtrix.org/t/tck2fixel-segmentation-fault/2497/11), if a `tck` file header contains an entry for the ROI that doesn't have the expected 2 fields, this leads to a segfault when using e.g. `tckinfo` or `tck2fixel`. For some reason, the user had a header entry of the form:
```
ROI: none
```
Whereas we would normally write something like:
```
ROI: seed mask.mif
```
i.e. two separate entries. 

The change here consists simply of making sure that if only one token is parsed, a second empty string is added as the second, which then avoids the invalid memory access, and permits these headers to be used (the alternative is simply to ignore them, but I'm not sure that's the best thing to do here). 