### PR TITLE
5ttedit: Support for floating-point input images

### DIFF
--- a/cmd/5ttedit.cpp
+++ b/cmd/5ttedit.cpp
@@ -35,34 +35,42 @@ void usage ()
 
   AUTHOR = "Robert E. Smith (robert.smith@florey.edu.au)";
 
-  SYNOPSIS = "Manually set the partial volume fractions in an ACT five-tissue-type (5TT) image using mask images";
+  SYNOPSIS = "Manually set the partial volume fractions in an ACT five-tissue-type (5TT) image";
+
+  DESCRIPTION + "The user-provided images are interpreted as desired partial volume fractions "
+                "in the output image. For any voxel with a non-zero value in such an image, this "
+                "will be the value for that tissue in the output 5TT image. For tissues for which "
+                "the user has not explicitly requested a change to the partial volume fraction, "
+                "the partial volume fraction may nevertheless change in order to preserve the "
+                "requirement of a unity sum of partial volume fractions in each voxel."
+
+              + "Any voxels that are included in the mask provided by the -none option will "
+                "be erased in the output image; this supersedes all other user inputs.";
 
   ARGUMENTS
   + Argument ("input",  "the 5TT image to be modified").type_image_in()
   + Argument ("output", "the output modified 5TT image").type_image_out();
 
   OPTIONS
-  + Option ("cgm",  "provide a mask of voxels that should be set to cortical grey matter")
+  + Option ("cgm",  "provide an image of new cortical grey matter partial volume fractions")
     + Argument ("image").type_image_in()
 
-  + Option ("sgm",  "provide a mask of voxels that should be set to sub-cortical grey matter")
+  + Option ("sgm",  "provide an image of new sub-cortical grey matter partial volume fractions")
     + Argument ("image").type_image_in()
 
-  + Option ("wm",   "provide a mask of voxels that should be set to white matter")
+  + Option ("wm",   "provide an image of new white matter partial volume fractions")
     + Argument ("image").type_image_in()
 
-  + Option ("csf",  "provide a mask of voxels that should be set to CSF")
+  + Option ("csf",  "provide an image of new CSF partial volume fractions")
     + Argument ("image").type_image_in()
 
-  + Option ("path", "provide a mask of voxels that should be set to pathological tissue")
+  + Option ("path", "provide an image of new pathological tissue partial volume fractions")
     + Argument ("image").type_image_in()
 
-  + Option ("none", "provide a mask of voxels that should be cleared (i.e. are non-brain); note that this will supersede all other provided masks")
+  + Option ("none", "provide a mask of voxels that should be cleared (i.e. are non-brain)")
     + Argument ("image").type_image_in();
 
 }
-
-
 
 
 class Modifier
@@ -70,71 +78,135 @@ class Modifier
   public:
     Modifier (Image<float>& input_image, Image<float>& output_image) :
         v_in  (input_image),
-        v_out (output_image) { }
+        v_out (output_image),
+        excess_volume_count (0),
+        inadequate_volume_count (0) { }
 
