### PR TITLE
Container: Additional fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,7 @@ RUN apt-get -qq update \
         libqt5core5a \
         libqt5gui5 \
         libqt5network5 \
+        libqt5svg5 \
         libqt5widgets5 \
         libquadmath0 \
         libtiff5 \

--- a/Singularity
+++ b/Singularity
@@ -39,7 +39,7 @@ Include: apt
     apt-get update && apt-get upgrade -y
 
 # Runtime requirements
-    apt-get update && apt-get install -y --no-install-recommends dc less libfftw3-bin liblapack3 libpng16-16 libqt5network5 libqt5widgets5 libtiff5 python3 python3-distutils zlib1g
+    apt-get update && apt-get install -y --no-install-recommends dbus dc less libfftw3-bin liblapack3 libpng16-16 libqt5network5 libqt5widgets5 libtiff5 python3 python3-distutils zlib1g
 
 # Build requirements
     apt-get update && apt-get install -y --no-install-recommends build-essential ca-certificates curl git libeigen3-dev libfftw3-dev libgl1-mesa-dev libpng-dev libqt5opengl5-dev libqt5svg5-dev libtiff5-dev qt5-qmake qtbase5-dev-tools wget zlib1g-dev
@@ -63,6 +63,9 @@ Include: apt
 
 # apt cleanup to recover as much space as possible
     apt-get remove -y build-essential ca-certificates curl git libeigen3-dev libfftw3-dev libgl1-mesa-dev libpng-dev libqt5opengl5-dev libqt5svg5-dev libtiff5-dev qt5-qmake qtbase5-dev-tools wget zlib1g-dev && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Configure DBus to facilitate mrview execution
+    dbus-uuidgen
 
 %runscript
     exec "$@"

--- a/docs/installation/using_containers.rst
+++ b/docs/installation/using_containers.rst
@@ -101,3 +101,8 @@ Run GUI command
 The following usage has been shown to work on Linux::
 
     singularity exec -B /run MRtrix3.sif mrview
+
+If you experience difficulties here with ``mrview``, you may have better
+success if the Singularity container is built directly from the *MRtrix3*
+source code using the definition file "``Singularity``" rather than
+converting from a Docker container or using a custom definition file.


### PR DESCRIPTION
Changes over and above #2370. Using that as the base branch in order to show differences, but will change base branch to `master` after that is merged.

3af9f6f6 contains two fixes:

- Singularity was refusing to run `mrview` due to an error I'd never seen previously. Don't know whether it is related to a change to the base container OS, or a change to the host system (which is the same one I first generated the container definition files); planning to also test on a different host system before merging.

- Building the Singularity container via the DockerHub image resulted in `mrview` not showing icons; yet executing `mrview` via Docker *did* show icons. Can't claim to know how that works, but it nevertheless looks like a missing SVG dependency.

I am still chasing issues with Docker running `mrview`. This morning it was giving me a bunch of error messages but nevertheless executing, whereas now this evening it's not working at all:

```
No protocol specified
qt.qpa.xcb: could not connect to display :1
qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: eglfs, linuxfb, minimal, minimalegl, offscreen, vnc, xcb.
```

Will continue chasing over the next few days.