### PR TITLE
FOD FMLS: Masks instead of lookup tables

### DIFF
--- a/cmd/fod2fixel.cpp
+++ b/cmd/fod2fixel.cpp
@@ -33,7 +33,7 @@
 
 #define DEFAULT_DIRECTION_SET 1281
 
-#define DIXEL_IMAGE_PREFIX "fixel_dixels_"
+#define AMPLITUDES_IMAGE_PREFIX "amplitudes_"
 
 
 const char* fixel_direction_choices[] { "mean", "peak", "lsq", nullptr };
@@ -89,9 +89,7 @@ const OptionGroup OutputOptions = OptionGroup ("Options to modulate outputs of f
                           "options are: " + join(fixel_direction_choices, ","))
     + Argument ("choice").type_choice (fixel_direction_choices)
 
-  + Option ("nolookup", "do not export the lookup table image")
-
-  + Option ("dixel_images", "write a set of dixel images, where each encodes the FOD amplitudes for one fixel in each voxel");
+  + Option ("amplitude_images", "write a set of dixel images, where each encodes the FOD amplitudes for one fixel in each voxel");
 
 
 
@@ -154,16 +152,15 @@ class Segmented_FOD_receiver {
   public:
 
     using DataImage = Image<float>;
-    using DixelImage = Image<float>;
-    using IndexImage = Image<index_type>;
-    using LookupImage = Image<uint8_t>;
+    using AmplitudeImage = Image<float>;
+    using IndexImage = Image<uint64_t>;
+    using DixelMaskImage = Image<bool>;
 
     Segmented_FOD_receiver (const Header& header,
                             const DWI::Directions::FastLookupSet& dirs,
                             const std::string& directory,
                             const fixel_dir_t fixel_directions,
                             bool save_as_nifti = false,
-                            bool write_lookup = true,
                             bool write_dixel = false);
 
     ~Segmented_FOD_receiver();
@@ -183,8 +180,9 @@ class Segmented_FOD_receiver {
       float integral;
       float max_peak_amp;
       float skew;
-      Primitive_FOD_lobe (Eigen::Vector3f dir, float integral, float max_peak_amp, float skew) :
-          dir (dir), integral (integral), max_peak_amp (max_peak_amp), skew (skew) {}
+      BitSet mask;
+      Primitive_FOD_lobe (Eigen::Vector3f dir, float integral, float max_peak_amp, float skew, const BitSet& mask) :
+          dir (dir), integral (integral), max_peak_amp (max_peak_amp), skew (skew), mask (mask) {}
     };
 
 
@@ -203,7 +201,8 @@ class Segmented_FOD_receiver {
             this->emplace_back (dir,
                                 lobe.get_integral(),
                                 lobe.get_max_peak_value(),
-                                std::acos (abs (lobe.get_mean_dir().dot (lobe.get_peak_dir(0)))));
+                                std::acos (abs (lobe.get_mean_dir().dot (lobe.get_peak_dir(0)))),
+                                lobe.get_mask());
           }
         }
         Eigen::Array3i vox;
@@ -211,12 +210,12 @@ class Segmented_FOD_receiver {
 
     Header H;
     const DWI::Directions::FastLookupSet& dirs;
-    const std::string fixel_directory_path, base_extension, index_path, dir_path, lookup_path;
+    std::string directions_keyval;
+    const std::string fixel_directory_path, base_extension, index_path, dir_path, dixel_mask_path;
     std::string afd_path, peak_amp_path, disp_path, skew_path;
     const fixel_dir_t fixel_directions;
 
-    LookupImage lookup_image;
-    vector<DixelImage> dixel_images;
+    vector<AmplitudeImage> amplitude_images;
     vector<Primitive_FOD_lobes> lobes;
     index_type fixel_count;
 };
@@ -228,15 +227,14 @@ Segmented_FOD_receiver::Segmented_FOD_receiver (const Header& header,
                                                 const std::string& directory,
                                                 const fixel_dir_t fixel_directions,
                                                 bool save_as_nifti,
-                                                bool write_lookup,
-                                                bool write_dixel) :
+                                                bool write_amplitude_images) :
     H (header),
     dirs (dirs),
     fixel_directory_path (directory),
     base_extension (save_as_nifti ? ".nii" : ".mif"),
     index_path (Path::join(fixel_directory_path, Fixel::basename_index + base_extension)),
     dir_path (Path::join(fixel_directory_path, Fixel::basename_directions + base_extension)),
