### PR TITLE
Fix build progress

### DIFF
--- a/build
+++ b/build
@@ -147,11 +147,13 @@ targets = []
 
 
 todo, headers, object_deps, file_flags = {}, {}, {}, {}
+formatstr=''
 lock = threading.Lock()
 print_lock = threading.Lock()
+index_lock = threading.Lock()
 stop = False
 error_stream = None
-main_cindex = 0
+todo_index = 0
 
 logfile = open ('build.log', 'wb') #pylint: disable=consider-using-with
 timingfile = None
@@ -686,6 +688,14 @@ for filepath in list_unexpected_bin_files(exe_suffix):
 class TargetException (Exception):
   pass
 
+
+def next_index ():
+  global todo_index
+  with index_lock:
+    todo_index+=1
+    return todo_index
+
+
 class Entry(object):
   def __init__ (self, name):
     name = os.path.normpath (name)
@@ -724,7 +734,8 @@ class Entry(object):
 
 
 
-  def execute (self, cindex, formatstr):
+  def execute (self):
+    global formatstr
     folder = os.path.dirname (self.name)
     try:
       os.makedirs (folder)
@@ -741,7 +752,7 @@ class Entry(object):
             fd.write ('<file>' + entry + '</file>\n')
         fd.write ('</qresource>\n</RCC>\n')
     if self.cmd:
-      return execute (formatstr.format (cindex, self.action, self.name), self.cmd)
+      return execute (formatstr.format (next_index(), self.action, self.name), self.cmd)
     return None
 
 
@@ -1078,25 +1089,21 @@ def list_lib_deps ():
 
 
 def build_next ():
-  global stop, main_cindex
-  total_count = len(todo)
-  cindex = 0
-  formatstr = '({:>'+str(len(str(total_count)))+'}/'+str(total_count)+') [{}] {}'
+  global stop, formatstr
+  formatstr = '({:>'+str(len(str(initial_num_todo)))+'}/'+str(initial_num_todo)+') [{}] {}'
 
   try:
     while not stop:
       current = None
       with lock:
         if todo:
-          for item in todo:
-            if todo[item].currently_being_processed:
+          for name,entry in todo.items():
+            if entry.currently_being_processed:
               continue
-            unsatisfied_deps = set(todo[item].deps).intersection (todo.keys())
+            unsatisfied_deps = set(entry.deps).intersection (todo.keys())
             if not unsatisfied_deps:
-              todo[item].currently_being_processed = True
-              current = item
-              main_cindex+=1
-              cindex = main_cindex
+              entry.currently_being_processed = True
+              current = name
               break
         else:
           stop = max (stop, 1)
@@ -1108,7 +1115,7 @@ def build_next ():
         continue
 
       target = todo[current]
-      if target.execute(cindex, formatstr):
+      if target.execute():
         target.currently_being_processed = False
         stop = 2
         return
@@ -1116,7 +1123,8 @@ def build_next ():
       with lock:
         del todo[current]
 
-  except Exception:
+  except Exception as excp:
+    disp (str(excp))
     stop = 2
     return
 
@@ -1434,18 +1442,19 @@ except (KeyError, TypeError):
     num_processors = os.sysconf('SC_NPROCESSORS_ONLN')
   except ValueError:
     num_processors = 1
+log ('''
+
+Build will use ''' + str(num_processors) + ''' threads
+
+''')
+
 
 while todo:
 
   stop = False
-  main_cindex = 0
   num_todo_previous = len(todo)
-
-  log ('''
-
-  launching ''' + str(num_processors) + ''' threads
-
-  ''')
+  initial_num_todo = len(todo)
+  todo_index = 0
 
   threads = []
   for i in range (1, num_processors): # pylint: disable=unused-variable

--- a/build
+++ b/build
@@ -1390,19 +1390,8 @@ except TargetException as excp:
 
 # for nogui config, remove GUI elements from targets and todo list:
 if nogui:
-  nogui_targets = []
-  for entry in targets:
-    if not is_GUI_target (entry):
-      nogui_targets.append (entry)
-  targets = nogui_targets
-
-  nogui_todo = {}
-  for item in todo:
-    if not is_GUI_target (todo[item].name):
-      nogui_todo[item] = todo[item]
-  todo = nogui_todo
-
-
+  targets = [ entry for entry in targets if not is_GUI_target (entry) ]
+  todo = { name:entry for name, entry in todo.items() if not is_GUI_target (name) }
 
 
 
@@ -1426,11 +1415,10 @@ Printing dependencies for all files:
     todo[entry].display()
   sys.exit (0)
 
-todo_tmp = {}
-for item in todo:
-  if todo[item].action != '--' and todo[item].need_rebuild():
-    todo_tmp[item] = todo[item]
-todo = todo_tmp
+
+
+# remove todo items that don't need rebuild:
+todo = { name:entry for name, entry in todo.items() if entry.action != '--' and entry.need_rebuild() }
 
 log ('TODO list contains ' + str(len(todo)) + ''' items
 


### PR DESCRIPTION
Attempt at fixing #2492. Definitely fixes the variability in the total number, but there is still scope for the numbering to be slightly out of order at the beginning, due to a race condition between when the index of the current job is generated and the point at which the status line is printed to the terminal. This could be fixed properly, but would require slightly deeper changes, and I'm not sure they're necessarily all that important. 