### PR TITLE
Update GitHub Actions workflow for merge queue

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,9 +3,11 @@ name: checks
 on:
   pull_request:
     types: [opened, synchronize]
-    branches:
-      - master
-      - dev
+    branches: [ master, dev ]
+  merge_group:
+    types: [checks_requested]
+    branches: [ master ]
+
 
 
 


### PR DESCRIPTION
The plan is to make use of GitHub's new merge queue feature, to reduce the faff when trying to merge multiple pull requests at the same time. More detail on the GitHub docs:
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue

Note that this has been activated on master.