-    void set_cgm_mask  (const std::string& path) { load (path, 0); }
-    void set_sgm_mask  (const std::string& path) { load (path, 1); }
-    void set_wm_mask   (const std::string& path) { load (path, 2); }
-    void set_csf_mask  (const std::string& path) { load (path, 3); }
-    void set_path_mask (const std::string& path) { load (path, 4); }
-    void set_none_mask (const std::string& path) { load (path, 5); }
-
-
-    bool operator() (const Iterator& pos)
+    ~Modifier()
     {
-      assign_pos_of (pos, 0, 3).to (v_out);
-      bool voxel_nulled = false;
-      if (buffers[5].valid()) {
-        assign_pos_of (pos, 0, 3).to (buffers[5]);
-        if (buffers[5].value()) {
-          for (auto i = Loop(3) (v_out); i; ++i)
-            v_out.value() = 0.0;
-          voxel_nulled = true;
-        }
+      if (excess_volume_count) {
+        WARN ("A total of " + str(excess_volume_count) + " voxels had a sum of"
+              "partial volume fractions across user-provided images greater than one "
+              "(these were auto-scaled to sum to one, but there may have been an error in generation of input images)");
       }
-      if (!voxel_nulled) {
-        unsigned int count = 0;
-        float values[5] = { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
-        for (size_t tissue = 0; tissue != 5; ++tissue) {
-          if (buffers[tissue].valid()) {
-            assign_pos_of (pos, 0, 3).to (buffers[tissue]);
-            if (buffers[tissue].value()) {
-              ++count;
-              values[tissue] = 1.0;
-            }
-          }
-        }
-        if (count) {
-          if (count > 1) {
-            const float multiplier = 1.0 / float(count);
-            for (size_t tissue = 0; tissue != 5; ++tissue)
-              values[tissue] *= multiplier;
-          }
-          for (auto i = Loop(3) (v_out); i; ++i)
-            v_out.value() = values[v_out.index(3)];
-        } else {
-          assign_pos_of (pos, 0, 3).to (v_in);
-          for (auto i = Loop(3) (v_in, v_out); i; ++i)
-            v_out.value() = v_in.value();
-        }
+      if (inadequate_volume_count) {
+        WARN ("A total of " + str(excess_volume_count) + " voxels were outside the brain "
+              "in the input image, the user provided non-zero partial volume fractions in at least one input volume, "
+              "but the sum of partial volume fractions across user-provided images was less than one "
+              "(these were auto-scaled to sum to one, but there may have been an error in generation of input images)");
       }
-      return true;
+    }
+
+    void set_cgm_input  (const std::string& path) { load (path, 0); }
+    void set_sgm_input  (const std::string& path) { load (path, 1); }
+    void set_wm_input   (const std::string& path) { load (path, 2); }
+    void set_csf_input  (const std::string& path) { load (path, 3); }
+    void set_path_input (const std::string& path) { load (path, 4); }
+
+
+    void set_none_mask (const std::string& path)
+    {
+      none = Image<bool>::open (path);
+      if (!dimensions_match (v_in, none, 0, 3))
+        throw Exception ("Image " + str(path) + " does not match 5TT image dimensions");
     }
 
 
+    bool operator() (const Iterator& pos);
+
   private:
     Image<float> v_in, v_out;
-    Image<bool> buffers[6];
+    Image<float> buffers[5];
+    Image<bool> none;
+    size_t excess_volume_count;
+    size_t inadequate_volume_count;
 
     void load (const std::string& path, const size_t index)
     {
-      assert (index <= 5);
-      buffers[index] = Image<bool>::open (path);
+      assert (index <= 4);
+      buffers[index] = Image<float>::open (path);
       if (!dimensions_match (v_in, buffers[index], 0, 3))
         throw Exception ("Image " + str(path) + " does not match 5TT image dimensions");
     }
 
 };
+
+
+
+
+
+bool Modifier::operator() (const Iterator& pos)
+{
+  assign_pos_of (pos, 0, 3).to (v_out);
+  bool voxel_nulled = false;
+  if (none.valid()) {
+    assign_pos_of (pos, 0, 3).to (none);
+    if (none.value()) {
+      for (auto i = Loop(3) (v_out); i; ++i)
+        v_out.value() = 0.0;
+      voxel_nulled = true;
+    }
+  }
+  if (!voxel_nulled) {
+    default_type sum_user = 0.0;
+    for (size_t tissue = 0; tissue != 5; ++tissue) {
+      if (buffers[tissue].valid()) {
+        assign_pos_of (pos, 0, 3).to (buffers[tissue]);
+        const float value = buffers[tissue].value();
+        if (value < 0.0)
+          throw Exception ("Invalid negative value found in image \"" + buffers[tissue].name() + "\"");
+        if (value > 1.0)
+          throw Exception ("Invalid value greater than zero found in image \"" + buffers[tissue].name() + "\"");
+        sum_user += value;
+      }
+    }
+    if (sum_user) {
+      if (float(sum_user) > 1.0) {
+        // Erroneous input from user;
+        //   we can rescale so that the sum of partial volume fractions is one,
+        //   but we should also warn the user about the bad input
+        for (auto i = Loop(3) (v_out); i; ++i)
+          v_out.value() = buffers[v_out.index(3)].valid() ? buffers[v_out.index(3)].value() / sum_user : 0.0;
+        ++excess_volume_count;
+      } else {
+        // Total of residual tissue fractions ignoring what is being explicitly modified
+        default_type sum_unmodified = 0.0;
+        for (auto i = Loop(3) (v_in); i; ++i) {
+          if (!buffers[v_in.index(3)].valid() || !buffers[v_in.index(3)].value())
+            sum_unmodified += v_in.value();
+        }
+        if (sum_unmodified) {
+          // Scale all of these so that after the requested tissue overrides,
+          //   inclusion of the unmodified tissues still results in a partial volume sum of one
+          const default_type unmodified_multiplier = sum_unmodified ?
+                                                      (1.0 / sum_unmodified) :
+                                                      0.0;
+          for (auto i = Loop(3) (v_in, v_out); i; ++i)
+            v_out.value() = (buffers[v_in.index(3)].valid() && buffers[v_in.index(3)].value()) ? 
+                            buffers[v_in.index(3)].value() :
+                            unmodified_multiplier * v_in.value();
+        } else {
+          // Voxel is zero-filled in input image;
+          //   ideally the user will have provided a unity sum of volume fractions as their input
+          if (float(sum_user) < 1.0) {
+            const float multiplier = 1.0 / sum_user;
+            for (auto i = Loop(3) (v_out); i; ++i)
+              v_out.value() = buffers[v_in.index(3)].valid() ?
+                              (buffers[v_in.index(3)].valid() * multiplier) :
+                              0.0;
+            ++inadequate_volume_count;
+          }
+        }
+      }
+    } else {
+      assign_pos_of (pos, 0, 3).to (v_in);
+      for (auto i = Loop(3) (v_in, v_out); i; ++i)
+        v_out.value() = v_in.value();
+    }
+  }
+  return true;
+}
+
 
 
 
@@ -149,12 +221,12 @@ void run ()
   Modifier modifier (in, out);
 
   auto
-  opt = get_options ("cgm");  if (opt.size()) modifier.set_cgm_mask  (opt[0][0]);
-  opt = get_options ("sgm");  if (opt.size()) modifier.set_sgm_mask  (opt[0][0]);
-  opt = get_options ("wm");   if (opt.size()) modifier.set_wm_mask   (opt[0][0]);
-  opt = get_options ("csf");  if (opt.size()) modifier.set_csf_mask  (opt[0][0]);
-  opt = get_options ("path"); if (opt.size()) modifier.set_path_mask (opt[0][0]);
-  opt = get_options ("none"); if (opt.size()) modifier.set_none_mask (opt[0][0]);
+  opt = get_options ("cgm");  if (opt.size()) modifier.set_cgm_input  (opt[0][0]);
+  opt = get_options ("sgm");  if (opt.size()) modifier.set_sgm_input  (opt[0][0]);
+  opt = get_options ("wm");   if (opt.size()) modifier.set_wm_input   (opt[0][0]);
+  opt = get_options ("csf");  if (opt.size()) modifier.set_csf_input  (opt[0][0]);
+  opt = get_options ("path"); if (opt.size()) modifier.set_path_input (opt[0][0]);
+  opt = get_options ("none"); if (opt.size()) modifier.set_none_mask  (opt[0][0]);
 
   ThreadedLoop ("Modifying ACT 5TT image", in, 0, 3, 2).run (modifier);
 

--- a/core/file/mmap.cpp
+++ b/core/file/mmap.cpp
@@ -112,7 +112,11 @@ namespace MR
           delayed_writeback = true;
         }
 
-        if (fsbuf.f_type == 0xff534d42 /* CIFS */|| fsbuf.f_type == 0x6969 /* NFS */ || 
+        std::stringstream s;
+        s << std::hex << fsbuf.f_type;
+        DEBUG ("Filesystem type for file \"" + Entry::name + "\": " + s.str());
+
+        if (fsbuf.f_type == 0xff534d42 /* CIFS */ || fsbuf.f_type == 0x6969 /* NFS */ || 
             fsbuf.f_type == 0x65735546 /* FUSE */ || fsbuf.f_type == 0x517b /* SMB */ || 
             fsbuf.f_type == 0x47504653 /* GPFS */ || fsbuf.f_type == 0xbd00bd0 /* LUSTRE */
 

--- a/docs/reference/commands/5ttedit.rst
+++ b/docs/reference/commands/5ttedit.rst
@@ -6,7 +6,7 @@
 Synopsis
 --------
 
-Manually set the partial volume fractions in an ACT five-tissue-type (5TT) image using mask images
+Manually set the partial volume fractions in an ACT five-tissue-type (5TT) image
 
 Usage
 --------
@@ -18,20 +18,27 @@ Usage
 -  *input*: the 5TT image to be modified
 -  *output*: the output modified 5TT image
 
+Description
+-----------
+
+The user-provided images are interpreted as desired partial volume fractions in the output image. For any voxel with a non-zero value in such an image, this will be the value for that tissue in the output 5TT image. For tissues for which the user has not explicitly requested a change to the partial volume fraction, the partial volume fraction may nevertheless change in order to preserve the requirement of a unity sum of partial volume fractions in each voxel.
+
+Any voxels that are included in the mask provided by the -none option will be erased in the output image; this supersedes all other user inputs.
+
 Options
 -------
 
--  **-cgm image** provide a mask of voxels that should be set to cortical grey matter
+-  **-cgm image** provide an image of new cortical grey matter partial volume fractions
 
--  **-sgm image** provide a mask of voxels that should be set to sub-cortical grey matter
+-  **-sgm image** provide an image of new sub-cortical grey matter partial volume fractions
 
--  **-wm image** provide a mask of voxels that should be set to white matter
+-  **-wm image** provide an image of new white matter partial volume fractions
 
--  **-csf image** provide a mask of voxels that should be set to CSF
+-  **-csf image** provide an image of new CSF partial volume fractions
 
--  **-path image** provide a mask of voxels that should be set to pathological tissue
+-  **-path image** provide an image of new pathological tissue partial volume fractions
 
--  **-none image** provide a mask of voxels that should be cleared (i.e. are non-brain); note that this will supersede all other provided masks
+-  **-none image** provide a mask of voxels that should be cleared (i.e. are non-brain)
 
 Standard options
 ^^^^^^^^^^^^^^^^

--- a/docs/reference/commands_list.rst
+++ b/docs/reference/commands_list.rst
@@ -145,7 +145,7 @@ List of MRtrix3 commands
     |cpp.png|, :ref:`5tt2gmwmi`, "Generate a mask image appropriate for seeding streamlines on the grey matter-white matter interface"
     |cpp.png|, :ref:`5tt2vis`, "Generate an image for visualisation purposes from an ACT 5TT segmented anatomical image"
     |cpp.png|, :ref:`5ttcheck`, "Thoroughly check that one or more images conform to the expected ACT five-tissue-type (5TT) format"
-    |cpp.png|, :ref:`5ttedit`, "Manually set the partial volume fractions in an ACT five-tissue-type (5TT) image using mask images"
+    |cpp.png|, :ref:`5ttedit`, "Manually set the partial volume fractions in an ACT five-tissue-type (5TT) image"
     |python.png|, :ref:`5ttgen`, "Generate a 5TT image suitable for ACT"
     |cpp.png|, :ref:`afdconnectivity`, "Obtain an estimate of fibre connectivity between two regions using AFD and streamlines tractography"
     |cpp.png|, :ref:`amp2response`, "Estimate response function coefficients based on the DWI signal in single-fibre voxels"


### PR DESCRIPTION
Started trying to document how I would like to see this modified, but eventually decided that it wouldn't take a whole lot more effort to just implement it.

@Arshiyasan Feel free to give a try if you'd like; might be preferable to thresholding at 0.5.

- [ ] Add capability to provide NaN values at input in order to force tissue volume fraction to zero
      (currently a zero in an input image means don't make any modification)
- [ ] Fully test all new features