### PR TITLE
Python: don't cleanup on SIGINT if -nocleanup option has been provided

### DIFF
--- a/lib/mrtrix3/app.py
+++ b/lib/mrtrix3/app.py
@@ -1165,10 +1165,13 @@ def handler(signum, _frame):
   sys.stderr.write('\n' + EXEC_NAME + ': ' + ANSI.error + msg + ANSI.clear + '\n')
   if os.getcwd() != WORKING_DIR:
     os.chdir(WORKING_DIR)
-  if SCRATCH_DIR and DO_CLEANUP:
-    try:
-      shutil.rmtree(SCRATCH_DIR)
-    except OSError:
-      pass
-    SCRATCH_DIR = ''
+  if SCRATCH_DIR:
+    if DO_CLEANUP:
+      try:
+        shutil.rmtree(SCRATCH_DIR)
+      except OSError:
+        pass
+      SCRATCH_DIR = ''
+    else:
+      sys.stderr.write(EXEC_NAME + ': ' + ANSI.console + 'Scratch directory retained; location: ' + SCRATCH_DIR + ANSI.clear + '\n')
   os._exit(signum) # pylint: disable=protected-access

--- a/lib/mrtrix3/app.py
+++ b/lib/mrtrix3/app.py
@@ -1165,7 +1165,7 @@ def handler(signum, _frame):
   sys.stderr.write('\n' + EXEC_NAME + ': ' + ANSI.error + msg + ANSI.clear + '\n')
   if os.getcwd() != WORKING_DIR:
     os.chdir(WORKING_DIR)
-  if SCRATCH_DIR:
+  if SCRATCH_DIR and DO_CLEANUP:
     try:
       shutil.rmtree(SCRATCH_DIR)
     except OSError:


### PR DESCRIPTION
When debugging long-running scripts (such as `dwifslpreproc`), it's sometimes useful to interrupt the process when it's already moved on from the problematic stage, but hitting Ctrl-C currently deletes the temporary folder even if the process was invoked with `-nocleanup`, which IMO is unexpected. This seems to fix it.