-    lookup_path (write_lookup ? Path::join (fixel_directory_path, Fixel::basename_lookup + base_extension) : ""),
+    dixel_mask_path (Path::join (fixel_directory_path, Fixel::basename_dixelmasks + base_extension)),
     fixel_directions (fixel_directions),
     fixel_count (0)
 {
@@ -244,23 +242,20 @@ Segmented_FOD_receiver::Segmented_FOD_receiver (const Header& header,
   for (size_t i = 0; i != dirs.size(); ++i)
     dirs_to_save.row(i) = dirs[i].cast<float>();
   Eigen::IOFormat format (Eigen::FullPrecision, Eigen::DontAlignCols, ",", "\n", "", "", "", "");
-  std::stringstream directions_keyval;
-  directions_keyval << std::fixed << dirs_to_save.format (format);
+  std::stringstream directions_keyval_stream;
+  directions_keyval_stream << std::fixed << dirs_to_save.format (format);
+  directions_keyval = directions_keyval_stream.str();
 
-  auto dixel_header (H);
-  dixel_header.size(3) = dirs.size();
-  ++dixel_header.stride(0); ++dixel_header.stride(1); ++dixel_header.stride(2); dixel_header.stride(3) = 0;
-  dixel_header.keyval()["directions"] = directions_keyval.str();
+  if (save_as_nifti)
+    MR::save_matrix (dirs_to_save, Path::join (fixel_directory_path, Fixel::basename_dixelmasks + ".csv"));
 
-  if (write_lookup) {
-    auto lookup_header (dixel_header);
-    lookup_header.datatype() = DataType::UInt8;
-    if (save_as_nifti)
-      MR::save_matrix (dirs_to_save, Path::join (fixel_directory_path, Fixel::basename_lookup + ".csv"));
-    lookup_image = LookupImage::create (lookup_path, lookup_header);
+  if (write_amplitude_images) {
+    auto amplitudes_header (H);
+    amplitudes_header.size(3) = dirs.size();
+    ++amplitudes_header.stride(0); ++amplitudes_header.stride(1); ++amplitudes_header.stride(2); amplitudes_header.stride(3) = 0;
+    amplitudes_header.keyval()["directions"] = directions_keyval;
+    amplitude_images.emplace_back (AmplitudeImage::create (Path::join (fixel_directory_path, std::string(AMPLITUDES_IMAGE_PREFIX) + "0" + base_extension), amplitudes_header));
   }
-  if (write_dixel)
-    dixel_images.emplace_back (DixelImage::create (Path::join (fixel_directory_path, std::string(DIXEL_IMAGE_PREFIX) + "0" + base_extension), dixel_header));
 }
 
 
@@ -271,18 +266,14 @@ bool Segmented_FOD_receiver::operator() (const FOD_lobes& in)
   if (in.size()) {
     lobes.emplace_back (in, fixel_directions);
     fixel_count += lobes.back().size();
-    if (lookup_image.valid()) {
-      assign_pos_of (in.vox).to (lookup_image);
-      lookup_image.row (3) = in.lut.matrix();
-    }
-    if (dixel_images.size()) {
+    if (amplitude_images.size()) {
       // If number of fixels in this voxel is larger than that encountered thus far,
       //   need to create new images to support exporting them
-      while (in.size() > dixel_images.size())
-        dixel_images.emplace_back (DixelImage::create (Path::join (fixel_directory_path, std::string(DIXEL_IMAGE_PREFIX) + str(dixel_images.size()) + base_extension), dixel_images.front()));
+      while (in.size() > amplitude_images.size())
+        amplitude_images.emplace_back (AmplitudeImage::create (Path::join (fixel_directory_path, std::string(AMPLITUDES_IMAGE_PREFIX) + str(amplitude_images.size()) + base_extension), amplitude_images.front()));
       for (size_t fixel_index = 0; fixel_index != in.size(); ++fixel_index) {
-        assign_pos_of (in.vox).to (dixel_images[fixel_index]);
-        dixel_images[fixel_index].row(3) = in[fixel_index].get_values().matrix();
+        assign_pos_of (in.vox).to (amplitude_images[fixel_index]);
+        amplitude_images[fixel_index].row(3) = in[fixel_index].get_values().matrix();
       }
     }
   }
@@ -298,6 +289,7 @@ Segmented_FOD_receiver::~Segmented_FOD_receiver()
 
   IndexImage index_image;
   DataImage dir_image;
+  DixelMaskImage dixel_mask_image;
   DataImage afd_image;
   DataImage peak_amp_image;
   DataImage disp_image;
@@ -314,7 +306,7 @@ Segmented_FOD_receiver::~Segmented_FOD_receiver()
   auto fixel_data_header (H);
   fixel_data_header.ndim() = 3;
   fixel_data_header.size(0) = fixel_count;
-  fixel_data_header.size(2) = 1;
+  fixel_data_header.size(1) = fixel_data_header.size(2) = 1;
   fixel_data_header.transform().setIdentity();
   fixel_data_header.spacing(0) = fixel_data_header.spacing(1) = fixel_data_header.spacing(2) = 1.0;
   fixel_data_header.datatype() = DataType::Float32;
@@ -322,8 +314,15 @@ Segmented_FOD_receiver::~Segmented_FOD_receiver()
 
   auto dir_header (fixel_data_header);
   dir_header.size(1) = 3;
+  dir_header.stride(1) = 2; dir_header.stride(0) = 1; dir_header.stride(2) = 3;
   dir_image = DataImage::create (dir_path, dir_header);
   dir_image.index(1) = 0;
+
+  auto dixel_mask_header (dir_header);
+  dixel_mask_header.datatype() = DataType::Bit;
+  dixel_mask_header.size(1) = dirs.size();
+  dixel_mask_header.keyval()["directions"] = directions_keyval;
+  dixel_mask_image = DixelMaskImage::create (dixel_mask_path, dixel_mask_header);
 
   if (afd_path.size()) {
     auto afd_header (fixel_data_header);
@@ -366,6 +365,11 @@ Segmented_FOD_receiver::~Segmented_FOD_receiver()
     for (size_t i = 0; i < n_vox_fixels; ++i) {
       dir_image.index(0) = offset + i;
       dir_image.row(1) = vox_fixels[i].dir;
+      dixel_mask_image.index(0) = offset + i;
+      for (size_t j = 0; j != dirs.size(); ++j) {
+        dixel_mask_image.index(1) = j;
+        dixel_mask_image.value() = vox_fixels[i].mask[j];
+      }
     }
 
     if (afd_image.valid()) {
@@ -432,8 +436,7 @@ void run ()
                                    fixel_directory_path,
                                    fixel_directions,
                                    get_options("nii").size(),
-                                   !get_options("nolookup").size(),
-                                   get_options("dixel_images").size());
+                                   get_options("amplitude_images").size());
 
   opt = get_options ("afd");      if (opt.size()) receiver.set_afd_output      (opt[0][0]);
   opt = get_options ("peak_amp"); if (opt.size()) receiver.set_peak_amp_output (opt[0][0]);

--- a/cmd/fod2fixel.cpp
+++ b/cmd/fod2fixel.cpp
@@ -262,7 +262,6 @@ Segmented_FOD_receiver::Segmented_FOD_receiver (const Header& header,
 
 bool Segmented_FOD_receiver::operator() (const FOD_lobes& in)
 {
-  assert (in.lut.size() == dirs.size());
   if (in.size()) {
     lobes.emplace_back (in, fixel_directions);
     fixel_count += lobes.back().size();

--- a/core/fixel/fixel.h
+++ b/core/fixel/fixel.h
@@ -38,7 +38,7 @@ namespace MR
 
     const std::string basename_index = "index";
     const std::string basename_directions = "directions";
-    const std::string basename_lookup = "lookup";
+    const std::string basename_dixelmasks = "dixelmasks";
 
 
   }

--- a/core/fixel/helpers.h
+++ b/core/fixel/helpers.h
@@ -24,6 +24,7 @@
 #include "algo/loop.h"
 #include "fixel/fixel.h"
 #include "formats/mrtrix_utils.h"
+#include "file/path.h"
 
 
 namespace MR
@@ -103,6 +104,24 @@ namespace MR
           && in.ndim() == 3
           && in.size(1) == 3
           && in.size(2) == 1;
+    }
+
+    FORCE_INLINE bool is_dixelmasks_filename (const std::string& path)
+    {
+      for (std::initializer_list<const std::string>::iterator it = supported_sparse_formats.begin();
+           it != supported_sparse_formats.end(); ++it) {
+        if (Path::basename (path) == Fixel::basename_dixelmasks + *it)
+          return true;
+      }
+      return false;
+    }
+
+    template <class HeaderType>
+    FORCE_INLINE bool is_dixelmasks_file (const HeaderType& in)
+    {
+      return is_dixelmasks_filename (in.name())
+          && in.ndim() == 3
+          && in.datatype() == DataType::Bit;
     }
 
 
@@ -268,12 +287,11 @@ namespace MR
 
 
 
-    FORCE_INLINE Header find_directions_header (const std::string fixel_directory_path)
+    FORCE_INLINE Header find_directions_header (Header& index_header)
     {
       bool directions_found (false);
       Header header;
       check_fixel_directory (fixel_directory_path);
-      Header index_header = Fixel::find_index_header (fixel_directory_path);
 
       auto dir_walker = Path::Dir (fixel_directory_path);
       std::string fname;
@@ -287,7 +305,7 @@ namespace MR
               directions_found = true;
               header = std::move (tmp_header);
             } else {
-              WARN ("fixel directions file (" + fname + ") does not contain the same number of elements as fixels in the index file" );
+              WARN ("fixel directions file (" + fname + ") does not contain the same number of elements as fixels in the index file");
             }
           }
         }
@@ -298,6 +316,83 @@ namespace MR
 
       return header;
     }
+
+
+
+    FORCE_INLINE Header find_directions_header (const std::string& fixel_directory_path)
+    {
+      Header index_header = Fixel::find_index_header (fixel_directory_path);
+      return find_directions_header (index_header);
+    }
+
+
+
+    FORCE_INLINE Header find_dixelmasks_header (Header& index_header)
+    {
+      bool dixelmasks_found (false);
+      Header header;
+      check_fixel_directory (fixel_directory_path);
+
+      auto dir_walker = Path::Dir (fixel_directory_path);
+      std::string fname;
+      while ((fname = dir_walker.read_name()).size()) {
+        if (is_dixelmasks_filename (fname)) {
+          Header tmp_header = Header::open (Path::join (fixel_directory_path, fname));
+          if (is_dixelmasks_file (tmp_header)) {
+            if (dimensions_match (index_header, tmp_header, 0, 3)) {
+              if (dixelmasks_found == true)
+                throw Exception ("multiple dixelmask files found in fixel image directory: " + fixel_directory_path);
+              dixelmasks_found = true;
+              header = std::move (tmp_header);
+            } else {
+              WARN ("dixelmasks image (" + fname + ") does not contain the same voxels as the index file");
+            }
+          }
+        }
+      }
+
+      return header;
+    }
+
+
+
+    FORCE_INLINE Header find_dixelmasks_header (const std::string& fixel_directory_path)
+    {
+      Header index_header = Fixel::find_index_header (fixel_directory_path);
+      return find_dixelmasks_header (index_header);
+    }
+
+
+
+    // TODO Modify to conform to parallel developments in handling of unit sphere direction sets
+    FORCE_INLINE Eigen::MatrixXd find_dixelmasks_directions (const Header& header)
+    {
+      const auto directions_it = header.keyval().find ("directions");
+      if (directions_it == header.keyval().end()) {
+        const std::string directory_path = Path::dirname (header.name());
+        Path::Dir dir (directory_path);
+        Eigen::MatrixXd result;
+        std::string filename;
+        while ((filename = dir.read_name()).size()) {
+          Eigen::MatrixXd data;
+          try {
+            data = load_matrix (Path::join (directory_path, filename));
+            if (!(data.cols() == 2 || data.cols() == 3))
+              throw Exception ("File \"" + filename + "\" does not contain direction set (matrix has " + str(data.cols()) + " columns)");
+            if (data.rows() != header.size(1))
+              throw Exception ("Number of directions in file \"" + filename + "\" (" + str(data.rows()) + ") does not correspond to number of dixels in mask image \"" + header.name() + "\" (" + str(header.size(1)) + ")");
+          } catch (Exception&) {}
+          if (result.rows())
+            throw Exception ("Multiple sidecar files corresponding to dixel mask image \"" + header.name() + "\" that contain direction set data");
+          result = data;
+        }
+        return result;
+      }
+      // TODO Perform additional verification once merged with other code
+      return deserialise_matrix (directions_it->second);
+    }
+
+
 
     //! Generate a header for a sparse data file (Nx1x1)
     FORCE_INLINE Header data_header_from_nfixels (const size_t nfixels) {
@@ -319,8 +414,6 @@ namespace MR
     template <class IndexHeaderType>
     FORCE_INLINE Header data_header_from_index (IndexHeaderType& index) {
       Header header (data_header_from_nfixels (get_number_of_fixels (index)));
-      for (size_t axis = 0; axis != 3; ++axis)
-        header.spacing (axis) = index.spacing (axis);
       header.keyval() = index.keyval();
       return header;
     }
@@ -338,8 +431,6 @@ namespace MR
     template <class IndexHeaderType>
     FORCE_INLINE Header directions_header_from_index (IndexHeaderType& index) {
       Header header = data_header_from_index (index);
-      for (size_t axis = 0; axis != 3; ++axis)
-        header.spacing (axis) = index.spacing (axis);
       header.size(1) = 3;
       header.stride(0) = 2;
       header.stride(1) = 1;
@@ -431,6 +522,9 @@ namespace MR
 
       return in_data_image;
     }
+
+
+
   }
 }
 

