### PR TITLE
Docs: Describe use of MSMT with single-shell data

### DIFF
--- a/docs/constrained_spherical_deconvolution/multi_shell_multi_tissue_csd.rst
+++ b/docs/constrained_spherical_deconvolution/multi_shell_multi_tissue_csd.rst
@@ -35,10 +35,10 @@ please refer to the :ref:`response_function_estimation` page for details.
 
 
 
-Invocation
-^^^^^^^^^^
+Three-tissue deconvolution
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Multi-shell multi-tissue CSD can be performed as:
+Multi-shell multi-tissue CSD using the common three macroscopic tissue components can be performed as:
 
 .. code-block:: console
 
@@ -52,7 +52,7 @@ where:
 
 - ``<tissue>.mif`` is the tissue-specific ODF (output), typically full FODs for WM and a single scalars for GM and CSF
 
-Note that input response functions and their corresponding output ODFs need to be specified in pairs.
+Note that input response functions and their corresponding output ODFs need to be specified at the command line in pairs.
 
 Typically, you will also want to use the ``-mask`` option to avoid unnecessary computations in non-brain voxels:
 
@@ -73,4 +73,24 @@ The resulting WM FODs can be displayed together with the tissue signal contribut
    mrview vf.mif -odf.load_sh wm.mif
 
 
+.. _msmt_with_single_shell_data:
 
+Single-shell data
+^^^^^^^^^^^^^^^^^
+
+The MSMT algorithm is typically understood as a solution for decomposing the DWI signal into three
+macroscopic tissue compartments based on multi-shell DWI data. It is generally well understood that this
+algorithm cannot intrinsically estimate these three components based on conventional "single-shell" DWI data
+(i.e. at least one *b*=0 volume and one *b*>0 shell). The MSMT algorithm can nevertheless still be utilised
+with such data as an alternative to the original :ref:`constrained_spherical_deconvolution` algorithm;
+potential benefits include:
+
+-   Application of a *hard* non-negativity constraint, such that negative amplitudes are almost entirely
+    absent from the output ODF(s), whereas the original CSD implementation constrains negative amplitudes
+    to be present but small.
+
+-   Possibility to estimate from the data *two* tissue ODFs rather than one, taking advantage of the
+    additional contrast present in the *b*=0 image data (which are not utilised at all in the original
+    CSD implementation). It is typically recommended in this instance to utilise WM-like and CSF-like
+    response functions, in order to estimate a WM-like ODF to which contamination from free-water-like
+    contributions to the DWI signal is reduced.

--- a/docs/constrained_spherical_deconvolution/response_function_estimation.rst
+++ b/docs/constrained_spherical_deconvolution/response_function_estimation.rst
@@ -29,10 +29,10 @@ While many algorithms exist, the following appear to perform well in a wide
 range of scenarios, based on experience and testing from both developers and
 the `MRtrix3 community <http://community.mrtrix.org>`__:
 
-**Single-tissue CSD:** If you intend to perform (single-tissue)
-:ref:`constrained_spherical_deconvolution` (e.g. via ``dwi2fod csd``),
-the tournier_ algorithm is a convenient and reliable way to estimate
-the single-fibre white matter response function:
+**Single-shell, single-tissue CSD:** If you intend to perform the original
+single-shell single-tissue :ref:`constrained_spherical_deconvolution`
+(e.g. via ``dwi2fod csd``), the tournier_ algorithm is a convenient and
+reliable way to estimate the single-fibre white matter response function:
 
 .. code-block:: console
 
@@ -52,6 +52,12 @@ CSF response functions:
    dwi2response dhollander dwi.mif wm_response.txt gm_response.txt csf_response.txt
 
 Other options include the msmt_5tt_ algorithm.
+
+Note that the multi-tissue CSD algorithm is still applicable to
+"single-shell" DWI data. A common strategy with such data is to estimate
+three tissue response functions (using an algorithm such as `dwi2response dhollander`),
+but to then use only a subset of those response functions for the deconvolution
+itself; see :ref:`msmt_with_single_shell_data`.
 
 Checking the results
 ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Quickly wrote a proposal change based on [recent forum thread](https://community.mrtrix.org/t/dwi2response-dhollander-with-single-shell-data/3514/9).

Only partially addresses #2265; should consider whether to:

- Combine CSD and MSMT CSD pages into a single page;
- Whether to add example commands or exemplar image output screenshots. 