### PR TITLE
Fix for mrview / singularity / NVIDIA

### DIFF
--- a/docs/installation/using_containers.rst
+++ b/docs/installation/using_containers.rst
@@ -104,7 +104,9 @@ Run GUI command
 The following basic usage has been shown to work on Linux::
 
     singularity run -B /run MRtrix3.sif mrview
-      OR (if using NVIDIA graphics drivers)
+
+If you have NVidia graphics drivers, you may need to instead use the `--nv` option::
+
     singularity run --nv /run MRtrix3.sif mrview
     
 If you wish to utilise a *clean environment* when executing ``mrview``,

--- a/docs/installation/using_containers.rst
+++ b/docs/installation/using_containers.rst
@@ -104,7 +104,9 @@ Run GUI command
 The following basic usage has been shown to work on Linux::
 
     singularity run -B /run MRtrix3.sif mrview
-
+      OR (if using NVIDIA graphics drivers)
+    singularity run --nv /run MRtrix3.sif mrview
+    
 If you wish to utilise a *clean environment* when executing ``mrview``,
 you will likely find that it is necessary to explicitly set the ``DISPLAY``
 and ``XDG_RUNTIME_DIR`` environment variables. This could be done in a


### PR DESCRIPTION
Simple addition to the documentation. Without the "--nv" flag, Singularity doesn't pass through the required access to NVIDIA drivers. If you're not using these, the existing code should work. But, if you do have NVIDIA drivers installed, you need to tell Singularity to get access to them.