### PR TITLE
Pipe image format: Revise error message

### DIFF
--- a/core/formats/pipe.cpp
+++ b/core/formats/pipe.cpp
@@ -64,7 +64,7 @@ namespace MR
         return false;
 
       if (isatty (STDOUT_FILENO))
-        throw Exception ("attempt to pipe image to standard output (this will leave temporary files behind)");
+        throw Exception ("cannot create output piped image: no command connected at other end of pipe to receive that image");
 
       H.name() = File::create_tempfile (0, "mif");
 


### PR DESCRIPTION
This popped up in evaluating #1392 / https://github.com/ankitasanil/mrtrix3/pull/1.

It seems to me that the error message created in this instance is not tailored to interpretation by a user who encounters that message.