--- a/docs/fixel_based_analysis/fixel_directory_format.rst
+++ b/docs/fixel_based_analysis/fixel_directory_format.rst
@@ -57,6 +57,7 @@ Dixel Mask File
 -   The dixel mask image is optional, but if present requires a fixed naming of ``dixelmasks.nii`` or ``dixelmasks.mif``.
 -   *d* corresponds to the number of unique directions in a dense set of directions on the unit hemisphere (see :ref:`fixels_dixels`).
 -   For a given fixel, each of the *d* values encodes whether that specific direction is attributed to that fixel.
+-   Note that it is possible for multiple fixels within the same voxel to have the same direction attributed to them.
 -   The direction set must be provided along with the lookup table.
     For `.mif` files, this can be embedded within the image header as key-value entry ``"directions"``.
     Alternatively, they can be provided in a sidecar text file named ``dixelmasks.\*``, where "``\*``" corresponds to a file extension corresponding to some supported text file format.

--- a/docs/fixel_based_analysis/fixel_directory_format.rst
+++ b/docs/fixel_based_analysis/fixel_directory_format.rst
@@ -49,18 +49,17 @@ Fixel Directions File
 -   **All fixel-based DWI models must specify the direction of each fixel**.
 -   Directions for each fixel must be saved within a single file named either ``directions.nii`` or ``directions.mif``.
 -   This can be considered as a special type of fixel data file, with dimensions (*n* x 3 x 1).
