### PR TITLE
Fix sprintf deprecation warning on macOS

### DIFF
--- a/core/file/mgh.h
+++ b/core/file/mgh.h
@@ -642,7 +642,7 @@ namespace MR
           {
             char buffer[MGH_MATRIX_STRLEN];
             memset (buffer, 0x00, MGH_MATRIX_STRLEN);
-            sprintf (buffer, "AutoAlign %10lf %10lf %10lf %10lf %10lf %10lf %10lf %10lf %10lf %10lf %10lf %10lf %10lf %10lf %10lf %10lf",
+            snprintf (buffer, sizeof(buffer)/sizeof(buffer[0]), "AutoAlign %10lf %10lf %10lf %10lf %10lf %10lf %10lf %10lf %10lf %10lf %10lf %10lf %10lf %10lf %10lf %10lf",
                     M(0,0), M(0,1), M(0,2), M(0,3),
                     M(1,0), M(1,1), M(1,2), M(1,3),
                     M(2,0), M(2,1), M(2,2), M(2,3),


### PR DESCRIPTION
Fixes the following warning when compiling on macOS13: "This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead."