### PR TITLE
ENH fod2fixel: Add option to output lookup table from FMLS process

### DIFF
--- a/cmd/fod2fixel.cpp
+++ b/cmd/fod2fixel.cpp
@@ -23,6 +23,7 @@
 #include "fixel/helpers.h"
 
 #include "math/SH.h"
+#include "math/sphere.h"
 
 #include "thread_queue.h"
 
@@ -258,9 +259,13 @@ void Segmented_FOD_receiver::commit ()
     lut_header.datatype().set_byte_order_native();
     // Add directions set to lut image header.
     std::stringstream dir_stream;
-    for (ssize_t d = 0; d < directions.size() - 1; ++d)
-      dir_stream << directions[d](0) << "," << directions[d](1) << "," << directions[d](2) << "\n";
-    dir_stream << directions[directions.size() - 1](0) << "," << directions[directions.size() - 1](1) << "," << directions[directions.size() - 1](2);
+    Eigen::Vector3d az_el_r;
+    for (ssize_t d = 0; d < directions.size() - 1; ++d) {
+      Math::Sphere::cartesian2spherical(directions[d], az_el_r);
+      dir_stream << az_el_r(0) << "," << az_el_r(1) << "\n";
+    }
+    Math::Sphere::cartesian2spherical(directions[directions.size() - 1], az_el_r);
+    dir_stream << az_el_r(0) << "," << az_el_r(1);
     lut_header.keyval()["directions"] = dir_stream.str();
     lut_image = make_unique<LutImage> (LutImage::create (Path::join(fixel_directory_path, lut_path), lut_header));
   }

--- a/cmd/sh2amp.cpp
+++ b/cmd/sh2amp.cpp
@@ -167,7 +167,18 @@ void run ()
     }
     catch (Exception& E) {
       auto header = Header::open (argument[1]);
-      directions = DWI::get_DW_scheme (header);
+      try {
+        directions = DWI::get_DW_scheme (header);
+      }
+      catch (Exception& E) {
+        auto it = header.keyval().find ("directions");
+        if (it != header.keyval().end()) {
+          try { directions = parse_matrix (it->second); }
+          catch (Exception& e) {
+            throw Exception (e, "unable to parse directions entry in image \"" + header.name() + "\"");
+          }
+        }
+      }
     }
   }
 

--- a/docs/reference/commands/fod2fixel.rst
+++ b/docs/reference/commands/fod2fixel.rst
@@ -36,6 +36,8 @@ Metric values for fixel-based sparse output images
 
 -  **-disp image** output a measure of dispersion per fixel as the ratio between FOD lobe integral and maximal peak amplitude
 
+-  **-lut image** output the voxel-wise directions lookup table from FMLS process
+
 FOD FMLS segmenter options
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
An implementation of the suggestions discussed in #2468. 

This catches the [`FOD_lobes` lookup table](https://github.com/MRtrix3/mrtrix3/blob/3.0.3/src/dwi/fmls.h#L167) from the FMLS process and adds the option to output this data as an XxYxZx1281 image with directions embedded in the header.

It assumes that the index values used in the lookup table correspond to the order of the corresponding `FOD_lobe`s within the `FOD_lobes` vector. (i.e. that the `i`th direction is indeed assigned to the fixel at `offset + vox_fixels.lut[i]`; I don't see how this could _not_ be the case but thought it worth mentioning anyway). 

Feedback welcome! Not sure the cartesian to spherical conversion is particularly optimal.

I've also added a change to `sh2amp` to allow the use of the `lut` output as a directions file (i.e. additionally looking for  a "directions" header entry if no valid DW scheme entry is found). This change is more specific to my use case and also feels a bit hacky, so I'm happy to re-push without bec52de if that would be preferable.

- [x] `./check_syntax` 
- [ ] `./docs/generate_user_docs.sh`: had issues building due to version conflict (the 3.0.03->3.0.4 change doesn't seem to be reflected in my local tags, but changing (and committing) `version.h` back to 3.0.3 didn't seem like the right option either?).