### PR TITLE
Use C++17 std::filesystem APIs

### DIFF
--- a/cmd/fixel2peaks.cpp
+++ b/cmd/fixel2peaks.cpp
@@ -25,6 +25,8 @@
 #include "fixel/helpers.h"
 #include "fixel/loop.h"
 
+#include <filesystem>
+
 using namespace MR;
 using namespace App;
 
@@ -61,17 +63,21 @@ void usage ()
 void run ()
 {
   Header index_header, directions_header, data_header;
+  const std::filesystem::path input_path{argument[0]};
+  
   try {
     Header input_header = Header::open (argument[0]);
+    const std::filesystem::path input_parent_dir = input_path.parent_path();
+
     if (Fixel::is_index_image (input_header)) {
       index_header = std::move (input_header);
-      directions_header = Fixel::find_directions_header (Path::dirname (argument[0]));
+      directions_header = Fixel::find_directions_header (input_parent_dir);
     } else if (Fixel::is_directions_file (input_header)) {
-      index_header = Fixel::find_index_header (Path::dirname (argument[0]));
+      index_header = Fixel::find_index_header (input_parent_dir);
       directions_header = std::move (input_header);
     } else if (Fixel::is_data_file (input_header)) {
-      index_header = Fixel::find_index_header (Path::dirname (argument[0]));
-      directions_header = Fixel::find_directions_header (Path::dirname (argument[0]));
+      index_header = Fixel::find_index_header (input_parent_dir);
+      directions_header = Fixel::find_directions_header (input_parent_dir);
       data_header = std::move (input_header);
       Fixel::check_fixel_size (index_header, data_header);
     } else {
@@ -81,8 +87,8 @@ void run ()
     try {
       if (!Path::is_dir (argument[0]))
         throw Exception ("Input path is not a directory");
-      index_header = Fixel::find_index_header (argument[0]);
-      directions_header = Fixel::find_directions_header (argument[0]);
+      index_header = Fixel::find_index_header (input_path);
+      directions_header = Fixel::find_directions_header (input_path);
     } catch (Exception& e_asdir) {
       Exception e ("Could not locate fixel data based on input string \"" + argument[0] + "\"");
       e.push_back ("Error when interpreting as image: ");

--- a/cmd/fixel2voxel.cpp
+++ b/cmd/fixel2voxel.cpp
@@ -32,6 +32,8 @@
 #include "fixel/helpers.h"
 #include "fixel/loop.h"
 
+#include <filesystem>
+
 using namespace MR;
 using namespace App;
 
@@ -488,11 +490,13 @@ class None : protected Base
 
 void run ()
 {
-  auto in_data = Fixel::open_fixel_data_file<typename FixelDataType::value_type> (argument[0]);
+  const std::filesystem::path input_file {argument[0]};
+
+  auto in_data = Fixel::open_fixel_data_file<typename FixelDataType::value_type> (input_file);
   if (in_data.size(2) != 1)
     throw Exception ("Input fixel data file must have a single scalar value per fixel (i.e. have dimensions Nx1x1)");
 
-  Header in_index_header = Fixel::find_index_header (Fixel::get_fixel_directory (argument[0]));
+  Header in_index_header = Fixel::find_index_header (Fixel::get_fixel_directory (input_file));
   auto in_index_image = in_index_header.get_image<typename FixelIndexType::value_type>();
 
   Image<float> in_directions;

--- a/cmd/fixelconvert.cpp
+++ b/cmd/fixelconvert.cpp
@@ -206,9 +206,9 @@ void convert_new2old ()
   auto opt = get_options ("value");
   if (!opt.size())
     throw Exception ("for converting from new to old formats, option -value is compulsory");
-  const std::string value_path = get_options ("value")[0][0];
+  const std::filesystem::path value_path {get_options ("value")[0][0]};
   opt = get_options ("in_size");
-  const std::string size_path = opt.size() ? std::string(opt[0][0]) : "";
+  const std::filesystem::path size_path {opt.size() ? std::string(opt[0][0]) : ""};
 
   Header H_index = Fixel::find_index_header (input_fixel_directory);
   Header H_dirs = Fixel::find_directions_header (input_fixel_directory);
@@ -216,11 +216,12 @@ void convert_new2old ()
   size_t size_index = H_data.size(), value_index = H_data.size();
 
   for (size_t i = 0; i != H_data.size(); ++i) {
-    if (Path::basename (H_data[i].name()) == Path::basename (value_path))
+    if (std::filesystem::path(H_data[i].name()).filename() == value_path.filename())
       value_index = i;
-    if (Path::basename (H_data[i].name()) == Path::basename (size_path))
+    if (std::filesystem::path(H_data[i].name()).filename() == size_path.filename())
       size_index = i;
   }
+
   if (value_index == H_data.size())
     throw Exception ("could not find image in input fixel directory corresponding to -value option");
 

--- a/cmd/fixelcorrespondence.cpp
+++ b/cmd/fixelcorrespondence.cpp
@@ -21,6 +21,8 @@
 #include "fixel/fixel.h"
 #include "fixel/helpers.h"
 
+#include <filesystem>
+
 using namespace MR;
 using namespace App;
 
@@ -57,8 +59,11 @@ void run ()
   const float angular_threshold = get_option_value ("angle", DEFAULT_ANGLE_THRESHOLD);
   const float angular_threshold_dp = cos (angular_threshold * (Math::pi/180.0));
 
-  const std::string input_file (argument[0]);
-  if (Path::is_dir (input_file))
+  const std::filesystem::path input_file (argument[0]);
+  const std::filesystem::path template_directory {argument[1]};
+  const std::filesystem::path output_fixel_directory {argument[2]};
+
+  if (std::filesystem::is_directory(input_file))
     throw Exception ("please input the specific fixel data file to be converted (not the fixel directory)");
 
   auto subject_index = Fixel::find_index_header (Fixel::get_fixel_directory (input_file)).get_image<index_type>();
@@ -70,11 +75,10 @@ void run ()
   auto subject_data = Image<float>::open (input_file);
   Fixel::check_fixel_size (subject_index, subject_data);
 
-  auto template_index = Fixel::find_index_header (argument[1]).get_image<index_type>();
-  auto template_directions = Fixel::find_directions_header (argument[1]).get_image<float>().with_direct_io();
+  auto template_index = Fixel::find_index_header (template_directory).get_image<index_type>();
+  auto template_directions = Fixel::find_directions_header (template_directory).get_image<float>().with_direct_io();
 
   check_dimensions (subject_index, template_index);
-  std::string output_fixel_directory = argument[2];
   Fixel::copy_index_and_directions_file (argument[1], output_fixel_directory);
 
   Header output_data_header (template_directions);

--- a/cmd/fixelcrop.cpp
+++ b/cmd/fixelcrop.cpp
@@ -74,8 +74,7 @@ void run ()
   }
 
   out_header.keyval ()[Fixel::n_fixels_key] = str (total_nfixels);
-  auto out_index_image = Image<index_type>::create (Path::join (out_fixel_directory, Path::basename (in_index_image.name())), out_header);
-
+  auto out_index_image = Image<index_type>::create(out_fixel_directory / in_index_image.name(), out_header);
 
   // Open all data images and create output date images with size equal to expected number of fixels
   vector<Header> in_headers = Fixel::find_data_headers (in_directory, in_index_header, true);

--- a/cmd/fixelcrop.cpp
+++ b/cmd/fixelcrop.cpp
@@ -52,7 +52,8 @@ void usage ()
 
 void run ()
 {
-  const auto in_directory = argument[0];
+  const std::filesystem::path in_directory {argument[0]};
+
   Fixel::check_fixel_directory (in_directory);
   Header in_index_header = Fixel::find_index_header (in_directory);
   auto in_index_image = in_index_header.get_image <index_type>();
@@ -60,7 +61,7 @@ void run ()
   auto mask_image = Image<bool>::open (argument[1]);
   Fixel::check_fixel_size (in_index_image, mask_image);
 
-  const auto out_fixel_directory = argument[2];
+  const std::filesystem::path out_fixel_directory {argument[2]};
   Fixel::check_fixel_directory (out_fixel_directory, true, true);
 
   Header out_header = Header (in_index_image);

--- a/cmd/fixelfilter.cpp
+++ b/cmd/fixelfilter.cpp
@@ -99,19 +99,19 @@ void run()
   Image<float> single_file;
   vector<Header> multiple_files;
   std::unique_ptr<Fixel::Filter::Base> filter;
-
+  const std::filesystem::path input_path {argument[0]};
   {
     Header index_header;
     Header output_header;
     try {
-      index_header = Fixel::find_index_header (argument[0]);
-      multiple_files = Fixel::find_data_headers (argument[0], index_header);
+      index_header = Fixel::find_index_header (input_path);
+      multiple_files = Fixel::find_data_headers (input_path, index_header);
       if (multiple_files.empty())
         throw Exception ("No fixel data files found in directory \"" + argument[0] + "\"");
       output_header = Header (multiple_files[0]);
     } catch (...) {
       try {
-        index_header = Fixel::find_index_header (Fixel::get_fixel_directory (argument[0]));
+        index_header = Fixel::find_index_header (Fixel::get_fixel_directory (input_path));
         single_file = Image<float>::open (argument[0]);
         Fixel::check_data_file (single_file);
         output_header = Header (single_file);

--- a/cmd/fod2fixel.cpp
+++ b/cmd/fod2fixel.cpp
@@ -31,7 +31,7 @@
 
 #include "file/path.h"
 
-
+#include <filesystem>
 
 
 using namespace MR;
@@ -115,12 +115,12 @@ class Segmented_FOD_receiver {
 
     void commit ();
 
-    void set_fixel_directory_output (const std::string& path) { fixel_directory_path = path; }
-    void set_index_output (const std::string& path) { index_path = path; }
-    void set_directions_output (const std::string& path) { dir_path = path; }
-    void set_afd_output (const std::string& path) { afd_path = path; }
-    void set_peak_amp_output (const std::string& path) { peak_amp_path = path; }
-    void set_disp_output (const std::string& path) { disp_path = path; }
+    void set_fixel_directory_output (const std::filesystem::path& path) { fixel_directory_path = path; }
+    void set_index_output (const std::filesystem::path& path) { index_path = path; }
+    void set_directions_output (const std::filesystem::path& path) { dir_path = path; }
+    void set_afd_output (const std::filesystem::path& path) { afd_path = path; }
+    void set_peak_amp_output (const std::filesystem::path& path) { peak_amp_path = path; }
+    void set_disp_output (const std::filesystem::path& path) { disp_path = path; }
 
     bool operator() (const FOD_lobes&);
 
@@ -154,7 +154,7 @@ class Segmented_FOD_receiver {
     };
 
     Header H;
-    std::string fixel_directory_path, index_path, dir_path, afd_path, peak_amp_path, disp_path;
+    std::filesystem::path fixel_directory_path, index_path, dir_path, afd_path, peak_amp_path, disp_path;
     vector<Primitive_FOD_lobes> lobes;
     index_type fixel_count;
     index_type max_per_voxel;
@@ -208,7 +208,7 @@ void Segmented_FOD_receiver::commit ()
   fixel_data_header.datatype() = DataType::Float32;
   fixel_data_header.datatype().set_byte_order_native();
 
-  if (dir_path.size()) {
+  if (!dir_path.empty()) {
     auto dir_header (fixel_data_header);
     dir_header.size(1) = 3;
     dir_image = make_unique<DataImage> (DataImage::create (Path::join(fixel_directory_path, dir_path), dir_header));
@@ -216,7 +216,7 @@ void Segmented_FOD_receiver::commit ()
     Fixel::check_fixel_size (*index_image, *dir_image);
   }
 
-  if (afd_path.size()) {
+  if (!afd_path.empty()) {
     auto afd_header (fixel_data_header);
     afd_header.size(1) = 1;
     afd_image = make_unique<DataImage> (DataImage::create (Path::join(fixel_directory_path, afd_path), afd_header));
@@ -224,7 +224,7 @@ void Segmented_FOD_receiver::commit ()
     Fixel::check_fixel_size (*index_image, *afd_image);
   }
 
-  if (peak_amp_path.size()) {
+  if (!peak_amp_path.empty()) {
     auto peak_amp_header (fixel_data_header);
     peak_amp_header.size(1) = 1;
     peak_amp_image = make_unique<DataImage> (DataImage::create (Path::join(fixel_directory_path, peak_amp_path), peak_amp_header));
@@ -232,7 +232,7 @@ void Segmented_FOD_receiver::commit ()
     Fixel::check_fixel_size (*index_image, *peak_amp_image);
   }
 
-  if (disp_path.size()) {
+  if (!disp_path.empty()) {
     auto disp_header (fixel_data_header);
     disp_header.size(1) = 1;
     disp_image = make_unique<DataImage> (DataImage::create (Path::join(fixel_directory_path, disp_path), disp_header));
@@ -302,7 +302,7 @@ void run ()
 
   Segmented_FOD_receiver receiver (H, maxnum, dir_as_peak);
 
-  auto& fixel_directory_path  = argument[1];
+  const std::filesystem::path fixel_directory_path {argument[1]};
   receiver.set_fixel_directory_output (fixel_directory_path);
 
   std::string file_extension (".mif");
@@ -315,9 +315,9 @@ void run ()
   receiver.set_directions_output (default_directions_filename);
 
   auto
-  opt = get_options ("afd");      if (opt.size()) receiver.set_afd_output      (opt[0][0]);
-  opt = get_options ("peak_amp"); if (opt.size()) receiver.set_peak_amp_output (opt[0][0]);
-  opt = get_options ("disp");     if (opt.size()) receiver.set_disp_output     (opt[0][0]);
+  opt = get_options ("afd");      if (opt.size()) receiver.set_afd_output      (std::filesystem::path{opt[0][0]});
+  opt = get_options ("peak_amp"); if (opt.size()) receiver.set_peak_amp_output (std::filesystem::path{opt[0][0]});
+  opt = get_options ("disp");     if (opt.size()) receiver.set_disp_output     (std::filesystem::path{opt[0][0]});
 
   opt = get_options ("mask");
   Image<float> mask;

--- a/cmd/mesh2voxel.cpp
+++ b/cmd/mesh2voxel.cpp
@@ -55,9 +55,9 @@ void usage ()
 
 void run ()
 {
-
+  const std::filesystem::path input_source_path {argument[0]};
   // Read in the mesh data
-  Surface::Mesh mesh (argument[0]);
+  Surface::Mesh mesh (input_source_path);
 
   // Get the template image
   Header template_header = Header::open (argument[1]);

--- a/cmd/meshfilter.cpp
+++ b/cmd/meshfilter.cpp
@@ -76,12 +76,14 @@ void usage ()
 
 void run ()
 {
-
+  const std::filesystem::path input_mesh_file {argument[0]};
+  const std::filesystem::path output_mesh_file{argument[2]};
+  
   MeshMulti in;
 
   // Read in the mesh data
   try {
-    Mesh mesh (argument[0]);
+    Mesh mesh (input_mesh_file);
     in.push_back (mesh);
   } catch (...) {
     in.load (argument[0]);
@@ -106,8 +108,8 @@ void run ()
 
   // Create the output file
   if (out.size() == 1)
-    out.front().save (argument[2]);
+    out.front().save (output_mesh_file);
   else
-    out.save (argument[2]);
+    out.save (output_mesh_file);
 
 }

--- a/cmd/mrclusterstats.cpp
+++ b/cmd/mrclusterstats.cpp
@@ -32,6 +32,7 @@
 #include "stats/permtest.h"
 #include "stats/tfce.h"
 
+#include <filesystem>
 
 using namespace MR;
 using namespace App;
@@ -180,7 +181,7 @@ std::shared_ptr<Voxel2Vector> SubjectVoxelImport::v2v = nullptr;
 
 
 void run() {
-
+  const std::filesystem::path input_path{argument[0]};
   const value_type cluster_forming_threshold = get_option_value ("threshold", NaN);
   const value_type tfce_dh = get_option_value ("tfce_dh", DEFAULT_TFCE_DH);
   const value_type tfce_H = get_option_value ("tfce_h", DEFAULT_TFCE_H);
@@ -203,7 +204,7 @@ void run() {
 
   // Read file names and check files exist
   CohortDataImport importer;
-  importer.initialise<SubjectVoxelImport> (argument[0]);
+  importer.initialise<SubjectVoxelImport> (input_path);
   for (size_t i = 0; i != importer.size(); ++i) {
     if (!dimensions_match (dynamic_cast<SubjectVoxelImport*>(importer[i].get())->header(), mask_header))
       throw Exception ("Image file \"" + importer[i]->name() + "\" does not match analysis mask");
@@ -223,7 +224,7 @@ void run() {
   auto opt = get_options ("column");
   for (size_t i = 0; i != opt.size(); ++i) {
     extra_columns.push_back (CohortDataImport());
-    extra_columns[i].initialise<SubjectVoxelImport> (opt[i][0]);
+    extra_columns[i].initialise<SubjectVoxelImport> (std::filesystem::path{opt[i][0]});
     if (!extra_columns[i].allFinite())
       nans_in_columns = true;
   }

--- a/cmd/mrregister.cpp
+++ b/cmd/mrregister.cpp
@@ -37,6 +37,8 @@
 #include "file/nifti_utils.h"
 
 
+#include <filesystem>
+
 using namespace MR;
 using namespace App;
 
@@ -684,7 +686,7 @@ void run () {
 
     if (!Path::is_mrtrix_image (opt[0][0]) && !(Path::has_suffix (opt[0][0], {".nii", ".nii.gz"}) &&
                                                 File::Config::get_bool ("NIfTIAutoLoadJSON", false) &&
-                                                Path::exists(File::NIfTI::get_json_path(opt[0][0]))))
+                                                std::filesystem::exists(File::NIfTI::get_json_path(opt[0][0]))))
       WARN ("nl_init input requires warp_full in original .mif/.mih file format or in NIfTI file format with associated JSON. "
             "Converting to other file formats may remove linear transformations stored in the image header.");
 

--- a/cmd/mrtransform.cpp
+++ b/cmd/mrtransform.cpp
@@ -299,7 +299,7 @@ void run ()
   if (opt.size()) {
     if (!Path::is_mrtrix_image (opt[0][0]) && !(Path::has_suffix (opt[0][0], {".nii", ".nii.gz"}) &&
                                                 File::Config::get_bool ("NIfTIAutoLoadJSON", false) &&
-                                                Path::exists(File::NIfTI::get_json_path(opt[0][0]))))
+                                                std::filesystem::exists(File::NIfTI::get_json_path(opt[0][0]))))
       WARN ("warp_full image is not in original .mif/.mih file format or in NIfTI file format with associated JSON.  "
             "Converting to other file formats may remove linear transformations stored in the image header.");
     warp = Image<default_type>::open (opt[0][0]).with_direct_io();

--- a/cmd/mtnormalise.cpp
+++ b/cmd/mtnormalise.cpp
@@ -533,7 +533,7 @@ void run ()
 
   Eigen::MatrixXd data (num_voxels, n_tissue_types);
   for (size_t n = 0; n < n_tissue_types; ++n) {
-    if (Path::exists (argument[2*n+1]) && !App::overwrite_files)
+    if (std::filesystem::exists (argument[2*n+1]) && !App::overwrite_files)
       throw Exception ("Output file \"" + argument[2*n+1] + "\" already exists. (use -force option to force overwrite)");
     load_data (data, argument[2*n], index);
   }

--- a/cmd/peaks2fixel.cpp
+++ b/cmd/peaks2fixel.cpp
@@ -21,6 +21,7 @@
 #include "fixel/fixel.h"
 #include "fixel/helpers.h"
 
+#include <filesystem>
 
 using namespace MR;
 using namespace App;
@@ -97,7 +98,9 @@ void run ()
     INFO ("Peaks have variable amplitudes; will create additional fixel data file \"" + dataname + "\"");
   }
 
-  Fixel::check_fixel_directory (argument[1], true, true);
+  const std::filesystem::path output_fixel_directory {argument[1]};
+
+  Fixel::check_fixel_directory (output_fixel_directory, true, true);
 
   // Easiest if we first make the index image
   const std::string index_path = Path::join (argument[1], "index.mif");

--- a/cmd/tckmap.cpp
+++ b/cmd/tckmap.cpp
@@ -380,7 +380,7 @@ void run () {
     if (writer_type != GREYSCALE)
       throw Exception ("Options for setting output image dimensionality are mutually exclusive");
     writer_type = DIXEL;
-    if (Path::exists (opt[0][0]))
+    if (std::filesystem::exists (opt[0][0]))
       dirs.reset (new Directions::FastLookupSet (str(opt[0][0])));
     else
       dirs.reset (new Directions::FastLookupSet (to<size_t>(opt[0][0])));

--- a/cmd/tckmap.cpp
+++ b/cmd/tckmap.cpp
@@ -380,7 +380,7 @@ void run () {
     if (writer_type != GREYSCALE)
       throw Exception ("Options for setting output image dimensionality are mutually exclusive");
     writer_type = DIXEL;
-    if (std::filesystem::exists (opt[0][0]))
+    if (std::filesystem::exists (std::filesystem::path{opt[0][0]}))
       dirs.reset (new Directions::FastLookupSet (str(opt[0][0])));
     else
       dirs.reset (new Directions::FastLookupSet (to<size_t>(opt[0][0])));

--- a/cmd/vectorstats.cpp
+++ b/cmd/vectorstats.cpp
@@ -27,6 +27,7 @@
 
 #include "stats/permtest.h"
 
+#include <filesystem>
 
 using namespace MR;
 using namespace App;
@@ -122,6 +123,8 @@ void run()
   CohortDataImport importer;
   matrix_type data;
   size_t num_inputs = 0, num_elements = 0;
+  const std::filesystem::path input_path{argument[0]};
+
   try {
     importer.initialise<SubjectVectorImport> (argument[0]);
     num_inputs = importer.size();

--- a/cmd/vectorstats.cpp
+++ b/cmd/vectorstats.cpp
@@ -126,7 +126,7 @@ void run()
   const std::filesystem::path input_path{argument[0]};
 
   try {
-    importer.initialise<SubjectVectorImport> (argument[0]);
+    importer.initialise<SubjectVectorImport> (input_path);
     num_inputs = importer.size();
     num_elements = importer[0]->size();
     for (size_t i = 0; i != importer.size(); ++i) {
@@ -165,7 +165,8 @@ void run()
   auto opt = get_options ("column");
   for (size_t i = 0; i != opt.size(); ++i) {
     extra_columns.push_back (CohortDataImport());
-    extra_columns[i].initialise<SubjectVectorImport> (opt[i][0]);
+    const std::filesystem::path column_path {opt[i][0]};
+    extra_columns[i].initialise<SubjectVectorImport> (column_path);
     if (!extra_columns[i].allFinite())
       nans_in_columns = true;
   }

--- a/cmd/warpconvert.cpp
+++ b/cmd/warpconvert.cpp
@@ -116,7 +116,7 @@ void run ()
   } else if (type == 2 || type == 3) {
     if (!Path::is_mrtrix_image (argument[0]) && !(Path::has_suffix (argument[0], {".nii", ".nii.gz"}) &&
                                                   File::Config::get_bool ("NIfTIAutoLoadJSON", false) &&
-                                                  Path::exists(File::NIfTI::get_json_path(opt[0][0]))))
+                                                  std::filesystem::exists(File::NIfTI::get_json_path(opt[0][0]))))
       WARN ("warp_full image is not in original .mif/.mih file format or in NIfTI file format with associated JSON.  "
             "Converting to other file formats may remove linear transformations stored in the image header.");
     auto warp = Image<default_type>::open (argument[0]).with_direct_io (3);

--- a/core/app.cpp
+++ b/core/app.cpp
@@ -1181,13 +1181,13 @@ namespace MR
       for (const auto& i : argument) {
         const std::string text = std::string (i);
         if (i.arg->type == ArgFileIn || i.arg->type == TracksIn) {
-          if (!Path::exists (text))
+          if (!std::filesystem::exists(text))
             throw Exception ("required input file \"" + text + "\" not found");
           if (!Path::is_file (text))
             throw Exception ("required input \"" + text + "\" is not a file");
         }
         if (i.arg->type == ArgDirectoryIn) {
-          if (!Path::exists (text))
+          if (!std::filesystem::exists(text))
             throw Exception ("required input directory \"" + text + "\" not found");
           if (!Path::is_dir (text))
             throw Exception ("required input \"" + text + "\" is not a directory");
@@ -1209,13 +1209,13 @@ namespace MR
           const Argument& arg = i.opt->operator [](j);
           const std::string text = std::string (i.args[j]);
           if (arg.type == ArgFileIn || arg.type == TracksIn) {
-            if (!Path::exists (text))
+            if (!std::filesystem::exists(text))
               throw Exception ("input file \"" + text + "\" for option \"-" + std::string(i.opt->id) + "\" not found");
             if (!Path::is_file (text))
               throw Exception ("input \"" + text + "\" for option \"-" + std::string(i.opt->id) + "\" is not a file");
           }
           if (arg.type == ArgDirectoryIn) {
-            if (!Path::exists (text))
+            if (!std::filesystem::exists(text))
               throw Exception ("input directory \"" + text + "\" for option \"-" + std::string(i.opt->id) + "\" not found");
             if (!Path::is_dir (text))
               throw Exception ("input \"" + text + "\" for option \"-" + std::string(i.opt->id) + "\" is not a directory");

--- a/core/app.h
+++ b/core/app.h
@@ -30,6 +30,7 @@
 #include "types.h"
 #include "file/path.h"
 
+#include <filesystem>
 
 extern void usage ();
 extern void run ();
@@ -165,13 +166,13 @@ namespace MR
 
 
 
-    inline void check_overwrite (const std::string& name)
+    inline void check_overwrite (const std::filesystem::path& name)
     {
-      if (Path::exists (name) && !overwrite_files) {
+      if (std::filesystem::exists (name) && !overwrite_files) {
         if (check_overwrite_files_func)
           check_overwrite_files_func (name);
         else
-          throw Exception ("output file \"" + name + "\" already exists (use -force option to force overwrite)");
+          throw Exception ("output file \"" + name.string() + "\" already exists (use -force option to force overwrite)");
       }
     }
 

--- a/core/file/gz.h
+++ b/core/file/gz.h
@@ -58,7 +58,7 @@ namespace MR
         void open (const std::string& fname, const char* mode) {
           close();
           filename = fname;
-          if (!MR::Path::exists (filename))
+          if (!std::filesystem::exists (filename))
             throw Exception ("cannot access file \"" + filename + "\": No such file or directory");
 
           gz = gzopen (filename.c_str(), mode);

--- a/core/file/name_parser.cpp
+++ b/core/file/name_parser.cpp
@@ -18,6 +18,8 @@
 
 #include "file/name_parser.h"
 
+#include <filesystem>
+
 namespace MR
 {
   namespace File
@@ -53,7 +55,7 @@ namespace MR
         return;
       }
 
-      folder_name = Path::dirname (specification);
+      folder_name = std::filesystem::path{specification}.parent_path();
 
 
       try {

--- a/core/file/nifti_utils.cpp
+++ b/core/file/nifti_utils.cpp
@@ -346,7 +346,7 @@ namespace MR
               else
                 assert (0);
               json_path += ".json";
-              if (Path::exists (json_path))
+              if (std::filesystem::exists(json_path))
                 File::JSON::load (H, json_path);
             }
           }
@@ -833,15 +833,20 @@ namespace MR
       }
 
 
-      std::string get_json_path (const std::string & nifti_path) {
-        std::string json_path;
+      std::filesystem::path get_json_path (const std::filesystem::path & nifti_path) {
+        std::filesystem::path json_path;
+
+        const auto nifti_path_string = nifti_path.string();
         if (Path::has_suffix (nifti_path, ".nii.gz"))
-          json_path = nifti_path.substr (0, nifti_path.size()-7);
+          json_path = nifti_path_string.substr (0, nifti_path_string.size()-7);
         else if (Path::has_suffix (nifti_path, ".nii"))
-          json_path = nifti_path.substr (0, nifti_path.size()-4);
+          json_path = nifti_path_string.substr (0, nifti_path_string.size()-4);
         else
-          assert (0);
-        return json_path + ".json";
+          assert (false);
+        
+        json_path.replace_extension(".json");
+
+        return json_path;
       }
 
 

--- a/core/file/path.h
+++ b/core/file/path.h
@@ -63,14 +63,6 @@ namespace MR
       return (i == std::string::npos ? name : name.substr (i+1));
     }
 
-
-    inline std::string dirname (const std::string& name)
-    {
-      size_t i = name.find_last_of (PATH_SEPARATORS);
-      return (i == std::string::npos ? std::string ("") : (i ? name.substr (0,i) : std::string(1, PATH_SEPARATORS[0])));
-    }
-
-
     inline std::string join (const std::string& first, const std::string& second)
     {
       if (first.empty())

--- a/core/file/path.h
+++ b/core/file/path.h
@@ -77,22 +77,6 @@ namespace MR
     }
 
 
-    inline bool exists (const std::string& path)
-    {
-      struct stat buf;
-#ifdef MRTRIX_WINDOWS
-      const std::string stripped (strip (path, PATH_SEPARATORS, false, true));
-      if (!stat (stripped.c_str(), &buf))
-#else
-      if (!stat (path.c_str(), &buf))
-#endif
-        return true;
-      if (errno == ENOENT) return false;
-      throw Exception (strerror (errno));
-      return false;
-    }
-
-
     inline bool is_dir (const std::string& path)
     {
       struct stat buf;

--- a/core/file/png.cpp
+++ b/core/file/png.cpp
@@ -185,7 +185,7 @@ namespace MR
           data_type (H.datatype()),
           outfile (NULL)
       {
-        if (Path::exists (filename) && !App::overwrite_files)
+        if (std::filesystem::exists(filename) && !App::overwrite_files)
           throw Exception ("output file \"" + filename + "\" already exists (use -force option to force overwrite)");
         if (!(png_ptr = png_create_write_struct (PNG_LIBPNG_VER_STRING, this, &error_handler, NULL)))
           throw Exception ("Unable to create PNG write structure for image \"" + filename + "\"");

--- a/core/fixel/helpers.h
+++ b/core/fixel/helpers.h
@@ -233,7 +233,7 @@ namespace MR
     }
 
 
-    FORCE_INLINE vector<Header> find_data_headers (const std::string &fixel_directory_path, const Header &index_header, const bool include_directions = false)
+    FORCE_INLINE vector<Header> find_data_headers (const std::filesystem::path &fixel_directory_path, const Header &index_header, const bool include_directions = false)
     {
       check_index_image (index_header);
       auto dir_walker = Path::Dir (fixel_directory_path);
@@ -418,11 +418,11 @@ namespace MR
 
     //! open a data file. checks that a user has not input a fixel directory or index image
     template <class ValueType>
-    Image<ValueType> open_fixel_data_file (const std::string& input_file) {
-      if (Path::is_dir (input_file))
+    Image<ValueType> open_fixel_data_file (const std::filesystem::path& input_file) {
+      if (std::filesystem::is_directory(input_file))
         throw Exception ("please input the specific fixel data file to be converted (not the fixel directory)");
 
-      Header in_data_header = Header::open (input_file);
+      Header in_data_header = Header::open (input_file.string());
       Fixel::check_data_file (in_data_header);
       auto in_data_image = in_data_header.get_image<ValueType>();
 

--- a/core/fixel/helpers.h
+++ b/core/fixel/helpers.h
@@ -365,7 +365,7 @@ namespace MR
       std::string output_path = Path::join (output_directory, Path::basename (input_header.name()));
 
       // If the index file already exists check it is the same as the input index file
-      if (Path::exists (output_path)) {
+      if (std::filesystem::exists(output_path)) {
         auto input_image = input_header.get_image<index_type>();
         auto output_image = Image<index_type>::open (output_path);
         if (!images_match_abs (input_image, output_image))
@@ -387,7 +387,7 @@ namespace MR
       std::string output_path = Path::join (output_directory, Path::basename (input_header.name()));
 
       // If the directions file already exists check it is the same as the input directions file
-      if (Path::exists (output_path)) {
+      if (std::filesystem::exists(output_path)) {
         auto input_image = input_header.get_image<float>();
         auto output_image = Image<float>::open (output_path);
         if (!images_match_abs (input_image, output_image))

--- a/core/formats/list.cpp
+++ b/core/formats/list.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <cstdlib>
+#include <array>
 
 #include "formats/list.h"
 
@@ -70,37 +71,6 @@ namespace MR
       nullptr
     };
 
-
-
-    const char* known_extensions[] = {
-      ".mih",
-      ".mif",
-      ".mif.gz",
-      ".img",
-      ".nii",
-      ".nii.gz",
-      ".bfloat",
-      ".bshort",
-      ".mri",
-      ".par",
-      ".mgh",
-      ".mgz",
-      ".mgh.gz",
-      ".msf",
-      ".msh",
-      ".dcm",
-#ifdef MRTRIX_TIFF_SUPPORT
-      ".tiff",
-      ".tif",
-      ".TIFF",
-      ".TIF",
-#endif
-#ifdef MRTRIX_PNG_SUPPORT
-      ".png",
-      ".PNG",
-#endif
-      nullptr
-    };
 
   }
 }

--- a/core/formats/list.h
+++ b/core/formats/list.h
@@ -108,7 +108,36 @@ namespace MR
     DECLARE_IMAGEFORMAT (MRtrix_sparse, "MRtrix WIP sparse image data format");
 
     /*! a list of all extensions for image formats that %MRtrix can handle. */
-    extern const char* known_extensions[];
+    using namespace std::string_literals;
+
+    const std::array known_extensions = {
+      ".mih"s,
+      ".mif"s,
+      ".mif.gz"s,
+      ".img"s,
+      ".nii"s,
+      ".nii.gz"s,
+      ".bfloat"s,
+      ".bshort"s,
+      ".mri"s,
+      ".par"s,
+      ".mgh"s,
+      ".mgz"s,
+      ".mgh.gz"s,
+      ".msf"s,
+      ".msh"s,
+      ".dcm"s,
+#ifdef MRTRIX_TIFF_SUPPORT
+      ".tiff"s,
+      ".tif"s,
+      ".TIFF"s,
+      ".TIF"s,
+#endif
+#ifdef MRTRIX_PNG_SUPPORT
+      ".png"s,
+      ".PNG"s,
+#endif
+    };
 
     /*! a list of all handlers for supported image formats. */
     extern const Base* handlers[];

--- a/core/formats/mrtrix_utils.cpp
+++ b/core/formats/mrtrix_utils.cpp
@@ -16,6 +16,7 @@
 
 #include "formats/mrtrix_utils.h"
 
+#include <filesystem>
 
 namespace MR
 {
@@ -151,8 +152,7 @@ namespace MR
             && fname[0] != PATH_SEPARATORS[1]
 #endif
            )
-          fname = Path::join (Path::dirname (H.name()), fname);
-
+          fname = std::filesystem::path{H.name()}.parent_path() / fname;
       }
 
     }

--- a/core/math/stats/import.h
+++ b/core/math/stats/import.h
@@ -28,6 +28,7 @@
 
 #include "math/stats/typedefs.h"
 
+#include <filesystem>
 
 namespace MR
 {
@@ -51,7 +52,7 @@ namespace MR
       class SubjectDataImportBase
       { 
         public:
-          SubjectDataImportBase (const std::string& path) :
+          SubjectDataImportBase (const std::filesystem::path& path) :
               path (path) { }
           virtual ~SubjectDataImportBase() { }
 
@@ -67,12 +68,12 @@ namespace MR
            */
           virtual default_type operator[] (const size_t index) const = 0;
 
-          const std::string& name() const { return path; }
+          std::string name() const { return path.string(); }
 
           virtual size_t size() const = 0;
 
         protected:
-          const std::string path;
+          const std::filesystem::path path;
 
       };
       //! @}

--- a/src/dwi/tractography/file_base.cpp
+++ b/src/dwi/tractography/file_base.cpp
@@ -22,7 +22,7 @@ namespace MR {
     namespace Tractography {
 
 
-      void __ReaderBase__::open (const std::string& file, const std::string& type, Properties& properties)
+      void __ReaderBase__::open (const std::filesystem::path& file, const std::string& type, Properties& properties)
       {
         properties.clear();
         dtype = DataType::Undefined;
@@ -41,7 +41,7 @@ namespace MR {
               properties.prior_rois.insert (std::pair<std::string,std::string> (V[0], V[1]));
             }
             catch (...) {
-              WARN ("invalid ROI specification in " + type  + " file \"" + file + "\" - ignored");
+              WARN ("invalid ROI specification in " + type  + " file \"" + file.string() + "\" - ignored");
             }
           }
           else if (key == "comment") properties.comments.push_back (kv.value());
@@ -51,14 +51,14 @@ namespace MR {
         }
 
         if (dtype == DataType::Undefined)
-          throw Exception ("no datatype specified for tracks file \"" + file + "\"");
+          throw Exception ("no datatype specified for tracks file \"" + file.string() + "\"");
         if (dtype != DataType::Float32LE && dtype != DataType::Float32BE &&
             dtype != DataType::Float64LE && dtype != DataType::Float64BE)
           throw Exception ("only supported datatype for tracks file are "
-              "Float32LE, Float32BE, Float64LE & Float64BE (in " + type  + " file \"" + file + "\")");
+              "Float32LE, Float32BE, Float64LE & Float64BE (in " + type  + " file \"" + file.string() + "\")");
 
         if (data_file.empty())
-          throw Exception ("missing \"files\" specification for " + type  + " file \"" + file + "\"");
+          throw Exception ("missing \"files\" specification for " + type  + " file \"" + file.string() + "\"");
 
         std::istringstream files_stream (data_file);
         std::string fname;
@@ -68,12 +68,12 @@ namespace MR {
           try { files_stream >> offset; }
           catch (...) {
             throw Exception ("invalid offset specified for file \""
-                + fname + "\" in " + type  + " file \"" + file + "\"");
+                + fname + "\" in " + type  + " file \"" + file.string() + "\"");
           }
         }
 
         if (fname != ".")
-          fname = Path::join (Path::dirname (file), fname);
+          fname = file.parent_path() / fname;
         else
           fname = file;
 

--- a/src/dwi/tractography/file_base.h
+++ b/src/dwi/tractography/file_base.h
@@ -27,8 +27,7 @@
 #include "file/path.h"
 #include "dwi/tractography/properties.h"
 
-
-
+#include <filesystem>
 
 namespace MR
 {
@@ -47,7 +46,7 @@ namespace MR
               in.close();
           }
 
-          void open (const std::string& file, const std::string& firstline, Properties& properties);
+          void open (const std::filesystem::path& file, const std::string& firstline, Properties& properties);
 
           void close () { in.close(); }
 

--- a/src/dwi/tractography/seeding/base.h
+++ b/src/dwi/tractography/seeding/base.h
@@ -101,7 +101,7 @@ namespace MR
             volume (0.0),
             count (0),
             type (desc),
-            name (Path::exists (in) ? Path::basename (in) : in),
+            name (std::filesystem::exists(in) ? Path::basename (in) : in),
             max_attempts (attempts) { }
 
           virtual ~Base() { }

--- a/src/fixel/matrix.cpp
+++ b/src/fixel/matrix.cpp
@@ -237,7 +237,7 @@ namespace MR
                                 const KeyValues& keyvals)
       {
 
-        if (Path::exists (path)) {
+        if (std::filesystem::exists(path)) {
           if (!Path::is_dir (path)) {
             if (App::overwrite_files) {
               File::remove (path);

--- a/src/fixel/matrix.cpp
+++ b/src/fixel/matrix.cpp
@@ -197,7 +197,7 @@ namespace MR
         };
 
 
-        auto directions_image = Fixel::find_directions_header (Path::dirname (index_image.name())).template get_image<default_type>().with_direct_io ({+2,+1});
+        auto directions_image = Fixel::find_directions_header (std::filesystem::path{index_image.name()}.parent_path()).template get_image<default_type>().with_direct_io ({+2,+1});
         DWI::Tractography::Properties properties;
         DWI::Tractography::Reader<float> track_file (track_filename, properties);
         const uint32_t num_tracks = properties["count"].empty() ? 0 : to<uint32_t>(properties["count"]);

--- a/src/gui/dialog/file.cpp
+++ b/src/gui/dialog/file.cpp
@@ -66,7 +66,7 @@ namespace MR
           std::string filename;
           if (qstring.size()) {
             filename = qstring.toUtf8().data();
-            std::string new_folder = Path::dirname (filename);
+            std::string new_folder = std::filesystem::path{filename}.parent_path().string();
             if (folder)
               *folder = new_folder;
           }
@@ -86,7 +86,7 @@ namespace MR
           if (qlist.size()) {
             for (int n = 0; n < qlist.size(); ++n)
               list.push_back (qlist[n].toUtf8().data());
-            std::string new_folder = Path::dirname (list[0]);
+            std::string new_folder = std::filesystem::path{list[0]}.parent_path().string();
             if (folder)
               *folder = new_folder;
           }
@@ -133,7 +133,7 @@ namespace MR
           std::string filename;
           if (qstring.size()) {
             filename = qstring.toUtf8().data();
-            std::string new_folder = Path::dirname (filename);
+            std::string new_folder = std::filesystem::path{filename}.parent_path().string();
             if (folder)
               *folder = new_folder;
           }

--- a/src/gui/mrview/tool/fixel/directory.cpp
+++ b/src/gui/mrview/tool/fixel/directory.cpp
@@ -61,7 +61,7 @@ namespace MR
 
 
           // Load fixel direction images
-          auto directions_image = MR::Fixel::find_directions_header (Path::dirname (fixel_data->name())).get_image<float>().with_direct_io ();
+          auto directions_image = MR::Fixel::find_directions_header (std::filesystem::path{fixel_data->name()}.parent_path()).get_image<float>().with_direct_io ();
           directions_image.index (1) = 0;
           for (auto l = Loop(0, 3) (*fixel_data); l; ++l) {
             fixel_data->index (3) = 0;
@@ -76,7 +76,7 @@ namespace MR
 
           // Load fixel data images keys
           // We will load the actual fixel data lazily upon request
-          auto data_headers = MR::Fixel::find_data_headers (Path::dirname (fixel_data->name ()), *fixel_data);
+          auto data_headers = MR::Fixel::find_data_headers (std::filesystem::path{fixel_data->name()}.parent_path(), *fixel_data);
           for (auto& header : data_headers) {
 
             if (header.size (1) != 1) continue;
@@ -92,10 +92,10 @@ namespace MR
         void Directory::lazy_load_fixel_value_file (const std::string& key) const {
 
           // We're assuming the key corresponds to the fixel data filename
-          const auto data_filepath = Path::join(Path::dirname (fixel_data->name ()), key);
+          const auto data_filepath = std::filesystem::path {fixel_data->name()}.parent_path() / key;
           fixel_values[key].loaded = true;
 
-          if (!Path::exists (data_filepath))
+          if (!std::filesystem::exists(data_filepath))
             return;
 
           auto H = Header::open (data_filepath);

--- a/src/gui/mrview/tool/fixel/directory.h
+++ b/src/gui/mrview/tool/fixel/directory.h
@@ -19,6 +19,8 @@
 
 #include "gui/mrview/tool/fixel/base_fixel.h"
 
+#include <filesystem>
+
 namespace MR
 {
   namespace GUI
@@ -30,8 +32,8 @@ namespace MR
         class Directory : public FixelType<FixelIndexImageType>
         { 
           public:
-            Directory (const std::string& filename, Fixel& fixel_tool) :
-              FixelType (MR::Fixel::find_index_header (Path::dirname (filename)).name (), fixel_tool)
+            Directory (const std::filesystem::path& filename, Fixel& fixel_tool) :
+              FixelType (MR::Fixel::find_index_header (filename.parent_path()).name (), fixel_tool)
             {
               value_types = {"unity"};
               colour_types = {"direction"};

--- a/src/registration/linear.h
+++ b/src/registration/linear.h
@@ -230,7 +230,7 @@ namespace MR
             for (size_t iter = 1; iter <= stage.stage_iterations; ++iter) {
               std::ostringstream oss;
               oss << diagnostics_image_prefix << "_stage-" << level + 1 << "_iter-" << iter << ".mif";
-              if (Path::exists(oss.str()) && !App::overwrite_files)
+              if (std::filesystem::exists(oss.str()) && !App::overwrite_files)
                 throw Exception ("diagnostics image file \"" + oss.str() + "\" already exists (use -force option to force overwrite)");
               stage.diagnostics_images.push_back(oss.str());
             }

--- a/src/registration/multi_contrast.h
+++ b/src/registration/multi_contrast.h
@@ -39,7 +39,7 @@ namespace MR
     FORCE_INLINE void check_image_output (const std::string& image_name, const Header& reference) {
       vector<std::string> V;
       if (!image_name.size()) throw Exception ("image output path is empty");
-        if (Path::exists (image_name) && !App::overwrite_files)
+        if (std::filesystem::exists(image_name) && !App::overwrite_files)
           throw Exception ("output image \"" + image_name + "\" already exists (use -force option to force overwrite)");
 
         Header H = reference;

--- a/src/registration/nonlinear.h
+++ b/src/registration/nonlinear.h
@@ -331,7 +331,7 @@ namespace MR
                 if (converged && diagnostics_image_prefix.size()) {
                   std::ostringstream oss;
                   oss << diagnostics_image_prefix << "_stage-" << level + 1 << ".mif";
-                  // if (Path::exists(oss.str()) && !App::overwrite_files)
+                  // if (std::filesystem::exists(oss.str()) && !App::overwrite_files)
                   //   throw Exception ("diagnostics image file \"" + oss.str() + "\" already exists (use -force option to force overwrite)");
                   Header hc (warped_header);
                   hc.ndim() = 4;

--- a/src/surface/freesurfer.cpp
+++ b/src/surface/freesurfer.cpp
@@ -27,7 +27,7 @@ namespace MR
 
 
 
-      void read_annot (const std::string& path, label_vector_type& labels, Connectome::LUT& lut)
+      void read_annot (const std::filesystem::path& path, label_vector_type& labels, Connectome::LUT& lut)
       {
         std::ifstream in (path.c_str(), std::ios_base::in | std::ios_base::binary);
         if (!in)
@@ -44,14 +44,14 @@ namespace MR
 
         const int32_t colortable_present = get_BE<int32_t> (in);
         if (!in.good()) {
-          WARN ("FreeSurfer annotation file \"" + Path::basename (path) + "\" does not contain colortable information");
+          WARN ("FreeSurfer annotation file \"" + path.filename().string() + "\" does not contain colortable information");
           labels = label_vector_type::Zero (num_vertices);
           for (size_t i = 0; i != vertices.size(); ++i)
             labels[vertices[i]] = vertex_labels[i];
           return;
         }
         if (!colortable_present)
-          throw Exception ("Error reading FreeSurfer annotation file \"" + Path::basename (path) + "\": Unexpected colortable flag");
+          throw Exception ("Error reading FreeSurfer annotation file \"" + path.filename().string() + "\": Unexpected colortable flag");
 
         // Structure that will map from the colour-based structure identifier to a more sensible index
         std::map<int32_t, Connectome::node_t> rgb2index;
@@ -79,7 +79,7 @@ namespace MR
 
           const int32_t version = -num_entries;
           if (version != 2)
-            throw Exception ("Error reading FreeSurfer annotation file \"" + Path::basename (path) + "\": Unsupported file version (" + str(version) + ")");
+            throw Exception ("Error reading FreeSurfer annotation file \"" + path.filename().string() + "\": Unsupported file version (" + str(version) + ")");
 
           num_entries = get_BE<int32_t> (in);
           const int32_t orig_lut_name_length = get_BE<int32_t> (in);
@@ -90,9 +90,9 @@ namespace MR
           for (int32_t i = 0; i != num_entries_to_read; ++i) {
             const int32_t structure = get_BE<int32_t> (in) + 1;
             if (structure < 0)
-              throw Exception ("Error reading FreeSurfer annotation file \"" + Path::basename (path) + "\": Negative structure index");
+              throw Exception ("Error reading FreeSurfer annotation file \"" + path.filename().string() + "\": Negative structure index");
             if (lut.find (structure) != lut.end())
-              throw Exception ("Error reading FreeSurfer annotation file \"" + Path::basename (path) + "\": Duplicate structure index");
+              throw Exception ("Error reading FreeSurfer annotation file \"" + path.filename().string() + "\": Duplicate structure index");
             const int32_t struct_name_length = get_BE<int32_t> (in);
             std::unique_ptr<char[]> struct_name (new char[struct_name_length]);
             in.read (struct_name.get(), struct_name_length);
@@ -114,7 +114,7 @@ namespace MR
 
 
 
-      void read_label (const std::string& path, VertexList& vertices, Scalar& scalar)
+      void read_label (const std::filesystem::path& path, VertexList& vertices, Scalar& scalar)
       {
         vertices.clear();
         scalar.resize(0);
@@ -126,13 +126,13 @@ namespace MR
         std::string line;
         std::getline (in, line);
         if (line.substr(0, 13) != "#!ascii label")
-          throw Exception ("Error parsing FreeSurfer label file \"" + Path::basename (path) + "\": Bad first line identifier");
+          throw Exception ("Error parsing FreeSurfer label file \"" + path.filename().string() + "\": Bad first line identifier");
         std::getline (in, line);
         uint32_t num_vertices = 0;
         try {
           num_vertices = to<size_t> (line);
         } catch (Exception& e) {
-          throw Exception (e, "Error parsing FreeSurfer label file \"" + Path::basename (path) + "\": Bad second line vertex count");
+          throw Exception (e, "Error parsing FreeSurfer label file \"" + path.filename().string() + "\": Bad second line vertex count");
         }
 
         for (size_t i = 0; i != num_vertices; ++i) {
@@ -141,19 +141,19 @@ namespace MR
           default_type x = NaN, y = NaN, z = NaN, value = NaN;
           sscanf (line.c_str(), "%u %lf %lf %lf %lf", &index, &x, &y, &z, &value);
           if (index == std::numeric_limits<uint32_t>::max())
-            throw Exception ("Error parsing FreeSurfer label file \"" + Path::basename (path) + "\": Malformed line");
+            throw Exception ("Error parsing FreeSurfer label file \"" + path.filename().string() + "\": Malformed line");
           if (index >= scalar.size()) {
             scalar.conservativeResizeLike (Scalar::Base::Constant (index+1, NaN));
             vertices.resize (index+1, Vertex (NaN, NaN, NaN));
           }
           if (std::isfinite (scalar[index]))
-            throw Exception ("Error parsing FreeSurfer label file \"" + Path::basename (path) + "\": Duplicated index (" + str(scalar[index]) + ")");
+            throw Exception ("Error parsing FreeSurfer label file \"" + path.filename().string() + "\": Duplicated index (" + str(scalar[index]) + ")");
           scalar[index] = value;
           vertices[index] = Vertex (x, y, z);
         }
 
         if (!in.good())
-          throw Exception ("Error parsing FreeSurfer label file \"" + Path::basename (path) + "\": End of file reached");
+          throw Exception ("Error parsing FreeSurfer label file \"" + path.filename().string() + "\": End of file reached");
         scalar.set_name (path);
       }
 

--- a/src/surface/freesurfer.h
+++ b/src/surface/freesurfer.h
@@ -19,6 +19,7 @@
 
 #include <stdint.h>
 #include <fstream>
+#include <filesystem>
 
 #include "raw.h"
 
@@ -61,8 +62,8 @@ namespace MR
 
 
 
-      void read_annot (const std::string&, label_vector_type&, Connectome::LUT&);
-      void read_label (const std::string&, VertexList&, Scalar&);
+      void read_annot (const std::filesystem::path&, label_vector_type&, Connectome::LUT&);
+      void read_label (const std::filesystem::path&, VertexList&, Scalar&);
 
 
 

--- a/src/surface/mesh.h
+++ b/src/surface/mesh.h
@@ -30,7 +30,7 @@
 
 #include "surface/types.h"
 
-
+#include <filesystem>
 
 namespace MR
 {
@@ -48,7 +48,7 @@ namespace MR
     class Mesh { 
 
       public:
-        Mesh (const std::string&);
+        Mesh (const std::filesystem::path&);
 
         Mesh (const Mesh& that) = default;
 
@@ -137,7 +137,7 @@ namespace MR
         }
 
 
-        void save (const std::string&, const bool binary = false) const;
+        void save (const std::filesystem::path&, const bool binary = false) const;
 
         size_t num_vertices() const { return vertices.size(); }
         size_t num_triangles() const { return triangles.size(); }
@@ -174,13 +174,13 @@ namespace MR
       private:
         std::string name;
 
-        void load_vtk (const std::string&);
-        void load_stl (const std::string&);
-        void load_obj (const std::string&);
-        void load_fs  (const std::string&);
-        void save_vtk (const std::string&, const bool) const;
-        void save_stl (const std::string&, const bool) const;
-        void save_obj (const std::string&) const;
+        void load_vtk (const std::filesystem::path&);
+        void load_stl (const std::filesystem::path&);
+        void load_obj (const std::filesystem::path&);
+        void load_fs  (const std::filesystem::path&);
+        void save_vtk (const std::filesystem::path&, const bool) const;
+        void save_stl (const std::filesystem::path&, const bool) const;
+        void save_obj (const std::filesystem::path&) const;
 
         void verify_data() const;
 

--- a/testing/cmd/testing_diff_fixel.cpp
+++ b/testing/cmd/testing_diff_fixel.cpp
@@ -57,7 +57,7 @@ void run ()
   while ((fname = dir_walker1.read_name()).size()) {
     auto in1 = Image<cdouble>::open (Path::join (fixel_directory1, fname));
     std::string filename2 = Path::join (fixel_directory2, fname);
-    if (!Path::exists (filename2))
+    if (!std::filesystem::exists(filename2))
       throw Exception ("File (" + fname + ") exists in fixel directory (" + fixel_directory1 + ") but not in fixel directory (" + fixel_directory2 + ") ");
     auto in2 = Image<cdouble>::open (filename2);
     Testing::diff_images (in1, in2);
@@ -65,7 +65,7 @@ void run ()
   auto dir_walker2 = Path::Dir (fixel_directory2);
   while ((fname = dir_walker2.read_name()).size()) {
     std::string filename1 = Path::join (fixel_directory1, fname);
-    if (!Path::exists (filename1))
+    if (!std::filesystem::exists(filename1))
       throw Exception ("File (" + fname + ") exists in fixel directory (" + fixel_directory2 + ") but not in fixel directory (" + fixel_directory1 + ") ");
   }
   CONSOLE ("data checked OK");

--- a/testing/cmd/testing_diff_matrix.cpp
+++ b/testing/cmd/testing_diff_matrix.cpp
@@ -14,6 +14,7 @@
  * For more details, see http://www.mrtrix.org/.
  */
 
+#include <filesystem>
 #include <fstream>
 
 #include "command.h"
@@ -49,7 +50,8 @@ void usage ()
 
 void run ()
 {
-
+  const std::filesystem::path first_matrix_path {argument[0]};
+  const std::filesystem::path second_matrix_path {argument[0]};
   const default_type tolerance_frac = get_option_value ("frac", 0.0);
   const default_type tolerance_abs = get_option_value ("abs", 0.0);
 
@@ -63,8 +65,11 @@ void run ()
     const auto in1c = load_matrix<cdouble> (argument[0]);
     const auto in2c = load_matrix<cdouble> (argument[1]);
 
+    const std::string first_path_string = first_matrix_path.string();
+    const std::string second_path_string = second_matrix_path.string();
+
     if (in1c.rows() != in2c.rows() || in1c.cols() != in2c.cols())
-      throw Exception ("matrices \"" + Path::basename (argument[0]) + "\" and \"" + Path::basename (argument[1]) + "\" do not have matching sizes"
+      throw Exception ("matrices \"" + first_path_string + "\" and \"" + second_path_string + "\" do not have matching sizes"
                        " (" + str(in1.rows()) + "x" + str(in1c.cols()) + " vs " + str(in2c.rows()) + "x" + str(in2c.cols()) + ")");
 
     if (bool(tolerance_frac)) {
@@ -72,7 +77,7 @@ void run ()
         for (ssize_t row = 0; row != in1c.rows(); ++row) {
           if ((abs (in1c(row, col).real() - in2c(row, col).real()) / (0.5 * (in1c(row, col).real() + in2c(row, col).real())) > tolerance_frac)
               || (abs (in1c(row, col).imag() - in2c(row, col).imag()) / (0.5 * (in1c(row, col).imag() + in2c(row, col).imag())) > tolerance_frac))
-            throw Exception ("matrices \"" + Path::basename (argument[0]) + "\" and \"" + Path::basename (argument[1]) + "\" do not match within fractional precision of " + str(tolerance_frac)
+            throw Exception ("matrices \"" + first_path_string + "\" and \"" + second_path_string + "\" do not match within fractional precision of " + str(tolerance_frac)
                              + " ((" + str(row) + ", " + str(col) + "): " + str(in1c(row, col)) + " vs " + str(in2c(row, col)) + ")");
         }
       }
@@ -83,7 +88,7 @@ void run ()
         for (ssize_t row = 0; row != in1c.rows(); ++row) {
           if ((abs (in1c(row, col).real() - in2c(row, col).real()) > tolerance_abs)
               || (abs (in1c(row, col).imag() - in2c(row, col).imag()) > tolerance_abs))
-            throw Exception ("matrices \"" + Path::basename (argument[0]) + "\" and \"" + Path::basename (argument[1]) + "\" do not match within absolute precision of " + str(tolerance_abs)
+            throw Exception ("matrices \"" + first_path_string + "\" and \"" + second_path_string + "\" do not match within absolute precision of " + str(tolerance_abs)
                              + " ((" + str(row) + ", " + str(col) + "): " + str(in1c(row, col)) + " vs " + str(in2c(row, col)) + ")");
         }
       }
@@ -93,14 +98,14 @@ void run ()
   }
 
   if (in1.rows() != in2.rows() || in1.cols() != in2.cols())
-    throw Exception ("matrices \"" + Path::basename (argument[0]) + "\" and \"" + Path::basename (argument[1]) + "\" do not have matching sizes"
+    throw Exception ("matrices \"" + first_path_string + "\" and \"" + second_path_string + "\" do not have matching sizes"
                      " (" + str(in1.rows()) + "x" + str(in1.cols()) + " vs " + str(in2.rows()) + "x" + str(in2.cols()) + ")");
 
   if (bool(tolerance_frac)) {
     for (ssize_t col = 0; col != in1.cols(); ++col) {
       for (ssize_t row = 0; row != in1.rows(); ++row) {
         if (abs (in1(row, col) - in2(row, col)) / (0.5 * (in1(row, col) + in2(row, col))) > tolerance_frac)
-          throw Exception ("matrices \"" + Path::basename (argument[0]) + "\" and \"" + Path::basename (argument[1]) + "\" do not match within fractional precision of " + str(tolerance_abs)
+          throw Exception ("matrices \"" + first_path_string + "\" and \"" + second_path_string + "\" do not match within fractional precision of " + str(tolerance_abs)
                            + " ((" + str(row) + ", " + str(col) + "): " + str(in1(row, col)) + " vs " + str(in2(row, col)) + ")");
       }
     }
@@ -110,7 +115,7 @@ void run ()
     for (ssize_t col = 0; col != in1.cols(); ++col) {
       for (ssize_t row = 0; row != in1.rows(); ++row) {
         if (abs (in1(row, col) - in2(row, col)) > tolerance_abs)
-          throw Exception ("matrices \"" + Path::basename (argument[0]) + "\" and \"" + Path::basename (argument[1]) + "\" do not match within absolute precision of " + str(tolerance_abs)
+          throw Exception ("matrices \"" + first_path_string + "\" and \"" + second_path_string + "\" do not match within absolute precision of " + str(tolerance_abs)
                            + " ((" + str(row) + ", " + str(col) + "): " + str(in1(row, col)) + " vs " + str(in2(row, col)) + ")");
       }
     }


### PR DESCRIPTION
This pull requests will contain changes to migrate our file system handling code to use the [std::filesystem](https://en.cppreference.com/w/cpp/filesystem) namespace introduced in C++17. 
The changes will likely affect a lot of code and files. It'd be good to get some feedback on the changes as early as possible to make the review process easier (and avoiding dealing with a giant final review). There may be places where the introduction of `std::filesystem::path` and related APIs may introduce undesired effects, it'd be good if we could catch them as early as possible.

The changes will address one of the objectives identified in #2585.