### PR TITLE
Mrview rename orientationlabel option

### DIFF
--- a/docs/reference/commands/mrview.rst
+++ b/docs/reference/commands/mrview.rst
@@ -72,7 +72,7 @@ View options
 
 -  **-voxelinfo boolean** *(multiple uses permitted)* Show or hide voxel information overlay.
 
--  **-orientationlabel boolean** *(multiple uses permitted)* Show or hide orientation label overlay.
+-  **-orientlabel boolean** *(multiple uses permitted)* Show or hide orientation label overlay.
 
 -  **-colourbar boolean** *(multiple uses permitted)* Show or hide colourbar overlay.
 

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -2089,12 +2089,12 @@ namespace MR
             return;
           }
 
-          if (opt.opt->is ("orientationlabel")) {
+          if (opt.opt->is ("orientlabel")) {
             try {
               show_orientation_labels_action->setChecked (to<bool> (opt[0]));
             }
             catch (Exception& E) {
-              throw Exception ("-orientationlabel option expects a boolean");
+              throw Exception ("-orientlabel option expects a boolean");
             }
             glarea->update();
             return;
@@ -2214,7 +2214,7 @@ namespace MR
           + Option ("voxelinfo", "Show or hide voxel information overlay.").allow_multiple()
           +   Argument ("boolean").type_bool ()
 
-          + Option ("orientationlabel", "Show or hide orientation label overlay.").allow_multiple()
+          + Option ("orientlabel", "Show or hide orientation label overlay.").allow_multiple()
           +   Argument ("boolean").type_bool ()
 
           + Option ("colourbar", "Show or hide colourbar overlay.").allow_multiple()


### PR DESCRIPTION
Apply #2569 to `dev` branch (see also #2581 for context). 

Basically, there is only a conflict between `mrview`'s `-orientationlabel` and `-orientation` options on `dev`, since the `-orientation` option _only_ exists on `dev` (#2155). I've therefore reverted #2569 with #2581 on `master`, and cherry-picked the changes onto `dev` in this PR. 

Hope that all makes sense...