### PR TITLE
fod2fixel: Fix -fmls_lobe_merge_ratio

### DIFF
--- a/src/dwi/fmls.cpp
+++ b/src/dwi/fmls.cpp
@@ -82,7 +82,7 @@ namespace MR {
           }
         }
 
-        opt = get_options ("fmls_merge_ratio");
+        opt = get_options ("fmls_lobe_merge_ratio");
         if (opt.size())
           segmenter.set_lobe_merge_ratio (default_type(opt[0][0]));
 


### PR DESCRIPTION
Command-line option non-functional due to an error in prior modification of the option name in #1932.

Fully expect that nobody other than myself has ever attempted to use this option. It's primarily to facilitate [a more advanced fixel segmentation](https://www.researchgate.net/publication/308380892_Sparse_re-parametrization_of_continuous_Fibre_Orientation_Distributions_using_spherical_harmonic_delta_functions) that I've never had the opportunity to finish off. So most likely hasn't detrimentally impacted any users. Indeed if anyone had used it, I would hope that they would have discovered that there were no differences in FOD segmentation between inclusion and omission of the option.