### PR TITLE
Changes to enable meshconvert to warp mesh files.

### DIFF
--- a/cmd/meshconvert.cpp
+++ b/cmd/meshconvert.cpp
@@ -16,6 +16,7 @@
 
 #include "command.h"
 #include "header.h"
+#include "image.h"
 #include "surface/mesh.h"
 #include "surface/mesh_multi.h"
 #include "surface/filter/vertex_transform.h"
@@ -28,16 +29,16 @@ using namespace MR::Surface;
 
 
 
-const char* transform_choices[] = { "first2real", "real2first", "voxel2real", "real2voxel", "fs2real", nullptr };
+const char* transform_choices[] = { "first2real", "real2first", "voxel2real", "real2voxel", "fs2real", "warp", nullptr };
 
 
 
 void usage ()
 {
 
-  AUTHOR = "Robert E. Smith (robert.smith@florey.edu.au)";
+  AUTHOR = "Robert E. Smith (robert.smith@florey.edu.au) and Arshiya Sangchooli (asangchooli@student.unimelb.edu.au)";
 
-  SYNOPSIS = "Convert meshes between different formats, and apply transformations";
+  SYNOPSIS = "Transform a mesh between different formats and apply transformations, or apply a non-linear transformation to a mesh";
 
   ARGUMENTS
   + Argument ("input",  "the input mesh file").type_file_in()
@@ -46,8 +47,11 @@ void usage ()
   OPTIONS
   + Option ("binary", "write the output mesh file in binary format (if supported)")
 
-  + Option ("transform", "transform vertices from one coordinate space to another, based on a template image; "
-                         "options are: " + join(transform_choices, ", "))
+  + Option ("transform", "either transform vertices from one coordinate space to another (based on a template image), "
+            "or apply a spatial transformation to them with the 'warp' mode (using a warp image). From a full warp "
+            "obtained by an image1->image2 registration, for example, a warp from the space of image2 to image1 for "
+            "the 'warp' mode of this command can be obtained using "
+            "'warpconvert <fullwarp> warpfull2deformation warp.mif -template <image2> -from 1'. options are: " + join(transform_choices, ", "))
     + Argument ("mode").type_choice (transform_choices)
     + Argument ("image").type_image_in();
 
@@ -81,6 +85,10 @@ void run ()
       case 2: transform->set_voxel2real(); break;
       case 3: transform->set_real2voxel(); break;
       case 4: transform->set_fs2real   (); break;
+      case 5:
+        transform->set_warp();
+        transform->set_warp_image(Image<float>::open(opt[0][1]));
+        break;
       default: throw Exception ("Unexpected mode for spatial transformation of vertices");
     }
     MeshMulti temp;

--- a/src/surface/filter/vertex_transform.h
+++ b/src/surface/filter/vertex_transform.h
@@ -18,6 +18,7 @@
 #define __surface_filter_vertex_transform_h__
 
 #include "header.h"
+#include "image.h"
 #include "transform.h"
 
 #include "surface/mesh.h"
@@ -37,7 +38,7 @@ namespace MR
       class VertexTransform : public Base
       { 
         public:
-          enum class transform_t { UNDEFINED, FIRST2REAL, REAL2FIRST, VOXEL2REAL, REAL2VOXEL, FS2REAL };
+          enum class transform_t { UNDEFINED, FIRST2REAL, REAL2FIRST, VOXEL2REAL, REAL2VOXEL, FS2REAL, WARP };
 
           VertexTransform (const Header& H) :
               header (H),
@@ -49,8 +50,11 @@ namespace MR
           void set_voxel2real() { mode = transform_t::VOXEL2REAL; }
           void set_real2voxel() { mode = transform_t::REAL2VOXEL; }
           void set_fs2real   () { mode = transform_t::FS2REAL   ; }
+          void set_warp      () { mode = transform_t::WARP      ; }
 
           transform_t get_mode() const { return mode; }
+
+          void set_warp_image (const Image<float>& warp) { warp_image = warp; }
 
           void operator() (const Mesh&, Mesh&) const override;
 
@@ -62,6 +66,7 @@ namespace MR
           const Header& header;
           Transform transform;
           transform_t mode;
+          Image<float> warp_image;
 
       };
 


### PR DESCRIPTION
As suggested by @Lestropie, this enhancement enables users to specify a new mode for `meshconvert` through setting `-transform warp <warp image>` to apply a deformation field to mesh files. The approach is similar to `tcktransform`. It works well on my data!