--   Directions must be specified with respect to the *scanner coordinate frame*, in *cartesian coordinates*.
+-   Directions must be specified with respect to the *scanner coordinate frame*, in *cartesian coordinates*, and have unity length.
 
-Lookup Table File
+Dixel Mask File
 .................
--   4D image (*i* X *j* X *k* X *d*).
--   The lookup table file is optional, but requires a fixed naming of ``lookup.nii`` or ``lookup.mif``.
+-   3D image (*n* X *d* X 1).
+-   The dixel mask image is optional, but if present requires a fixed naming of ``dixelmasks.nii`` or ``dixelmasks.mif``.
 -   *d* corresponds to the number of unique directions in a dense set of directions on the unit hemisphere (see :ref:`fixels_dixels`).
--   For a given voxel, each of the *d* values contains the index of the fixel (relative to the index of the first fixel in that voxel) to which that direction should be attributed.
--   Where a given direction should not be attributed to any fixel within the voxel, the value stored will be equal to the number of fixels in that voxel.
+-   For a given fixel, each of the *d* values encodes whether that specific direction is attributed to that fixel.
 -   The direction set must be provided along with the lookup table.
     For `.mif` files, this can be embedded within the image header as key-value entry ``"directions"``.
-    Alternatively, they can be provided in a sidecar text file named ``lookup.\*``, where "``\*``" corresponds to a file extension corresponding to some supported text file format.
+    Alternatively, they can be provided in a sidecar text file named ``dixelmasks.\*``, where "``\*``" corresponds to a file extension corresponding to some supported text file format.
     In both cases, each direction must be specified as a unit 3-vector with respect to the scanner coordinate frame, as is required for the fixel directions file (see above).
 
 Fixel Data File

