### PR TITLE
Dwi2mask synthstrip: New algorithm for dwi2mask

### DIFF
--- a/bin/dwi2mask
+++ b/bin/dwi2mask
@@ -94,7 +94,8 @@ def execute(): #pylint: disable=unused-variable
               + ' |'
               + ' mrconvert - '
               + path.from_user(app.ARGS.output)
-              + ' -strides ' + ','.join(str(value) for value in strides),
+              + ' -strides ' + ','.join(str(value) for value in strides)
+              + ' -datatype bit',
               mrconvert_keyval=path.from_user(app.ARGS.input, False),
               force=app.FORCE_OVERWRITE)
 

--- a/docs/reference/commands/dwi2mask.rst
+++ b/docs/reference/commands/dwi2mask.rst
@@ -870,7 +870,7 @@ dwi2mask synthstrip
 Synopsis
 --------
 
-Use the Synthstrip heuristic (based on skull-stripping method)
+Use the FreeSurfer Synthstrip method on the mean b=0 image
 
 Usage
 -----
@@ -881,6 +881,11 @@ Usage
 
 -  *input*: The input DWI series
 -  *output*: The output mask image
+
+Description
+-----------
+
+This algorithm requires that the SynthStrip method be installed and available via PATH; this could be via Freesufer 7.3.0 or later, or the dedicated Singularity container.
 
 Options
 -------
@@ -935,6 +940,8 @@ Standard options
 
 References
 ^^^^^^^^^^
+
+* A. Hoopes, J. S. Mora, A. V. Dalca, B. Fischl, M. Hoffmann. SynthStrip: Skull-Stripping for Any Brain Image. NeuroImage, 2022, 260, 119474
 
 Tournier, J.-D.; Smith, R. E.; Raffelt, D.; Tabbara, R.; Dhollander, T.; Pietsch, M.; Christiaens, D.; Jeurissen, B.; Yeh, C.-H. & Connelly, A. MRtrix3: A fast, flexible and open software framework for medical image processing and visualisation. NeuroImage, 2019, 202, 116137
 

--- a/docs/reference/commands/dwi2mask.rst
+++ b/docs/reference/commands/dwi2mask.rst
@@ -15,7 +15,7 @@ Usage
 
     dwi2mask algorithm [ options ] ...
 
--  *algorithm*: Select the algorithm to be used to complete the script operation; additional details and options become available once an algorithm is nominated. Options are: 3dautomask, ants, b02template, consensus, fslbet, hdbet, legacy, mean, trace
+-  *algorithm*: Select the algorithm to be used to complete the script operation; additional details and options become available once an algorithm is nominated. Options are: 3dautomask, ants, b02template, consensus, fslbet, hdbet, legacy, mean, synthstrip, trace
 
 Description
 -----------
@@ -846,6 +846,107 @@ Tournier, J.-D.; Smith, R. E.; Raffelt, D.; Tabbara, R.; Dhollander, T.; Pietsch
 
 
 **Author:** Warda Syeda (wtsyeda@unimelb.edu.au)
