### PR TITLE
DICOM: Change slice timing priority

### DIFF
--- a/core/file/dicom/mapper.cpp
+++ b/core/file/dicom/mapper.cpp
@@ -308,13 +308,6 @@ namespace MR {
               slices_timing_str.push_back (temp);
             }
           }
-        } else if (std::isfinite (frame.time_after_start)) {
-          DEBUG ("Taking slice timing information from CSA TimeAfterStart field");
-          default_type min_time_after_start = std::numeric_limits<default_type>::infinity();
-          for (size_t n = 0; n != dim[1]; ++n)
-            min_time_after_start = std::min (min_time_after_start, frames[n]->time_after_start);
-          for (size_t n = 0; n != dim[1]; ++n)
-            slices_timing_float.push_back (frames[n]->time_after_start - min_time_after_start);
         } else if (std::isfinite (static_cast<default_type>(frame.acquisition_time))) {
           DEBUG ("Estimating slice timing from DICOM AcquisitionTime field");
           default_type min_acquisition_time = std::numeric_limits<default_type>::infinity();
@@ -322,6 +315,13 @@ namespace MR {
             min_acquisition_time = std::min (min_acquisition_time, default_type(frames[n]->acquisition_time));
           for (size_t n = 0; n != dim[1]; ++n)
             slices_timing_float.push_back (default_type(frames[n]->acquisition_time) - min_acquisition_time);
+        } else if (std::isfinite (frame.time_after_start)) {
+          DEBUG ("Taking slice timing information from CSA TimeAfterStart field");
+          default_type min_time_after_start = std::numeric_limits<default_type>::infinity();
+          for (size_t n = 0; n != dim[1]; ++n)
+            min_time_after_start = std::min (min_time_after_start, frames[n]->time_after_start);
+          for (size_t n = 0; n != dim[1]; ++n)
+            slices_timing_float.push_back (frames[n]->time_after_start - min_time_after_start);
         }
         if (slices_timing_float.size()) {
           const size_t slices_acquired_at_zero = std::count (slices_timing_float.begin(), slices_timing_float.end(), 0.0f);


### PR DESCRIPTION
Reported by @bjeurissen.

Between two DWI series, one stored in mosiac format and one not, the current code produces a clearly erroneous slice timing vector in the latter case. The proposed change results in the use of DICOM field `AcquisitionTime` in the latter case, which produces an identical result between the two datasets (ignoring floating-point precision, since slice timing for mosaics is reported and propagated as a string).

Outstanding questions:

-   `dcm2niix` reports fractionally different slice timing for the non-mosaic dataset. I don't see any obvious source for this discrepancy. It's possible that it is deriving timings to a greater precision than what is reported in the DICOM headers, but I'm not sure.

-  I don't recall whether the CSA `TimeAfterStart` source was prioritised over `AcquisitionTime` due to behaviour in some other dataset, and therefore whether this change may result in erroneous behaviour elsewhere. @jdtournier Would your private DICOM test suite pick up such a change?