### PR TITLE
dwi2mask consensus: Fix user omission of b02template

### DIFF
--- a/lib/mrtrix3/dwi2mask/consensus.py
+++ b/lib/mrtrix3/dwi2mask/consensus.py
@@ -79,9 +79,11 @@ def execute(): #pylint: disable=unused-variable
   # For "template" algorithm, can run twice with two different softwares
   # Ideally this would be determined based on the help page,
   #   rather than pre-programmed
-  algorithm_list = [item for item in algorithm_list if item != 'b02template']
-  algorithm_list.append('b02template -software antsfull')
-  algorithm_list.append('b02template -software fsl')
+  # Don't use "-software antsquick"; we're assuming that "antsfull" is superior
+  if 'b02template' in algorithm_list:
+    algorithm_list = [item for item in algorithm_list if item != 'b02template']
+    algorithm_list.append('b02template -software antsfull')
+    algorithm_list.append('b02template -software fsl')
   app.debug(str(algorithm_list))
 
   mask_list = []


### PR DESCRIPTION
If the user manually provides a list of algorithms to be used, and that list does not include "`b02template`", do not go on to insert separate `dwi2mask b02template` calls for the different software algorithms that can be used within such.