### PR TITLE
Dicom fix missing import siemens enhanced

### DIFF
--- a/core/file/dicom/element.cpp
+++ b/core/file/dicom/element.cpp
@@ -323,8 +323,9 @@ namespace MR {
         if (VR == VR_SQ) return SEQ;
         if (VR == VR_DA) return DATE;
         if (VR == VR_TM) return TIME;
+        if (VR == VR_DT) return DATETIME;
         if (VR == VR_AE || VR == VR_AS || VR == VR_CS ||
-            VR == VR_DS || VR == VR_DT || VR == VR_IS || VR == VR_LO ||
+            VR == VR_DS || VR == VR_IS || VR == VR_LO ||
             VR == VR_LT || VR == VR_PN || VR == VR_SH || VR == VR_ST ||
             VR == VR_UI || VR == VR_UT || VR == VR_AT) return STRING;
         return OTHER;
@@ -414,6 +415,20 @@ namespace MR {
       {
         assert (type() == TIME);
         return Time (std::string (reinterpret_cast<const char*> (data), size));
+      }
+
+
+
+
+      std::pair<Date,Time> Element::get_datetime () const
+      {
+        assert (type() == DATETIME);
+        if (size < 21)
+          throw Exception ("malformed DateTime entry");
+        return {
+          Date (std::string (reinterpret_cast<const char*> (data), 8)),
+          Time (std::string (reinterpret_cast<const char*> (data+8), 13))
+        };
       }
 
 

--- a/core/file/dicom/element.h
+++ b/core/file/dicom/element.h
@@ -101,6 +101,7 @@ namespace MR {
             FLOAT,
             DATE,
             TIME,
+            DATETIME,
             STRING,
             SEQ,
             OTHER
@@ -158,6 +159,7 @@ namespace MR {
           vector<default_type> get_float () const;
           Date get_date () const;
           Time get_time () const;
+          std::pair<Date,Time> get_datetime () const;
           vector<std::string> get_string () const;
 
           int32_t     get_int (size_t idx, int32_t default_value = 0)                    const { auto v (get_int());    return check_get (idx, v.size()) ? v[idx] : default_value; }

--- a/core/file/dicom/image.cpp
+++ b/core/file/dicom/image.cpp
@@ -206,6 +206,9 @@ namespace MR {
             return;
           case 0x0028U:
             switch (item.element) {
+              case 0x0002U:
+                samples_per_pixel = item.get_uint (0, samples_per_pixel);
+                return;
               case 0x0010U:
                 dim[1] = item.get_uint (0, dim[1]);
                 return;
@@ -291,7 +294,7 @@ namespace MR {
                   if (in_frames) {
                     calc_distance();
                     frames.push_back (std::shared_ptr<Frame> (new Frame (*this)));
-                    frame_offset += dim[0] * dim[1] * (bits_alloc/8);
+                    frame_offset += dim[0] * dim[1] * (bits_alloc/8) * samples_per_pixel;
                   }
                   else
                     in_frames = true;

--- a/core/file/dicom/image.cpp
+++ b/core/file/dicom/image.cpp
@@ -110,6 +110,9 @@ namespace MR {
               case 0x9074U:
                 acquisition_time = item.get_datetime().second;
                 return;
+              case 0x9082U:
+                echo_time = item.get_float (0, echo_time);
+                return;
               case 0x9087U:
                 { // ugly hack to handle badly formatted Philips data:
                   default_type v = item.get_float (0, bvalue);

--- a/core/file/dicom/image.cpp
+++ b/core/file/dicom/image.cpp
@@ -547,7 +547,7 @@ namespace MR {
           const Frame& frame (**frame_it);
 
           if ((!frame.ignore_series_num && frame.series_num != previous->series_num ) ||
-              frame.acq != previous->acq)
+              frame.acq != previous->acq || frame.distance < previous->distance)
             update_count (2, dim, index);
           else if (frame.distance != previous->distance)
             update_count (1, dim, index);

--- a/core/file/dicom/image.cpp
+++ b/core/file/dicom/image.cpp
@@ -107,6 +107,9 @@ namespace MR {
               case 0x1314U:
                 flip_angle = item.get_float (0, flip_angle);
                 return;
+              case 0x9074U:
+                acquisition_time = item.get_datetime().second;
+                return;
               case 0x9087U:
                 { // ugly hack to handle badly formatted Philips data:
                   default_type v = item.get_float (0, bvalue);

--- a/core/file/dicom/image.h
+++ b/core/file/dicom/image.h
@@ -35,6 +35,7 @@ namespace MR {
           Frame () {
             acq_dim[0] = acq_dim[1] = dim[0] = dim[1] = instance =
                 series_num = acq = sequence = echo_index = grad_number = UINT_MAX;
+            samples_per_pixel = 1;
             position_vector[0] = position_vector[1] = position_vector[2] = NaN;
             orientation_x[0] = orientation_x[1] = orientation_x[2] = NaN;
             orientation_y[0] = orientation_y[1] = orientation_y[2] = NaN;
@@ -56,7 +57,7 @@ namespace MR {
             bipolar_flag = readoutmode_flag = 0;
           }
 
-          size_t acq_dim[2], dim[2], series_num, instance, acq, sequence, echo_index, grad_number;
+          size_t acq_dim[2], dim[2], series_num, instance, acq, sequence, echo_index, grad_number, samples_per_pixel;
           Eigen::Vector3d position_vector, orientation_x, orientation_y, orientation_z, G;
           default_type distance, pixel_size[2], slice_thickness, slice_spacing, scale_slope, scale_intercept, bvalue;
           size_t data, bits_alloc, data_size, frame_offset;

--- a/core/file/dicom/mapper.cpp
+++ b/core/file/dicom/mapper.cpp
@@ -208,9 +208,14 @@ namespace MR {
             H.keyval()["FlipAngle"] = join (frame.flip_angles, ",");
         }
 
-        size_t nchannels = image.frames.size() ? 1 : image.data_size / (frame.dim[0] * frame.dim[1] * (frame.bits_alloc/8));
-        if (nchannels > 1)
-          INFO ("data segment is larger than expected from image dimensions - interpreting as multi-channel data");
+        size_t nchannels = image.samples_per_pixel;
+        if (nchannels == 1 && !image.frames.size()) {
+          // only guess number of samples per pixel if not explicitly set in
+          // DICOM and not using multi-frame:
+          nchannels = image.data_size / (frame.dim[0] * frame.dim[1] * (frame.bits_alloc/8));
+          if (nchannels > 1)
+            INFO ("data segment is larger than expected from image dimensions - interpreting as multi-channel data");
+        }
 
         H.ndim() = 3 + (dim[0]*dim[2]>1) + (nchannels>1);
 


### PR DESCRIPTION
Based on test data provided by @bjeurissen where some attributes were missing , namely `SliceTiming`, `EchoTime`, `MultibandAccelerationFactor` & `SliceEncodingDirection`. For some reason, fixing the slice timing import also fixed the MB factor and slice direction imports (presumably because [these are only carried over if the slice timings are known](https://github.com/MRtrix3/mrtrix3/blob/master/core/file/dicom/mapper.cpp#L345-L353)). 

The `EchoTime` can be imported correctly if we accept the `EffectiveEchoTime` as equivalent. Not sure whether that will cause problems down the track, but it probably feels safe enough for now...?