### PR TITLE
seeding from user-provided coordinates

### DIFF
--- a/docs/reference/commands/tckgen.rst
+++ b/docs/reference/commands/tckgen.rst
@@ -78,6 +78,8 @@ Tractography seeding mechanisms; at least one must be provided
 
 -  **-seed_image image** *(multiple uses permitted)* seed streamlines entirely at random within a mask image 
 
+-  **-seed_coordinates cds_path** seed from coordinates provided in a file as space-separated Mx3 matrix (XYZ per row), must not provide any other seeding mechanism.
+
 -  **-seed_sphere spec** *(multiple uses permitted)* spherical seed as four comma-separated values (XYZ position and radius)
 
 -  **-seed_random_per_voxel image num_per_voxel** *(multiple uses permitted)* seed a fixed number of streamlines per voxel in a mask image; random placement of seeds in each voxel

--- a/src/dwi/tractography/seeding/basic.cpp
+++ b/src/dwi/tractography/seeding/basic.cpp
@@ -42,6 +42,15 @@ namespace MR
 
 
 
+        bool Seed_coordinates::get_seed (Eigen::Vector3f& p) const
+        {
+          int coordinate_index = std::uniform_int_distribution<> (0, seed_cds.rows()-1)(rng);
+          p = seed_cds.row(coordinate_index);
+          return true;
+        }
+
+
+
 
         bool SeedMask::get_seed (Eigen::Vector3f& p) const
         {
@@ -56,8 +65,6 @@ namespace MR
           p = (*mask.voxel2scanner) * p;
           return true;
         }
-
-
 
 
 
@@ -94,10 +101,6 @@ namespace MR
           p = (*mask.voxel2scanner) * p;
           return true;
         }
-
-
-
-
 
 
 

--- a/src/dwi/tractography/seeding/basic.h
+++ b/src/dwi/tractography/seeding/basic.h
@@ -59,7 +59,29 @@ namespace MR
             Eigen::Vector3f pos;
             float rad;
 
+        };    
+
+
+
+        class Seed_coordinates : public Base
+        { MEMALIGN(Seed_coordinates)
+
+          public:
+            Seed_coordinates (const std::string& in) :
+              Base (in, "coordinate matrix", MAX_TRACKING_SEED_ATTEMPTS_RANDOM) {
+                seed_cds = load_matrix<float> (in);
+                if (seed_cds.cols() != 3)
+                  throw Exception ("Could not parse file \"" + in + "\" as a coordinate input; needs to have 3 columns"); 
+                volume = 0.0;               
+              }
+
+            virtual bool get_seed (Eigen::Vector3f& p) const override;
+
+          private:
+            Eigen::MatrixXf seed_cds;
+
         };
+
 
 
         class SeedMask : public Base

--- a/src/dwi/tractography/seeding/seeding.cpp
+++ b/src/dwi/tractography/seeding/seeding.cpp
@@ -38,6 +38,10 @@ namespace MR
       + Option ("seed_image", "seed streamlines entirely at random within a mask image ").allow_multiple()
         + Argument ("image").type_image_in()
 
+      + Option ("seed_coordinates", "seed from coordinates provided in a file as space-separated Mx3 matrix "
+                                    "(XYZ per row), must not provide any other seeding mechanism")
+        + Argument ("cds_path").type_text()
+
       + Option ("seed_sphere", "spherical seed as four comma-separated values (XYZ position and radius)").allow_multiple()
         + Argument ("spec").type_sequence_float()
 
@@ -119,6 +123,14 @@ namespace MR
         auto opt = get_options ("seed_image");
         for (size_t i = 0; i < opt.size(); ++i) {
           SeedMask* seed = new SeedMask (opt[i][0]);
+          list.add (seed);
+        }
+
+        opt = get_options ("seed_coordinates"); 
+        if (opt.size()) {
+          if (list.num_seeds())
+            throw Exception ("If seeding from coordinates, cannot specify any other type of seed!");
+          Seed_coordinates* seed = new Seed_coordinates (opt[0][0]);
           list.add (seed);
         }
 


### PR DESCRIPTION
Follow up on [this MRtrix community post](https://community.mrtrix.org/t/seeding-from-pre-defined-coordinates/3276) @Lestropie.

All self-explanatory, the user-supplied file containing a matrix of coordinates is parsed, then seed coordinates (rows in the matrix) are selected at random until tckgen conditions are met (desired number of seeds / streamlines / etc reached) allowing repeated use of each coordinate.

_Technically, this mode is considered "Mechanism that provides random seed locations" in how it's handled so in the code it is defined by volume. As coordinates do not have a volume (volume is explicitly set to 0.0), the user is prevented from requesting any other seeding mechanisms in parallel as these would dominate._