--- a/docs/reference/commands/fod2fixel.rst
+++ b/docs/reference/commands/fod2fixel.rst
@@ -65,9 +65,7 @@ Options to modulate outputs of fod2fixel
 
 -  **-fixel_dirs choice** choose what will be used to define the direction of each fixel; options are: mean,peak,lsq
 
--  **-nolookup** do not export the lookup table image
-
--  **-dixel_images** write a set of dixel images, where each encodes the FOD amplitudes for one fixel in each voxel
+-  **-amplitude_images** write a set of dixel images, where each encodes the FOD amplitudes for one fixel in each voxel
 
 Standard options
 ^^^^^^^^^^^^^^^^

--- a/src/dwi/fmls.h
+++ b/src/dwi/fmls.h
@@ -239,8 +239,6 @@ namespace MR
           void         set_lobe_merge_ratio     (const default_type i) { lobe_merge_ratio = i; }
           bool         get_calculate_lsq_dir    ()               const { return calculate_lsq_dir; }
           void         set_calculate_lsq_dir    (const bool i)         { calculate_lsq_dir = i; }
-          bool         get_create_lookup_table  ()               const { return create_lookup_table; }
-          void         set_create_lookup_table  (const bool i)         { create_lookup_table = i; }
 
         private:
 
@@ -260,7 +258,6 @@ namespace MR
           default_type peak_value_threshold; // Absolute threshold for the peak amplitude of the lobe
           default_type lobe_merge_ratio;     // Determines whether two lobes get agglomerated into one, depending on the FOD amplitude at the current point and how it compares to the maximal amplitudes of the lobes to which it could be assigned
           bool         calculate_lsq_dir;    // Whether to invest the clock cycles in calculating the least square direction
