### PR TITLE
App::get_matches(): Fix memleak

### DIFF
--- a/core/app.cpp
+++ b/core/app.cpp
@@ -128,7 +128,14 @@ namespace MR
       inline void get_matches (vector<const Option*>& candidates, const OptionGroup& group, const std::string& stub)
       {
         for (size_t i = 0; i < group.size(); ++i) {
-          if (stub.compare (0, stub.size(), group[i].id, stub.size()) == 0)
+          bool match = true;
+          for (size_t c = 0; c != stub.size(); ++c) {
+            if (!group[i].id[c] || (stub[c] != group[i].id[c])) {
+              match = false;
+              break;
+            }
+          }
+          if (match)
             candidates.push_back (&group[i]);
         }
       }


### PR DESCRIPTION
Discovered this while playing with ASan (#2612) to diagnose a fault with my own code. Seems that `std::string::compare()` is buffer-overrunning the C-style string. And because it's a C-style string, we can't query the size. So this code goes one character at a time. But it would be preferable for all of the back-end, including command-line parsing, to be using `std::string` and safe pointers (#2111).