### PR TITLE
link to FFTW3 on all platforms

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -6,14 +6,12 @@ add_library(mrtrix::core ALIAS mrtrix-core)
 find_package(Eigen3 REQUIRED)
 find_package(ZLIB REQUIRED)
 
-if(WIN32)
-    find_package(FFTW3 CONFIG REQUIRED)
-endif()
+find_package(FFTW3 CONFIG REQUIRED)
 
 target_link_libraries(mrtrix-core PUBLIC
     Eigen3::Eigen
     ZLIB::ZLIB
-    $<IF:$<PLATFORM_ID:Windows>,FFTW3::fftw3,fftw3>
+    FFTW3::fftw3
 )
 
 target_include_directories(mrtrix-core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
This fixes FFTW3 linking issues on macOS