### PR TITLE
PNG: handle single sagittal or coronal slices correctly

### DIFF
--- a/core/formats/png.cpp
+++ b/core/formats/png.cpp
@@ -146,15 +146,9 @@ namespace MR
         case 1:
           throw Exception ("Cannot generate PNG image with only 1 axis");
         case 2:
-          if (H.ndim() == 3) {
-            // Which axis do we remove?
-            // If axis 0 or 1 is size 1, then let's leave the header as 3D
-            // If however all 3 axes are greater than 1, we're going to remove
-            //   the final axis, which will then be looped over via the NameParser
-            if (H.size(0) > 1 && H.size(1) > 1)
-              H.ndim() = 2;
-          }
-          break;
+          if (H.ndim() == 2)
+            break;
+          // otherwise proceed to case 3:
         case 3:
           if (H.size(1) == 1) {
             axis_to_zero = 1;


### PR DESCRIPTION
Came across this while answering a question on the forum. On current `master`, this happens:
```
$ mrconvert ~/data/anat.nii -coord 0 70 out-[].png 

mrconvert: [SYSTEM FATAL CODE: SIGSEGV (11)] Segmentation fault: Invalid memory access
```
Or alternatively:
```
$ mrconvert ~/data/anat.nii -coord 0 70 - | mrconvert - out-[].png 
mrconvert: [100%] copying from "/home/donald/data/anat.nii" to "/tmp/mrtrix-tmp-ck4o7Y.mif"
terminate called after throwing an instance of 'std::bad_alloc'
  what():  std::bad_alloc
Aborted (core dumped)
```
Basically any attempt to convert a single sagittal or coronal slice using the square bracket syntax. Works OK if output file is simply `out.png` (not using square bracket syntax). Also works OK if selecting a single axial slice. 

Changes in the PR seem to fix the problem. 