### PR TITLE
Potential fix for GCC12 warning on MSYS2

### DIFF
--- a/core/math/stats/glm.cpp
+++ b/core/math/stats/glm.cpp
@@ -254,7 +254,7 @@ namespace MR
 
         matrix_type std_effect_size (const matrix_type& measurements, const matrix_type& design, const vector<Hypothesis>& hypotheses)
         {
-          const auto stdev_reciprocal = vector_type::Ones (measurements.cols()) / stdev (measurements, design).array().col(0);
+          const vector_type stdev_reciprocal = vector_type::Ones (measurements.cols()) / stdev (measurements, design).array().col(0);
           matrix_type result (measurements.cols(), hypotheses.size());
           for (size_t ic = 0; ic != hypotheses.size(); ++ic)
             result.col (ic) = abs_effect_size (measurements, design, hypotheses[ic]) * stdev_reciprocal;
@@ -348,7 +348,7 @@ namespace MR
           }
 
           class Source
-          { 
+          {
             public:
               Source (const size_t num_elements) :
                   num_elements (num_elements),
@@ -372,7 +372,7 @@ namespace MR
           };
 
           class Functor
-          { 
+          {
             public:
               Functor (const matrix_type& data, const matrix_type& design_fixed, const vector<CohortDataImport>& extra_data, const vector<Hypothesis>& hypotheses, const index_array_type& variance_groups,
                        vector_type& cond, matrix_type& betas, matrix_type& abs_effect_size, matrix_type& std_effect_size, matrix_type& stdev) :


### PR DESCRIPTION
Hypothetical fix for below compilation warning resulting in CI failure on #2624.

Have not been able to reproduce this, so running through CI to see what happens.

```
ERROR: ( 37/547) [CC] tmp/core/math/stats/glm.o

g++ -c -std=c++11 -DMRTRIX_BUILD_TYPE="release version with asserts" -pthread -DMRTRIX_WINDOWS -mms-bitfields -Wa,-mbig-obj -D_FILE_OFFSET_BITS=[64](https://github.com/MRtrix3/mrtrix3/actions/runs/4892616869/jobs/8734587104#step:7:65) -Werror -DMRTRIX_WORD64 -DMRTRIX_HAVE_EIGEN_UNSUPPORTED_SPECIAL_FUNCTIONS -DEIGEN_FFTW_DEFAULT -DMRTRIX_TIFF_SUPPORT -DLIBDEFLATE_DLL -idirafter D:/a/_temp/msys64/ucrt64/include/webp -DMRTRIX_PNG_SUPPORT -idirafter D:/a/_temp/msys64/ucrt64/include/libpng16 -Wall -O3 -D_GLIBCXX_DEBUG=1 -D_GLIBCXX_DEBUG_PEDANTIC=1 -Isrc -I./core -Icmd -idirafter D:/a/_temp/msys64/ucrt64/include/eigen3 -DEIGEN_DONT_PARALLELIZE core/math/stats/glm.cpp -o tmp/core/math/stats/glm.o

failed with output

In file included from D:/a/_temp/msys64/ucrt64/include/eigen3/Eigen/Core:253,
                 from D:/a/_temp/msys64/ucrt64/include/eigen3/Eigen/Geometry:11,
                 from ./core/types.h:76,
                 from ./core/mrtrix.h:37,
                 from ./core/cmdline_option.h:28,
                 from ./core/app.h:29,
                 from ./core/math/stats/glm.h:20,
                 from core/math/stats/glm.cpp:17:
In member function 'const Eigen::internal::scalar_quotient_op<LhsScalar, RhsScalar>::result_type Eigen::internal::scalar_quotient_op<LhsScalar, RhsScalar>::operator()(const LhsScalar&, const RhsScalar&) const [with LhsScalar = double; RhsScalar = double]',
    inlined from 'Eigen::internal::binary_evaluator<Eigen::CwiseBinaryOp<BinaryOp, Lhs, Rhs>, Eigen::internal::IndexBased, Eigen::internal::IndexBased>::CoeffReturnType Eigen::internal::binary_evaluator<Eigen::CwiseBinaryOp<BinaryOp, Lhs, Rhs>, Eigen::internal::IndexBased, Eigen::internal::IndexBased>::coeff(Eigen::Index) const [with BinaryOp = Eigen::internal::scalar_quotient_op<double, double>; Lhs = const Eigen::CwiseNullaryOp<Eigen::internal::scalar_constant_op<double>, Eigen::Array<double, -1, 1> >; Rhs = const Eigen::Block<Eigen::ArrayWrapper<Eigen::Matrix<double, -1, -1> >, -1, 1, true>]' at D:/a/_temp/msys64/ucrt64/include/eigen3/Eigen/src/Core/CoreEvaluators.h:775:22,
    inlined from 'Eigen::internal::binary_evaluator<Eigen::CwiseBinaryOp<BinaryOp, Lhs, Rhs>, Eigen::internal::IndexBased, Eigen::internal::IndexBased>::CoeffReturnType Eigen::internal::binary_evaluator<Eigen::CwiseBinaryOp<BinaryOp, Lhs, Rhs>, Eigen::internal::IndexBased, Eigen::internal::IndexBased>::coeff(Eigen::Index) const [with BinaryOp = Eigen::internal::scalar_product_op<double, double>; Lhs = const Eigen::Array<double, -1, 1>; Rhs = const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::CwiseNullaryOp<Eigen::internal::scalar_constant_op<double>, Eigen::Array<double, -1, 1> >, const Eigen::Block<Eigen::ArrayWrapper<Eigen::Matrix<double, -1, -1> >, -1, 1, true> >]' at D:/a/_temp/msys64/ucrt64/include/eigen3/Eigen/src/Core/CoreEvaluators.h:775:66,
    inlined from 'void Eigen::internal::generic_dense_assignment_kernel<DstEvaluatorTypeT, SrcEvaluatorTypeT, Functor, Version>::assignCoeff(Eigen::Index) [with DstEvaluatorTypeT = Eigen::internal::evaluator<Eigen::Block<Eigen::Matrix<double, -1, -1>, -1, 1, true> >; SrcEvaluatorTypeT = Eigen::internal::evaluator<Eigen::CwiseBinaryOp<Eigen::internal::scalar_product_op<double, double>, const Eigen::Array<double, -1, 1>, const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::CwiseNullaryOp<Eigen::internal::scalar_constant_op<double>, Eigen::Array<double, -1, 1> >, const Eigen::Block<Eigen::ArrayWrapper<Eigen::Matrix<double, -1, -1> >, -1, 1, true> > > >; Functor = Eigen::internal::assign_op<double, double>; int Version = 0]' at D:/a/_temp/msys64/ucrt64/include/eigen3/Eigen/src/Core/AssignEvaluator.h:660:61,
    inlined from 'static void Eigen::internal::unaligned_dense_assignment_loop<false>::run(Kernel&, Eigen::Index, Eigen::Index) [with Kernel = Eigen::internal::generic_dense_assignment_kernel<Eigen::internal::evaluator<Eigen::Block<Eigen::Matrix<double, -1, -1>, -1, 1, true> >, Eigen::internal::evaluator<Eigen::CwiseBinaryOp<Eigen::internal::scalar_product_op<double, double>, const Eigen::Array<double, -1, 1>, const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::CwiseNullaryOp<Eigen::internal::scalar_constant_op<double>, Eigen::Array<double, -1, 1> >, const Eigen::Block<Eigen::ArrayWrapper<Eigen::Matrix<double, -1, -1> >, -1, 1, true> > > >, Eigen::internal::assign_op<double, double>, 0>]' at D:/a/_temp/msys64/ucrt64/include/eigen3/Eigen/src/Core/AssignEvaluator.h:411:25,
    inlined from 'static void Eigen::internal::dense_assignment_loop<Kernel, 3, 0>::run(Kernel&) [with Kernel = Eigen::internal::generic_dense_assignment_kernel<Eigen::internal::evaluator<Eigen::Block<Eigen::Matrix<double, -1, -1>, -1, 1, true> >, Eigen::internal::evaluator<Eigen::CwiseBinaryOp<Eigen::internal::scalar_product_op<double, double>, const Eigen::Array<double, -1, 1>, const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::CwiseNullaryOp<Eigen::internal::scalar_constant_op<double>, Eigen::Array<double, -1, 1> >, const Eigen::Block<Eigen::ArrayWrapper<Eigen::Matrix<double, -1, -1> >, -1, 1, true> > > >, Eigen::internal::assign_op<double, double>, 0>]' at D:/a/_temp/msys64/ucrt64/include/eigen3/Eigen/src/Core/AssignEvaluator.h:434:58,
    inlined from 'void Eigen::internal::call_dense_assignment_loop(DstXprType&, const SrcXprType&, const Functor&) [with DstXprType = Eigen::Block<Eigen::Matrix<double, -1, -1>, -1, 1, true>; SrcXprType = Eigen::CwiseBinaryOp<scalar_product_op<double, double>, const Eigen::Array<double, -1, 1>, const Eigen::CwiseBinaryOp<scalar_quotient_op<double, double>, const Eigen::CwiseNullaryOp<scalar_constant_op<double>, Eigen::Array<double, -1, 1> >, const Eigen::Block<Eigen::ArrayWrapper<Eigen::Matrix<double, -1, -1> >, -1, 1, true> > >; Functor = assign_op<double, double>]' at D:/a/_temp/msys64/ucrt64/include/eigen3/Eigen/src/Core/AssignEvaluator.h:785:37,
    inlined from 'static void Eigen::internal::Assignment<DstXprType, SrcXprType, Functor, Eigen::internal::Dense2Dense, Weak>::run(DstXprType&, const SrcXprType&, const Functor&) [with DstXprType = Eigen::Block<Eigen::Matrix<double, -1, -1>, -1, 1, true>; SrcXprType = Eigen::CwiseBinaryOp<Eigen::internal::scalar_product_op<double, double>, const Eigen::Array<double, -1, 1>, const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::CwiseNullaryOp<Eigen::internal::scalar_constant_op<double>, Eigen::Array<double, -1, 1> >, const Eigen::Block<Eigen::ArrayWrapper<Eigen::Matrix<double, -1, -1> >, -1, 1, true> > >; Functor = Eigen::internal::assign_op<double, double>; Weak = void]' at D:/a/_temp/msys64/ucrt64/include/eigen3/Eigen/src/Core/AssignEvaluator.h:954:31,
    inlined from 'void Eigen::internal::call_assignment_no_alias(Dst&, const Src&, const Func&) [with Dst = Eigen::Block<Eigen::Matrix<double, -1, -1>, -1, 1, true>; Src = Eigen::CwiseBinaryOp<scalar_product_op<double, double>, const Eigen::Array<double, -1, 1>, const Eigen::CwiseBinaryOp<scalar_quotient_op<double, double>, const Eigen::CwiseNullaryOp<scalar_constant_op<double>, Eigen::Array<double, -1, 1> >, const Eigen::Block<Eigen::ArrayWrapper<Eigen::Matrix<double, -1, -1> >, -1, 1, true> > >; Func = assign_op<double, double>]' at D:/a/_temp/msys64/ucrt64/include/eigen3/Eigen/src/Core/AssignEvaluator.h:890:49,
    inlined from 'void Eigen::internal::call_assignment(Dst&, const Src&, const Func&, typename enable_if<(! evaluator_assume_aliasing<Src>::value), void*>::type) [with Dst = Eigen::Block<Eigen::Matrix<double, -1, -1>, -1, 1, true>; Src = Eigen::CwiseBinaryOp<scalar_product_op<double, double>, const Eigen::Array<double, -1, 1>, const Eigen::CwiseBinaryOp<scalar_quotient_op<double, double>, const Eigen::CwiseNullaryOp<scalar_constant_op<double>, Eigen::Array<double, -1, 1> >, const Eigen::Block<Eigen::ArrayWrapper<Eigen::Matrix<double, -1, -1> >, -1, 1, true> > >; Func = assign_op<double, double>]' at D:/a/_temp/msys64/ucrt64/include/eigen3/Eigen/src/Core/AssignEvaluator.h:858:27,
    inlined from 'void Eigen::internal::call_assignment(Dst&, const Src&) [with Dst = Eigen::Block<Eigen::Matrix<double, -1, -1>, -1, 1, true>; Src = Eigen::CwiseBinaryOp<scalar_product_op<double, double>, const Eigen::Array<double, -1, 1>, const Eigen::CwiseBinaryOp<scalar_quotient_op<double, double>, const Eigen::CwiseNullaryOp<scalar_constant_op<double>, Eigen::Array<double, -1, 1> >, const Eigen::Block<Eigen::ArrayWrapper<Eigen::Matrix<double, -1, -1> >, -1, 1, true> > >]' at D:/a/_temp/msys64/ucrt64/include/eigen3/Eigen/src/Core/AssignEvaluator.h:836:18,
    inlined from 'Derived& Eigen::MatrixBase<Derived>::operator=(const Eigen::DenseBase<OtherDerived>&) [with OtherDerived = Eigen::CwiseBinaryOp<Eigen::internal::scalar_product_op<double, double>, const Eigen::Array<double, -1, 1>, const Eigen::CwiseBinaryOp<Eigen::internal::scalar_quotient_op<double, double>, const Eigen::CwiseNullaryOp<Eigen::internal::scalar_constant_op<double>, Eigen::Array<double, -1, 1> >, const Eigen::Block<Eigen::ArrayWrapper<Eigen::Matrix<double, -1, -1> >, -1, 1, true> > >; Derived = Eigen::Block<Eigen::Matrix<double, -1, -1>, -1, 1, true>]' at D:/a/_temp/msys64/ucrt64/include/eigen3/Eigen/src/Core/Assign.h:66:28,
    inlined from 'MR::Math::Stats::matrix_type MR::Math::Stats::GLM::std_effect_size(const MR::Math::Stats::matrix_type&, const MR::Math::Stats::matrix_type&, const MR::vector<Hypothesis>&)' at core/math/stats/glm.cpp:260:88:
D:/a/_temp/msys64/ucrt64/include/eigen3/Eigen/src/Core/functors/BinaryFunctors.h:388:128: error: pointer may be used after 'void free(void*)' [-Werror=use-after-free]
  388 |   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const result_type operator() (const LhsScalar& a, const RhsScalar& b) const { return a / b; }
      |                                                                                                                              ~~^~~
In file included from D:/a/_temp/msys64/ucrt64/include/eigen3/Eigen/Core:166:
In function 'void Eigen::internal::aligned_free(void*)',
    inlined from 'void Eigen::internal::conditional_aligned_free(void*) [with bool Align = true]' at D:/a/_temp/msys64/ucrt64/include/eigen3/Eigen/src/Core/util/Memory.h:259:15,
    inlined from 'void Eigen::internal::conditional_aligned_delete_auto(T*, std::size_t) [with T = double; bool Align = true]' at D:/a/_temp/msys64/ucrt64/include/eigen3/Eigen/src/Core/util/Memory.h:446:34,
    inlined from 'Eigen::DenseStorage<T, -1, -1, -1, _Options>::~DenseStorage() [with T = double; int _Options = 0]' at D:/a/_temp/msys64/ucrt64/include/eigen3/Eigen/src/Core/DenseStorage.h:4[65](https://github.com/MRtrix3/mrtrix3/actions/runs/4892616869/jobs/8734587104#step:7:66):109,
    inlined from 'Eigen::PlainObjectBase<Eigen::Matrix<double, -1, -1> >::~PlainObjectBase()' at D:/a/_temp/msys64/ucrt64/include/eigen3/Eigen/src/Core/PlainObjectBase.h:98:7,
    inlined from 'Eigen::Matrix<double, -1, -1>::~Matrix()' at D:/a/_temp/msys64/ucrt64/include/eigen3/Eigen/src/Core/Matrix.h:1[78](https://github.com/MRtrix3/mrtrix3/actions/runs/4892616869/jobs/8734587104#step:7:79):7,
    inlined from 'MR::Math::Stats::matrix_type MR::Math::Stats::GLM::std_effect_size(const MR::Math::Stats::matrix_type&, const MR::Math::Stats::matrix_type&, const MR::vector<Hypothesis>&)' at core/math/stats/glm.cpp:257:[89](https://github.com/MRtrix3/mrtrix3/actions/runs/4892616869/jobs/8734587104#step:7:90):
D:/a/_temp/msys64/ucrt64/include/eigen3/Eigen/src/Core/util/Memory.h:203:9: note: call to 'void free(void*)' here
  203 |     free(ptr);
      |     ~~~~^~~~~
```

