### PR TITLE
python library: tweak execute to work with VS Code #2472

### DIFF
--- a/lib/mrtrix3/__init__.py
+++ b/lib/mrtrix3/__init__.py
@@ -84,4 +84,4 @@ setup_ansi()
 # Execute a command
 def execute(): #pylint: disable=unused-variable
   from . import app #pylint: disable=import-outside-toplevel
-  app._execute(inspect.getmodule(inspect.stack()[-1][0])) # pylint: disable=protected-access
+  app._execute(inspect.getmodule(inspect.stack()[1][0])) # pylint: disable=protected-access


### PR DESCRIPTION
This modification allows debugging scripts with VS Code #2472. Does not break modules or the main library on macOS. I don't have Windows so untested there.

Closes #2472.