### PR TITLE
Fix compilation warnings on GCC13

### DIFF
--- a/cmd/dwi2adc.cpp
+++ b/cmd/dwi2adc.cpp
@@ -47,13 +47,18 @@ using value_type = float;
 
 
 
-class DWI2ADC { 
+class DWI2ADC {
   public:
     DWI2ADC (const Eigen::MatrixXd& binv, size_t dwi_axis) :
       dwi (binv.cols()),
       adc (2),
       binv (binv),
       dwi_axis (dwi_axis) { }
+    DWI2ADC (const DWI2ADC& that) :
+      dwi (that.dwi.size()),
+      adc (that.adc.size()),
+      binv (that.binv),
+      dwi_axis (that.dwi_axis) {}
 
     template <class DWIType, class ADCType>
       void operator() (DWIType& dwi_image, ADCType& adc_image) {

--- a/cmd/fod2fixel.cpp
+++ b/cmd/fod2fixel.cpp
@@ -240,7 +240,7 @@ void Segmented_FOD_receiver::commit ()
     Fixel::check_fixel_size (*index_image, *disp_image);
   }
 
-  size_t offset (0), lobe_index (0);
+  size_t offset = 0;
 
 
   for (const auto& vox_fixels : lobes) {
@@ -283,7 +283,6 @@ void Segmented_FOD_receiver::commit ()
     }
 
     offset += n_vox_fixels;
-    lobe_index ++;
   }
 
   assert (offset == fixel_count);

--- a/cmd/shbasis.cpp
+++ b/cmd/shbasis.cpp
@@ -116,13 +116,11 @@ void check_and_update (Header& H, const conv_t conversion)
   header_mask.ndim() = 3;
   header_mask.datatype() = DataType::Bit;
   auto mask = Image<bool>::scratch (header_mask);
-  size_t voxel_count = 0;
   {
     for (auto i = Loop ("Masking image based on DC term", image, 0, 3) (image, mask); i; ++i) {
       const value_type value = image.value();
       if (value && std::isfinite (value)) {
         mask.value() = true;
-        ++voxel_count;
       } else {
         mask.value() = false;
       }

--- a/cmd/tckconvert.cpp
+++ b/cmd/tckconvert.cpp
@@ -392,26 +392,27 @@ class PLYWriter: public WriterInterface<float> {
     }
 
     void computeNormals ( const Streamline<float>& tck, Streamline<float>& normals) {
-      Eigen::Vector3f sPrev, sNext, pt1, pt2, n, normal;
-      sPrev = (tck[1] - tck[0]).normalized();
-
+      Eigen::Vector3f sPrev = (tck[1] - tck[0]).normalized();
+      Eigen::Vector3f normal = Eigen::Vector3f::Zero();
+      
       // Find a good starting normal
-      for (size_t idx = 1; idx < tck.size(); idx++) {
-        pt1 = tck[idx];
-        pt2 = tck[idx+1];
-        sNext = (pt2 - pt1).normalized();
-        n = sPrev.cross(sNext);
+      for (size_t idx = 1; idx < tck.size() - 1; idx++) {
+        const auto& pt1 = tck[idx];
+        const auto& pt2 = tck[idx+1];
+        const auto sNext = (pt2 - pt1).normalized();
+        const auto n = sPrev.cross(sNext);
         if ( n.norm() > 1.0E-3 ) {
           normal = n;
           sPrev = sNext;
           break;
         }
       }
+
       normal.normalize();  // vtkPolyLine.cxx:170
-      for (size_t idx = 0; idx < tck.size(); idx++) {
-        pt1 = tck[idx];
-        pt2 = tck[idx+1];
-        sNext = (pt2 - pt1).normalized();
+      for (size_t idx = 0; idx < tck.size() - 1; idx++) {
+        const auto& pt1 = tck[idx];
+        const auto& pt2 = tck[idx+1];
+        const auto sNext = (pt2 - pt1).normalized();
 
         // compute rotation vector vtkPolyLine.cxx:187
         auto w = sPrev.cross(normal);

--- a/cmd/warpcorrect.cpp
+++ b/cmd/warpcorrect.cpp
@@ -50,13 +50,20 @@ void usage ()
 
 using value_type = float;
 
-class BoundsCheck { 
+class BoundsCheck {
   public:
     BoundsCheck (value_type tolerance, const Eigen::Matrix<value_type, 3, 1>& marker, size_t& total_count):
-     precision (tolerance),
-     vec (marker),
-     counter (total_count),
-     count (0) { }
+        precision (tolerance),
+        vec (marker),
+        counter (total_count),
+        count (0),
+        val ({NaN, NaN, NaN}) { }
+    BoundsCheck (const BoundsCheck& that) :
+        precision (that.precision),
+        vec (that.vec),
+        counter (that.counter),
+        count (0),
+        val ({NaN, NaN, NaN}) { }
     template <class ImageTypeIn, class ImageTypeOut>
       void operator() (ImageTypeIn& in, ImageTypeOut& out)
       {

--- a/core/fixel/fixel.h
+++ b/core/fixel/fixel.h
@@ -19,6 +19,7 @@
 #define __fixel_fixel_h__
 
 #include <string>
+#include <cstdint>
 
 namespace MR
 {

--- a/core/image_helpers.h
+++ b/core/image_helpers.h
@@ -534,7 +534,7 @@ namespace MR
     template <class ImageType>
       class ConstRow { 
         public:
-          ConstRow (ImageType& image, size_t axis) : axis (axis), image (image) { assert (axis >= 0 && axis < image.ndim()); }
+          ConstRow (ImageType& image, size_t axis) : axis (axis), image (image) { assert (axis < image.ndim()); }
           ssize_t size () const { return image.size (axis); }
           typename ImageType::value_type operator[] (ssize_t n) const { image.index (axis) = n; return image.value(); }
           const size_t axis;

--- a/core/math/SH.h
+++ b/core/math/SH.h
@@ -186,7 +186,7 @@ namespace MR
         }
 
       template <typename ValueType>
-      class Transform { 
+      class Transform {
         public:
           using matrix_type = Eigen::Matrix<ValueType,Eigen::Dynamic,Eigen::Dynamic>;
 
@@ -387,7 +387,7 @@ namespace MR
 
       //! used to speed up SH calculation
       template <typename ValueType> class PrecomputedFraction
-      { 
+      {
         public:
           PrecomputedFraction () : f1 (0.0), f2 (0.0) { }
           ValueType f1, f2;
@@ -397,7 +397,7 @@ namespace MR
 
       //! Precomputed Associated Legrendre Polynomials - used to speed up SH calculation
       template <typename ValueType> class PrecomputedAL
-      { 
+      {
         public:
           using value_type = ValueType;
 
@@ -601,7 +601,7 @@ namespace MR
             }
           }
 
-          amplitude = sh[0] * AL[0];
+          amplitude = sh[index (0, 0)] * AL[index_mpos (0, 0)];
           for (int l = 2; l <= (int) lmax; l+=2) {
             const value_type& v (sh[index (l,0)]);
             amplitude += v * AL[index_mpos (l,0)];
@@ -650,7 +650,7 @@ namespace MR
 
       //! a class to hold the coefficients for an apodised point-spread function.
       template <typename ValueType> class aPSF
-      { 
+      {
         public:
           aPSF (const size_t lmax) :
             lmax (lmax),

--- a/core/math/SH.h
+++ b/core/math/SH.h
@@ -579,6 +579,10 @@ namespace MR
             typename VectorType::Scalar& d2SH_daz2,
             PrecomputedAL<typename VectorType::Scalar>* precomputer)
         {
+          if(lmax < 0){
+            throw std::logic_error("lmax cannot be negative!");
+          }
+
           using value_type = typename VectorType::Scalar;
           value_type sel = std::sin (elevation);
           value_type cel = std::cos (elevation);

--- a/src/dwi/tractography/GT/internalenergy.cpp
+++ b/src/dwi/tractography/GT/internalenergy.cpp
@@ -93,17 +93,19 @@ namespace MR {
         {
           double sum = 0.0;
           double t = rng_uniform() * normalization;
-          ParticleEnd pe;
-          for (vector<ParticleEnd>::iterator it = neighbourhood.begin(); it != neighbourhood.end(); ++it)
-          {
-            sum += it->p_suc;
-            if (sum >= t) {
-              return *it;
-            }
+
+          auto neighbour = std::find_if(neighbourhood.begin(), neighbourhood.end(), [&](const ParticleEnd& particle){
+            sum += particle.p_suc;
+            return sum >= t;
+          });
+
+          if(neighbour != neighbourhood.end()){
+            return *neighbour;
           }
-          return pe;
+          else {
+            throw Exception("Unable to pick neighbour!");
+          }
         }
-        
         
       }
     }

--- a/src/dwi/tractography/GT/particle.h
+++ b/src/dwi/tractography/GT/particle.h
@@ -225,10 +225,10 @@ namespace MR {
          */
         struct ParticleEnd
         { 
-          Particle* par;
-          int alpha;
-          float e_conn;
-          double p_suc;
+          Particle* par = nullptr;
+          int alpha = 0;
+          float e_conn = 0.0;
+          double p_suc = 1.0;
         };
         
         

--- a/src/dwi/tractography/SIFT/model_base.h
+++ b/src/dwi/tractography/SIFT/model_base.h
@@ -63,20 +63,20 @@ namespace MR
 
 
         class FixelBase
-        { 
+        {
 
           public:
             FixelBase () :
               FOD (0.0),
               TD (0.0),
               weight (0.0),
-              dir () { }
+              dir ({NaN, NaN, NaN}) { }
 
             FixelBase (const default_type amp) :
               FOD (amp),
               TD (0.0),
               weight (1.0),
-              dir () { }
+              dir ({NaN, NaN, NaN}) { }
 
             FixelBase (const default_type amp, const Eigen::Vector3d& d) :
               FOD (amp),
@@ -126,7 +126,7 @@ namespace MR
 
         template <class Fixel>
         class ModelBase : public Mapping::Fixel_TD_map<Fixel>
-        { 
+        {
 
           protected:
             using MapVoxel = typename Fixel_map<Fixel>::MapVoxel;

--- a/src/dwi/tractography/mapping/fixel_td_map.h
+++ b/src/dwi/tractography/mapping/fixel_td_map.h
@@ -37,7 +37,7 @@ namespace MR
 
       template <class Fixel>
       class Fixel_TD_map : public Fixel_map<Fixel>
-      { 
+      {
 
           using MapVoxel = typename Fixel_map<Fixel>::MapVoxel;
           using VoxelAccessor = typename Fixel_map<Fixel>::VoxelAccessor;
@@ -51,6 +51,7 @@ namespace MR
           virtual ~Fixel_TD_map() { }
 
           virtual bool operator() (const SetDixel& in);
+          using Fixel_map<Fixel>::operator();
 
         protected:
           using Fixel_map<Fixel>::accessor;

--- a/src/gui/mrview/tool/base.cpp
+++ b/src/gui/mrview/tool/base.cpp
@@ -28,7 +28,7 @@ namespace MR
 
         void Dock::closeEvent (QCloseEvent*) { assert (tool); tool->close_event(); }
 
-        void __Action__::visibility_slot (bool visible) { setChecked (dock->isVisible()); }
+        void __Action__::visibility_slot (bool) { setChecked (dock->isVisible()); }
 
 
         Base::Base (Dock* parent) :

--- a/src/stats/tfce.h
+++ b/src/stats/tfce.h
@@ -42,13 +42,16 @@ namespace MR
 
 
       class EnhancerBase : public Stats::EnhancerBase
-      { 
+      {
         public:
           virtual ~EnhancerBase() { }
         protected:
           // Alternative functor that also takes the threshold value;
           //   makes TFCE integration cleaner
           virtual void operator() (in_column_type /*input_statistics*/, const value_type /*threshold*/, out_column_type /*enhanced_statistics*/) const = 0;
+          // While we don't use this function, it reassures the compiler that we are not accidentally
+          //   hiding the virutal function of the base class using the function above
+          using Stats::EnhancerBase::operator();
           friend class Wrapper;
       };
 
@@ -56,7 +59,7 @@ namespace MR
 
 
       class Wrapper : public Stats::EnhancerBase
-      { 
+      {
         public:
           Wrapper (const std::shared_ptr<TFCE::EnhancerBase> base) : enhancer (base), dH (NaN), E (NaN), H (NaN) { }
           Wrapper (const std::shared_ptr<TFCE::EnhancerBase> base, const default_type dh, const default_type e, const default_type h) : enhancer (base), dH (dh), E (e), H (h) { }


### PR DESCRIPTION
While I was not able to reproduce the MSYS2 CI compilation issue currently manifesting in #2624, upgrading to GCC13 in my MSYS2 resulted in other compilation warnings. This fixes some but not all of them: some files relating to registration are failing to compile but do not produce any error message.

Pending observations here and in #2631, Will want to either rebase or cherry-pick to `master`.