### PR TITLE
mrtrix3.run: Fix default MRTRIX_LOGLEVEL

### DIFF
--- a/lib/mrtrix3/run.py
+++ b/lib/mrtrix3/run.py
@@ -64,7 +64,7 @@ class Shared(object):
       self.env.pop('MRTRIX_QUIET')
     except KeyError:
       pass
-    self.env['MRTRIX_LOGLEVEL'] = 1
+    self.env['MRTRIX_LOGLEVEL'] = '1'
 
     # Flagged by calling the set_continue() function;
     #   run.command() and run.function() calls will be skipped until one of the inputs to


### PR DESCRIPTION
Default value for environment variable `MRTRIX_LOGLEVEL` was being erroneously written as an integer type rather than a string. In some environments, the `subprocess` module attempts to check whether environment variables correspond to filesystem paths, and this results in a `TypeError` due to this specific envvar not being a string.
