### PR TITLE
connectomestats: Fix GLM mode selection

### DIFF
--- a/cmd/connectomestats.cpp
+++ b/cmd/connectomestats.cpp
@@ -271,7 +271,7 @@ void run()
       ++progress;
     }
   }
-  const bool nans_in_data = data.allFinite();
+  const bool nans_in_data = !data.allFinite();
 
   // Only add contrast matrix row number to image outputs if there's more than one hypothesis
   auto postfix = [&] (const size_t i) { return (num_hypotheses > 1) ? ("_" + hypotheses[i].name()) : ""; };


### PR DESCRIPTION
In almost all use cases, bug resulted in use of GLM with variable design matrix per edge, which results in re-calculation of certain data for each edge when those data could have instead been pre-calculated for efficiency.

If anyone were to provide input data where the connectome matrices contained non-finite data, bug would have resulted in non-finite test statistics, which in turn would have been reported, so confident that nobody has thus far attempted to do so.