### PR TITLE
DICOM: Tweak terminal messages

### DIFF
--- a/core/file/dicom/tree.cpp
+++ b/core/file/dicom/tree.cpp
@@ -119,10 +119,10 @@ namespace MR {
       void Tree::read (const std::string& filename)
       {
         description = filename;
-        ProgressBar progress ("scanning DICOM folder \"" + shorten (filename) + "\"", 0);
-        if (Path::is_dir (filename))
+        if (Path::is_dir (filename)) {
+          ProgressBar progress ("scanning folder \"" + shorten (filename) + "\" for DICOM data", 0);
           read_dir (filename, progress);
-        else {
+        } else {
           try {
             read_file (filename);
           }
@@ -130,10 +130,8 @@ namespace MR {
           }
         }
 
-        if (size() > 0)
-          return;
-
-        throw Exception ("no DICOM images found in \"" + filename + "\"");
+        if (!size())
+          throw Exception ("no DICOM images found in \"" + filename + "\"");
       }
 
 

--- a/core/formats/dicom.cpp
+++ b/core/formats/dicom.cpp
@@ -31,9 +31,11 @@ namespace MR
 
     std::unique_ptr<ImageIO::Base> DICOM::read (Header& H) const
     {
-      if (!Path::is_dir (H.name())) 
-        if (!Path::has_suffix (H.name(), ".dcm"))
-          return std::unique_ptr<ImageIO::Base>();
+      if (Path::is_dir (H.name())) {
+        INFO ("Image path \"" + H.name() + "\" is a directory; will attempt to parse as DICOM series");
+      } else if (!Path::has_suffix (H.name(), ".dcm")) {
+        return std::unique_ptr<ImageIO::Base>();
+      }
 
       File::Dicom::Tree dicom;
 
@@ -41,7 +43,7 @@ namespace MR
       dicom.sort();
 
       auto series = File::Dicom::select_func (dicom);
-      if (series.empty()) 
+      if (series.empty())
         throw Exception ("no DICOM series selected");
 
       return dicom_to_mapper (H, series);


### PR DESCRIPTION
Proposed modifications based on confusion from new user.

"Directories are DICOMs and files are other image formats" perhaps shouldn't be assumed knowledge.

Details in commit message https://github.com/MRtrix3/mrtrix3/commit/942744c739282627bc95501defac9bc3774cde5c; open to suggestions for changes.