### PR TITLE
PNG export: Exception on too few axes

### DIFF
--- a/core/formats/png.cpp
+++ b/core/formats/png.cpp
@@ -132,6 +132,16 @@ namespace MR
       if (H.ndim() == 4 && H.size(3) > 4)
         throw Exception ("A 4D image written to PNG must have between one and four volumes (requested: " + str(H.size(3)) + ")");
 
+      // TODO After looping over axes via square-bracket notation,
+      //   there needs to be at least two axes with size greater than one
+      size_t unity_axes = 0;
+      for (size_t axis = 0; axis != H.ndim(); ++axis) {
+        if (H.size (axis) == 1)
+          ++unity_axes;
+      }
+      if (unity_axes - (H.ndim() - num_axes) < 2)
+        throw Exception ("Too few (non-unity) image axes to support PNG export");
+
       // For 4D images, can support:
       // - 1 volume (just greyscale)
       // - 2 volumes (save as greyscale & alpha)


### PR DESCRIPTION
Supersedes #2465.

This section of code is also relevant to #2179.

As described in [this comment](https://github.com/MRtrix3/mrtrix3/pull/2465#issuecomment-1097528572), the usage resulting in a segfault is likely not that intended. But further, attempting to save to `out-[].png` from a 1 x 128 x 128 image could (theoretically at least) yield either a single 128 x 128 image (effectively "ignoring" the square-bracket syntax), or, more faithfully, 128 different 1 x 128 images. Presence of unity axes is already used within the PNG handling to identify the slice orientation to use for PNG files.

For now, this comment instead catches the likely erroneous but also potentially ambiguous usage and errors out, rather than segfaulting. Later, hopefully for `3.1.0`, I'll try to restructure the relevant code in order to address #2179, and hopefully if the code is better structured the right solution in this instance will fall out.