### PR TITLE
Correctly transform mask instead of last contrast

### DIFF
--- a/bin/population_template
+++ b/bin/population_template
@@ -1003,7 +1003,7 @@ def execute(): #pylint: disable=unused-variable
     if use_masks:
       progress = app.ProgressBar('Reslicing input masks to average header', len(ins))
       for inp in ins:
-        run.command('mrtransform ' + inp.ims_path[cid] + ' ' + inp.msk_transformed + ' ' +
+        run.command('mrtransform ' + inp.msk_path + ' ' + inp.msk_transformed + ' ' +
                     '-interp nearest -template ' + cns.templates[0] + ' ' +
                     datatype_option)
         progress.increment()


### PR DESCRIPTION
mrtransform was erroneously applied to the last contrast instead of the mask when initial alignment was turned off. Only happens when initial alignment is turned off, so most studies will not be affected by this.