+
+**Copyright:** Copyright (c) 2008-2023 the MRtrix3 contributors.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Covered Software is provided under this License on an "as is"
+basis, without warranty of any kind, either expressed, implied, or
+statutory, including, without limitation, warranties that the
+Covered Software is free of defects, merchantable, fit for a
+particular purpose or non-infringing.
+See the Mozilla Public License v. 2.0 for more details.
+
+For more details, see http://www.mrtrix.org/.
+
+.. _dwi2mask_synthstrip:
+
+dwi2mask synthstrip
+===================
+
+Synopsis
+--------
+
+Use the Synthstrip heuristic (based on skull-stripping method)
+
+Usage
+-----
+
+::
+
+    dwi2mask synthstrip input output [ options ]
+
+-  *input*: The input DWI series
+-  *output*: The output mask image
+
+Options
+-------
+
+- **-clean_scale** the maximum scale used to cut bridges. A certain maximum scale cuts bridges up to a width (in voxels) of 2x the provided scale. Setting this to 0 disables the mask cleaning step. (Default: 2)
+
+Options specific to the ' Synthstrip 'algorithm
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- **-s** The output stripped image
+
+- **-h** The help messeage of Synthstrip algorithm
+
+- **-g** Use the GPU
+
+- **-mo** Alternative model weights
+
+- **-nocsf** Compute the immediate boundary of brain matter excluding surrounding CSF
+
+- **-b** Control the boundary distance from the brain
+
+Options for importing the diffusion gradient table
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- **-grad** Provide the diffusion gradient table in MRtrix format
+
+- **-fslgrad bvecs bvals** Provide the diffusion gradient table in FSL bvecs/bvals format
+
+Additional standard options for Python scripts
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- **-nocleanup** do not delete intermediate files during script execution, and do not delete scratch directory at script completion.
+
+- **-scratch /path/to/scratch/** manually specify the path in which to generate the scratch directory.
+
+- **-continue <ScratchDir> <LastFile>** continue the script from a previous execution; must provide the scratch directory path, and the name of the last successfully-generated file.
+
+Standard options
+^^^^^^^^^^^^^^^^
+
+- **-info** display information messages.
+
+- **-quiet** do not display information messages or progress status. Alternatively, this can be achieved by setting the MRTRIX_QUIET environment variable to a non-empty string.
+
+- **-debug** display debugging messages.
+
+- **-force** force overwrite of output files.
+
+- **-nthreads number** use this number of threads in multi-threaded applications (set to 0 to disable multi-threading).
+
+- **-config key value**  *(multiple uses permitted)* temporarily set the value of an MRtrix config file entry.
+
+- **-help** display this information page and exit.
+
+- **-version** display version information and exit.
+
+References
+^^^^^^^^^^
+
+Tournier, J.-D.; Smith, R. E.; Raffelt, D.; Tabbara, R.; Dhollander, T.; Pietsch, M.; Christiaens, D.; Jeurissen, B.; Yeh, C.-H. & Connelly, A. MRtrix3: A fast, flexible and open software framework for medical image processing and visualisation. NeuroImage, 2019, 202, 116137
+
+--------------
+
+
+
+**Author:** Ruobing Chen(chrc@student.unimelb.edu.au)
 
 **Copyright:** Copyright (c) 2008-2023 the MRtrix3 contributors.
 

--- a/docs/reference/commands/dwi2mask.rst
+++ b/docs/reference/commands/dwi2mask.rst
@@ -885,22 +885,18 @@ Usage
 Options
 -------
 
-- **-clean_scale** the maximum scale used to cut bridges. A certain maximum scale cuts bridges up to a width (in voxels) of 2x the provided scale. Setting this to 0 disables the mask cleaning step. (Default: 2)
+Options specific to the 'Synthstrip' algorithm
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Options specific to the ' Synthstrip 'algorithm
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+- **-stripped** The output stripped image
 
-- **-s** The output stripped image
+- **-gpu** Use the GPU
 
-- **-h** The help messeage of Synthstrip algorithm
-
-- **-g** Use the GPU
-
-- **-mo** Alternative model weights
+- **-model file** Alternative model weights
 
 - **-nocsf** Compute the immediate boundary of brain matter excluding surrounding CSF
 
-- **-b** Control the boundary distance from the brain
+- **-border** Control the boundary distance from the brain
 
 Options for importing the diffusion gradient table
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -946,7 +942,7 @@ Tournier, J.-D.; Smith, R. E.; Raffelt, D.; Tabbara, R.; Dhollander, T.; Pietsch
 
 
 
-**Author:** Ruobing Chen(chrc@student.unimelb.edu.au)
+**Author:** Ruobing Chen (chrc@student.unimelb.edu.au)
 
 **Copyright:** Copyright (c) 2008-2023 the MRtrix3 contributors.
 

--- a/lib/mrtrix3/dwi2mask/synthstrip.py
+++ b/lib/mrtrix3/dwi2mask/synthstrip.py
@@ -84,11 +84,7 @@ def execute(): #pylint: disable=unused-variable
   if app.ARGS.mo:
     cmd_string+= ' --model' + father_path + ' -model.nii'
 
-  #try:
-  #  #run.command( 'mri_synthstip -i 3dbzero.nii -o' + str(app.ARGS.o)+ '-m' + str(app.ARGS.m)+'-no-csf'+str(app.ARGS.no-csf)+'-b'+str(app.ARGS.b))
-  #  run.command( 'mri_synthstrip -i 3dbzero.nii -o stripped.nii -m synthstrip_mask.nii')
-  #except run.MRtrixError:
-  #  app.warn('The input image may have more than 1 frames.')
+
   if app.ARGS.h:
     run.command(cmd_string)
     return 'input.mif'

--- a/lib/mrtrix3/dwi2mask/synthstrip.py
+++ b/lib/mrtrix3/dwi2mask/synthstrip.py
@@ -20,6 +20,7 @@ from mrtrix3 import app, path, run
 
 
 SYNTHSTRIP_CMD='mri_synthstrip'
+SYNTHSTRIP_SINGULARITY='sythstrip-singularity'
 
 
 def usage(base_parser, subparsers): #pylint: disable=unused-variable
@@ -51,7 +52,9 @@ def execute(): #pylint: disable=unused-variable
 
   synthstrip_cmd = shutil.which(SYNTHSTRIP_CMD)
   if not synthstrip_cmd:
-    raise MRtrixError('Unable to locate "Synthstrip" executable; please check installation')
+    synthstrip_cmd=shutil.which(SYNTHSTRIP_SINGULARITY)
+    if not synthstrip_cmd:
+      raise MRtrixError('Unable to locate "Synthstrip" executable; please check installation')
 
   output_file = 'synthstrip_mask.nii'
   stripped_file = 'stripped.nii'

--- a/lib/mrtrix3/dwi2mask/synthstrip.py
+++ b/lib/mrtrix3/dwi2mask/synthstrip.py
@@ -27,6 +27,9 @@ def usage(base_parser, subparsers): #pylint: disable=unused-variable
   parser = subparsers.add_parser('synthstrip', parents=[base_parser])
   parser.set_author('Ruobing Chen (chrc@student.unimelb.edu.au)')
   parser.set_synopsis('Use the Synthstrip heuristic (based on skull-stripping method)')
+  parser.add_description('This scrip assumes that this system has Freesufer 7.3.2 or later version installed in it.'
+                         'The Synthstrip algorithm uses mean b=0 DWI input with skull-stripping based method to generate a mask.')
+  parser.add_citation('A. Hoopes, J. S. Mora, A. V. Dalca, B. Fischl*, M. Hoffmann* (*equal contribution)', is_external=True)
   parser.add_argument('input', help='The input DWI series')
   parser.add_argument('output', help='The output mask image')
   options=parser.add_argument_group('Options specific to the \'Synthstrip\' algorithm')

--- a/lib/mrtrix3/dwi2mask/synthstrip.py
+++ b/lib/mrtrix3/dwi2mask/synthstrip.py
@@ -26,10 +26,10 @@ SYNTHSTRIP_SINGULARITY='sythstrip-singularity'
 def usage(base_parser, subparsers): #pylint: disable=unused-variable
   parser = subparsers.add_parser('synthstrip', parents=[base_parser])
   parser.set_author('Ruobing Chen (chrc@student.unimelb.edu.au)')
-  parser.set_synopsis('Use the Synthstrip heuristic (based on skull-stripping method)')
-  parser.add_description('This scrip assumes that this system has Freesufer 7.3.2 or later version installed in it.'
-                         'The Synthstrip algorithm uses mean b=0 DWI input with skull-stripping based method to generate a mask.')
-  parser.add_citation('A. Hoopes, J. S. Mora, A. V. Dalca, B. Fischl*, M. Hoffmann* (*equal contribution)', is_external=True)
+  parser.set_synopsis('Use the FreeSurfer Synthstrip method on the mean b=0 image')
+  parser.add_description('This algorithm requires that the SynthStrip method be installed and available via PATH; '
+                         'this could be via Freesufer 7.3.0 or later, or the dedicated Singularity container.')
+  parser.add_citation('A. Hoopes, J. S. Mora, A. V. Dalca, B. Fischl, M. Hoffmann. SynthStrip: Skull-Stripping for Any Brain Image. NeuroImage, 2022, 260, 119474', is_external=True)
   parser.add_argument('input', help='The input DWI series')
   parser.add_argument('output', help='The output mask image')
   options=parser.add_argument_group('Options specific to the \'Synthstrip\' algorithm')

--- a/lib/mrtrix3/dwi2mask/synthstrip.py
+++ b/lib/mrtrix3/dwi2mask/synthstrip.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2008-2023 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
+import shutil
+import argparse
+import os
+import warnings
+from mrtrix3 import MRtrixError
+from mrtrix3 import app, run
+
+
+DEFAULT_CLEAN_SCALE = 2
+SYNTHSTRIP='mri_synthstrip'
+
+
+def usage(base_parser, subparsers): #pylint: disable=unused-variable
+  parser = subparsers.add_parser('synthstrip', parents=[base_parser])
+  parser.set_author('Ruobing Chen(chrc@student.unimelb.edu.au)')
+  parser.set_synopsis('Use the Synthstrip heuristic (based on skull-stripping method)')
+  parser.add_argument('input',  help='The input DWI series')
+  parser.add_argument('output', help='The output mask image')
+  options=parser.add_argument_group('Options specific to the \' Synthstrip \'algorithm')
+  options.add_argument('-s', action='store_true', default=False, help='The output stripped image')
+  options.add_argument('-h', action='store_true',default=False, help='The help messeage of Synthstrip algorithm')
+  options.add_argument('-g', action='store_true',default=False, help='Use the GPU')
+  options.add_argument('-mo',action='store_true',default=False,help='Alternative model weights')
+  options.add_argument('-nocsf',action='store_true', default=False, help='Compute the immediate boundary of brain matter excluding surrounding CSF')
+  options.add_argument('-b', type=int,help='Control the boundary distance from the brain')
+  parser.add_argument('-clean_scale',
+                      type=int,
+                      default=DEFAULT_CLEAN_SCALE,
+                      help='the maximum scale used to cut bridges. A certain maximum scale cuts '
+                           'bridges up to a width (in voxels) of 2x the provided scale. Setting '
+                           'this to 0 disables the mask cleaning step. (Default: ' + str(DEFAULT_CLEAN_SCALE) + ')')
+  
+
+
+def get_inputs(): #pylint: disable=unused-variable
+  pass
+
+
+
+def needs_mean_bzero(): #pylint: disable=unused-variable
+  return True
+
+
+
+def execute(): #pylint: disable=unused-variable
+  
+  run.command('dwiextract input.mif - -bzero | mrmath - mean mean_bzero.mif -axis 3')
+  
+  run.command('mrconvert mean_bzero.mif 3dbzero.mif -axes 0,1,2')
+  app.cleanup('mean_bzero.mif')
+  run.command('mrconvert 3dbzero.mif 3dbzero.nii')
+  app.cleanup('3dbzero.mif')
+  
+  
+  synthstrip_cmd = shutil.which("mri_synthstrip")
+  if not synthstrip_cmd:
+    raise MRtrixError('Unable to locate "Synthstrip" executable; please check installation')
+  
+  cmd_string =SYNTHSTRIP + ' -i' +' 3dbzero.nii' + ' -m' +' synthstrip_mask.nii'
+  output_file='synthstrip_mask.mif'
+  #current_path=os.path.abspath('input.mif')
+  current_path=os.path.abspath(__file__)
+  father_path=os.path.abspath(os.path.dirname(current_path))
+
+
+  if app.ARGS.h:
+    cmd_string=SYNTHSTRIP +' -h'
+    warnings.warn('Displaying help message will not produce any desired files,the output of this command only produce the original input file with desired output file name, if need files, please rerun the command without -h syntax')
+  if app.ARGS.s:
+    cmd_string+=' -o '+ father_path+'/stripped.nii'
+    warnings.warn('The stripped file will be saved in mrtrix3/lib/mrtrix3/dwi2mask')
+  if app.ARGS.g:
+    cmd_string+=' -g'
+    
+  if app.ARGS.nocsf:
+    cmd_string+=' --no-csf'
+
+  if app.ARGS.b is not None:
+    cmd_string += ' -b' + ' '+str(app.ARGS.b)
+
+  if app.ARGS.mo:
+    cmd_string+= ' --model' + father_path + ' -model.nii'
+
+  #try:
+  #  #run.command( 'mri_synthstip -i 3dbzero.nii -o' + str(app.ARGS.o)+ '-m' + str(app.ARGS.m)+'-no-csf'+str(app.ARGS.no-csf)+'-b'+str(app.ARGS.b))
+  #  run.command( 'mri_synthstrip -i 3dbzero.nii -o stripped.nii -m synthstrip_mask.nii')
+  #except run.MRtrixError:
+  #  app.warn('The input image may have more than 1 frames.')
+  if app.ARGS.h:
+    run.command(cmd_string)
+    return 'input.mif'
+  else:
+    run.command(cmd_string)
+    run.command('mrconvert synthstrip_mask.nii synthstrip_mask.mif -datatype bit')
+    app.cleanup('3dbzero.nii')
+  
+    app.cleanup('synthstrip_mask.nii')
+  
+    return output_file

--- a/lib/mrtrix3/dwi2mask/synthstrip.py
+++ b/lib/mrtrix3/dwi2mask/synthstrip.py
@@ -14,7 +14,6 @@
 # For more details, see http://www.mrtrix.org/.
 
 import shutil
-import argparse
 import os
 import warnings
 from mrtrix3 import MRtrixError
@@ -52,13 +51,13 @@ def needs_mean_bzero(): #pylint: disable=unused-variable
 
 
 def execute(): #pylint: disable=unused-variable
-  
 
-  
+
+
   synthstrip_cmd = shutil.which(SYNTHSTRIP_CMD)
   if not synthstrip_cmd:
     raise MRtrixError('Unable to locate "Synthstrip" executable; please check installation')
-  
+
   cmd_string =SYNTHSTRIP_CMD+ ' -i bzero.nii -m synthstrip_mask.nii'
   output_file='synthstrip_mask.mif'
   #current_path=os.path.abspath('input.mif')
@@ -68,13 +67,14 @@ def execute(): #pylint: disable=unused-variable
 
   if app.ARGS.h:
     cmd_string=SYNTHSTRIP_CMD +' -h'
+    output_file='input.mif'
     warnings.warn('Displaying help message will not produce any desired files,the output of this command only produce the original input file with desired output file name, if need files, please rerun the command without -h syntax')
   if app.ARGS.s:
     cmd_string+=' -o '+ father_path+'/stripped.nii'
     warnings.warn('The stripped file will be saved in mrtrix3/lib/mrtrix3/dwi2mask')
   if app.ARGS.g:
     cmd_string+=' -g'
-    
+
   if app.ARGS.nocsf:
     cmd_string+=' --no-csf'
 
@@ -84,15 +84,19 @@ def execute(): #pylint: disable=unused-variable
   if app.ARGS.mo:
     cmd_string+= ' --model' + father_path + ' -model.nii'
 
+  run.command(cmd_string)
+  run.command('mrconvert synthstrip_mask.nii synthstrip_mask.mif -datatype bit')
+  app.cleanup('synthstrip_mask.nii')
+  return output_file
 
-  if app.ARGS.h:
-    run.command(cmd_string)
-    return 'input.mif'
-  else:
-    run.command(cmd_string)
-    run.command('mrconvert synthstrip_mask.nii synthstrip_mask.mif -datatype bit')
-    
-  
-    app.cleanup('synthstrip_mask.nii')
-  
-    return output_file
+  #if app.ARGS.h:
+  #  run.command(cmd_string)
+  #  return 'input.mif'
+  #else:
+  #  run.command(cmd_string)
+  #  run.command('mrconvert synthstrip_mask.nii synthstrip_mask.mif -datatype bit')
+
+
+#    app.cleanup('synthstrip_mask.nii')
+
+#    return output_file

--- a/lib/mrtrix3/dwi2mask/synthstrip.py
+++ b/lib/mrtrix3/dwi2mask/synthstrip.py
@@ -21,13 +21,13 @@ from mrtrix3 import MRtrixError
 from mrtrix3 import app, run
 
 
-DEFAULT_CLEAN_SCALE = 2
-SYNTHSTRIP='mri_synthstrip'
+
+SYNTHSTRIP_CMD='mri_synthstrip'
 
 
 def usage(base_parser, subparsers): #pylint: disable=unused-variable
   parser = subparsers.add_parser('synthstrip', parents=[base_parser])
-  parser.set_author('Ruobing Chen(chrc@student.unimelb.edu.au)')
+  parser.set_author('Ruobing Chen (chrc@student.unimelb.edu.au)')
   parser.set_synopsis('Use the Synthstrip heuristic (based on skull-stripping method)')
   parser.add_argument('input',  help='The input DWI series')
   parser.add_argument('output', help='The output mask image')
@@ -38,13 +38,7 @@ def usage(base_parser, subparsers): #pylint: disable=unused-variable
   options.add_argument('-mo',action='store_true',default=False,help='Alternative model weights')
   options.add_argument('-nocsf',action='store_true', default=False, help='Compute the immediate boundary of brain matter excluding surrounding CSF')
   options.add_argument('-b', type=int,help='Control the boundary distance from the brain')
-  parser.add_argument('-clean_scale',
-                      type=int,
-                      default=DEFAULT_CLEAN_SCALE,
-                      help='the maximum scale used to cut bridges. A certain maximum scale cuts '
-                           'bridges up to a width (in voxels) of 2x the provided scale. Setting '
-                           'this to 0 disables the mask cleaning step. (Default: ' + str(DEFAULT_CLEAN_SCALE) + ')')
-  
+
 
 
 def get_inputs(): #pylint: disable=unused-variable
@@ -59,19 +53,13 @@ def needs_mean_bzero(): #pylint: disable=unused-variable
 
 def execute(): #pylint: disable=unused-variable
   
-  run.command('dwiextract input.mif - -bzero | mrmath - mean mean_bzero.mif -axis 3')
+
   
-  run.command('mrconvert mean_bzero.mif 3dbzero.mif -axes 0,1,2')
-  app.cleanup('mean_bzero.mif')
-  run.command('mrconvert 3dbzero.mif 3dbzero.nii')
-  app.cleanup('3dbzero.mif')
-  
-  
-  synthstrip_cmd = shutil.which("mri_synthstrip")
+  synthstrip_cmd = shutil.which(SYNTHSTRIP_CMD)
   if not synthstrip_cmd:
     raise MRtrixError('Unable to locate "Synthstrip" executable; please check installation')
   
-  cmd_string =SYNTHSTRIP + ' -i' +' 3dbzero.nii' + ' -m' +' synthstrip_mask.nii'
+  cmd_string =SYNTHSTRIP_CMD+ ' -i bzero.nii -m synthstrip_mask.nii'
   output_file='synthstrip_mask.mif'
   #current_path=os.path.abspath('input.mif')
   current_path=os.path.abspath(__file__)
@@ -79,7 +67,7 @@ def execute(): #pylint: disable=unused-variable
 
 
   if app.ARGS.h:
-    cmd_string=SYNTHSTRIP +' -h'
+    cmd_string=SYNTHSTRIP_CMD +' -h'
     warnings.warn('Displaying help message will not produce any desired files,the output of this command only produce the original input file with desired output file name, if need files, please rerun the command without -h syntax')
   if app.ARGS.s:
     cmd_string+=' -o '+ father_path+'/stripped.nii'
@@ -107,7 +95,7 @@ def execute(): #pylint: disable=unused-variable
   else:
     run.command(cmd_string)
     run.command('mrconvert synthstrip_mask.nii synthstrip_mask.mif -datatype bit')
-    app.cleanup('3dbzero.nii')
+    
   
     app.cleanup('synthstrip_mask.nii')
   

--- a/lib/mrtrix3/dwi2mask/synthstrip.py
+++ b/lib/mrtrix3/dwi2mask/synthstrip.py
@@ -57,23 +57,23 @@ def execute(): #pylint: disable=unused-variable
   stripped_file = 'stripped.nii'
   cmd_string = SYNTHSTRIP_CMD + ' -i bzero.nii -m ' + output_file
 
-  if app.ARGS.s:
+  if app.ARGS.stripped:
     cmd_string += ' -o ' + stripped_file
-  if app.ARGS.g:
+  if app.ARGS.gpu:
     cmd_string += ' -g'
 
   if app.ARGS.nocsf:
     cmd_string += ' --no-csf'
 
-  if app.ARGS.b is not None:
-    cmd_string += ' -b' + ' ' + str(app.ARGS.b)
+  if app.ARGS.border is not None:
+    cmd_string += ' -b' + ' ' + str(app.ARGS.border)
 
   if app.ARGS.model:
     cmd_string += ' --model' + path.from_user(app.ARGS.model)
 
   run.command(cmd_string)
-  if app.ARGS.s:
-    run.command('mrconvert ' + stripped_file + ' ' + path.from_user(app.ARGS.s),
+  if app.ARGS.stripped:
+    run.command('mrconvert ' + stripped_file + ' ' + path.from_user(app.ARGS.stripped),
                 mrconvert_keyval=path.from_user(app.ARGS.input, False),
                 force=app.FORCE_OVERWRITE)
   return output_file

--- a/testing/scripts/tests/dwi2mask
+++ b/testing/scripts/tests/dwi2mask
@@ -22,6 +22,8 @@ dwi2mask fslbet tmp-sub-01_dwi.mif ../tmp/dwi2mask/fslbet_rescale.mif -rescale -
 dwi2mask hdbet tmp-sub-01_dwi.mif ../tmp/dwi2mask/hdbet.mif -force
 dwi2mask legacy tmp-sub-01_dwi.mif ../tmp/dwi2mask/legacy.mif -force && testing_diff_image ../tmp/dwi2mask/legacy.mif dwi2mask/legacy.mif.gz
 dwi2mask mean tmp-sub-01_dwi.mif ../tmp/dwi2mask/mean.mif -force && testing_diff_image ../tmp/dwi2mask/mean.mif dwi2mask/mean.mif.gz
+dwi2mask synthstrip tmp-sub-01_dwi.mif ../tmp/dwi2mask/synthstrip_default.mif -force
+dwi2mask synthstrip tmp-sub-01_dwi.mif ../tmp/dwi2mask/synthstrip_options.mif -stripped ../tmp/dwi2mask/synthstrip_stripped.mif -gpu -nocsf -border 0 -force
 dwi2mask trace tmp-sub-01_dwi.mif ../tmp/dwi2mask/trace_default.mif -force && testing_diff_image ../tmp/dwi2mask/trace_default.mif dwi2mask/trace_default.mif.gz
 dwi2mask trace tmp-sub-01_dwi.mif ../tmp/dwi2mask/trace_iterative.mif -iterative -force && testing_diff_image ../tmp/dwi2mask/trace_iterative.mif dwi2mask/trace_iterative.mif.gz
 


### PR DESCRIPTION
Add a new script to execute the algorithm called Synthstrip which uses the skull-stripping method to produce a brain mask. The script can execute normally and should produce the desired output. However, the difference-comparing test is unnecessary because it makes use of additional software outside the MRtrix3. If the developer changes the source code of the software, it is possible for the script to produce a different output file while no changes are made to the script. In order to function the Synthstrip correctly, users need to have FreeSurfer v7.3.2 or a later version installed on their native systems. This is related to #2500 