### PR TITLE
Calculate inter-quartile range in mrstats

### DIFF
--- a/core/math/median.h
+++ b/core/math/median.h
@@ -68,6 +68,34 @@ namespace MR
         return med_val;
     }
 
+    template <class Container>
+    inline typename Container::value_type quantile (Container& list, default_type quantile)
+    {
+        size_t num = list.size();
+        // remove NaNs:
+        for (size_t n = 0; n < num; ++n) {
+          while (not_a_number (list[n]) && n < num) {
+            --num;
+            //std::swap (list[n], list[num]);
+            // Commented std::swap to provide bool compatibility
+            typename Container::value_type temp = list[num]; list[num] = list[n]; list[n] = temp;
+          }
+        }
+        if (!num)
+          return std::numeric_limits<typename Container::value_type>::quiet_NaN();
+
+        default_type f;
+        default_type t = std::modf(num * quantile, &f);
+        size_t loc = size_t(f);
+        std::nth_element (list.begin(), list.begin()+loc, list.begin()+loc);
+        typename Container::value_type val0 = list[loc];
+        std::nth_element (list.begin(), list.begin()+loc, list.begin()+loc+1);
+        typename Container::value_type val1 = list[loc+1];
+        typename Container::value_type val = (1-t)*val0 + t*val1;
+
+        return val;
+    }
+
 
     // Weiszfeld median
     template <class MatrixType = Eigen::Matrix<default_type, 3, Eigen::Dynamic>, class  VectorType = Eigen::Matrix<default_type, 3, 1>>

--- a/core/stats.cpp
+++ b/core/stats.cpp
@@ -24,7 +24,7 @@ namespace MR
 
     using namespace App;
 
-    const char * field_choices[] = { "mean", "median", "std", "std_rv", "min", "max", "count", nullptr };
+    const char * field_choices[] = { "mean", "median", "std", "std_rv", "iqr", "min", "max", "count", nullptr };
 
     const OptionGroup Options = OptionGroup ("Statistics options")
     + Option ("output",

--- a/core/stats.h
+++ b/core/stats.h
@@ -90,6 +90,7 @@ namespace MR
               else if (fields[n] == "median") std::cout << ( values.size() > 0 ? str(Math::median (values)) : "N/A" ) << " ";
               else if (fields[n] == "std") std::cout << ( count > 1 ? str(std) : "N/A" ) << " ";
               else if (fields[n] == "std_rv") std::cout << ( count > 1 ? str(std_rv) : "N/A" ) << " ";
+              else if (fields[n] == "iqr") std::cout << ( values.size() > 0 ? str(Math::quantile (values, 0.75) - Math::quantile (values, 0.25)) : "N/A" ) << " ";
               else if (fields[n] == "min") std::cout << str(min) << " ";
               else if (fields[n] == "max") std::cout << str(max) << " ";
               else if (fields[n] == "count") std::cout << count << " ";


### PR DESCRIPTION
Adds a means to calculate the inter-quartile range on an image, which can be a more robust estimate of variance. For example:
```
mrstats image.mif -output iqr
```

Alternatively, we could also output any percentile in addition to the median and IQR. I'm just not sure what would be the logical way to design the command interface. Any thoughts?