### PR TITLE
population_template initialisation and drift correction fixes

### DIFF
--- a/bin/population_template
+++ b/bin/population_template
@@ -585,7 +585,12 @@ def parse_input_files(in_files, mask_files, contrasts, f_agg_weight=None, whites
 
 
 def execute(): #pylint: disable=unused-variable
-  from mrtrix3 import MRtrixError, app, image, matrix, path, run #pylint: disable=no-name-in-module, import-outside-toplevel
+  from mrtrix3 import MRtrixError, app, image, matrix, path, run, EXE_LIST #pylint: disable=no-name-in-module, import-outside-toplevel
+
+  expected_commands = ['mrgrid', 'mrregister', 'mrtransform', 'mraverageheader', 'mrconvert', 'mrmath', 'transformcalc', 'mrfilter']
+  for cmd in expected_commands:
+    if cmd not in EXE_LIST :
+      raise MRtrixError("Could not find " + cmd + " in bin/. Binary commands not compiled?")
 
   if not app.ARGS.type in REGISTRATION_MODES:
     raise MRtrixError("registration type must be one of %s. provided: %s" % (str(REGISTRATION_MODES), app.ARGS.type))

--- a/bin/population_template
+++ b/bin/population_template
@@ -53,6 +53,7 @@ def usage(cmdline): #pylint: disable=unused-variable
 
   linoptions = cmdline.add_argument_group('Options for the linear registration')
   linoptions.add_argument('-linear_no_pause', action='store_true', help='Do not pause the script if a linear registration seems implausible')
+  linoptions.add_argument('-linear_no_drift_correction', action='store_true', help='Deactivate correction of template appearance (scale and shear) over iterations')
   linoptions.add_argument('-linear_estimator', help='Specify estimator for intensity difference metric. Valid choices are: l1 (least absolute: |x|), l2 (ordinary least squares), lp (least powers: |x|^1.2), Default: None (no robust estimator used)')
   linoptions.add_argument('-rigid_scale', help='Specify the multi-resolution pyramid used to build the rigid template, in the form of a list of scale factors (default: %s). This and affine_scale implicitly  define the number of template levels' % ','.join([str(x) for x in DEFAULT_RIGID_SCALES]))
   linoptions.add_argument('-rigid_lmax', help='Specify the lmax used for rigid registration for each scale factor, in the form of a list of integers (default: %s). The list must be the same length as the linear_scale factor list' % ','.join([str(x) for x in DEFAULT_RIGID_LMAX]))
@@ -84,6 +85,7 @@ def usage(cmdline): #pylint: disable=unused-variable
   options.add_argument('-aggregation_weights', help='Comma separated file containing weights used for weighted image aggregation. Each row must contain the identifiers of the input image and its weight. Note that this weighs intensity values not transformations (shape).')
   options.add_argument('-nanmask', action='store_true', help='Optionally apply masks to (transformed) input images using NaN values to specify include areas for registration and aggregation. Only works if -mask_dir has been input.')
   options.add_argument('-copy_input', action='store_true', help='Copy input images and masks into local scratch directory.')
+  options.add_argument('-delete_temporary_files', action='store_true', help='Delete temporary files from scratch directory during template creation.')
 
 # ENH: add option to initialise warps / transformations
 
@@ -1167,8 +1169,8 @@ def execute(): #pylint: disable=unused-variable
           regtype_option = ' -type rigid'
           output_option = ' -rigid ' + os.path.join('linear_transforms_%02i' % level, inp.uid + '.txt')
           contrast_weight_option = cns.rigid_weight_option
-          if level > 0:
-            initialise_option = ' -rigid_init_matrix ' + os.path.join('linear_transforms_%02i' % (level - 1), inp.uid + '.txt')
+          initialise_option = (' -rigid_init_matrix ' +
+                               os.path.join('linear_transforms_%02i' % (level - 1) if level > 0 else 'linear_transforms_initial', inp.uid + '.txt'))
           if do_fod_registration:
             lmax_option = ' -rigid_lmax ' + str(lmax)
           if linear_estimator:
@@ -1181,8 +1183,8 @@ def execute(): #pylint: disable=unused-variable
           regtype_option = ' -type affine'
           output_option = ' -affine ' + os.path.join('linear_transforms_%02i' % level, inp.uid + '.txt')
           contrast_weight_option = cns.affine_weight_option
-          if level > 0:
-            initialise_option = ' -affine_init_matrix ' + os.path.join('linear_transforms_%02i' % (level - 1), inp.uid + '.txt')
+          initialise_option = (' -affine_init_matrix ' +
+                               os.path.join('linear_transforms_%02i' % (level - 1) if level > 0 else 'linear_transforms_initial', inp.uid + '.txt'))
           if do_fod_registration:
             lmax_option = ' -affine_lmax ' + str(lmax)
           if linear_estimator:
@@ -1223,19 +1225,48 @@ def execute(): #pylint: disable=unused-variable
             run.function(os.remove, im_temp)
         progress.increment()
 
-      # Here we ensure the template doesn't drift or scale
-      # TODO matrix avarage might produce a large FOV for large rotations  # pylint: disable=fixme
-      run.command('transformcalc ' + ' '.join(path.all_in_dir('linear_transforms_%02i' % level)) +
-                  ' average linear_transform_average.txt -quiet', force=True)
-      if linear_type[level] == 'rigid':
-        run.command('transformcalc linear_transform_average.txt rigid linear_transform_average.txt -quiet', force=True)
-      run.command('transformcalc linear_transform_average.txt invert linear_transform_average_inv.txt -quiet', force=True)
+      # Here we ensure the overall template properties don't change (too much) over levels
+      # The reference is the initialisation as that's used to construct the average space.
+      # T_i: linear trafo for case i, i.e. template(x) = E [ image_i(T_i x) ]
+      # R_i: inital trafo for case i (identity if initial alignment is none)
+      # A = E[ T_i ]: average of current trafos
+      # B = E[ R_i ]: average of initial trafos
+      # C_i' = T_i B A^{-1}: "drift" corrected T_i
+      # T_i <- C_i
+      # Notes:
+      #   - This approximately stabilises E[ T_i ], its' relatively close to B
+      #   - Not sure whether it's preferable to stabilise E[ T_i^{-1} ]
+      #   - If one subject's registration fails, this will affect the average and therefore the template which could result in instable behaviour.
+      #   - The template appearance changes slightly over levels, but the template and trafos are affected in the same way so should not affect template convergence.
+      if not app.ARGS.linear_no_drift_correction:
+        run.command('transformcalc ' + ' '.join([os.path.join('linear_transforms_initial', inp.uid + '.txt') for _inp in ins]) +
+                    ' average linear_transform_average_init.txt -quiet', force=True)
+        run.command('transformcalc ' + ' '.join([os.path.join('linear_transforms_%02i' % level, inp.uid + '.txt') for _inp in ins]) +
+                    ' average linear_transform_average_%02i_uncorrected.txt -quiet' % level, force=True)
+        run.command('transformcalc linear_transform_average_%02i_uncorrected.txt invert '  % level +
+                    'linear_transform_average_%02i_uncorrected_inv.txt -quiet' % level, force=True)
 
-      average_inv = matrix.load_transform('linear_transform_average_inv.txt')
-      if average_inv is not None:
+        transform_average_init = matrix.load_transform('linear_transform_average_init.txt')
+        transform_average_current_inv = matrix.load_transform('linear_transform_average_%02i_uncorrected_inv.txt' % level)
+
+        transform_update = matrix.dot(transform_average_init, transform_average_current_inv)
+        matrix.save_transform(os.path.join('linear_transforms_%02i_drift_correction.txt' %  level), transform_update, force=True)
+        if regtype == 'rigid':
+          run.command('transformcalc ' + os.path.join('linear_transforms_%02i_drift_correction.txt' %  level) +
+                      ' rigid ' + os.path.join('linear_transforms_%02i_drift_correction.txt' %  level) + ' -quiet', force=True)
+          transform_update = matrix.load_transform(os.path.join('linear_transforms_%02i_drift_correction.txt' %  level))
+
         for inp in ins:
-          transform = matrix.dot(matrix.load_transform(os.path.join('linear_transforms_%02i' % level, inp.uid + '.txt')), average_inv)
-          matrix.save_transform(os.path.join('linear_transforms_%02i' % level, inp.uid + '.txt'), transform, force=True)
+          transform = matrix.load_transform('linear_transforms_%02i/' % level + inp.uid + '.txt')
+          transform_updated = matrix.dot(transform, transform_update)
+          run.function(copy, 'linear_transforms_%02i/' % level + inp.uid + '.txt', 'linear_transforms_%02i/' % level + inp.uid + '.precorrection')
+          matrix.save_transform(os.path.join('linear_transforms_%02i' % level, inp.uid + '.txt'), transform_updated, force=True)
+
+        # compute average trafos and its properties for easier debugging
+        run.command('transformcalc ' + ' '.join([os.path.join('linear_transforms_%02i' % level, _inp.uid + '.txt') for _inp in ins]) +
+                    ' average linear_transform_average_%02i.txt -quiet' % level, force=True)
+        run.command('transformcalc linear_transform_average_%02i.txt decompose linear_transform_average_%02i.dec' % (level, level), force=True)
+
 
       for cid in range(n_contrasts):
         for inp in ins:
@@ -1266,6 +1297,8 @@ def execute(): #pylint: disable=unused-variable
         calculate_isfinite(ins, cns)
 
       for cid in range(n_contrasts):
+        if level > 0 and app.ARGS.delete_temporary_files:
+          os.remove(cns.templates[cid])
         cns.templates[cid] = 'linear_template%02i%s.mif' % (level, cns.suff[cid])
         aggregate(ins, cns.templates[cid], cid, agg_measure)
         if cns.n_volumes[cid] == 1:
@@ -1369,6 +1402,8 @@ def execute(): #pylint: disable=unused-variable
         calculate_isfinite(ins, cns)
 
       for cid in range(n_contrasts):
+        if level > 0 and app.ARGS.delete_temporary_files:
+          os.remove(cns.templates[cid])
         cns.templates[cid] = 'nl_template%02i%s.mif' % (level, cns.suff[cid])
         aggregate(ins, cns.templates[cid], cid, agg_measure)
         if cns.n_volumes[cid] == 1:

--- a/docs/reference/commands/population_template.rst
+++ b/docs/reference/commands/population_template.rst
@@ -57,6 +57,8 @@ Input, output and general options
 
 - **-copy_input** Copy input images and masks into local scratch directory.
 
+- **-delete_temporary_files** Delete temporary files from scratch directory during template creation.
+
 Options for the non-linear registration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -76,6 +78,8 @@ Options for the linear registration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - **-linear_no_pause** Do not pause the script if a linear registration seems implausible
+
+- **-linear_no_drift_correction** Deactivate correction of template appearance (scale and shear) over iterations
 
 - **-linear_estimator** Specify estimator for intensity difference metric. Valid choices are: l1 (least absolute: \|x\|), l2 (ordinary least squares), lp (least powers: \|x\|^1.2), Default: None (no robust estimator used)
 


### PR DESCRIPTION
1. proposed fix to #2467 
2. also fixes that the intialisation was not used in the first registration level
3. while at it, also added the option to delete intermediate templates which could be handy if many levels are requested and storage space in scratch is limited

For context regarding 1.:

The initial template space is computed after the initial trafos `R_i` (default: translations to centre of mass) are applied to the input images. 
The drift correction is supposed to prevent changes in appearance to the template over template levels and used the average transformation `A = E [T_i ]` across the image trafos `T_i` which include the initialisation. Hence for large "outliers" in the initialisation (i.e. one subject is far form the others in scanner space), the initial drift correction moves the template content out of the template FOV (as reported in #2467). The proposed fix computes `E [R_i ]` and corrects drift via `T_i <- T_i E [R_i ] (E [T_i ])^{-1}`. This _approximately_ preserves the size and shape of the image relative to the (average) original input images. Suggestions on how to improve drift correction are very welcome. 

BTW, on my test data (neonatal FA maps), deactivating drift correction via `-linear_no_drift_correction` leads to visible distortion in the affine levels that increase with the number of levels iterations. It's also worth thinking about implementing some form of (approximate) average shape preservation for the nonlinear registration.

This PR alters the behaviour and output of `population_template` for all types or registration except for `nonlinear` so we'd need to tag it. Test data needs to be updated as well. Should this go to master? 