### PR TITLE
Stats commands: Clarify non-stationarity correction in help pages

### DIFF
--- a/cmd/fixelcfestats.cpp
+++ b/cmd/fixelcfestats.cpp
@@ -73,6 +73,10 @@ void usage ()
     "outside the processing mask will immediately disappear from view as soon as any data-file-based fixel colouring or "
     "thresholding is applied."
 
+  + "For Connectivity-based Fixel Enhancement, use of the -nonstationarity option for empirical non-stationarity correction "
+    "is generally discouraged, unless the data are of exceptionally high quality. The intrinsic non-stationarity correction "
+    "that is applied by default (i.e. if the -cfe_legacy option is not used) provides superior statistical power in most scenarios."
+
   + Math::Stats::GLM::column_ones_description
 
   + Fixel::format_description;

--- a/core/math/stats/shuffle.cpp
+++ b/core/math/stats/shuffle.cpp
@@ -67,7 +67,7 @@ namespace MR
         if (include_nonstationarity) {
 
           result
-          + Option ("nonstationarity", "perform non-stationarity correction")
+          + Option ("nonstationarity", "perform empirical non-parametric non-stationarity correction")
 
           + Option ("skew_nonstationarity", "specify the skew parameter for empirical statistic calculation (default for this command is " + str(default_skew) + ")")
             + Argument ("value").type_float (0.0)

--- a/docs/reference/commands/connectomestats.rst
+++ b/docs/reference/commands/connectomestats.rst
@@ -52,7 +52,7 @@ Options relating to shuffling of data for nonparametric statistical inference
 
 -  **-permutations file** manually define the permutations (relabelling). The input should be a text file defining a m x n matrix, where each relabelling is defined as a column vector of size m, and the number of columns, n, defines the number of permutations. Can be generated with the palm_quickperms function in PALM (http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/PALM). Overrides the -nshuffles option.
 
--  **-nonstationarity** perform non-stationarity correction
+-  **-nonstationarity** perform empirical non-parametric non-stationarity correction
 
 -  **-skew_nonstationarity value** specify the skew parameter for empirical statistic calculation (default for this command is 1)
 

--- a/docs/reference/commands/fixelcfestats.rst
+++ b/docs/reference/commands/fixelcfestats.rst
@@ -29,6 +29,8 @@ Unlike previous versions of this command, where a whole-brain tractogram file wo
 
 Note that if the -mask option is used, the output fixel directory will still contain the same set of fixels as that present in the input fixel template, in order to retain fixel correspondence. However a consequence of this is that all fixels in the template will be initialy visible when the output fixel directory is loaded in mrview. Those fixels outside the processing mask will immediately disappear from view as soon as any data-file-based fixel colouring or thresholding is applied.
 
+For Connectivity-based Fixel Enhancement, use of the -nonstationarity option for empirical non-stationarity correction is generally discouraged, unless the data are of exceptionally high quality. The intrinsic non-stationarity correction that is applied by default (i.e. if the -cfe_legacy option is not used) provides superior statistical power in most scenarios.
+
 In some software packages, a column of ones is automatically added to the GLM design matrix; the purpose of this column is to estimate the "global intercept", which is the predicted value of the observed variable if all explanatory variables were to be zero. However there are rare situations where including such a column would not be appropriate for a particular experimental design. Hence, in MRtrix3 statistical inference commands, it is up to the user to determine whether or not this column of ones should be included in their design matrix, and add it explicitly if necessary. The contrast matrix must also reflect the presence of this additional column.
 
 Fixel data are stored utilising the fixel directory format described in the main documentation, which can be found at the following link:  |br|
@@ -56,7 +58,7 @@ Options relating to shuffling of data for nonparametric statistical inference
 
 -  **-permutations file** manually define the permutations (relabelling). The input should be a text file defining a m x n matrix, where each relabelling is defined as a column vector of size m, and the number of columns, n, defines the number of permutations. Can be generated with the palm_quickperms function in PALM (http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/PALM). Overrides the -nshuffles option.
 
--  **-nonstationarity** perform non-stationarity correction
+-  **-nonstationarity** perform empirical non-parametric non-stationarity correction
 
 -  **-skew_nonstationarity value** specify the skew parameter for empirical statistic calculation (default for this command is 1)
 

--- a/docs/reference/commands/mrclusterstats.rst
+++ b/docs/reference/commands/mrclusterstats.rst
@@ -46,7 +46,7 @@ Options relating to shuffling of data for nonparametric statistical inference
 
 -  **-permutations file** manually define the permutations (relabelling). The input should be a text file defining a m x n matrix, where each relabelling is defined as a column vector of size m, and the number of columns, n, defines the number of permutations. Can be generated with the palm_quickperms function in PALM (http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/PALM). Overrides the -nshuffles option.
 
--  **-nonstationarity** perform non-stationarity correction
+-  **-nonstationarity** perform empirical non-parametric non-stationarity correction
 
 -  **-skew_nonstationarity value** specify the skew parameter for empirical statistic calculation (default for this command is 1)
 


### PR DESCRIPTION
Based on [recent forum thread](https://community.mrtrix.org/t/fba-results-show-different-compared-to-tbss/5532). Will eventually be evidenced in a publication, but with or without that, it's probably beneficial to clarify that "do more processing = better" is not necessarily true in this case.