### PR TITLE
Add compiler caching support for CI checks

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,6 +18,8 @@ jobs:
     env:
       CFLAGS: -Werror
       QT_SELECT: qt5
+      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_CACHE_SIZE: "2G"
 
     steps:
     - uses: actions/checkout@v1
@@ -27,8 +29,14 @@ jobs:
          sudo apt-get update
          sudo apt-get install clang libqt5opengl5-dev libqt5svg5-dev libglvnd-dev libeigen3-dev zlib1g-dev libfftw3-dev 
 
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.3
+    
+    - name: Run sccache-stats
+      run: sccache --show-stats
+        
     - name: configure
-      run: ./configure -assert || { cat configure.log; false; }
+      run: COMPILER_PREFIX=sccache ./configure -assert || { cat configure.log; false; }
 
     - name: build
       run: ./build -nowarnings -persistent -nopaginate || { cat build.log; false; }
@@ -52,6 +60,8 @@ jobs:
       CXX: g++-9
       CFLAGS: -Werror
       QT_SELECT: qt5
+      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_CACHE_SIZE: "2G"
 
     steps:
     - uses: actions/checkout@v1
@@ -61,12 +71,17 @@ jobs:
          sudo apt-get update
          sudo apt-get install g++-9 libqt5opengl5-dev libqt5svg5-dev libglvnd-dev libeigen3-dev zlib1g-dev libfftw3-dev 
 
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.3
+    
+    - name: Run sccache-stats
+      run: sccache --show-stats
+      
     - name: configure
-      run: ./configure -nooptim || { cat configure.log; false; }
+      run: COMPILER_PREFIX=sccache ./configure -nooptim || { cat configure.log; false; }
 
     - name: build
       run: ./build -nowarnings -persistent -nopaginate || { cat build.log; false; }
-
 
 
 

--- a/configure
+++ b/configure
@@ -88,6 +88,9 @@ ENVIRONMENT VARIABLES
     Multiple environment variables can be set this way as needed.
     The following environment variables are available:
 
+    COMPILER_PREFIX
+        A custom prefix to invoke the compiler. Useful for tools like ccache.
+        
     CXX
         The compiler command to use. The default is "clang++", falling back to
         "g++" if not found.
@@ -1476,6 +1479,11 @@ with open (config_filename, 'w', encoding='utf-8') as config_file:
   commit (config_file, 'exe_suffix', exe_suffix)
   commit (config_file, 'lib_prefix', lib_prefix)
   commit (config_file, 'lib_suffix', lib_suffix)
+
+  if "COMPILER_PREFIX" in os.environ.keys():
+    print("\n USING COMPILER PREFIX", os.environ["COMPILER_PREFIX"])
+    cpp.insert(0, os.environ["COMPILER_PREFIX"])
+  
   commit (config_file, 'cpp', cpp)
   commit (config_file, 'cpp_flags', cpp_flags)
   commit (config_file, 'ld', ld)


### PR DESCRIPTION
This pull request add supports for compiler caching in the CI checks workflow. It uses [sccache](https://github.com/mozilla/sccache) which is a compiler cache that speeds up recompilation by caching previous compilations by automatically detecting whether the same compilation is already cached. This allows us to leverage the free cache (up to 10GB) provided by Github Actions. At the moment, it only works with Clang and GCC builds on Linux.

In our current workflow, all the checks are done by compiling from scratch and for example, a typical CI build with Clang on Linux takes about 35-40 minutes. My preliminary tests show that sccache can complete a cached build in about 5-10 minutes. 

I've decided to use sccache instead of the more popular [ccache](https://ccache.dev/) because in my experience it has been more reliable on Windows (particularly with MSVC) and because they provide a pre-made [Github Action](https://github.com/marketplace/actions/sccache-action) to facilitate integration. However, this is not necessary and we could use ccache if wanted (integrating it should be [fairly straightforward](https://cristianadam.eu/20200113/speeding-up-c-plus-plus-github-actions-using-ccache/)).

Any feedback welcome!