-          bool         create_lookup_table;  // If false, don't waste the memory required to create and store this
 
           // By default, the mean direction of each FOD lobe is calculated by taking a weighted average of the
           //   Euclidean unit vectors (weights are FOD amplitudes). This is not strictly mathematically correct, and


### PR DESCRIPTION
Likely resolves #2637.

The storage size problem was worse than I thought.
For the BATMAN dataset, `fod2fixel` produces ~ 100,000 fixels and requires ~ 5.5MB.
Writing the lookup table as currently done in #2625 requires an additional ~ 700MB.
The solution here requires an additional ~ 16MB.

In addition to the reduction in storage space, it actually provides a little bit more information.
Part of the FOD FMLS segmentation process is identifying dixels where the FOD lobes that are segmented as two different fixels "touch".
By representing the association between dixels and fixels as a binary dixel mask per fixel rather than a fixel index per dixel, it's possible to attribute such dixels to *both* fixels, which is more faithful, even if it potentially means more complex calculations downstream.

Given the magnitude of the change in storage, I think I need to commit to this solution.
But in addition to the consequences to the stuff that I'm implementing for which this is all requisite, it also modulates the proposed change to the fixel directory format.

#### Question:

People need to be content with both the proposed structure and the image name (I'm not sold on "`dixelmasks.mif`", open to suggestions).
