### PR TITLE
configure: ignore CFLAGS & LDFLAGS from qmake

### DIFF
--- a/configure
+++ b/configure
@@ -1291,21 +1291,15 @@ int main() { Foo f; }
               line = line.strip()
               if line.startswith ('DEFINES'):
                 qt_defines = shlex.split (line[line.find('=')+1:].strip())
-              elif line.startswith ('CXXFLAGS'):
-                qt_cflags = shlex.split (line[line.find('=')+1:].strip())
               elif line.startswith ('INCPATH'):
                 qt_includes = shlex.split (line[line.find('=')+1:].strip())
               elif line.startswith ('LIBS'):
                 qt_libs = shlex.split (line[line.find('=')+1:].strip())
-              elif line.startswith ('LFLAGS'):
-                qt_ldflags = shlex.split (line[line.find('=')+1:].strip())
-          if qt_defines or qt_cflags or qt_includes or qt_libs or qt_ldflags:
+          if qt_defines or qt_includes or qt_libs:
             log ('ok\n')
             log ('  qt_defines: ' + str(qt_defines) + '\n')
-            log ('  qt_cflags: ' + str(qt_cflags) + '\n')
             log ('  qt_includes: ' + str(qt_includes) + '\n')
             log ('  qt_libs: ' + str(qt_libs) + '\n')
-            log ('  qt_ldflags: ' + str(qt_ldflags) + '\n\n')
             break
         except OSError:
           log ('not found\n')
@@ -1318,8 +1312,7 @@ int main() { Foo f; }
         if entry[2:].startswith('..'):
           qt_includes[index] = '-I' + os.path.abspath(qt_dir.name + '/' + entry[2:])
 
-      qt_cflags = [ entry for entry in qt_cflags if entry != '-O2' ]
-      qt = qt_cflags + qt_defines + qt_includes
+      qt = qt_defines + qt_includes
       qt_cflags = []
       for entry in qt:
         if entry[0] != '$' and not entry == '-I.':
@@ -1329,9 +1322,8 @@ int main() { Foo f; }
           else:
             qt_cflags += [ entry ]
 
-      qt = qt_ldflags + qt_libs
       qt_ldflags = []
-      for entry in qt:
+      for entry in qt_libs:
         if entry[0] != '$':
           qt_ldflags += [ entry.replace('\"','').replace("'",'') ]
 


### PR DESCRIPTION
The LTO options introduced with Qt 5.15 cause non-trivial conflicts with clang++ (at least it does on Arch Linux). I expect this will start to become problematic for other users soon. 

Looking at the flags added by Qt, it looks like they don't add much over what we normally use. It's probably just as easy to ignore the additional flags that `qmake` suggest (`CFLAGS` & `LDFLAGS`), and stick to grabbing only the main ones (`DEFINES`, `INCPATH` & `LIBS`). 

Works fine on Linux, will need checking on other OS's. 