### PR TITLE
fsl.check_first(): Utilise PID

### DIFF
--- a/bin/labelsgmfix
+++ b/bin/labelsgmfix
@@ -105,8 +105,8 @@ def execute(): #pylint: disable=unused-variable
   first_input_is_brain_extracted = ''
   if app.ARGS.premasked:
     first_input_is_brain_extracted = ' -b'
-  run.command(first_cmd + ' -m none -s ' + ','.join(structure_map.keys()) + ' -i T1.nii' + first_input_is_brain_extracted + ' -o first')
-  fsl.check_first('first', structure_map.keys())
+  first_stdout = run.command(first_cmd + ' -m none -s ' + ','.join(structure_map.keys()) + ' -i T1.nii' + first_input_is_brain_extracted + ' -o first').stdout
+  fsl.check_first('first', structures=structure_map.keys(), first_stdout=first_stdout)
 
   # Generate an empty image that will be used to construct the new SGM nodes
   run.command('mrcalc parc.mif 0 -min sgm.mif')

--- a/lib/mrtrix3/_5ttgen/fsl.py
+++ b/lib/mrtrix3/_5ttgen/fsl.py
@@ -188,8 +188,8 @@ def execute(): #pylint: disable=unused-variable
   first_verbosity_option = ''
   if app.VERBOSITY == 3:
     first_verbosity_option = ' -v'
-  run.command(first_cmd + ' -m none -s ' + ','.join(sgm_structures) + ' -i ' + first_input + ' -o first' + first_brain_extracted_option + first_debug_option + first_verbosity_option)
-  fsl.check_first('first', sgm_structures)
+  first_stdout = run.command(first_cmd + ' -m none -s ' + ','.join(sgm_structures) + ' -i ' + first_input + ' -o first' + first_brain_extracted_option + first_debug_option + first_verbosity_option).stdout
+  fsl.check_first('first', structures=sgm_structures, first_stdout=first_stdout)
 
   # Convert FIRST meshes to partial volume images
   pve_image_list = [ ]

--- a/lib/mrtrix3/_5ttgen/hsvs.py
+++ b/lib/mrtrix3/_5ttgen/hsvs.py
@@ -515,8 +515,8 @@ def execute(): #pylint: disable=unused-variable
       from_first = { key: value for key, value in from_first.items() if 'Hippocampus' not in value and 'Amygdala' not in value }
     if thalami_method != 'first':
       from_first = { key: value for key, value in from_first.items() if 'Thalamus' not in value }
-    run.command(first_cmd + ' -s ' + ','.join(from_first.keys()) + ' -i T1.nii -b -o first')
-    fsl.check_first('first', from_first.keys())
+    first_stdout = run.command(first_cmd + ' -s ' + ','.join(from_first.keys()) + ' -i T1.nii -b -o first').stdout
+    fsl.check_first('first', structures=from_first.keys(), first_stdout=first_stdout)
     app.cleanup(glob.glob('T1_to_std_sub.*'))
     progress = app.ProgressBar('Mapping FIRST segmentations to image', 2*len(from_first))
     for key, value in from_first.items():


### PR DESCRIPTION
Attempt at resolving #2595.

If possible, it will take the PID reported on stdout and wait for its completion.
Looking at the `run_first_all` code, I think that `fsl_sub` is used in such a way that each spawned processes inherits the previously executed processes as its children, as it's the PID of the last executed job that is sent to stdout.

This does as intended on my own system, in that the PID reported by `run_first_all` no longer exists and so the function can proceed as normal. However it really requires testing on a system with SGE configured. @glasserm is this something you're in a position to do easily?

Also, I've left the `path.wait_for()` call in place where SGE is easily detected just as a failsafe; I don't expect that code to actually be used anymore since it will only execute if the PID can't be queried.
