### PR TITLE
Replace MR::vector with std::vector

### DIFF
--- a/check_syntax
+++ b/check_syntax
@@ -64,12 +64,6 @@ for f in $(find cmd core src -type f -name '*.h' -o -name '*.cpp' | $grep -v '_m
 # remove quoted strings:
   cat .check_syntax2.tmp | perl -pe 's/(")(\\"|.)*?"//g' > .check_syntax.tmp
 
-# detect any instances of std::vector:
-  res="$res"$(
-    cat .check_syntax.tmp | \
-# match for the parts we're interested in and output just the bits that match:
-    $grep -Po '(?<!::)std::vector\b'
-  )
 
 
 # detect any instances of std::make_shared:
@@ -126,7 +120,6 @@ else
   echo "" >> $LOG
   echo "Please check the following syntax requirements:
   - Add MEMALIGN() or NOMEMALIGN macro to any class declarations identified above;
-  - Replace all occurrences of std::vector<> with MR::vector<> (or just vector<>);
   - Avoid use of std::make_shared();
   - Replace all instances of std::abs() with MR::abs() (or just abs());
   - Replace all instances of %zu in print() calls with PRI_SIZET." >> $LOG

--- a/cmd/afdconnectivity.cpp
+++ b/cmd/afdconnectivity.cpp
@@ -233,7 +233,7 @@ value_type AFDConnectivity::get (const std::string& path)
     if (all_fixels) {
 
       // All fixels contribute to the result
-      for (vector<AFDConnFixel>::const_iterator i = fixels.begin(); i != fixels.end(); ++i) {
+      for (std::vector<AFDConnFixel>::const_iterator i = fixels.begin(); i != fixels.end(); ++i) {
         if (i->is_selected())
           sum_volumes += i->get_FOD();
       }

--- a/cmd/amp2response.cpp
+++ b/cmd/amp2response.cpp
@@ -102,9 +102,9 @@ Eigen::Matrix<default_type, 3, 3> gen_rotation_matrix (const Eigen::Vector3d& di
 }
 
 
-vector<size_t> all_volumes (const size_t num)
+std::vector<size_t> all_volumes (const size_t num)
 {
-  vector<size_t> result (num);
+  std::vector<size_t> result (num);
   for (size_t i = 0; i != num; ++i)
     result[i] = i;
   return result;
@@ -117,7 +117,7 @@ class Accumulator {
   public:
     class Shared { 
       public:
-        Shared (int lmax, const vector<size_t>& volumes, const Eigen::MatrixXd& dirs) :
+        Shared (int lmax, const std::vector<size_t>& volumes, const Eigen::MatrixXd& dirs) :
           lmax (lmax),
           dirs (dirs),
           volumes (volumes),
@@ -127,7 +127,7 @@ class Accumulator {
 
         const int lmax;
         const Eigen::MatrixXd& dirs;
-        const vector<size_t>& volumes;
+        const std::vector<size_t>& volumes;
         Eigen::MatrixXd M;
         Eigen::VectorXd b;
         size_t count;
@@ -210,8 +210,8 @@ void run ()
   auto header = Header::open (argument[0]);
 
   // May be dealing with multiple shells
-  vector<Eigen::MatrixXd> dirs_azel;
-  vector<vector<size_t>> volumes;
+  std::vector<Eigen::MatrixXd> dirs_azel;
+  std::vector<std::vector<size_t>> volumes;
   std::unique_ptr<DWI::Shells> shells;
 
   auto opt = get_options ("directions");
@@ -221,7 +221,7 @@ void run ()
   } else {
     auto hit = header.keyval().find ("directions");
     if (hit != header.keyval().end()) {
-      vector<default_type> dir_vector;
+      std::vector<default_type> dir_vector;
       for (auto line : split_lines (hit->second)) {
         auto v = parse_floats (line);
         dir_vector.insert (dir_vector.end(), v.begin(), v.end());
@@ -244,7 +244,7 @@ void run ()
     }
   }
 
-  vector<uint32_t> lmax;
+  std::vector<uint32_t> lmax;
   uint32_t max_lmax = 0;
   opt = get_options ("lmax");
   if (get_options("isotropic").size()) {

--- a/cmd/amp2sh.cpp
+++ b/cmd/amp2sh.cpp
@@ -87,8 +87,8 @@ class Amp2SHCommon {
   public:
     template <class MatrixType>
       Amp2SHCommon (const MatrixType& sh2amp,
-          const vector<size_t>& bzeros,
-          const vector<size_t>& dwis,
+          const std::vector<size_t>& bzeros,
+          const std::vector<size_t>& dwis,
           bool normalise_to_bzero) :
         sh2amp (sh2amp),
         amp2sh (Math::pinv (sh2amp)),
@@ -98,8 +98,8 @@ class Amp2SHCommon {
 
 
     Eigen::MatrixXd sh2amp, amp2sh;
-    const vector<size_t>& bzeros;
-    const vector<size_t>& dwis;
+    const std::vector<size_t>& bzeros;
+    const std::vector<size_t>& dwis;
     bool normalise;
 };
 
@@ -204,7 +204,7 @@ void run ()
   auto amp = Image<value_type>::open (argument[0]).with_direct_io (3);
   Header header (amp);
 
-  vector<size_t> bzeros, dwis;
+  std::vector<size_t> bzeros, dwis;
   Eigen::MatrixXd dirs;
   auto opt = get_options ("directions");
   if (opt.size()) {
@@ -215,7 +215,7 @@ void run ()
   else {
     auto hit = header.keyval().find ("directions");
     if (hit != header.keyval().end()) {
-      vector<default_type> dir_vector;
+      std::vector<default_type> dir_vector;
       for (auto line : split_lines (hit->second)) {
         auto v = parse_floats (line);
         dir_vector.insert (dir_vector.end(), v.begin(), v.end());

--- a/cmd/connectome2tck.cpp
+++ b/cmd/connectome2tck.cpp
@@ -161,9 +161,9 @@ void run ()
   Tractography::Properties properties;
   Tractography::Reader<float> reader (argument[0], properties);
 
-  vector< vector<node_t> > assignments_lists;
+  std::vector< std::vector<node_t> > assignments_lists;
   assignments_lists.reserve (to<size_t>(properties["count"]));
-  vector<NodePair> assignments_pairs;
+  std::vector<NodePair> assignments_pairs;
   bool nonpair_found = false;
   node_t max_node_index = 0;
   {
@@ -175,7 +175,7 @@ void run ()
       if (line.empty())
         continue;
       std::stringstream line_stream (line);
-      vector<node_t> nodes;
+      std::vector<node_t> nodes;
       while (1) {
         node_t n;
         line_stream >> n;
@@ -217,7 +217,7 @@ void run ()
   const bool keep_self = get_options ("keep_self").size();
 
   // Get the list of nodes of interest
-  vector<node_t> nodes;
+  std::vector<node_t> nodes;
   opt = get_options ("nodes");
   bool manual_node_list = false;
   if (opt.size()) {
@@ -257,8 +257,8 @@ void run ()
     // Load the node image, get the centres of mass
     // Generate exemplars - these can _only_ be done per edge, and requires a mutex per edge to multi-thread
     auto image = Image<node_t>::open (opt[0][0]);
-    vector<Eigen::Vector3f> COMs (max_node_index+1, Eigen::Vector3f (0.0f, 0.0f, 0.0f));
-    vector<size_t> volumes (max_node_index+1, 0);
+    std::vector<Eigen::Vector3f> COMs (max_node_index+1, Eigen::Vector3f (0.0f, 0.0f, 0.0f));
+    std::vector<size_t> volumes (max_node_index+1, 0);
     for (auto i = Loop() (image); i; ++i) {
       const node_t index = image.value();
       if (index) {
@@ -316,7 +316,7 @@ void run ()
       } else {
         // For each node in the list, write one file for an exemplar to every other node
         ProgressBar progress ("writing exemplars to files", nodes.size() * COMs.size());
-        for (vector<node_t>::const_iterator n = nodes.begin(); n != nodes.end(); ++n) {
+        for (std::vector<node_t>::const_iterator n = nodes.begin(); n != nodes.end(); ++n) {
           for (size_t i = first_node; i != COMs.size(); ++i) {
             generator.write (*n, i, prefix + str(*n) + "-" + str(i) + ".tck", weights_prefix.size() ? (weights_prefix + str(*n) + "-" + str(i) + ".csv") : "");
             ++progress;
@@ -325,7 +325,7 @@ void run ()
       }
     } else if (file_format == 1) { // One file per node
       ProgressBar progress ("writing exemplars to files", nodes.size());
-      for (vector<node_t>::const_iterator n = nodes.begin(); n != nodes.end(); ++n) {
+      for (std::vector<node_t>::const_iterator n = nodes.begin(); n != nodes.end(); ++n) {
         generator.write (*n, prefix + str(*n) + ".tck", weights_prefix.size() ? (weights_prefix + str(*n) + ".csv") : "");
         ++progress;
       }
@@ -361,7 +361,7 @@ void run ()
         INFO ("A total of " + str (writer.file_count()) + " output track files will be generated (one for each edge)");
         break;
       case 1: // One file per node
-        for (vector<node_t>::const_iterator i = nodes.begin(); i != nodes.end(); ++i)
+        for (std::vector<node_t>::const_iterator i = nodes.begin(); i != nodes.end(); ++i)
           writer.add (*i, prefix + str(*i) + ".tck", weights_prefix.size() ? (weights_prefix + str(*i) + ".csv") : "");
         INFO ("A total of " + str (writer.file_count()) + " output track files will be generated (one for each node)");
         break;

--- a/cmd/connectomestats.cpp
+++ b/cmd/connectomestats.cpp
@@ -224,7 +224,7 @@ void run()
 
   // Before validating the contrast matrix, we first need to see if there are any
   //   additional design matrix columns coming from edge-wise subject data
-  vector<CohortDataImport> extra_columns;
+  std::vector<CohortDataImport> extra_columns;
   bool nans_in_columns = false;
   auto opt = get_options ("column");
   for (size_t i = 0; i != opt.size(); ++i) {
@@ -249,7 +249,7 @@ void run()
     CONSOLE ("Number of variance groups: " + str(num_vgs));
 
   // Load hypotheses
-  const vector<Hypothesis> hypotheses = Math::Stats::GLM::load_hypotheses (argument[3]);
+  const std::vector<Hypothesis> hypotheses = Math::Stats::GLM::load_hypotheses (argument[3]);
   const size_t num_hypotheses = hypotheses.size();
   if (hypotheses[0].cols() != num_factors)
     throw Exception ("the number of columns in the contrast matrix (" + str(hypotheses[0].cols()) + ")"

--- a/cmd/dcmedit.cpp
+++ b/cmd/dcmedit.cpp
@@ -94,8 +94,8 @@ inline uint16_t read_hex (const std::string& m)
 
 void run ()
 {
-  vector<Tag> tags;
-  vector<uint16_t> VRs;
+  std::vector<Tag> tags;
+  std::vector<uint16_t> VRs;
 
   auto opt = get_options ("anonymise");
   if (opt.size()) {

--- a/cmd/dcminfo.cpp
+++ b/cmd/dcminfo.cpp
@@ -67,7 +67,7 @@ void run ()
   if (opt.size()) {
     std::istringstream hex;
 
-    vector<Tag> tags (opt.size());
+    std::vector<Tag> tags (opt.size());
     for (size_t n = 0; n < opt.size(); ++n) {
       tags[n].group = read_hex (opt[n][0]);
       tags[n].element = read_hex (opt[n][1]);

--- a/cmd/dirflip.cpp
+++ b/cmd/dirflip.cpp
@@ -64,7 +64,7 @@ class Shared {
       progress ("optimising directions for eddy-currents", target_num_permutations),
       best_signs (directions.rows(), 1), best_eddy (std::numeric_limits<value_type>::max()) { }
 
-    bool update (value_type eddy, const vector<int>& signs)
+    bool update (value_type eddy, const std::vector<int>& signs)
     {
       std::lock_guard<std::mutex> lock (mutex);
       if (eddy < best_eddy) {
@@ -79,7 +79,7 @@ class Shared {
 
 
 
-    value_type eddy (size_t i, size_t j, const vector<int>& signs) const {
+    value_type eddy (size_t i, size_t j, const std::vector<int>& signs) const {
       vector3_type a = { directions(i,0), directions(i,1), directions(i,2) };
       vector3_type b = { directions(j,0), directions(j,1), directions(j,2) };
       if (signs[i] < 0) a = -a;
@@ -88,8 +88,8 @@ class Shared {
     }
 
 
-    vector<int> get_init_signs () const { return vector<int> (directions.rows(), 1); }
-    const vector<int>& get_best_signs () const { return best_signs; }
+    std::vector<int> get_init_signs () const { return std::vector<int> (directions.rows(), 1); }
+    const std::vector<int>& get_best_signs () const { return best_signs; }
 
 
   protected:
@@ -97,7 +97,7 @@ class Shared {
     const size_t target_num_permutations;
     size_t num_permutations;
     ProgressBar progress;
-    vector<int> best_signs;
+    std::vector<int> best_signs;
     value_type best_eddy;
     std::mutex mutex;
 
@@ -138,7 +138,7 @@ class Processor {
 
   protected:
     Shared& shared;
-    vector<int> signs;
+    std::vector<int> signs;
     Math::RNG rng;
     std::uniform_int_distribution<int> uniform;
 };
@@ -156,7 +156,7 @@ void run ()
 
   size_t num_permutations = get_option_value<size_t> ("permutations", default_permutations);
 
-  vector<int> signs;
+  std::vector<int> signs;
   {
     Shared eddy_shared (directions, num_permutations);
     Thread::run (Thread::multi (Processor (eddy_shared)), "eval thread");

--- a/cmd/dirmerge.cpp
+++ b/cmd/dirmerge.cpp
@@ -51,7 +51,7 @@ OPTIONS
 
 using value_type = double;
 using Direction = Eigen::Matrix<value_type,3,1>;
-using DirectionSet = vector<Direction>;
+using DirectionSet = std::vector<Direction>;
 
 
 struct OutDir { 
@@ -73,8 +73,8 @@ void run ()
   value_type bipolar_weight = 1.0 - unipolar_weight;
 
 
-  vector<vector<DirectionSet>> dirs;
-  vector<value_type> bvalue ((argument.size() - 2) / (1+num_subsets));
+  std::vector<std::vector<DirectionSet>> dirs;
+  std::vector<value_type> bvalue ((argument.size() - 2) / (1+num_subsets));
   INFO ("expecting " + str(bvalue.size()) + " b-values");
   if (bvalue.size()*(1+num_subsets) + 2 != argument.size())
     throw Exception ("inconsistent number of arguments");
@@ -84,7 +84,7 @@ void run ()
   size_t current = 1, nb = 0;
   while (current < argument.size()-1) {
     bvalue[nb] = to<value_type> (argument[current++]);
-    vector<DirectionSet> d;
+    std::vector<DirectionSet> d;
     for (size_t i = 0; i < num_subsets; ++i) {
       auto m = DWI::Directions::load_cartesian (argument[current++]);
       DirectionSet set;
@@ -93,7 +93,7 @@ void run ()
       d.push_back (set);
     }
     INFO ("found b = " + str(bvalue[nb]) + ", " +
-        str ([&]{ vector<size_t> s; for (auto& n : d) s.push_back (n.size()); return s; }()) + " volumes");
+        str ([&]{ std::vector<size_t> s; for (auto& n : d) s.push_back (n.size()); return s; }()) + " volumes");
 
     dirs.push_back (d);
     ++nb;
@@ -109,7 +109,7 @@ void run ()
   size_t first = std::uniform_int_distribution<size_t> (0, dirs[0][0].size()-1)(rng);
 
 
-  vector<OutDir> merged;
+  std::vector<OutDir> merged;
 
   auto push = [&](size_t b, size_t p, size_t n)
   {
@@ -153,7 +153,7 @@ void run ()
 
 
 
-  vector<float> fraction;
+  std::vector<float> fraction;
   for (auto& d : dirs) {
     size_t n = 0;
     for (auto& m : d)
@@ -163,7 +163,7 @@ void run ()
 
   push (0, 0, first);
 
-  vector<size_t> counts (bvalue.size(), 0);
+  std::vector<size_t> counts (bvalue.size(), 0);
   ++counts[0];
 
   auto num_for_b = [&](size_t b) {

--- a/cmd/dirorder.cpp
+++ b/cmd/dirorder.cpp
@@ -52,10 +52,10 @@ using value_type = double;
 
 
 
-vector<size_t> optimise (const Eigen::MatrixXd& directions, const size_t first_volume)
+std::vector<size_t> optimise (const Eigen::MatrixXd& directions, const size_t first_volume)
 {
-  vector<size_t> indices (1, first_volume);
-  vector<size_t> remaining;
+  std::vector<size_t> indices (1, first_volume);
+  std::vector<size_t> remaining;
   for (size_t n = 0; n < size_t(directions.rows()); ++n)
     if (n != indices[0])
       remaining.push_back (n);
@@ -88,7 +88,7 @@ vector<size_t> optimise (const Eigen::MatrixXd& directions, const size_t first_v
 
 
 
-value_type calc_cost (const Eigen::MatrixXd& directions, const vector<size_t>& order)
+value_type calc_cost (const Eigen::MatrixXd& directions, const std::vector<size_t>& order)
 {
   const size_t start = Math::SH::NforL (2);
   if (size_t(directions.rows()) <= start)
@@ -127,10 +127,10 @@ void run ()
   }
 
   value_type min_cost = std::numeric_limits<value_type>::infinity();
-  vector<size_t> best_order;
+  std::vector<size_t> best_order;
   ProgressBar progress ("Determining best reordering", directions.rows());
   for (size_t first_volume = 0; first_volume != last_candidate_first_volume; ++first_volume) {
-    const vector<size_t> order = optimise (directions, first_volume);
+    const std::vector<size_t> order = optimise (directions, first_volume);
     const value_type cost = calc_cost (directions, order);
     if (cost < min_cost) {
       min_cost = cost;

--- a/cmd/dirsplit.cpp
+++ b/cmd/dirsplit.cpp
@@ -62,13 +62,13 @@ class Shared {
           if (s >= num_subsets) s = 0;
         }
         INFO ("split " + str(directions.rows()) + " directions into subsets with " +
-            str([&]{ vector<size_t> c; for (auto& x : subset) c.push_back (x.size()); return c; }()) + " volumes");
+            str([&]{ std::vector<size_t> c; for (auto& x : subset) c.push_back (x.size()); return c; }()) + " volumes");
       }
 
 
 
 
-    bool update (value_type energy, const vector<vector<size_t>>& set)
+    bool update (value_type energy, const std::vector<std::vector<size_t>>& set)
     {
       std::lock_guard<std::mutex> lock (mutex);
       if (!progress) progress.reset (new ProgressBar ("distributing directions", target_num_permutations));
@@ -91,14 +91,14 @@ class Shared {
     }
 
 
-    const vector<vector<size_t>>& get_init_subset () const { return subset; }
-    const vector<vector<size_t>>& get_best_subset () const { return best_subset; }
+    const std::vector<std::vector<size_t>>& get_init_subset () const { return subset; }
+    const std::vector<std::vector<size_t>>& get_best_subset () const { return best_subset; }
 
 
   protected:
     const Eigen::MatrixXd& directions;
     std::mutex mutex;
-    vector<vector<size_t>> subset, best_subset;
+    std::vector<std::vector<size_t>> subset, best_subset;
     value_type best_energy;
     const size_t target_num_permutations;
     size_t num_permutations;
@@ -153,7 +153,7 @@ class EnergyCalculator {
 
   protected:
     Shared& shared;
-    vector<vector<size_t>> subset;
+    std::vector<std::vector<size_t>> subset;
     Math::RNG rng;
 };
 
@@ -173,7 +173,7 @@ void run ()
 
   const size_t num_permutations = get_option_value<size_t> ("permutations", default_permutations);
 
-  vector<vector<size_t>> best;
+  std::vector<std::vector<size_t>> best;
   {
     Shared shared (directions, num_subsets, num_permutations);
     Thread::run (Thread::multi (EnergyCalculator (shared)), "energy eval thread");

--- a/cmd/dirstat.cpp
+++ b/cmd/dirstat.cpp
@@ -144,7 +144,7 @@ void run ()
 
 
 
-vector<default_type> summarise_NN (const vector<double>& NN)
+std::vector<default_type> summarise_NN (const std::vector<double>& NN)
 {
   double NN_min = std::numeric_limits<double>::max();
   double NN_mean = 0.0;
@@ -166,7 +166,7 @@ vector<default_type> summarise_NN (const vector<double>& NN)
 
 
 
-vector<default_type> summarise_E (const vector<double>& E)
+std::vector<default_type> summarise_E (const std::vector<double>& E)
 {
   double E_min = std::numeric_limits<double>::max();
   double E_total = 0.0;
@@ -185,7 +185,7 @@ vector<default_type> summarise_E (const vector<double>& E)
 class Metrics
 { 
   public:
-    vector<default_type> BN, UN, BE, UE, SH;
+    std::vector<default_type> BN, UN, BE, UE, SH;
     default_type ASYM;
     size_t ndirs;
 };
@@ -201,11 +201,11 @@ Metrics compute (Eigen::MatrixXd& directions)
     throw Exception ("unexpected matrix size for scheme \"" + str(argument[0]) + "\"");
   Math::Sphere::normalise_cartesian (directions);
 
-  vector<double> NN_bipolar (directions.rows(), -1.0);
-  vector<double> NN_unipolar (directions.rows(), -1.0);
+  std::vector<double> NN_bipolar (directions.rows(), -1.0);
+  std::vector<double> NN_unipolar (directions.rows(), -1.0);
 
-  vector<double> E_bipolar (directions.rows(), 0.0);
-  vector<double> E_unipolar (directions.rows(), 0.0);
+  std::vector<double> E_bipolar (directions.rows(), 0.0);
+  std::vector<double> E_unipolar (directions.rows(), 0.0);
 
   for (ssize_t i = 0; i < directions.rows()-1; ++i) {
     for (ssize_t j = i+1; j < directions.rows(); ++j) {

--- a/cmd/dwi2fod.cpp
+++ b/cmd/dwi2fod.cpp
@@ -181,7 +181,7 @@ class CSD_Processor {
 class MSMT_Processor { 
   public:
     MSMT_Processor (const DWI::SDeconv::MSMT_CSD::Shared& shared, Image<bool>& mask_image,
-      vector< Image<float> > odf_images, Image<float> dwi_modelled = Image<float>()) :
+      std::vector< Image<float> > odf_images, Image<float> dwi_modelled = Image<float>()) :
         sdeconv (shared),
         mask_image (mask_image),
         odf_images (odf_images),
@@ -224,7 +224,7 @@ class MSMT_Processor {
   private:
     DWI::SDeconv::MSMT_CSD sdeconv;
     Image<bool> mask_image;
-    vector< Image<float> > odf_images;
+    std::vector< Image<float> > odf_images;
     Image<float> modelled_image;
     Eigen::VectorXd dwi_data;
     Eigen::VectorXd output_data;
@@ -289,8 +289,8 @@ void run ()
     shared.parse_cmdline_options();
 
     const size_t num_tissues = (argument.size()-2)/2;
-    vector<std::string> response_paths;
-    vector<std::string> odf_paths;
+    std::vector<std::string> response_paths;
+    std::vector<std::string> odf_paths;
     for (size_t i = 0; i < num_tissues; ++i) {
       response_paths.push_back (argument[i*2+2]);
       odf_paths.push_back (argument[i*2+3]);
@@ -306,7 +306,7 @@ void run ()
 
     DWI::stash_DW_scheme (header_out, shared.grad);
 
-    vector< Image<float> > odfs;
+    std::vector< Image<float> > odfs;
     for (size_t i = 0; i < num_tissues; ++i) {
       header_out.size (3) = Math::SH::NforL (shared.lmax[i]);
       odfs.push_back (Image<float> (Image<float>::create (odf_paths[i], header_out)));

--- a/cmd/dwidenoise.cpp
+++ b/cmd/dwidenoise.cpp
@@ -132,7 +132,7 @@ public:
   using MatrixType = Eigen::Matrix<F, Eigen::Dynamic, Eigen::Dynamic>;
   using SValsType = Eigen::VectorXd;
 
-  DenoisingFunctor (int ndwi, const vector<uint32_t>& extent,
+  DenoisingFunctor (int ndwi, const std::vector<uint32_t>& extent,
                     Image<bool>& mask, Image<real_type>& noise,
                     Image<uint16_t>& rank, bool exp1)
     : extent {{extent[0]/2, extent[1]/2, extent[2]/2}},
@@ -268,7 +268,7 @@ private:
 
 template <typename T>
 void process_image (Header& data, Image<bool>& mask, Image<real_type>& noise, Image<uint16_t>& rank,
-                    const std::string& output_name, const vector<uint32_t>& extent, bool exp1)
+                    const std::string& output_name, const std::vector<uint32_t>& extent, bool exp1)
   {
     auto input = data.get_image<T>().with_direct_io(3);
     // create output
@@ -297,7 +297,7 @@ void run ()
   }
 
   opt = get_options("extent");
-  vector<uint32_t> extent;
+  std::vector<uint32_t> extent;
   if (opt.size()) {
     extent = parse_ints<uint32_t> (opt[0][0]);
     if (extent.size() == 1)

--- a/cmd/dwiextract.cpp
+++ b/cmd/dwiextract.cpp
@@ -73,7 +73,7 @@ void run()
 
   // Want to support non-shell-like data if it's just a straight extraction
   //   of all dwis or all bzeros i.e. don't initialise the Shells class
-  vector<uint32_t> volumes;
+  std::vector<uint32_t> volumes;
   bool bzero = get_options ("bzero").size();
   if (get_options ("shells").size() || get_options ("singleshell").size()) {
     DWI::Shells shells (grad);
@@ -108,7 +108,7 @@ void run()
     const auto filter = parse_floats (opt[0][0]);
     if (!(filter.size() == 3 || filter.size() == 4))
       throw Exception ("Phase encoding filter must be a comma-separated list of either 3 or 4 numbers");
-    vector<uint32_t> new_volumes;
+    std::vector<uint32_t> new_volumes;
     for (const auto i : volumes) {
       bool keep = true;
       for (size_t axis = 0; axis != 3; ++axis) {

--- a/cmd/fixel2sh.cpp
+++ b/cmd/fixel2sh.cpp
@@ -80,7 +80,7 @@ void run ()
   out_header.size (3) = n_sh_coeff;
 
   auto sh_image = Image<float>::create (argument[1], out_header);
-  vector<default_type> sh_values;
+  std::vector<default_type> sh_values;
   Eigen::Matrix<default_type, Eigen::Dynamic, 1> apsf_values;
 
   for (auto l1 = Loop ("converting fixel image to spherical harmonic image", in_index_image) (in_index_image, sh_image); l1; ++l1) {

--- a/cmd/fixelcfestats.cpp
+++ b/cmd/fixelcfestats.cpp
@@ -261,7 +261,7 @@ void run()
 
   // Before validating the contrast matrix, we first need to see if there are any
   //   additional design matrix columns coming from fixel-wise subject data
-  vector<Math::Stats::CohortDataImport> extra_columns;
+  std::vector<Math::Stats::CohortDataImport> extra_columns;
   bool nans_in_columns = false;
   opt = get_options ("column");
   for (size_t i = 0; i != opt.size(); ++i) {
@@ -301,7 +301,7 @@ void run()
     CONSOLE ("Number of variance groups: " + str(num_vgs));
 
   // Load hypotheses
-  const vector<Math::Stats::GLM::Hypothesis> hypotheses = Math::Stats::GLM::load_hypotheses (argument[3]);
+  const std::vector<Math::Stats::GLM::Hypothesis> hypotheses = Math::Stats::GLM::load_hypotheses (argument[3]);
   const size_t num_hypotheses = hypotheses.size();
   if (hypotheses[0].cols() != num_factors)
     throw Exception ("The number of columns in the contrast matrix (" + str(hypotheses[0].cols()) + ")"

--- a/cmd/fixelconvert.cpp
+++ b/cmd/fixelconvert.cpp
@@ -212,7 +212,7 @@ void convert_new2old ()
 
   Header H_index = Fixel::find_index_header (input_fixel_directory);
   Header H_dirs = Fixel::find_directions_header (input_fixel_directory);
-  vector<Header> H_data = Fixel::find_data_headers (input_fixel_directory, H_index, false);
+  std::vector<Header> H_data = Fixel::find_data_headers (input_fixel_directory, H_index, false);
   size_t size_index = H_data.size(), value_index = H_data.size();
 
   for (size_t i = 0; i != H_data.size(); ++i) {

--- a/cmd/fixelcrop.cpp
+++ b/cmd/fixelcrop.cpp
@@ -77,9 +77,9 @@ void run ()
 
 
   // Open all data images and create output date images with size equal to expected number of fixels
-  vector<Header> in_headers = Fixel::find_data_headers (in_directory, in_index_header, true);
-  vector<Image<float> > in_data_images;
-  vector<Image<float> > out_data_images;
+  std::vector<Header> in_headers = Fixel::find_data_headers (in_directory, in_index_header, true);
+  std::vector<Image<float> > in_data_images;
+  std::vector<Image<float> > out_data_images;
   for (auto& in_data_header : in_headers) {
     in_data_images.push_back(in_data_header.get_image<float>().with_direct_io());
     check_dimensions (in_data_images.back(), mask_image, {0, 2});

--- a/cmd/fixelfilter.cpp
+++ b/cmd/fixelfilter.cpp
@@ -97,7 +97,7 @@ void run()
                                       "mask" };
 
   Image<float> single_file;
-  vector<Header> multiple_files;
+  std::vector<Header> multiple_files;
   std::unique_ptr<Fixel::Filter::Base> filter;
 
   {

--- a/cmd/fod2fixel.cpp
+++ b/cmd/fod2fixel.cpp
@@ -136,7 +136,7 @@ class Segmented_FOD_receiver {
     };
 
 
-    class Primitive_FOD_lobes : public vector<Primitive_FOD_lobe> { 
+    class Primitive_FOD_lobes : public std::vector<Primitive_FOD_lobe> { 
       public:
         Primitive_FOD_lobes (const FOD_lobes& in, const index_type maxcount, bool dir_from_peak) :
             vox (in.vox)
@@ -155,7 +155,7 @@ class Segmented_FOD_receiver {
 
     Header H;
     std::string fixel_directory_path, index_path, dir_path, afd_path, peak_amp_path, disp_path;
-    vector<Primitive_FOD_lobes> lobes;
+    std::vector<Primitive_FOD_lobes> lobes;
     index_type fixel_count;
     index_type max_per_voxel;
     bool dir_from_peak;

--- a/cmd/label2mesh.cpp
+++ b/cmd/label2mesh.cpp
@@ -68,7 +68,7 @@ void run ()
 
   using voxel_corner_t = Eigen::Array<int, 3, 1>;
 
-  vector<voxel_corner_t> lower_corners, upper_corners;
+  std::vector<voxel_corner_t> lower_corners, upper_corners;
   {
     for (auto i = Loop ("Importing label image", labels) (labels); i; ++i) {
       const uint32_t index = labels.value();
@@ -92,7 +92,7 @@ void run ()
   meshes[0].set_name ("none");
   const bool blocky = get_options ("blocky").size();
 
-  vector<uint32_t> missing_nodes;
+  std::vector<uint32_t> missing_nodes;
   for (uint32_t i = 1; i != upper_corners.size(); ++i) {
     if (upper_corners[i][0] < 0)
       missing_nodes.push_back (i);
@@ -111,7 +111,7 @@ void run ()
     auto worker = [&] (const size_t& in)
     {
       meshes[in].set_name (str(in));
-      vector<int> from, dimensions;
+      std::vector<int> from, dimensions;
       for (size_t axis = 0; axis != 3; ++axis) {
         from.push_back (lower_corners[in][axis]);
         dimensions.push_back (upper_corners[in][axis] - lower_corners[in][axis] + 1);

--- a/cmd/labelstats.cpp
+++ b/cmd/labelstats.cpp
@@ -98,7 +98,7 @@ void run ()
   Eigen::IOFormat fmt (Eigen::StreamPrecision, 0, ", ", "\n", "[ ", " ]", "", "");
   std::stringstream com_stringstream;
   com_stringstream << coms.format (fmt);
-  const vector<std::string> com_strings = split(com_stringstream.str(), "\n");
+  const std::vector<std::string> com_strings = split(com_stringstream.str(), "\n");
   assert (com_strings.size() == size_t(masses.size()));
 
   // Find width of first non-empty string, in order to centralise header label

--- a/cmd/maskdump.cpp
+++ b/cmd/maskdump.cpp
@@ -44,7 +44,7 @@ void run ()
   if (H.datatype() != DataType::Bit)
     WARN ("Input is not a genuine boolean mask image");
   auto in = H.get_image<bool>();
-  vector< Eigen::ArrayXi > locations;
+  std::vector< Eigen::ArrayXi > locations;
   for (auto l = Loop(in) (in); l; ++l) {
     if (in.value()) {
       Eigen::ArrayXi this_voxel (in.ndim());

--- a/cmd/maskfilter.cpp
+++ b/cmd/maskfilter.cpp
@@ -134,7 +134,7 @@ void run () {
     Filter::ConnectedComponents filter (input_image, std::string("applying connected-component filter to image ") + Path::basename (argument[0]));
     auto opt = get_options ("axes");
     if (opt.size()) {
-      const vector<int> axes = opt[0][0];
+      const std::vector<int> axes = opt[0][0];
       filter.set_axes (axes);
     }
     bool largest_only = false;
@@ -197,7 +197,7 @@ void run () {
     Filter::Fill filter (input_image, std::string("filling interior of image ") + Path::basename (argument[0]));
     auto opt = get_options ("axes");
     if (opt.size()) {
-      const vector<int> axes = opt[0][0];
+      const std::vector<int> axes = opt[0][0];
       filter.set_axes (axes);
     }
     opt = get_options ("connectivity");

--- a/cmd/mraverageheader.cpp
+++ b/cmd/mraverageheader.cpp
@@ -69,7 +69,7 @@ void run ()
 
     bool fill = get_options ("fill").size();
 
-    vector<Header> headers_in;
+    std::vector<Header> headers_in;
     size_t dim (Header::open (argument[0]).ndim());
     if (dim < 3 or dim > 4)
       throw Exception ("Please provide 3D or 4D images");
@@ -85,7 +85,7 @@ void run ()
         }
     }
 
-    vector<Eigen::Transform<default_type, 3, Eigen::Projective>> transform_header_with;
+    std::vector<Eigen::Transform<default_type, 3, Eigen::Projective>> transform_header_with;
     auto H = compute_minimum_average_header (headers_in, transform_header_with, resolution, padding);
     H.datatype() = DataType::Bit;
     if (fill) {

--- a/cmd/mrcalc.cpp
+++ b/cmd/mrcalc.cpp
@@ -276,7 +276,7 @@ OPTIONS
 class Evaluator;
 
 
-class Chunk : public vector<complex_type> { 
+class Chunk : public std::vector<complex_type> { 
   public:
     complex_type value;
 };
@@ -288,7 +288,7 @@ class ThreadLocalStorageItem {
     copy_ptr<Image<complex_type>> image;
 };
 
-class ThreadLocalStorage : public vector<ThreadLocalStorageItem> { 
+class ThreadLocalStorage : public std::vector<ThreadLocalStorageItem> { 
   public:
 
       void load (Chunk& chunk, Image<complex_type>& image) {
@@ -315,7 +315,7 @@ class ThreadLocalStorage : public vector<ThreadLocalStorageItem> {
     void reset (const Iterator& current_position) { current = 0; iter = &current_position; }
 
     const Iterator* iter;
-    vector<size_t> axes, size;
+    std::vector<size_t> axes, size;
 
   private:
     size_t current;
@@ -418,7 +418,7 @@ class Evaluator {
     const std::string id;
     const char* format;
     bool ZtoR, RtoZ;
-    vector<StackEntry> operands;
+    std::vector<StackEntry> operands;
 
     Chunk& evaluate (ThreadLocalStorage& storage) const {
       Chunk& in1 (operands[0].evaluate (storage));
@@ -618,7 +618,7 @@ class TernaryEvaluator : public Evaluator {
 
 
 template <class Operation>
-void unary_operation (const std::string& operation_name, vector<StackEntry>& stack, Operation operation)
+void unary_operation (const std::string& operation_name, std::vector<StackEntry>& stack, Operation operation)
 {
   if (stack.empty())
     throw Exception ("no operand in stack for operation \"" + operation_name + "\"!");
@@ -643,7 +643,7 @@ void unary_operation (const std::string& operation_name, vector<StackEntry>& sta
 
 
 template <class Operation>
-void binary_operation (const std::string& operation_name, vector<StackEntry>& stack, Operation operation)
+void binary_operation (const std::string& operation_name, std::vector<StackEntry>& stack, Operation operation)
 {
   if (stack.size() < 2)
     throw Exception ("not enough operands in stack for operation \"" + operation_name + "\"");
@@ -668,7 +668,7 @@ void binary_operation (const std::string& operation_name, vector<StackEntry>& st
 
 
 template <class Operation>
-void ternary_operation (const std::string& operation_name, vector<StackEntry>& stack, Operation operation)
+void ternary_operation (const std::string& operation_name, std::vector<StackEntry>& stack, Operation operation)
 {
   if (stack.size() < 3)
     throw Exception ("not enough operands in stack for operation \"" + operation_name + "\"");
@@ -743,7 +743,7 @@ void get_header (const StackEntry& entry, Header& header)
 class ThreadFunctor { 
   public:
     ThreadFunctor (
-        const vector<size_t>& inner_axes,
+        const std::vector<size_t>& inner_axes,
         const StackEntry& top_of_stack,
         Image<complex_type>& output_image) :
       top_entry (top_of_stack),
@@ -791,7 +791,7 @@ class ThreadFunctor {
 
     const StackEntry& top_entry;
     Image<complex_type> image;
-    decltype (Loop (vector<size_t>())) loop;
+    decltype (Loop (std::vector<size_t>())) loop;
     ThreadLocalStorage storage;
     size_t chunk_size;
 };
@@ -800,7 +800,7 @@ class ThreadFunctor {
 
 
 
-void run_operations (const vector<StackEntry>& stack)
+void run_operations (const std::vector<StackEntry>& stack)
 {
   Header header;
   get_header (stack[0], header);
@@ -901,7 +901,7 @@ class OpTernary : public OpBase {
  **********************************************************************/
 
 void run () {
-  vector<StackEntry> stack;
+  std::vector<StackEntry> stack;
 
   for (int n = 1; n < App::argc; ++n) {
 

--- a/cmd/mrcat.cpp
+++ b/cmd/mrcat.cpp
@@ -63,7 +63,7 @@ OPTIONS
 
 
 template <typename value_type>
-void write (vector<Header>& in,
+void write (std::vector<Header>& in,
             const size_t axis,
             Header& header_out)
 {
@@ -95,7 +95,7 @@ void write (vector<Header>& in,
 void run ()
 {
   size_t num_images = argument.size()-1;
-  vector<Header> headers;
+  std::vector<Header> headers;
   ssize_t max_axis_nonunity = 0;
   for (size_t i = 0; i != num_images; ++i) {
     Header H = Header::open (argument[i]);

--- a/cmd/mrclusterstats.cpp
+++ b/cmd/mrclusterstats.cpp
@@ -218,7 +218,7 @@ void run() {
   // Before validating the contrast matrix, we first need to see if there are any
   //   additional design matrix columns coming from voxel-wise subject data
   // TODO Functionalise this
-  vector<CohortDataImport> extra_columns;
+  std::vector<CohortDataImport> extra_columns;
   bool nans_in_columns = false;
   auto opt = get_options ("column");
   for (size_t i = 0; i != opt.size(); ++i) {
@@ -243,7 +243,7 @@ void run() {
     CONSOLE ("Number of variance groups: " + str(num_vgs));
 
   // Load hypotheses
-  const vector<Hypothesis> hypotheses = Math::Stats::GLM::load_hypotheses (argument[2]);
+  const std::vector<Hypothesis> hypotheses = Math::Stats::GLM::load_hypotheses (argument[2]);
   const size_t num_hypotheses = hypotheses.size();
   if (hypotheses[0].cols() != num_factors)
     throw Exception ("The number of columns in the contrast matrix (" + str(hypotheses[0].cols()) + ")"

--- a/cmd/mrcolour.cpp
+++ b/cmd/mrcolour.cpp
@@ -30,8 +30,8 @@ using namespace MR;
 using namespace App;
 
 
-vector<std::string> colourmap_choices_std;
-vector<const char*> colourmap_choices_cstr;
+std::vector<std::string> colourmap_choices_std;
+std::vector<const char*> colourmap_choices_cstr;
 
 void usage ()
 {

--- a/cmd/mrconvert.cpp
+++ b/cmd/mrconvert.cpp
@@ -234,7 +234,7 @@ void usage ()
 
 
 
-void permute_DW_scheme (Header& H, const vector<int>& axes)
+void permute_DW_scheme (Header& H, const std::vector<int>& axes)
 {
   auto in = DWI::parse_DW_scheme (H);
   if (!in.rows())
@@ -256,7 +256,7 @@ void permute_DW_scheme (Header& H, const vector<int>& axes)
 
 
 
-void permute_PE_scheme (Header& H, const vector<int>& axes)
+void permute_PE_scheme (Header& H, const std::vector<int>& axes)
 {
   auto in = PhaseEncoding::parse_scheme (H);
   if (!in.rows())
@@ -276,7 +276,7 @@ void permute_PE_scheme (Header& H, const vector<int>& axes)
 
 
 
-void permute_slice_direction (Header& H, const vector<int>& axes)
+void permute_slice_direction (Header& H, const std::vector<int>& axes)
 {
   auto it = H.keyval().find ("SliceEncodingDirection");
   if (it == H.keyval().end())
@@ -290,7 +290,7 @@ void permute_slice_direction (Header& H, const vector<int>& axes)
 
 
 template <class ImageType>
-inline vector<int> set_header (Header& header, const ImageType& input)
+inline std::vector<int> set_header (Header& header, const ImageType& input)
 {
   header.ndim() = input.ndim();
   for (size_t n = 0; n < header.ndim(); ++n) {
@@ -301,7 +301,7 @@ inline vector<int> set_header (Header& header, const ImageType& input)
   header.transform() = input.transform();
 
   auto opt = get_options ("axes");
-  vector<int32_t> axes;
+  std::vector<int32_t> axes;
   if (opt.size()) {
     axes = parse_ints<int32_t> (opt[0][0]);
     header.ndim() = axes.size();
@@ -325,7 +325,7 @@ inline vector<int> set_header (Header& header, const ImageType& input)
 
   opt = get_options ("vox");
   if (opt.size()) {
-    vector<default_type> vox = parse_floats (opt[0][0]);
+    std::vector<default_type> vox = parse_floats (opt[0][0]);
     if (vox.size() > header.ndim())
       throw Exception ("too many axes supplied to -vox option");
     if (vox.size() == 1)
@@ -363,7 +363,7 @@ void copy_permute (const InputType& in, Header& header_out, const std::string& o
 
 
 template <typename T>
-void extract (Header& header_in, Header& header_out, const vector<vector<uint32_t>>& pos, const std::string& output_filename)
+void extract (Header& header_in, Header& header_out, const std::vector<std::vector<uint32_t>>& pos, const std::string& output_filename)
 {
   auto in = header_in.get_image<T>();
   if (pos.empty()) {
@@ -460,9 +460,9 @@ void run ()
 
 
   opt = get_options ("coord");
-  vector<vector<uint32_t>> pos;
+  std::vector<std::vector<uint32_t>> pos;
   if (opt.size()) {
-    pos.assign (header_in.ndim(), vector<uint32_t>());
+    pos.assign (header_in.ndim(), std::vector<uint32_t>());
     for (size_t n = 0; n < opt.size(); n++) {
       size_t axis = opt[n][0];
       if (axis >= header_in.ndim())
@@ -521,7 +521,7 @@ void run ()
   opt = get_options ("scaling");
   if (opt.size()) {
     if (header_out.datatype().is_integer()) {
-      vector<default_type> scaling = opt[0][0];
+      std::vector<default_type> scaling = opt[0][0];
       if (scaling.size() != 2)
         throw Exception ("-scaling option expects comma-separated 2-vector of floating-point values");
       header_out.intensity_offset() = scaling[0];

--- a/cmd/mrdegibbs.cpp
+++ b/cmd/mrdegibbs.cpp
@@ -116,12 +116,12 @@ void run ()
   int mode = get_option_value ("mode", 0);
 
 
-  vector<size_t> slice_axes = { 0, 1 };
+  std::vector<size_t> slice_axes = { 0, 1 };
   auto opt = get_options ("axes");
   const bool axes_set_manually = opt.size();
   if (opt.size()) {
-    vector<uint32_t> axes = parse_ints<uint32_t> (opt[0][0]);
-    if (axes == vector<uint32_t> ({ 0, 1, 2 })) {
+    std::vector<uint32_t> axes = parse_ints<uint32_t> (opt[0][0]);
+    if (axes == std::vector<uint32_t> ({ 0, 1, 2 })) {
       mode = 1;
     }
     else {
@@ -144,7 +144,7 @@ void run ()
     else {
       try {
         const Eigen::Vector3d slice_encoding_axis_onehot = Axes::id2dir (slice_encoding_it->second);
-        vector<size_t> auto_slice_axes = { 0, 0 };
+        std::vector<size_t> auto_slice_axes = { 0, 0 };
         if (slice_encoding_axis_onehot[0])
           auto_slice_axes = { 1, 2 };
         else if (slice_encoding_axis_onehot[1])
@@ -180,7 +180,7 @@ void run ()
   }
 
   // build vector of outer axes:
-  vector<size_t> outer_axes (header.ndim());
+  std::vector<size_t> outer_axes (header.ndim());
   std::iota (outer_axes.begin(), outer_axes.end(), 0);
   for (const auto axis : slice_axes) {
     auto it = std::find (outer_axes.begin(), outer_axes.end(), axis);

--- a/cmd/mredit.cpp
+++ b/cmd/mredit.cpp
@@ -157,7 +157,7 @@ void run ()
     else
       centre_scannerspace = transform.voxel2scanner * centre_voxelspace;
     std::set<Vox> processed;
-    vector<Vox> to_expand;
+    std::vector<Vox> to_expand;
     const Vox seed_voxel (centre_voxelspace);
     processed.insert (seed_voxel);
     to_expand.push_back (seed_voxel);

--- a/cmd/mrfilter.cpp
+++ b/cmd/mrfilter.cpp
@@ -158,7 +158,7 @@ void run () {
       //   convert between cfloat and cdouble...
       auto input = Image<cdouble>::open (argument[0]);
 
-      vector<size_t> axes = { 0, 1, 2 };
+      std::vector<size_t> axes = { 0, 1, 2 };
       auto opt = get_options ("axes");
       if (opt.size()) {
          axes = parse_ints<size_t> (opt[0][0]);
@@ -213,7 +213,7 @@ void run () {
       auto input = Image<float>::open (argument[0]);
       Filter::Gradient filter (input, get_options ("magnitude").size());
 
-      vector<default_type> stdev;
+      std::vector<default_type> stdev;
       auto opt = get_options ("stdev");
       if (opt.size()) {
         stdev = parse_floats (opt[0][0]);
@@ -267,7 +267,7 @@ void run () {
       if (opt.size()) {
         if (stdev_supplied)
           throw Exception ("the stdev and FWHM options are mutually exclusive.");
-        vector<default_type> stdevs = parse_floats((opt[0][0]));
+        std::vector<default_type> stdevs = parse_floats((opt[0][0]));
         for (size_t d = 0; d < stdevs.size(); ++d)
           stdevs[d] = stdevs[d] / 2.3548;  //convert FWHM to stdev
         filter.set_stdev (stdevs);

--- a/cmd/mrgrid.cpp
+++ b/cmd/mrgrid.cpp
@@ -168,7 +168,7 @@ void run () {
     }
 
     // over-sampling
-    vector<uint32_t> oversample = Adapter::AutoOverSample;
+    std::vector<uint32_t> oversample = Adapter::AutoOverSample;
     opt = get_options ("oversample");
     if (opt.size()) {
       oversample = parse_ints<uint32_t> (opt[0][0]);
@@ -192,7 +192,7 @@ void run () {
     regrid_filter.set_interp_type (interp);
     regrid_filter.set_oversample (oversample);
 
-    vector<default_type> scale;
+    std::vector<default_type> scale;
     opt = get_options ("scale");
     if (opt.size()) {
       scale = parse_floats (opt[0][0]);
@@ -202,7 +202,7 @@ void run () {
       ++resize_option_count;
     }
 
-    vector<uint32_t> image_size;
+    std::vector<uint32_t> image_size;
     opt = get_options ("size");
     if (opt.size()) {
       image_size = parse_ints<uint32_t> (opt[0][0]);
@@ -210,7 +210,7 @@ void run () {
       ++resize_option_count;
     }
 
-    vector<default_type> voxel_size;
+    std::vector<default_type> voxel_size;
     opt = get_options ("voxel");
     if (opt.size()) {
       voxel_size = parse_floats (opt[0][0]);
@@ -246,7 +246,7 @@ void run () {
 
     const size_t nd = get_options ("nd").size() ? input_header.ndim() : 3;
 
-    vector<vector<ssize_t>> bounds (input_header.ndim(), vector<ssize_t> (2));
+    std::vector<std::vector<ssize_t>> bounds (input_header.ndim(), std::vector<ssize_t> (2));
     for (size_t axis = 0; axis < input_header.ndim(); axis++) {
       bounds[axis][0] = 0;
       bounds[axis][1] = input_header.size (axis) - 1;
@@ -268,9 +268,9 @@ void run () {
       }
 
       struct BoundsCheck { 
-        vector<vector<ssize_t>>& overall_bounds;
-        vector<vector<ssize_t>> bounds;
-        BoundsCheck (vector<vector<ssize_t>>& overall_bounds) : overall_bounds (overall_bounds), bounds (overall_bounds) { }
+        std::vector<std::vector<ssize_t>>& overall_bounds;
+        std::vector<std::vector<ssize_t>> bounds;
+        BoundsCheck (std::vector<std::vector<ssize_t>>& overall_bounds) : overall_bounds (overall_bounds), bounds (overall_bounds) { }
         ~BoundsCheck () {
           for (size_t axis = 0; axis != 3; ++axis) {
             overall_bounds[axis][0] = std::min (bounds[axis][0], overall_bounds[axis][0]);
@@ -361,7 +361,7 @@ void run () {
       std::string::size_type start = 0, end;
       end = spec.find_first_of(":", start);
       if (end == std::string::npos) { // spec = delta_lower,delta_upper
-        vector<int> delta; // 0: not changed, > 0: pad, < 0: crop
+        std::vector<int> delta; // 0: not changed, > 0: pad, < 0: crop
         try { delta = parse_ints<int> (opt[i][1]); }
         catch (Exception& E) { Exception (E, "-axis " + str(axis) + ": can't parse delta specifier \"" + spec + "\""); }
         if (delta.size() != 2)
@@ -390,8 +390,8 @@ void run () {
     if (crop_pad_option_count == 0)
       throw Exception ("no crop or pad option supplied");
 
-    vector<ssize_t> from (input_header.ndim());
-    vector<ssize_t> size (input_header.ndim());
+    std::vector<ssize_t> from (input_header.ndim());
+    std::vector<ssize_t> size (input_header.ndim());
     for (size_t axis = 0; axis < input_header.ndim(); axis++) {
       from[axis] = bounds[axis][0];
       size[axis] = bounds[axis][1] - from[axis] + 1;

--- a/cmd/mrhistmatch.cpp
+++ b/cmd/mrhistmatch.cpp
@@ -73,12 +73,12 @@ void match_linear (Image<float>& input,
                    Image<bool>& mask_target,
                    const bool estimate_intercept)
 {
-  vector<float> input_data, target_data;
+  std::vector<float> input_data, target_data;
   {
     ProgressBar progress ("Loading & sorting image data", 4);
 
     auto fill = [] (Image<float>& image, Image<bool>& mask) {
-      vector<float> data;
+      std::vector<float> data;
       if (mask.valid()) {
         Adapter::Replicate<Image<bool>> mask_replicate (mask, image);
         for (auto l = Loop(image) (image, mask_replicate); l; ++l) {

--- a/cmd/mrinfo.cpp
+++ b/cmd/mrinfo.cpp
@@ -143,7 +143,7 @@ void print_spacing (const Header& header)
 void print_strides (const Header& header)
 {
   std::string buffer;
-  vector<ssize_t> strides (Stride::get (header));
+  std::vector<ssize_t> strides (Stride::get (header));
   Stride::symbolise (strides);
   for (size_t i = 0; i < header.ndim(); ++i) {
     if (i) buffer += " ";
@@ -209,15 +209,15 @@ void header2json (const Header& header, nlohmann::json& json)
 {
   // Capture _all_ header fields, not just the optional key-value pairs
   json["name"] = header.name();
-  vector<size_t> size (header.ndim());
-  vector<default_type> spacing (header.ndim());
+  std::vector<size_t> size (header.ndim());
+  std::vector<default_type> spacing (header.ndim());
   for (size_t axis = 0; axis != header.ndim(); ++axis) {
     size[axis] = header.size (axis);
     spacing[axis] = header.spacing (axis);
   }
   json["size"] = size;
   json["spacing"] = spacing;
-  vector<ssize_t> strides (Stride::get (header));
+  std::vector<ssize_t> strides (Stride::get (header));
   Stride::symbolise (strides);
   json["strides"] = strides;
   json["format"] = header.format();

--- a/cmd/mrmath.cpp
+++ b/cmd/mrmath.cpp
@@ -126,7 +126,7 @@ class Median {
     value_type result () {
       return Math::median(values);
     }
-    vector<value_type> values;
+    std::vector<value_type> values;
 };
 
 class Sum { 
@@ -414,7 +414,7 @@ void run ()
       throw Exception ("mrmath requires either multiple input images, or the -axis option to be provided");
 
     // Pre-load all image headers
-    vector<Header> headers_in (num_inputs);
+    std::vector<Header> headers_in (num_inputs);
 
     // Header of first input image is the template to which all other input images are compared
     headers_in[0] = Header::open (argument[0]);

--- a/cmd/mrregister.cpp
+++ b/cmd/mrregister.cpp
@@ -128,7 +128,7 @@ using value_type = double;
 
 void run () {
 
-  vector<Header> input1, input2;
+  std::vector<Header> input1, input2;
   const size_t n_images = argument.size() / 2;
   { // parse arguments and load input headers
     if (n_images * 2 != argument.size()) {
@@ -223,7 +223,7 @@ void run () {
   }
 
   // multi-contrast settings
-  vector<Registration::MultiContrastSetting> mc_params (n_images);
+  std::vector<Registration::MultiContrastSetting> mc_params (n_images);
   for (auto& mc : mc_params) {
     mc.do_reorientation = do_reorientation;
   }
@@ -278,7 +278,7 @@ void run () {
   INFO ("maximum input lmax: "+str(max_mc_image_lmax));
 
   opt = get_options ("transformed");
-  vector<std::string> im1_transformed_paths;
+  std::vector<std::string> im1_transformed_paths;
   if (opt.size()) {
     if (opt.size() > n_images)
       throw Exception ("number of -transformed images exceeds number of contrasts");
@@ -292,8 +292,8 @@ void run () {
   }
 
 
-  vector<std::string> input1_midway_transformed_paths;
-  vector<std::string> input2_midway_transformed_paths;
+  std::vector<std::string> input1_midway_transformed_paths;
+  std::vector<std::string> input2_midway_transformed_paths;
   opt = get_options ("transformed_midway");
   if (opt.size()) {
     if (opt.size() > n_images)
@@ -451,7 +451,7 @@ void run () {
   }
 
   opt = get_options ("rigid_lmax");
-  vector<uint32_t> rigid_lmax;
+  std::vector<uint32_t> rigid_lmax;
   if (opt.size ()) {
     if (!do_rigid)
       throw Exception ("the -rigid_lmax option has been set when no rigid registration is requested");
@@ -603,7 +603,7 @@ void run () {
   }
 
   opt = get_options ("affine_lmax");
-  vector<uint32_t> affine_lmax;
+  std::vector<uint32_t> affine_lmax;
   if (opt.size ()) {
     if (!do_affine)
       throw Exception ("the -affine_lmax option has been set when no affine registration is requested");
@@ -713,7 +713,7 @@ void run () {
   if (opt.size ()) {
     if (!do_nonlinear)
       throw Exception ("the non-linear multi-resolution scale factors were input when no non-linear registration is requested");
-    vector<default_type> scale_factors = parse_floats (opt[0][0]);
+    std::vector<default_type> scale_factors = parse_floats (opt[0][0]);
     if (nonlinear_init) {
       WARN ("-nl_scale option ignored since only the full resolution will be performed when initialising with non-linear warp");
     } else {
@@ -725,7 +725,7 @@ void run () {
   if (opt.size ()) {
     if (!do_nonlinear)
       throw Exception ("the number of non-linear iterations have been input when no non-linear registration is requested");
-    vector<uint32_t> iterations_per_level = parse_ints<uint32_t> (opt[0][0]);
+    std::vector<uint32_t> iterations_per_level = parse_ints<uint32_t> (opt[0][0]);
     if (nonlinear_init && iterations_per_level.size() > 1)
       throw Exception ("when initialising the non-linear registration the max number of iterations can only be defined for a single level");
     else
@@ -754,7 +754,7 @@ void run () {
   }
 
   opt = get_options ("nl_lmax");
-  vector<uint32_t> nl_lmax;
+  std::vector<uint32_t> nl_lmax;
   if (opt.size()) {
     if (!do_nonlinear)
       throw Exception ("the -nl_lmax option has been set when no non-linear registration is requested");
@@ -773,7 +773,7 @@ void run () {
 
   opt = get_options ("mc_weights");
   if (opt.size()) {
-    vector<default_type> mc_weights = parse_floats (opt[0][0]);
+    std::vector<default_type> mc_weights = parse_floats (opt[0][0]);
     if (mc_weights.size() == 1)
       mc_weights.resize (n_images, mc_weights[0]);
     else if (mc_weights.size() != n_images)
@@ -864,7 +864,7 @@ void run () {
     } else { // 3D
       if (rigid_metric == Registration::NCC){
         Registration::Metric::LocalCrossCorrelation metric;
-        vector<size_t> extent(3,3);
+        std::vector<size_t> extent(3,3);
         rigid_registration.set_extent (extent);
         rigid_registration.run_masked (metric, rigid, images1, images2, im1_mask, im2_mask);
       }
@@ -933,7 +933,7 @@ void run () {
     } else { // 3D
       if (affine_metric == Registration::NCC){
         Registration::Metric::LocalCrossCorrelation metric;
-        vector<size_t> extent(3,3);
+        std::vector<size_t> extent(3,3);
         affine_registration.set_extent (extent);
         affine_registration.run_masked (metric, affine, images1, images2, im1_mask, im2_mask);
       }

--- a/cmd/mrstats.cpp
+++ b/cmd/mrstats.cpp
@@ -129,7 +129,7 @@ void run ()
     check_dimensions (mask, header, 0, 3);
   }
 
-  vector<std::string> fields;
+  std::vector<std::string> fields;
   opt = get_options ("output");
   for (size_t n = 0; n < opt.size(); ++n)
     fields.push_back (opt[n][0]);

--- a/cmd/mrthreshold.cpp
+++ b/cmd/mrthreshold.cpp
@@ -153,12 +153,12 @@ Image<bool> get_mask (const Image<value_type>& in)
 }
 
 
-vector<value_type> get_data (Image<value_type>& in,
+std::vector<value_type> get_data (Image<value_type>& in,
                              Image<bool>& mask,
                              const size_t max_axis,
                              const bool ignore_zero)
 {
-  vector<value_type> data;
+  std::vector<value_type> data;
   data.reserve (voxel_count (in, 0, max_axis));
   if (mask.valid()) {
     Adapter::Replicate<Image<bool>> mask_replicate (mask, in);
@@ -251,7 +251,7 @@ default_type calculate (Image<value_type>& in,
     if (max_axis < in.ndim()) {
 
       // Need to extract just the current 3D volume
-      vector<size_t> in_from (in.ndim()), in_size (in.ndim());
+      std::vector<size_t> in_from (in.ndim()), in_size (in.ndim());
       size_t axis;
       for (axis = 0; axis != 3; ++axis) {
         in_from[axis] = 0;
@@ -263,7 +263,7 @@ default_type calculate (Image<value_type>& in,
       }
       Adapter::Subset<Image<value_type>> in_subset (in, in_from, in_size);
       if (mask.valid()) {
-        vector<size_t> mask_from (mask.ndim()), mask_size (mask.ndim());
+        std::vector<size_t> mask_from (mask.ndim()), mask_size (mask.ndim());
         for (axis = 0; axis != 3; ++axis) {
           mask_from[axis] = 0;
           mask_size[axis] = mask.size (axis);

--- a/cmd/mrtransform.cpp
+++ b/cmd/mrtransform.cpp
@@ -208,7 +208,7 @@ void usage ()
 }
 
 void apply_warp (Image<float>& input, Image<float>& output, Image<default_type>& warp,
-  const int interp, const float out_of_bounds_value, const vector<uint32_t>& oversample, const bool jacobian_modulate = false) {
+  const int interp, const float out_of_bounds_value, const std::vector<uint32_t>& oversample, const bool jacobian_modulate = false) {
   switch (interp) {
   case 0:
     Filter::warp<Interp::Nearest> (input, output, warp, out_of_bounds_value, oversample, jacobian_modulate);
@@ -358,7 +358,7 @@ void run ()
 
   // Flip
   opt = get_options ("flip");
-  vector<int32_t> axes;
+  std::vector<int32_t> axes;
   if (opt.size()) {
     axes = parse_ints<int32_t> (opt[0][0]);
     transform_type flip;
@@ -538,7 +538,7 @@ void run ()
   }
 
   // over-sampling
-  vector<uint32_t> oversample = Adapter::AutoOverSample;
+  std::vector<uint32_t> oversample = Adapter::AutoOverSample;
   opt = get_options ("oversample");
   if (opt.size()) {
     if (!template_header.valid() && !warp)

--- a/cmd/mtnormalise.cpp
+++ b/cmd/mtnormalise.cpp
@@ -513,7 +513,7 @@ void run ()
   size_t max_balance_iter = DEFAULT_BALANCE_MAXITER_VALUE;
   auto opt = get_options ("niter");
   if (opt.size()) {
-    vector<size_t> num = parse_ints<size_t> (opt[0][0]);
+    std::vector<size_t> num = parse_ints<size_t> (opt[0][0]);
     if (num.size() < 1 && num.size() > 2)
       throw Exception ("unexpected number of entries provided to option \"-niter\"");
     for (auto n : num)

--- a/cmd/peaks2fixel.cpp
+++ b/cmd/peaks2fixel.cpp
@@ -49,10 +49,10 @@ void usage ()
 
 
 
-vector<Eigen::Vector3d> get (Image<float>& data)
+std::vector<Eigen::Vector3d> get (Image<float>& data)
 {
   data.index(3) = 0;
-  vector<Eigen::Vector3d> result;
+  std::vector<Eigen::Vector3d> result;
   while (data.index(3) < data.size(3)) {
     Eigen::Vector3d direction;
     for (size_t axis = 0; axis != 3; ++axis) {

--- a/cmd/sh2amp.cpp
+++ b/cmd/sh2amp.cpp
@@ -114,7 +114,7 @@ class SH2Amp {
 
 class SH2AmpMultiShell { 
   public:
-    SH2AmpMultiShell (const vector<Eigen::MatrixXd>& dirs, const DWI::Shells& shells, bool nonneg) :
+    SH2AmpMultiShell (const std::vector<Eigen::MatrixXd>& dirs, const DWI::Shells& shells, bool nonneg) :
       transforms (dirs),
       shells (shells),
       nonnegative (nonneg) { }
@@ -138,7 +138,7 @@ class SH2AmpMultiShell {
     }
 
   private:
-    const vector<Eigen::MatrixXd>& transforms;
+    const std::vector<Eigen::MatrixXd>& transforms;
     const DWI::Shells& shells;
     const bool nonnegative;
     Eigen::VectorXd sh, amp;
@@ -220,7 +220,7 @@ void run ()
     else if (! (sh_data.ndim() == 4 || ( sh_data.ndim() > 4 && ( sh_data.size(4) != 1 ))) )
       throw Exception ("number of shells differs between gradient scheme and input data");
 
-    vector<Eigen::MatrixXd> transforms;
+    std::vector<Eigen::MatrixXd> transforms;
 
     for (size_t n = 0; n < shells.count(); ++n) {
       Eigen::MatrixXd dirs (shells[n].count(), 2);

--- a/cmd/sh2peaks.cpp
+++ b/cmd/sh2peaks.cpp
@@ -167,7 +167,7 @@ class Processor {
                Eigen::Matrix<value_type, Eigen::Dynamic, 2>& directions,
                int lmax,
                int npeaks,
-               vector<Direction> true_peaks,
+               std::vector<Direction> true_peaks,
                value_type threshold,
                Image<value_type> ipeaks_data,
                bool use_precomputer) :
@@ -193,7 +193,7 @@ class Processor {
         return true;
       }
 
-      vector<Direction> all_peaks;
+      std::vector<Direction> all_peaks;
 
       for (size_t i = 0; i < size_t(dirs.rows()); i++) {
         Direction p (dirs (i,0), dirs (i,1));
@@ -267,9 +267,9 @@ class Processor {
     Image<value_type> dirs_vox;
     Eigen::Matrix<value_type, Eigen::Dynamic, 2> dirs;
     int lmax, npeaks;
-    vector<Direction> true_peaks;
+    std::vector<Direction> true_peaks;
     value_type threshold;
-    vector<Direction> peaks_out;
+    std::vector<Direction> peaks_out;
     Image<value_type> ipeaks_vox;
     Math::SH::PrecomputedAL<value_type>* precomputer;
 
@@ -325,7 +325,7 @@ void run ()
   int npeaks = get_option_value ("num", DEFAULT_NPEAKS);
 
   opt = get_options ("direction");
-  vector<Direction> true_peaks;
+  std::vector<Direction> true_peaks;
   for (size_t n = 0; n < opt.size(); ++n) {
     Direction p (Math::pi*to<float> (opt[n][0]) /180.0, Math::pi*float (opt[n][1]) /180.0);
     true_peaks.push_back (p);

--- a/cmd/shbasis.cpp
+++ b/cmd/shbasis.cpp
@@ -78,7 +78,7 @@ void usage ()
 
 // Perform a linear regression on the power ratio in each order
 // Omit l=2 - tends to be abnormally small due to non-isotropic brain-wide fibre distribution
-std::pair<float, float> get_regression (const vector<float>& ratios)
+std::pair<float, float> get_regression (const std::vector<float>& ratios)
 {
   const size_t n = ratios.size() - 1;
   Eigen::VectorXf Y (n), b (2);
@@ -136,7 +136,7 @@ void check_and_update (Header& H, const conv_t conversion)
   if (App::log_level > 0 && App::log_level < 2)
     progress.reset (new ProgressBar ("Evaluating SH basis of image \"" + H.name() + "\"", N-1));
 
-  vector<float> ratios;
+  std::vector<float> ratios;
 
   for (size_t l = 2; l <= lmax; l += 2) {
 
@@ -311,7 +311,7 @@ void run ()
     }
   }
 
-  for (vector<ParsedArgument>::const_iterator i = argument.begin(); i != argument.end(); ++i) {
+  for (std::vector<ParsedArgument>::const_iterator i = argument.begin(); i != argument.end(); ++i) {
 
     const std::string path = *i;
     Header H = Header::open (path);

--- a/cmd/shconv.cpp
+++ b/cmd/shconv.cpp
@@ -63,7 +63,7 @@ using value_type = float;
 
 class SConvFunctor { 
   public:
-  SConvFunctor (const vector<Eigen::MatrixXd>& responses, vector<Image<value_type>>& inputs) :
+  SConvFunctor (const std::vector<Eigen::MatrixXd>& responses, std::vector<Image<value_type>>& inputs) :
     responses (responses),
     inputs (inputs) { }
 
@@ -85,8 +85,8 @@ class SConvFunctor {
     }
 
   protected:
-    const vector<Eigen::MatrixXd>& responses;
-    vector<Image<value_type>> inputs;
+    const std::vector<Eigen::MatrixXd>& responses;
+    std::vector<Image<value_type>> inputs;
     Eigen::VectorXd in, out;
 
 };
@@ -101,8 +101,8 @@ void run()
   if (!(argument.size() & size_t(1U)))
     throw Exception ("unexpected number of arguments");
 
-  vector<Image<value_type>> inputs ((argument.size() - 1) / 2);
-  vector<Eigen::MatrixXd> responses (inputs.size());
+  std::vector<Image<value_type>> inputs ((argument.size() - 1) / 2);
+  std::vector<Eigen::MatrixXd> responses (inputs.size());
 
   size_t lmax = 0;
   for (size_t n = 0; n < inputs.size(); ++n) {

--- a/cmd/tck2connectome.cpp
+++ b/cmd/tck2connectome.cpp
@@ -189,7 +189,7 @@ void run ()
 
   // First, find out how many segmented nodes there are, so the matrix can be pre-allocated
   // Also check for node volume for all nodes
-  vector<uint32_t> node_volumes (1, 0);
+  std::vector<uint32_t> node_volumes (1, 0);
   node_t max_node_index = 0;
   for (auto i = Loop (node_image, 0, 3) (node_image); i; ++i) {
     if (node_image.value() > max_node_index) {

--- a/cmd/tck2fixel.cpp
+++ b/cmd/tck2fixel.cpp
@@ -43,8 +43,8 @@ class TrackProcessor {
    using SetVoxelDir = DWI::Tractography::Mapping::SetVoxelDir;
 
    TrackProcessor (Image<index_type>& fixel_indexer,
-                   const vector<Eigen::Vector3d>& fixel_directions,
-                   vector<uint16_t>& fixel_TDI,
+                   const std::vector<Eigen::Vector3d>& fixel_directions,
+                   std::vector<uint16_t>& fixel_TDI,
                    const float angular_threshold):
      fixel_indexer (fixel_indexer) ,
      fixel_directions (fixel_directions),
@@ -54,7 +54,7 @@ class TrackProcessor {
 
    bool operator () (const SetVoxelDir& in)  {
      // For each voxel tract tangent, assign to a fixel
-     vector<int32_t> tract_fixel_indices;
+     std::vector<int32_t> tract_fixel_indices;
      for (SetVoxelDir::const_iterator i = in.begin(); i != in.end(); ++i) {
        assign_pos_of (*i).to (fixel_indexer);
        fixel_indexer.index(3) = 0;
@@ -85,8 +85,8 @@ class TrackProcessor {
 
  private:
    Image<index_type> fixel_indexer;
-   const vector<Eigen::Vector3d>& fixel_directions;
-   vector<uint16_t>& fixel_TDI;
+   const std::vector<Eigen::Vector3d>& fixel_directions;
+   std::vector<uint16_t>& fixel_TDI;
    const float angular_threshold_dp;
 };
 
@@ -137,8 +137,8 @@ void run ()
 
   const float angular_threshold = get_option_value ("angle", DEFAULT_ANGLE_THRESHOLD);
 
-  vector<Eigen::Vector3d> positions (num_fixels);
-  vector<Eigen::Vector3d> directions (num_fixels);
+  std::vector<Eigen::Vector3d> positions (num_fixels);
+  std::vector<Eigen::Vector3d> directions (num_fixels);
 
   const std::string output_fixel_folder = argument[2];
   Fixel::copy_index_and_directions_file (input_fixel_folder, output_fixel_folder);
@@ -159,7 +159,7 @@ void run ()
     }
   }
 
-  vector<uint16_t> fixel_TDI (num_fixels, 0.0);
+  std::vector<uint16_t> fixel_TDI (num_fixels, 0.0);
   const std::string track_filename = argument[0];
   DWI::Tractography::Properties properties;
   DWI::Tractography::Reader<float> track_file (track_filename, properties);

--- a/cmd/tckconvert.cpp
+++ b/cmd/tckconvert.cpp
@@ -197,7 +197,7 @@ class VTKWriter: public WriterInterface<float> {
     File::OFStream VTKout;
     const bool write_ascii;
     size_t offset_num_points;
-    vector<std::pair<size_t,size_t>> track_list;
+    std::vector<std::pair<size_t,size_t>> track_list;
     size_t current_index = 0;
 
 };
@@ -206,9 +206,9 @@ class VTKWriter: public WriterInterface<float> {
 
 
 
-template <class T> void loadLines(vector<int64_t>& lines, std::ifstream& input, int number_of_line_indices)
+template <class T> void loadLines(std::vector<int64_t>& lines, std::ifstream& input, int number_of_line_indices)
 {
-  vector<T> buffer (number_of_line_indices);
+  std::vector<T> buffer (number_of_line_indices);
   input.read((char*) &buffer[0], number_of_line_indices * sizeof(T));
   lines.resize (number_of_line_indices);
   // swap from big endian
@@ -274,8 +274,8 @@ class VTKReader: public ReaderInterface<float> {
     }
 
   private:
-    vector<float> points;
-    vector<int64_t> lines;
+    std::vector<float> points;
+    std::vector<int64_t> lines;
     int lineIdx;
     int number_of_lines;
     int number_of_line_indices;
@@ -343,7 +343,7 @@ class ASCIIWriter: public WriterInterface<float> {
 
   private:
     File::NameParser parser;
-    vector<uint32_t> count;
+    std::vector<uint32_t> count;
 
 };
 

--- a/cmd/tckdfc.cpp
+++ b/cmd/tckdfc.cpp
@@ -241,7 +241,7 @@ class Count_receiver
 void run ()
 {
   bool is_static = get_options ("static").size();
-  vector<float> window;
+  std::vector<float> window;
 
   auto opt = get_options ("dynamic");
   if (opt.size()) {
@@ -310,7 +310,7 @@ void run ()
 
   Image<float> fmri_image (Image<float>::open (argument[1]).with_direct_io(3));
 
-  vector<default_type> voxel_size;
+  std::vector<default_type> voxel_size;
   opt = get_options("vox");
   if (opt.size())
     voxel_size = parse_floats (opt[0][0]);

--- a/cmd/tckedit.cpp
+++ b/cmd/tckedit.cpp
@@ -143,7 +143,7 @@ void run ()
   // Get the consensus streamline properties from among the multiple input files
   Tractography::Properties properties;
   size_t count = 0;
-  vector<std::string> input_file_list;
+  std::vector<std::string> input_file_list;
 
   for (size_t file_index = 0; file_index != num_inputs; ++file_index) {
 

--- a/cmd/tckinfo.cpp
+++ b/cmd/tckinfo.cpp
@@ -63,7 +63,7 @@ void run ()
 
     if (properties.comments.size()) {
       std::cout << "    Comments:             ";
-      for (vector<std::string>::iterator i = properties.comments.begin(); i != properties.comments.end(); ++i)
+      for (std::vector<std::string>::iterator i = properties.comments.begin(); i != properties.comments.end(); ++i)
         std::cout << (i == properties.comments.begin() ? "" : "                       ") << *i << "\n";
     }
 

--- a/cmd/tckmap.cpp
+++ b/cmd/tckmap.cpp
@@ -295,7 +295,7 @@ void run () {
 
   const size_t num_tracks = properties["count"].empty() ? 0 : to<size_t> (properties["count"]);
 
-  vector<default_type> voxel_size = get_option_value ("vox", vector<default_type>());
+  std::vector<default_type> voxel_size = get_option_value ("vox", std::vector<default_type>());
 
   if (voxel_size.size() == 1) {
     auto v = voxel_size.front();                                                                                          

--- a/cmd/tcksample.cpp
+++ b/cmd/tcksample.cpp
@@ -166,7 +166,7 @@ class SamplerNonPrecise
       } else {
         if (statistic == MEDIAN) {
           // Don't bother with a weighted median here
-          vector<value_type> data;
+          std::vector<value_type> data;
           data.assign (values.data(), values.data() + values.size());
           out.second = Math::median (data);
         } else if (statistic == MIN) {
@@ -260,7 +260,7 @@ class SamplerPrecise
             bool operator< (const WeightSort& that) const { return value < that.value; }
             value_type value, length;
         };
-        vector<WeightSort> data;
+        std::vector<WeightSort> data;
         for (const auto& v : voxels) {
           assign_pos_of (v).to (image);
           data.push_back (WeightSort (v, (image.value() * get_tdi_multiplier (v))));

--- a/cmd/tcksift.cpp
+++ b/cmd/tcksift.cpp
@@ -122,7 +122,7 @@ void run ()
       sifter.set_csv_path (opt[0][0]);
     opt = get_options ("output_at_counts");
     if (opt.size()) {
-      vector<uint32_t> counts = parse_ints<uint32_t> (opt[0][0]);
+      std::vector<uint32_t> counts = parse_ints<uint32_t> (opt[0][0]);
       sifter.set_regular_outputs (counts, debug_path);
     }
 

--- a/cmd/tckstats.cpp
+++ b/cmd/tckstats.cpp
@@ -110,8 +110,8 @@ void run ()
   float max_length = -std::numeric_limits<float>::infinity();
   size_t empty_streamlines = 0, zero_length_streamlines = 0;
   default_type sum_lengths = 0.0, sum_weights = 0.0;
-  vector<default_type> histogram;
-  vector<LW> all_lengths;
+  std::vector<default_type> histogram;
+  std::vector<LW> all_lengths;
   all_lengths.reserve (header_count);
 
   {
@@ -194,11 +194,11 @@ void run ()
   }
 
   default_type ssd = 0.0;
-  for (vector<LW>::const_iterator i = all_lengths.begin(); i != all_lengths.end(); ++i)
+  for (std::vector<LW>::const_iterator i = all_lengths.begin(); i != all_lengths.end(); ++i)
     ssd += i->get_weight() * Math::pow2 (i->get_length() - mean_length);
   const float stdev = sum_weights ? (std::sqrt (ssd / (((count - 1) / default_type(count)) * sum_weights))) : NaN;
 
-  vector<std::string> fields;
+  std::vector<std::string> fields;
   auto opt = get_options ("output");
   for (size_t n = 0; n < opt.size(); ++n)
     fields.push_back (opt[n][0]);

--- a/cmd/tensor2metric.cpp
+++ b/cmd/tensor2metric.cpp
@@ -153,7 +153,7 @@ class Processor {
         Image<value_type>& mk_img,
         Image<value_type>& ak_img,
         Image<value_type>& rk_img,
-        vector<uint32_t>& vals,
+        std::vector<uint32_t>& vals,
         int modulate,
         Eigen::MatrixXd mk_dirs,
         int rk_ndirs) :
@@ -355,7 +355,7 @@ class Processor {
     Image<value_type> mk_img;
     Image<value_type> ak_img;
     Image<value_type> rk_img;
-    vector<uint32_t> vals;
+    std::vector<uint32_t> vals;
     const int modulate;
     Eigen::MatrixXd mk_dirs;
     Eigen::MatrixXd mk_bmat, rk_bmat;
@@ -455,7 +455,7 @@ void run ()
     metric_count++;
   }
 
-  vector<uint32_t> vals = {1};
+  std::vector<uint32_t> vals = {1};
   opt = get_options ("num");
   if (opt.size()) {
     vals = parse_ints<uint32_t> (opt[0][0]);

--- a/cmd/transformcalc.cpp
+++ b/cmd/transformcalc.cpp
@@ -215,7 +215,7 @@ void run ()
       transform_type transform_out;
       Eigen::Transform<default_type, 3, Eigen::Projective> Tin;
       Eigen::MatrixXd Min;
-      vector<Eigen::MatrixXd> matrices;
+      std::vector<Eigen::MatrixXd> matrices;
       for (size_t i = 0; i < num_inputs; i++) {
         DEBUG(str(argument[i]));
         Tin = load_transform (argument[i]);

--- a/cmd/transformcompose.cpp
+++ b/cmd/transformcompose.cpp
@@ -96,7 +96,7 @@ using value_type = float;
 
 void run ()
 {
-  vector<std::unique_ptr<TransformBase>> transform_list;
+  std::vector<std::unique_ptr<TransformBase>> transform_list;
   std::unique_ptr<Header> template_header;
 
   for (size_t i = 0; i < argument.size() - 1; ++i) {

--- a/cmd/transformconvert.cpp
+++ b/cmd/transformconvert.cpp
@@ -62,7 +62,7 @@ void usage ()
 
 
 transform_type get_flirt_transform (const Header& header) {
-  vector<size_t> axes;
+  std::vector<size_t> axes;
   transform_type nifti_transform = File::NIfTI::adjust_transform (header, axes);
   if (nifti_transform.matrix().topLeftCorner<3,3>().determinant() < 0.0)
     return nifti_transform;
@@ -82,7 +82,7 @@ transform_type get_flirt_transform (const Header& header) {
 // template <class ValueType = default_type>
 //   transform_type parse_surfer_transform (const std::string& filename) {
 //     std::ifstream stream (filename, std::ios_base::in | std::ios_base::binary);
-//     vector<vector<ValueType>> V;
+//     std::vector<std::vector<ValueType>> V;
 //     std::string sbuf;
 //     std::string file_version;
 //     while (getline (stream, sbuf)) {
@@ -103,7 +103,7 @@ transform_type get_flirt_transform (const Header& header) {
 
 //     for (auto i = 0; i<4 && getline (stream, sbuf); ++i){
 //       // sbuf = strip (sbuf.substr (0, sbuf.find_first_of ('type')));
-//       V.push_back (vector<ValueType>());
+//       V.push_back (std::vector<ValueType>());
 //       const auto elements = MR::split (sbuf, " ,;\t", true);
 //       for (const auto& entry : elements)
 //         V.back().push_back (to<ValueType> (entry));
@@ -130,7 +130,7 @@ transform_type get_flirt_transform (const Header& header) {
 template <typename TransformationType>
 void parse_itk_trafo (const std::string& itk_file, TransformationType& transformation, Eigen::Vector3d& centre_of_rotation) {
   const std::string first_line = "#Insight Transform File V1.0";
-  vector<std::string> supported_transformations = {"MatrixOffsetTransformBase_double_3_3",
+  std::vector<std::string> supported_transformations = {"MatrixOffsetTransformBase_double_3_3",
                                                         "MatrixOffsetTransformBase_float_3_3",
                                                         "AffineTransform_double_3_3",
                                                         "AffineTransform_float_3_3"
@@ -151,7 +151,7 @@ void parse_itk_trafo (const std::string& itk_file, TransformationType& transform
     else if (file.key() == "Parameters") {
       line = file.value();
       std::replace (line.begin(), line.end(), ' ', ',');
-      vector<default_type> parameters (parse_floats (line));
+      std::vector<default_type> parameters (parse_floats (line));
       if (parameters.size() != 12)
         throw Exception ("Expected itk file with 12 parameters but has " + str(parameters.size()) + " parameters.");
       transformation.linear().row(0) << parameters[0], parameters[1], parameters[2];
@@ -163,7 +163,7 @@ void parse_itk_trafo (const std::string& itk_file, TransformationType& transform
     else if (file.key() == "FixedParameters") {
       line = file.value();
       std::replace (line.begin(), line.end(), ' ', ',');
-      vector<default_type> fixed_parameters (parse_floats (line));
+      std::vector<default_type> fixed_parameters (parse_floats (line));
       centre_of_rotation << fixed_parameters[0], fixed_parameters[1], fixed_parameters[2];
       invalid--;
     }

--- a/cmd/tsfinfo.cpp
+++ b/cmd/tsfinfo.cpp
@@ -70,7 +70,7 @@ void run ()
 
     if (properties.comments.size()) {
       std::cout << "    Comments:             ";
-      for (vector<std::string>::iterator i = properties.comments.begin(); i != properties.comments.end(); ++i)
+      for (std::vector<std::string>::iterator i = properties.comments.begin(); i != properties.comments.end(); ++i)
         std::cout << (i == properties.comments.begin() ? "" : "                       ") << *i << "\n";
     }
 
@@ -102,7 +102,7 @@ void run ()
         filename.replace (filename.size()-4-num.size(), num.size(), num);
 
         File::OFStream out (filename);
-        for (vector<float>::iterator i = tck.begin(); i != tck.end(); ++i)
+        for (std::vector<float>::iterator i = tck.begin(); i != tck.end(); ++i)
           out << (*i) << "\n";
         out.close();
 

--- a/cmd/tsfsmooth.cpp
+++ b/cmd/tsfsmooth.cpp
@@ -54,7 +54,7 @@ void run ()
 
   float stdev = get_option_value ("stdev", DEFAULT_SMOOTHING);
 
-  vector<float> kernel (2 * ceil(2.5 * stdev) + 1, 0);
+  std::vector<float> kernel (2 * ceil(2.5 * stdev) + 1, 0);
   float norm_factor = 0.0;
   float radius = (kernel.size() - 1.0) / 2.0;
   for (size_t c = 0; c < kernel.size(); ++c) {

--- a/cmd/vectorstats.cpp
+++ b/cmd/vectorstats.cpp
@@ -157,7 +157,7 @@ void run()
 
   // Before validating the contrast matrix, we first need to see if there are any
   //   additional design matrix columns coming from element-wise subject data
-  vector<CohortDataImport> extra_columns;
+  std::vector<CohortDataImport> extra_columns;
   bool nans_in_columns = false;
   auto opt = get_options ("column");
   for (size_t i = 0; i != opt.size(); ++i) {
@@ -182,7 +182,7 @@ void run()
     CONSOLE ("Number of variance groups: " + str(num_vgs));
 
   // Load hypotheses
-  const vector<Hypothesis> hypotheses = Math::Stats::GLM::load_hypotheses (argument[2]);
+  const std::vector<Hypothesis> hypotheses = Math::Stats::GLM::load_hypotheses (argument[2]);
   const size_t num_hypotheses = hypotheses.size();
   if (hypotheses[0].cols() != num_factors)
     throw Exception ("The number of columns in the contrast matrix (" + str(hypotheses[0].cols()) + ")"

--- a/core/adapter/extract.h
+++ b/core/adapter/extract.h
@@ -38,7 +38,7 @@ namespace MR
         using base_type::parent;
 
 
-        Extract1D (const ImageType& original, const size_t axis, const vector<uint32_t>& indices) :
+        Extract1D (const ImageType& original, const size_t axis, const std::vector<uint32_t>& indices) :
           base_type (original),
           extract_axis (axis),
           indices (indices),
@@ -93,7 +93,7 @@ namespace MR
 
       private:
         const size_t extract_axis;
-        vector<uint32_t> indices;
+        std::vector<uint32_t> indices;
         const ssize_t nsize;
         transform_type trans;
         ssize_t current_pos;
@@ -123,7 +123,7 @@ namespace MR
         using base_type::parent;
 
 
-        Extract (const ImageType& original, const vector<vector<uint32_t>>& indices) :
+        Extract (const ImageType& original, const std::vector<std::vector<uint32_t>>& indices) :
           base_type (original),
           current_pos (ndim()),
           indices (indices),
@@ -163,9 +163,9 @@ namespace MR
         }
 
       private:
-        vector<ssize_t> current_pos;
-        vector<vector<uint32_t> > indices;
-        vector<ssize_t> sizes;
+        std::vector<ssize_t> current_pos;
+        std::vector<std::vector<uint32_t> > indices;
+        std::vector<ssize_t> sizes;
         transform_type trans;
     };
 

--- a/core/adapter/gaussian1D.h
+++ b/core/adapter/gaussian1D.h
@@ -109,7 +109,7 @@ namespace MR
         default_type stdev;
         ssize_t radius;
         size_t axis;
-        vector<default_type> kernel;
+        std::vector<default_type> kernel;
         const bool zero_boundary;
       };
   }

--- a/core/adapter/gradient1D.h
+++ b/core/adapter/gradient1D.h
@@ -93,8 +93,8 @@ namespace MR
         size_t axis;
         value_type result;
         const bool wrt_spacing;
-        vector<value_type> derivative_weights;
-        vector<value_type> half_derivative_weights;
+        std::vector<value_type> derivative_weights;
+        std::vector<value_type> half_derivative_weights;
       };
   }
 }

--- a/core/adapter/median.h
+++ b/core/adapter/median.h
@@ -42,15 +42,15 @@ namespace MR
 
         Median (const ImageType& parent) :
           base_type (parent) {
-            set_extent (vector<int>(1,3));
+            set_extent (std::vector<int>(1,3));
           }
 
-        Median (const ImageType& parent, const vector<uint32_t>& extent) :
+        Median (const ImageType& parent, const std::vector<uint32_t>& extent) :
           base_type (parent) {
             set_extent (extent);
           }
 
-        void set_extent (const vector<uint32_t>& ext)
+        void set_extent (const std::vector<uint32_t>& ext)
         {
           for (size_t i = 0; i < ext.size(); ++i)
             if (! (ext[i] & uint32_t(1)))
@@ -58,7 +58,7 @@ namespace MR
           if (ext.size() != 1 && ext.size() != 3)
             throw Exception ("unexpected number of elements specified in extent");
           if (ext.size() == 1)
-            extent = vector<uint32_t> (3, ext[0]);
+            extent = std::vector<uint32_t> (3, ext[0]);
           else
             extent = ext;
 
@@ -99,8 +99,8 @@ namespace MR
         }
 
       protected:
-        vector<uint32_t> extent;
-        vector<value_type> values;
+        std::vector<uint32_t> extent;
+        std::vector<value_type> values;
       };
 
   }

--- a/core/adapter/neighbourhood3D.h
+++ b/core/adapter/neighbourhood3D.h
@@ -75,7 +75,7 @@ namespace MR
 
       protected:
         using base_type::parent;
-        vector<ssize_t> from_, size_;
+        std::vector<ssize_t> from_, size_;
         Iterator iter_;
         transform_type transform_;
     };

--- a/core/adapter/normalise3D.h
+++ b/core/adapter/normalise3D.h
@@ -41,15 +41,15 @@ namespace MR
 
         Normalise3D (const ImageType& parent) :
           base_type (parent) {
-            set_extent (vector<int>(1,3));
+            set_extent (std::vector<int>(1,3));
           }
 
-        Normalise3D (const ImageType& parent, const vector<uint32_t>& extent) :
+        Normalise3D (const ImageType& parent, const std::vector<uint32_t>& extent) :
           base_type (parent) {
             set_extent (extent);
           }
 
-        void set_extent (const vector<uint32_t>& ext)
+        void set_extent (const std::vector<uint32_t>& ext)
         {
           for (size_t i = 0; i < ext.size(); ++i)
             if (! (ext[i] & uint32_t(1)))
@@ -57,7 +57,7 @@ namespace MR
           if (ext.size() != 1 && ext.size() != 3)
             throw Exception ("unexpected number of elements specified in extent");
           if (ext.size() == 1)
-            extent = vector<uint32_t> (3, ext[0]);
+            extent = std::vector<uint32_t> (3, ext[0]);
           else
             extent = ext;
 
@@ -104,7 +104,7 @@ namespace MR
         }
 
       protected:
-        vector<uint32_t> extent;
+        std::vector<uint32_t> extent;
         value_type mean;
         value_type pos_value;
         size_t nelements;

--- a/core/adapter/permute_axes.h
+++ b/core/adapter/permute_axes.h
@@ -36,7 +36,7 @@ namespace MR
         using base_type::size;
         using base_type::parent;
 
-        PermuteAxes (const ImageType& original, const vector<int>& axes) :
+        PermuteAxes (const ImageType& original, const std::vector<int>& axes) :
           base_type (original),
             axes_ (axes) {
               for (int i = 0; i < static_cast<int> (parent().ndim()); ++i) {
@@ -84,8 +84,8 @@ next_axis:
           }
 
         private:
-          vector<int> axes_;
-          vector<size_t> non_existent_axes;
+          std::vector<int> axes_;
+          std::vector<size_t> non_existent_axes;
 
       };
 

--- a/core/adapter/regrid.h
+++ b/core/adapter/regrid.h
@@ -42,9 +42,9 @@ namespace MR
             base_type (original),
             from_ (container_cast<decltype(from_)>(from)),
             size_ (container_cast<decltype(size_)>(size)),
-            index_invalid_lower_upper ([&]{ vector<vector<ssize_t>> v; for (size_t d = 0; d < from_.size(); ++d) {
-              v.push_back (vector<ssize_t> {from_[d] < 0 ? -(ssize_t) from_[d] - 1 : -1, original.size(d) - from_[d]}); } return v; }()),
-            index_requires_bound_check ([&]{ vector<bool> v; for (size_t d = 0; d < from_.size(); ++d) {
+            index_invalid_lower_upper ([&]{ std::vector<std::vector<ssize_t>> v; for (size_t d = 0; d < from_.size(); ++d) {
+              v.push_back (std::vector<ssize_t> {from_[d] < 0 ? -(ssize_t) from_[d] - 1 : -1, original.size(d) - from_[d]}); } return v; }()),
+            index_requires_bound_check ([&]{ std::vector<bool> v; for (size_t d = 0; d < from_.size(); ++d) {
               v.push_back (from_[d] < 0 || size_[d] > original.size(d) - from_[d]); } return v; }()),
             fill_ (fill),
             transform_ (original.transform()),
@@ -99,12 +99,12 @@ namespace MR
 
       protected:
         using base_type::parent;
-        const vector<ssize_t> from_, size_;
-        const vector<vector<ssize_t>> index_invalid_lower_upper;
-        const vector<bool> index_requires_bound_check;
+        const std::vector<ssize_t> from_, size_;
+        const std::vector<std::vector<ssize_t>> index_invalid_lower_upper;
+        const std::vector<bool> index_requires_bound_check;
         const value_type fill_;
         transform_type transform_;
-        vector<ssize_t> index_;
+        std::vector<ssize_t> index_;
     };
 
   }

--- a/core/adapter/replicate.h
+++ b/core/adapter/replicate.h
@@ -78,7 +78,7 @@ namespace MR
       protected:
         using base_type::parent;
         Header header_;
-        vector<ssize_t> pos_;
+        std::vector<ssize_t> pos_;
 
     };
 

--- a/core/adapter/reslice.cpp
+++ b/core/adapter/reslice.cpp
@@ -21,7 +21,7 @@ namespace MR
   namespace Adapter
   {
     const transform_type NoTransform = transform_type::Identity();
-    const vector<uint32_t> AutoOverSample;
+    const std::vector<uint32_t> AutoOverSample;
   }
 }
 

--- a/core/adapter/reslice.h
+++ b/core/adapter/reslice.h
@@ -62,7 +62,7 @@ namespace MR
 
 
     extern const transform_type NoTransform;
-    extern const vector<uint32_t> AutoOverSample;
+    extern const std::vector<uint32_t> AutoOverSample;
 
     //! \addtogroup interp
     // @{
@@ -119,7 +119,7 @@ namespace MR
           Reslice (const ImageType& original,
                    const HeaderType& reference,
                    const transform_type& transform = NoTransform,
-                   const vector<uint32_t>& oversample = AutoOverSample,
+                   const std::vector<uint32_t>& oversample = AutoOverSample,
                    const value_type value_when_out_of_bounds = Interp::Base<ImageType>::default_out_of_bounds_value()) :
             interp (original, value_when_out_of_bounds),
             x { 0, 0, 0 },

--- a/core/adapter/subset.h
+++ b/core/adapter/subset.h
@@ -69,7 +69,7 @@ namespace MR
 
       protected:
         using base_type::parent;
-        const vector<ssize_t> from_, size_;
+        const std::vector<ssize_t> from_, size_;
         transform_type transform_;
     };
 

--- a/core/algo/histogram.cpp
+++ b/core/algo/histogram.cpp
@@ -49,7 +49,7 @@ namespace MR
           M = load_matrix (path);
           if (M.cols() == 1)
             throw Exception ("Histogram template must have at least 2 columns");
-          vector<default_type>().swap (data);
+          std::vector<default_type>().swap (data);
           auto V = M.row(0);
           num_bins = V.size();
           bin_width = (V[num_bins-1] - V[0]) / default_type(num_bins-1);
@@ -79,7 +79,7 @@ namespace MR
             // Need to adjust the bin width accordingly... kinda ugly hack
             // Will need to revisit if mrstats gets capability to compute statistics across all volumes rather than splitting
             bin_width = 2.0 * get_iqr() * std::pow(static_cast<default_type>(data.size() / num_volumes), -1.0/3.0);
-            vector<default_type>().swap (data); // No longer required; free the memory used
+            std::vector<default_type>().swap (data); // No longer required; free the memory used
             // If the input data are integers, the bin width should also be an integer, to avoid getting
             //   regular spike artifacts in the histogram
             if (is_integer) {

--- a/core/algo/histogram.h
+++ b/core/algo/histogram.h
@@ -82,7 +82,7 @@ namespace MR
           default_type min, max, bin_width;
           size_t num_bins;
           const bool ignore_zero;
-          vector<default_type> data;
+          std::vector<default_type> data;
 
           default_type get_iqr();
 

--- a/core/algo/iterator.h
+++ b/core/algo/iterator.h
@@ -52,7 +52,7 @@ namespace MR
       }
 
     private:
-      vector<ssize_t> d, p;
+      std::vector<ssize_t> d, p;
 
       void value () const { assert (0); }
   };

--- a/core/algo/loop.h
+++ b/core/algo/loop.h
@@ -136,7 +136,7 @@ namespace MR
    * following example:
    * \code
    * float value = 0.0;
-   * vector<size_t> order = { 1, 0, 2 };
+   * std::vector<size_t> order = { 1, 0, 2 };
    *
    * LoopInOrder loop (vox, order);
    * for (auto i = loop.run (vox); i; ++i)
@@ -298,16 +298,16 @@ namespace MR
 
 
   struct LoopAlongDynamicAxes { 
-    const vector<size_t> axes;
+    const std::vector<size_t> axes;
 
     template <class... ImageType>
       struct Run { 
-        const vector<size_t> axes;
+        const std::vector<size_t> axes;
         const std::tuple<ImageType&...> vox;
         const size_t from;
         const ssize_t size0;
         bool ok;
-        FORCE_INLINE Run (const vector<size_t>& axes, const std::tuple<ImageType&...>& vox) :
+        FORCE_INLINE Run (const std::vector<size_t>& axes, const std::tuple<ImageType&...>& vox) :
           axes (axes), vox (vox), from (axes[0]), size0 (std::get<0>(vox).size(from)), ok (true) {
             for (auto axis : axes)
               MR::apply (set_pos (axis, 0), vox);
@@ -337,13 +337,13 @@ namespace MR
 
   struct LoopAlongDynamicAxesProgress : public LoopAlongDynamicAxes { 
       const std::string text;
-      LoopAlongDynamicAxesProgress (const std::string& text, const vector<size_t>& axes) :
+      LoopAlongDynamicAxesProgress (const std::string& text, const std::vector<size_t>& axes) :
         LoopAlongDynamicAxes ({ axes }), text (text) { }
 
       template <class... ImageType>
         struct Run : public LoopAlongDynamicAxes::Run<ImageType...> { 
           MR::ProgressBar progress;
-          FORCE_INLINE Run (const std::string& text, const vector<size_t>& axes, const std::tuple<ImageType&...>& vox) :
+          FORCE_INLINE Run (const std::string& text, const std::vector<size_t>& axes, const std::tuple<ImageType&...>& vox) :
             LoopAlongDynamicAxes::Run<ImageType...> (axes, vox), progress (text, MR::voxel_count (std::get<0>(vox), axes)) { }
           FORCE_INLINE void operator++() { LoopAlongDynamicAxes::Run<ImageType...>::operator++(); ++progress; }
           FORCE_INLINE void operator++(int) { operator++(); }
@@ -380,11 +380,11 @@ namespace MR
     { return { progress_message, axis_from, axis_to }; }
 
   FORCE_INLINE LoopAlongDynamicAxes
-    Loop (const vector<size_t>& axes)
+    Loop (const std::vector<size_t>& axes)
     { return { axes }; }
 
   FORCE_INLINE LoopAlongDynamicAxesProgress
-    Loop (const std::string& progress_message, const vector<size_t>& axes)
+    Loop (const std::string& progress_message, const std::vector<size_t>& axes)
     { return { progress_message, axes }; }
 
   template <class ImageType> FORCE_INLINE LoopAlongDynamicAxes

--- a/core/algo/neighbourhooditerator.h
+++ b/core/algo/neighbourhooditerator.h
@@ -41,7 +41,7 @@ namespace MR
     public:
       NeighbourhoodIterator() = delete;
       template <class IteratorType>
-        NeighbourhoodIterator (const IteratorType& iter, const vector<size_t>& extent) :
+        NeighbourhoodIterator (const IteratorType& iter, const std::vector<size_t>& extent) :
           dim (iter.ndim()),
           offset (iter.ndim()),
           // pos (iter.ndim()),
@@ -108,7 +108,7 @@ namespace MR
 
 
     private:
-      vector<ssize_t> dim, offset, pos_orig, ext;
+      std::vector<ssize_t> dim, offset, pos_orig, ext;
       Eigen::Matrix< ssize_t, 1, Eigen::Dynamic > pos;
       bool has_next_;
 

--- a/core/algo/random_loop.h
+++ b/core/algo/random_loop.h
@@ -76,9 +76,9 @@ namespace MR
       ImageType& image;
       RandomEngine& engine;
       size_t ax;
-      vector<size_t> idx;
-      vector<size_t>::iterator it;
-      vector<size_t>::iterator stop;
+      std::vector<size_t> idx;
+      std::vector<size_t>::iterator it;
+      std::vector<size_t>::iterator stop;
       size_t max_cnt;
       bool status;
       size_t cnt;

--- a/core/algo/random_threaded_loop.h
+++ b/core/algo/random_threaded_loop.h
@@ -36,16 +36,16 @@ namespace MR
     template <int N, class Functor, class... ImageType>
       struct RandomThreadedLoopRunInner
       { 
-        const vector<size_t>& outer_axes;
+        const std::vector<size_t>& outer_axes;
         decltype (Loop (outer_axes)) loop;
         typename std::remove_reference<Functor>::type func;
         double density;
         Math::RNG::Uniform<double> rng;
-        const vector<size_t> dims;
+        const std::vector<size_t> dims;
         std::tuple<ImageType...> vox;
 
-        RandomThreadedLoopRunInner (const vector<size_t>& outer_axes, const vector<size_t>& inner_axes,
-            const Functor& functor, const double voxel_density, const vector<size_t> dimensions, ImageType&... voxels) :
+        RandomThreadedLoopRunInner (const std::vector<size_t>& outer_axes, const std::vector<size_t>& inner_axes,
+            const Functor& functor, const double voxel_density, const std::vector<size_t> dimensions, ImageType&... voxels) :
           outer_axes (outer_axes),
           loop (Loop (inner_axes)),
           func (functor),
@@ -70,8 +70,8 @@ namespace MR
     template <class Functor, class... ImageType>
       struct RandomThreadedLoopRunInner<0,Functor,ImageType...>
       { 
-        const vector<size_t>& outer_axes;
-        const vector<size_t> inner;
+        const std::vector<size_t>& outer_axes;
+        const std::vector<size_t> inner;
         decltype (Loop (outer_axes)) loop;
         // Random_loop<Iterator, std::default_random_engine>  random_loop;
         typename std::remove_reference<Functor>::type func;
@@ -80,10 +80,10 @@ namespace MR
         size_t cnt;
         // Math::RNG::Uniform<double> rng;
         std::default_random_engine random_engine;
-        vector<size_t> idx;
-        vector<size_t>::iterator it;
-        vector<size_t>::iterator stop;
-        const vector<size_t> dims;
+        std::vector<size_t> idx;
+        std::vector<size_t>::iterator it;
+        std::vector<size_t>::iterator stop;
+        const std::vector<size_t> dims;
         // ImageType& image;
         // RandomEngine& engine;
         // size_t max_cnt;
@@ -91,8 +91,8 @@ namespace MR
         // size_t cnt;
 
 
-        RandomThreadedLoopRunInner (const vector<size_t>& outer_axes, const vector<size_t>& inner_axes,
-            const Functor& functor, const double voxel_density, const vector<size_t>& dimensions, ImageType&... voxels) :
+        RandomThreadedLoopRunInner (const std::vector<size_t>& outer_axes, const std::vector<size_t>& inner_axes,
+            const Functor& functor, const double voxel_density, const std::vector<size_t>& dimensions, ImageType&... voxels) :
           outer_axes (outer_axes),
           inner (inner_axes),
           loop (Loop (inner_axes)),
@@ -105,7 +105,7 @@ namespace MR
             Math::RNG rng;
             typename std::default_random_engine::result_type seed = rng.get_seed();
             random_engine = std::default_random_engine{static_cast<std::default_random_engine::result_type>(seed)};
-            idx = vector<size_t>(dims[inner_axes[0]]);
+            idx = std::vector<size_t>(dims[inner_axes[0]]);
             std::iota (std::begin(idx), std::end(idx), 0);
           }
 
@@ -141,11 +141,11 @@ namespace MR
       struct RandomThreadedLoopRunOuter { 
         Iterator iterator;
         OuterLoopType outer_loop;
-        vector<size_t> inner_axes;
+        std::vector<size_t> inner_axes;
 
         //! invoke \a functor (const Iterator& pos) per voxel <em> in the outer axes only</em>
         template <class Functor>
-          void run_outer (Functor&& functor, const double voxel_density, const vector<size_t>& dimensions)
+          void run_outer (Functor&& functor, const double voxel_density, const std::vector<size_t>& dimensions)
           {
             if (Thread::threads_to_execute() == 0) {
               for (auto i = outer_loop (iterator); i; ++i){
@@ -187,7 +187,7 @@ namespace MR
 
         //! invoke \a functor (const Iterator& pos) per voxel <em> in the outer axes only</em>
         template <class Functor, class... ImageType>
-          void run (Functor&& functor, const double voxel_density, vector<size_t> dimensions, ImageType&&... vox)
+          void run (Functor&& functor, const double voxel_density, std::vector<size_t> dimensions, ImageType&&... vox)
           {
             RandomThreadedLoopRunInner<
               sizeof...(ImageType),
@@ -208,24 +208,24 @@ namespace MR
 
 
   template <class HeaderType>
-    inline RandomThreadedLoopRunOuter<decltype(Loop(vector<size_t>()))> RandomThreadedLoop (
+    inline RandomThreadedLoopRunOuter<decltype(Loop(std::vector<size_t>()))> RandomThreadedLoop (
         const HeaderType& source,
-        const vector<size_t>& outer_axes,
-        const vector<size_t>& inner_axes) {
+        const std::vector<size_t>& outer_axes,
+        const std::vector<size_t>& inner_axes) {
       return { source, Loop (outer_axes), inner_axes };
     }
 
 
   template <class HeaderType>
-    inline RandomThreadedLoopRunOuter<decltype(Loop(vector<size_t>()))> RandomThreadedLoop (
+    inline RandomThreadedLoopRunOuter<decltype(Loop(std::vector<size_t>()))> RandomThreadedLoop (
         const HeaderType& source,
-        const vector<size_t>& axes,
+        const std::vector<size_t>& axes,
         size_t num_inner_axes = 1) {
       return { source, Loop (get_outer_axes (axes, num_inner_axes)), get_inner_axes (axes, num_inner_axes) };
     }
 
   template <class HeaderType>
-    inline RandomThreadedLoopRunOuter<decltype(Loop(vector<size_t>()))> RandomThreadedLoop (
+    inline RandomThreadedLoopRunOuter<decltype(Loop(std::vector<size_t>()))> RandomThreadedLoop (
         const HeaderType& source,
         size_t from_axis = 0,
         size_t to_axis = std::numeric_limits<size_t>::max(),
@@ -236,19 +236,19 @@ namespace MR
       }
 
   template <class HeaderType>
-    inline RandomThreadedLoopRunOuter<decltype(Loop("", vector<size_t>()))> RandomThreadedLoop (
+    inline RandomThreadedLoopRunOuter<decltype(Loop("", std::vector<size_t>()))> RandomThreadedLoop (
         const std::string& progress_message,
         const HeaderType& source,
-        const vector<size_t>& outer_axes,
-        const vector<size_t>& inner_axes) {
+        const std::vector<size_t>& outer_axes,
+        const std::vector<size_t>& inner_axes) {
       return { source, Loop (progress_message, outer_axes), inner_axes };
     }
 
   template <class HeaderType>
-    inline RandomThreadedLoopRunOuter<decltype(Loop("", vector<size_t>()))> RandomThreadedLoop (
+    inline RandomThreadedLoopRunOuter<decltype(Loop("", std::vector<size_t>()))> RandomThreadedLoop (
         const std::string& progress_message,
         const HeaderType& source,
-        const vector<size_t>& axes,
+        const std::vector<size_t>& axes,
         size_t num_inner_axes = 1) {
       return { source,
         Loop (progress_message, get_outer_axes (axes, num_inner_axes)),
@@ -256,7 +256,7 @@ namespace MR
       }
 
   template <class HeaderType>
-    inline RandomThreadedLoopRunOuter<decltype(Loop("", vector<size_t>()))> RandomThreadedLoop (
+    inline RandomThreadedLoopRunOuter<decltype(Loop("", std::vector<size_t>()))> RandomThreadedLoop (
         const std::string& progress_message,
         const HeaderType& source,
         size_t from_axis = 0,

--- a/core/algo/stochastic_threaded_loop.h
+++ b/core/algo/stochastic_threaded_loop.h
@@ -36,14 +36,14 @@ namespace MR
     template <int N, class Functor, class... ImageType>
       struct StochasticThreadedLoopRunInner
       { 
-        const vector<size_t>& outer_axes;
+        const std::vector<size_t>& outer_axes;
         decltype (Loop (outer_axes)) loop;
         typename std::remove_reference<Functor>::type func;
         double density;
         Math::RNG::Uniform<double> rng;
         std::tuple<ImageType...> vox;
 
-        StochasticThreadedLoopRunInner (const vector<size_t>& outer_axes, const vector<size_t>& inner_axes,
+        StochasticThreadedLoopRunInner (const std::vector<size_t>& outer_axes, const std::vector<size_t>& inner_axes,
             const Functor& functor, const double voxel_density, ImageType&... voxels) :
           outer_axes (outer_axes),
           loop (Loop (inner_axes)),
@@ -69,14 +69,14 @@ namespace MR
     template <class Functor, class... ImageType>
       struct StochasticThreadedLoopRunInner<0,Functor,ImageType...>
       { 
-        const vector<size_t>& outer_axes;
+        const std::vector<size_t>& outer_axes;
         decltype (Loop (outer_axes)) loop;
         typename std::remove_reference<Functor>::type func;
         double density;
         Math::RNG::Uniform<double> rng;
 
 
-        StochasticThreadedLoopRunInner (const vector<size_t>& outer_axes, const vector<size_t>& inner_axes,
+        StochasticThreadedLoopRunInner (const std::vector<size_t>& outer_axes, const std::vector<size_t>& inner_axes,
             const Functor& functor, const double voxel_density, ImageType&... voxels) :
           outer_axes (outer_axes),
           loop (Loop (inner_axes)),
@@ -101,7 +101,7 @@ namespace MR
       struct StochasticThreadedLoopRunOuter { 
         Iterator iterator;
         OuterLoopType outer_loop;
-        vector<size_t> inner_axes;
+        std::vector<size_t> inner_axes;
 
         //! invoke \a functor (const Iterator& pos) per voxel <em> in the outer axes only</em>
         template <class Functor>
@@ -168,24 +168,24 @@ namespace MR
 
 
   template <class HeaderType>
-    inline StochasticThreadedLoopRunOuter<decltype(Loop(vector<size_t>()))> StochasticThreadedLoop (
+    inline StochasticThreadedLoopRunOuter<decltype(Loop(std::vector<size_t>()))> StochasticThreadedLoop (
         const HeaderType& source,
-        const vector<size_t>& outer_axes,
-        const vector<size_t>& inner_axes) {
+        const std::vector<size_t>& outer_axes,
+        const std::vector<size_t>& inner_axes) {
       return { source, Loop (outer_axes), inner_axes };
     }
 
 
   template <class HeaderType>
-    inline StochasticThreadedLoopRunOuter<decltype(Loop(vector<size_t>()))> StochasticThreadedLoop (
+    inline StochasticThreadedLoopRunOuter<decltype(Loop(std::vector<size_t>()))> StochasticThreadedLoop (
         const HeaderType& source,
-        const vector<size_t>& axes,
+        const std::vector<size_t>& axes,
         size_t num_inner_axes = 1) {
       return { source, Loop (get_outer_axes (axes, num_inner_axes)), get_inner_axes (axes, num_inner_axes) };
     }
 
   template <class HeaderType>
-    inline StochasticThreadedLoopRunOuter<decltype(Loop(vector<size_t>()))> StochasticThreadedLoop (
+    inline StochasticThreadedLoopRunOuter<decltype(Loop(std::vector<size_t>()))> StochasticThreadedLoop (
         const HeaderType& source,
         size_t from_axis = 0,
         size_t to_axis = std::numeric_limits<size_t>::max(),
@@ -196,19 +196,19 @@ namespace MR
       }
 
   template <class HeaderType>
-    inline StochasticThreadedLoopRunOuter<decltype(Loop("", vector<size_t>()))> StochasticThreadedLoop (
+    inline StochasticThreadedLoopRunOuter<decltype(Loop("", std::vector<size_t>()))> StochasticThreadedLoop (
         const std::string& progress_message,
         const HeaderType& source,
-        const vector<size_t>& outer_axes,
-        const vector<size_t>& inner_axes) {
+        const std::vector<size_t>& outer_axes,
+        const std::vector<size_t>& inner_axes) {
       return { source, Loop (progress_message, outer_axes), inner_axes };
     }
 
   template <class HeaderType>
-    inline StochasticThreadedLoopRunOuter<decltype(Loop("", vector<size_t>()))> StochasticThreadedLoop (
+    inline StochasticThreadedLoopRunOuter<decltype(Loop("", std::vector<size_t>()))> StochasticThreadedLoop (
         const std::string& progress_message,
         const HeaderType& source,
-        const vector<size_t>& axes,
+        const std::vector<size_t>& axes,
         size_t num_inner_axes = 1) {
       return { source,
         Loop (progress_message, get_outer_axes (axes, num_inner_axes)),
@@ -216,7 +216,7 @@ namespace MR
       }
 
   template <class HeaderType>
-    inline StochasticThreadedLoopRunOuter<decltype(Loop("", vector<size_t>()))> StochasticThreadedLoop (
+    inline StochasticThreadedLoopRunOuter<decltype(Loop("", std::vector<size_t>()))> StochasticThreadedLoop (
         const std::string& progress_message,
         const HeaderType& source,
         size_t from_axis = 0,

--- a/core/algo/threaded_copy.h
+++ b/core/algo/threaded_copy.h
@@ -43,7 +43,7 @@ namespace MR
     inline void threaded_copy (
         InputImageType& source, 
         OutputImageType& destination, 
-        const vector<size_t>& axes,
+        const std::vector<size_t>& axes,
         size_t num_axes_in_thread = 1) 
     {
       ThreadedLoop (source, axes, num_axes_in_thread)
@@ -70,7 +70,7 @@ namespace MR
         const std::string& message, 
         InputImageType& source, 
         OutputImageType& destination, 
-        const vector<size_t>& axes,
+        const std::vector<size_t>& axes,
         size_t num_axes_in_thread = 1)
     {
       ThreadedLoop (message, source, axes, num_axes_in_thread)
@@ -95,7 +95,7 @@ namespace MR
     inline void threaded_copy_with_progress (
         InputImageType& source,
         OutputImageType& destination, 
-        const vector<size_t>& axes, 
+        const std::vector<size_t>& axes, 
         size_t num_axes_in_thread = 1)
     {
       threaded_copy_with_progress_message ("copying from \"" + shorten (source.name()) + "\" to \"" + shorten (destination.name()) + "\"",

--- a/core/algo/threaded_loop.h
+++ b/core/algo/threaded_loop.h
@@ -94,13 +94,13 @@ namespace MR
    * is to be processed, since its order of traversal will have the most
    * influence on performance (by making the most efficient use of the
    * hardware's RAM access and CPU cache). It is also possible to supply a
-   * `vector<size_t>` directly if required.
+   * `std::vector<size_t>` directly if required.
    *
    * These axes can be restricted to a specific range to allow volume-wise
    * processing, etc.  The inner axes can be specified by supplying how many
    * are needed; they will then be taken from the list of axes to be looped
    * over, in order of increasing stride. It is also possible to provide the
-   * list of inners axes and outer axes as separate `vector<size_t>`
+   * list of inners axes and outer axes as separate `std::vector<size_t>`
    * arguments.
    *
    *
@@ -242,21 +242,21 @@ namespace MR
 
   namespace {
 
-    inline vector<size_t> get_inner_axes (const vector<size_t>& axes, size_t num_inner_axes) {
+    inline std::vector<size_t> get_inner_axes (const std::vector<size_t>& axes, size_t num_inner_axes) {
       return { axes.begin(), axes.begin()+num_inner_axes };
     }
 
-    inline vector<size_t> get_outer_axes (const vector<size_t>& axes, size_t num_inner_axes) {
+    inline std::vector<size_t> get_outer_axes (const std::vector<size_t>& axes, size_t num_inner_axes) {
       return { axes.begin()+num_inner_axes, axes.end() };
     }
 
     template <class HeaderType>
-      inline vector<size_t> get_inner_axes (const HeaderType& source, size_t num_inner_axes, size_t from_axis, size_t to_axis) {
+      inline std::vector<size_t> get_inner_axes (const HeaderType& source, size_t num_inner_axes, size_t from_axis, size_t to_axis) {
         return get_inner_axes (Stride::order (source, from_axis, to_axis), num_inner_axes);
       }
 
     template <class HeaderType>
-      inline vector<size_t> get_outer_axes (const HeaderType& source, size_t num_inner_axes, size_t from_axis, size_t to_axis) {
+      inline std::vector<size_t> get_outer_axes (const HeaderType& source, size_t num_inner_axes, size_t from_axis, size_t to_axis) {
         return get_outer_axes (Stride::order (source, from_axis, to_axis), num_inner_axes);
       }
 
@@ -264,12 +264,12 @@ namespace MR
     template <int N, class Functor, class... ImageType>
       struct ThreadedLoopRunInner
       { 
-        const vector<size_t>& outer_axes;
+        const std::vector<size_t>& outer_axes;
         decltype (Loop (outer_axes)) loop;
         typename std::remove_reference<Functor>::type func;
         std::tuple<ImageType...> vox;
 
-        ThreadedLoopRunInner (const vector<size_t>& outer_axes, const vector<size_t>& inner_axes,
+        ThreadedLoopRunInner (const std::vector<size_t>& outer_axes, const std::vector<size_t>& inner_axes,
             const Functor& functor, ImageType&... voxels) :
           outer_axes (outer_axes),
           loop (Loop (inner_axes)),
@@ -287,11 +287,11 @@ namespace MR
     template <class Functor, class... ImageType>
       struct ThreadedLoopRunInner<0,Functor,ImageType...>
       { 
-        const vector<size_t>& outer_axes;
+        const std::vector<size_t>& outer_axes;
         decltype (Loop (outer_axes)) loop;
         typename std::remove_reference<Functor>::type func;
 
-        ThreadedLoopRunInner (const vector<size_t>& outer_axes, const vector<size_t>& inner_axes,
+        ThreadedLoopRunInner (const std::vector<size_t>& outer_axes, const std::vector<size_t>& inner_axes,
             const Functor& functor, ImageType&... /*voxels*/) :
           outer_axes (outer_axes),
           loop (Loop (inner_axes)),
@@ -317,7 +317,7 @@ namespace MR
       struct ThreadedLoopRunOuter { 
         Iterator iterator;
         OuterLoopType outer_loop;
-        vector<size_t> inner_axes;
+        std::vector<size_t> inner_axes;
 
         //! invoke \a functor (const Iterator& pos) per voxel <em> in the outer axes only</em>
         template <class Functor>
@@ -390,28 +390,28 @@ namespace MR
   //! Multi-threaded loop object
   //* \sa image_thread_looping for details */
   template <class HeaderType>
-    inline ThreadedLoopRunOuter<decltype(Loop(vector<size_t>()))>
+    inline ThreadedLoopRunOuter<decltype(Loop(std::vector<size_t>()))>
     ThreadedLoop (
         const HeaderType& source,
-        const vector<size_t>& outer_axes,
-        const vector<size_t>& inner_axes)
+        const std::vector<size_t>& outer_axes,
+        const std::vector<size_t>& inner_axes)
     { return { source, Loop (outer_axes), inner_axes }; }
 
 
   //! Multi-threaded loop object
   //* \sa image_thread_looping for details */
   template <class HeaderType>
-    inline ThreadedLoopRunOuter<decltype(Loop(vector<size_t>()))>
+    inline ThreadedLoopRunOuter<decltype(Loop(std::vector<size_t>()))>
     ThreadedLoop (
         const HeaderType& source,
-        const vector<size_t>& axes,
+        const std::vector<size_t>& axes,
         size_t num_inner_axes = 1)
     { return { source, Loop (get_outer_axes (axes, num_inner_axes)), get_inner_axes (axes, num_inner_axes) }; }
 
   //! Multi-threaded loop object
   //* \sa image_thread_looping for details */
   template <class HeaderType>
-    inline ThreadedLoopRunOuter<decltype(Loop(vector<size_t>()))>
+    inline ThreadedLoopRunOuter<decltype(Loop(std::vector<size_t>()))>
     ThreadedLoop (
         const HeaderType& source,
         size_t from_axis = 0,
@@ -426,22 +426,22 @@ namespace MR
   //! Multi-threaded loop object
   //* \sa image_thread_looping for details */
   template <class HeaderType>
-    inline ThreadedLoopRunOuter<decltype(Loop("", vector<size_t>()))>
+    inline ThreadedLoopRunOuter<decltype(Loop("", std::vector<size_t>()))>
     ThreadedLoop (
         const std::string& progress_message,
         const HeaderType& source,
-        const vector<size_t>& outer_axes,
-        const vector<size_t>& inner_axes)
+        const std::vector<size_t>& outer_axes,
+        const std::vector<size_t>& inner_axes)
     { return { source, Loop (progress_message, outer_axes), inner_axes }; }
 
   //! Multi-threaded loop object
   //* \sa image_thread_looping for details */
   template <class HeaderType>
-    inline ThreadedLoopRunOuter<decltype(Loop("", vector<size_t>()))>
+    inline ThreadedLoopRunOuter<decltype(Loop("", std::vector<size_t>()))>
     ThreadedLoop (
         const std::string& progress_message,
         const HeaderType& source,
-        const vector<size_t>& axes,
+        const std::vector<size_t>& axes,
         size_t num_inner_axes = 1)
     {
       return { source,
@@ -452,7 +452,7 @@ namespace MR
   //! Multi-threaded loop object
   //* \sa image_thread_looping for details */
   template <class HeaderType>
-    inline ThreadedLoopRunOuter<decltype(Loop("", vector<size_t>()))>
+    inline ThreadedLoopRunOuter<decltype(Loop("", std::vector<size_t>()))>
     ThreadedLoop (
         const std::string& progress_message,
         const HeaderType& source,

--- a/core/app.cpp
+++ b/core/app.cpp
@@ -91,8 +91,8 @@ namespace MR
 
     std::string NAME;
     std::string command_history_string;
-    vector<ParsedArgument> argument;
-    vector<ParsedOption> option;
+    std::vector<ParsedArgument> argument;
+    std::vector<ParsedOption> option;
 
     //ENVVAR name: MRTRIX_QUIET
     //ENVVAR Do not display information messages or progress status. This has
@@ -125,7 +125,7 @@ namespace MR
     namespace
     {
 
-      inline void get_matches (vector<const Option*>& candidates, const OptionGroup& group, const std::string& stub)
+      inline void get_matches (std::vector<const Option*>& candidates, const OptionGroup& group, const std::string& stub)
       {
         for (size_t i = 0; i < group.size(); ++i) {
           if (stub.compare (0, stub.size(), group[i].id, stub.size()) == 0)
@@ -156,11 +156,11 @@ namespace MR
         if (size (line) < indent)
           resize (line, indent, ' ');
 
-        vector<std::string> paragraphs = split (text, "\n");
+        std::vector<std::string> paragraphs = split (text, "\n");
 
         for (size_t n = 0; n < paragraphs.size(); ++n) {
           size_t i = 0;
-          vector<std::string> words = split (paragraphs[n]);
+          std::vector<std::string> words = split (paragraphs[n]);
           while (i < words.size()) {
             do {
               line += " " + words[i++];
@@ -462,7 +462,7 @@ namespace MR
 
     std::string OptionList::syntax (int format) const
     {
-      vector<std::string> group_names;
+      std::vector<std::string> group_names;
       for (size_t i = 0; i < size(); ++i) {
         if (std::find (group_names.begin(), group_names.end(), (*this)[i].name) == group_names.end())
           group_names.push_back ((*this)[i].name);
@@ -743,7 +743,7 @@ namespace MR
       }
 
 
-      vector<std::string> group_names;
+      std::vector<std::string> group_names;
       for (size_t i = 0; i < OPTIONS.size(); ++i) {
         if (std::find (group_names.begin(), group_names.end(), OPTIONS[i].name) == group_names.end())
           group_names.push_back (OPTIONS[i].name);
@@ -877,7 +877,7 @@ namespace MR
       }
 
 
-      vector<std::string> group_names;
+      std::vector<std::string> group_names;
       for (size_t i = 0; i < OPTIONS.size(); ++i) {
         if (std::find (group_names.begin(), group_names.end(), OPTIONS[i].name) == group_names.end())
           group_names.push_back (OPTIONS[i].name);
@@ -943,7 +943,7 @@ namespace MR
     {
       if (consume_dash (arg) && *arg && !isdigit (*arg) && *arg != '.') {
         while (consume_dash(arg));
-        vector<const Option*> candidates;
+        std::vector<const Option*> candidates;
         std::string root (arg);
 
         for (size_t i = 0; i < OPTIONS.size(); ++i)
@@ -1110,7 +1110,7 @@ namespace MR
           s += " " + std::string(a);
         e.push_back (s);
         if (argument.size() > num_args_required) {
-          vector<std::string> potential_options;
+          std::vector<std::string> potential_options;
           for (const auto& a : argument) {
             for (const auto& og : OPTIONS) {
               for (const auto& o : og) {
@@ -1305,9 +1305,9 @@ namespace MR
 
 
 
-    const vector<ParsedOption> get_options (const std::string& name)
+    const std::vector<ParsedOption> get_options (const std::string& name)
     {
-      vector<ParsedOption> matches;
+      std::vector<ParsedOption> matches;
       for (size_t i = 0; i < option.size(); ++i) {
         assert (option[i].opt);
         if (option[i].opt->is (name))

--- a/core/app.h
+++ b/core/app.h
@@ -73,7 +73,7 @@ namespace MR
     // @{
 
     //! vector of strings to hold more comprehensive command description
-    class Description : public vector<const char*> { 
+    class Description : public std::vector<const char*> { 
       public:
         Description& operator+ (const char* text) {
           push_back (text);
@@ -107,7 +107,7 @@ namespace MR
     };
 
     //! a class to hold the list of Example's
-    class ExampleList : public vector<Example> { 
+    class ExampleList : public std::vector<Example> { 
       public:
         ExampleList& operator+ (const Example& example) {
           push_back (example);
@@ -121,7 +121,7 @@ namespace MR
 
 
     //! a class to hold the list of Argument's
-    class ArgumentList : public vector<Argument> { 
+    class ArgumentList : public std::vector<Argument> { 
       public:
         ArgumentList& operator+ (const Argument& argument) {
           push_back (argument);
@@ -136,7 +136,7 @@ namespace MR
 
 
     //! a class to hold the list of option groups
-    class OptionList : public vector<OptionGroup> { 
+    class OptionList : public std::vector<OptionGroup> { 
       public:
         OptionList& operator+ (const OptionGroup& option_group) {
           push_back (option_group);
@@ -156,7 +156,7 @@ namespace MR
         OptionGroup& back () {
           if (empty())
             push_back (OptionGroup());
-          return vector<OptionGroup>::back();
+          return std::vector<OptionGroup>::back();
         }
 
         std::string syntax (int format) const;
@@ -216,25 +216,25 @@ namespace MR
         uint64_t as_uint () const { return uint64_t (as_int()); }
         default_type as_float () const;
 
-        vector<int32_t> as_sequence_int () const {
+        std::vector<int32_t> as_sequence_int () const {
           assert (arg->type == IntSeq);
           try { return parse_ints<int32_t> (p); }
           catch (Exception& e) { error (e); }
-          return vector<int32_t>();
+          return std::vector<int32_t>();
         }
 
-        vector<uint32_t> as_sequence_uint () const {
+        std::vector<uint32_t> as_sequence_uint () const {
           assert (arg->type == IntSeq);
           try { return parse_ints<uint32_t> (p); }
           catch (Exception& e) { error (e); }
-          return vector<uint32_t>();
+          return std::vector<uint32_t>();
         }
 
-        vector<default_type> as_sequence_float () const {
+        std::vector<default_type> as_sequence_float () const {
           assert (arg->type == FloatSeq);
           try { return parse_floats (p); }
           catch (Exception& e) { error (e); }
-          return vector<default_type>();
+          return std::vector<default_type>();
         }
 
         operator bool () const { return as_bool(); }
@@ -246,9 +246,9 @@ namespace MR
         operator long long unsigned int () const { return as_uint(); }
         operator float () const { return as_float(); }
         operator double () const { return as_float(); }
-        operator vector<int32_t> () const { return as_sequence_int(); }
-        operator vector<uint32_t> () const { return as_sequence_uint(); }
-        operator vector<default_type> () const { return as_sequence_float(); }
+        operator std::vector<int32_t> () const { return as_sequence_int(); }
+        operator std::vector<uint32_t> () const { return as_sequence_uint(); }
+        operator std::vector<default_type> () const { return as_sequence_float(); }
 
         const char* c_str () const { return p; }
 
@@ -329,9 +329,9 @@ namespace MR
 
 
     //! the list of arguments parsed from the command-line
-    extern vector<ParsedArgument> argument;
+    extern std::vector<ParsedArgument> argument;
     //! the list of options parsed from the command-line
-    extern vector<ParsedOption> option;
+    extern std::vector<ParsedOption> option;
 
     //! additional description of the command over and above the synopsis
     /*! This is designed to be used within each command's usage() function. Add
@@ -444,11 +444,11 @@ namespace MR
      *    std::string arg1 = opt[0][0];
      *    int arg2 = opt[0][1];
      *    float arg3 = opt[0][2];
-     *    vector<int> arg4 = opt[0][3];
+     *    std::vector<int> arg4 = opt[0][3];
      *    auto values = opt[0][4].as_sequence_float();
      * }
      * \endcode */
-    const vector<ParsedOption> get_options (const std::string& name);
+    const std::vector<ParsedOption> get_options (const std::string& name);
 
 
     //! Returns the option value if set, and the default otherwise.

--- a/core/cmdline_option.h
+++ b/core/cmdline_option.h
@@ -340,7 +340,7 @@ namespace MR
      * Options can also be specified as required (see required() function), or
      * as multiple (see allow_multiple() function).
      */
-    class Option : public vector<Argument> { 
+    class Option : public std::vector<Argument> { 
       public:
         Option () : id (nullptr), flags (Optional) { }
 
@@ -415,7 +415,7 @@ namespace MR
      * }
      * \endcode
      */
-    class OptionGroup : public vector<Option> { 
+    class OptionGroup : public std::vector<Option> { 
       public:
         OptionGroup (const char* group_name = "OPTIONS") : name (group_name) { }
         const char* name;
@@ -434,7 +434,7 @@ namespace MR
         Option& back () {
           if (empty())
             push_back (Option());
-          return vector<Option>::back();
+          return std::vector<Option>::back();
         }
 
         std::string header (int format) const;

--- a/core/dwi/gradient.cpp
+++ b/core/dwi/gradient.cpp
@@ -146,7 +146,7 @@ namespace MR
       // bvecs format actually assumes a LHS coordinate system even if image is
       // stored using RHS - x axis is flipped to make linear 3x3 part of
       // transform have negative determinant:
-      vector<size_t> order;
+      std::vector<size_t> order;
       auto adjusted_transform = File::NIfTI::adjust_transform (header, order);
       if (adjusted_transform.linear().determinant() > 0.0)
         bvecs.row(0) = -bvecs.row(0);
@@ -183,7 +183,7 @@ namespace MR
 
       // deal with FSL requiring gradient directions to coincide with data strides
       // also transpose matrices in preparation for file output
-      vector<size_t> order;
+      std::vector<size_t> order;
       auto adjusted_transform = File::NIfTI::adjust_transform (header, order);
       Eigen::MatrixXd bvecs (3, grad.rows());
       Eigen::MatrixXd bvals (1, grad.rows());

--- a/core/dwi/shells.cpp
+++ b/core/dwi/shells.cpp
@@ -49,7 +49,7 @@ namespace MR
 
 
 
-    Shell::Shell (const Eigen::MatrixXd& grad, const vector<size_t>& indices) :
+    Shell::Shell (const Eigen::MatrixXd& grad, const std::vector<size_t>& indices) :
         volumes (indices),
         mean (0.0),
         stdev (0.0),
@@ -57,14 +57,14 @@ namespace MR
         max (0.0)
     {
       assert (volumes.size());
-      for (vector<size_t>::const_iterator i = volumes.begin(); i != volumes.end(); i++) {
+      for (std::vector<size_t>::const_iterator i = volumes.begin(); i != volumes.end(); i++) {
         const default_type b = grad (*i, 3);
         mean += b;
         min = std::min (min, b);
         max = std::max (min, b);
       }
       mean /= default_type(volumes.size());
-      for (vector<size_t>::const_iterator i = volumes.begin(); i != volumes.end(); i++)
+      for (std::vector<size_t>::const_iterator i = volumes.begin(); i != volumes.end(); i++)
         stdev += Math::pow2 (grad (*i, 3) - mean);
       stdev = std::sqrt (stdev / (volumes.size() - 1));
     }
@@ -111,11 +111,11 @@ namespace MR
       auto opt = App::get_options ("shells");
       if (opt.size()) {
 
-        vector<default_type> desired_bvalues = opt[0][0];
+        std::vector<default_type> desired_bvalues = opt[0][0];
         bool bzero_selected = false;
         size_t nonbzero_selected_count = 0;
 
-        for (vector<default_type>::const_iterator b = desired_bvalues.begin(); b != desired_bvalues.end(); ++b) {
+        for (std::vector<default_type>::const_iterator b = desired_bvalues.begin(); b != desired_bvalues.end(); ++b) {
 
           if (*b < 0)
             throw Exception ("Cannot select shells corresponding to negative b-values");
@@ -185,7 +185,7 @@ namespace MR
                 // First, check to see if all non-zero shells have (effectively) non-zero standard deviation
                 // (If one non-zero shell has negligible standard deviation, assume a Poisson distribution for all shells)
                 bool zero_stdev = false;
-                for (vector<Shell>::const_iterator s = shells.begin(); s != shells.end(); ++s) {
+                for (std::vector<Shell>::const_iterator s = shells.begin(); s != shells.end(); ++s) {
                   if (!s->is_bzero() && s->get_stdev() < 1.0) {
                     zero_stdev = true;
                     break;
@@ -270,7 +270,7 @@ namespace MR
       }
 
       // Erase the unwanted shells
-      vector<Shell> new_shells;
+      std::vector<Shell> new_shells;
       for (size_t s = 0; s != count(); ++s) {
         if (to_retain[s])
           new_shells.push_back (shells[s]);
@@ -285,7 +285,7 @@ namespace MR
 
     Shells& Shells::reject_small_shells (const size_t min_volumes)
     {
-      for (vector<Shell>::iterator s = shells.begin(); s != shells.end();) {
+      for (std::vector<Shell>::iterator s = shells.begin(); s != shells.end();) {
         if (!s->is_bzero() && s->count() < min_volumes)
           s = shells.erase (s);
         else
@@ -300,7 +300,7 @@ namespace MR
     Shells::Shells (const Eigen::MatrixXd& grad)
     {
       BValueList bvals = grad.col (3);
-      vector<size_t> clusters (bvals.size(), 0);
+      std::vector<size_t> clusters (bvals.size(), 0);
       const size_t num_shells = clusterBvalues (bvals, clusters);
 
       if ((num_shells < 1) || (num_shells > std::sqrt (default_type(grad.rows()))))
@@ -308,7 +308,7 @@ namespace MR
 
       for (size_t shellIdx = 0; shellIdx <= num_shells; shellIdx++) {
 
-        vector<size_t> volumes;
+        std::vector<size_t> volumes;
         for (size_t volumeIdx = 0; volumeIdx != clusters.size(); ++volumeIdx) {
           if (clusters[volumeIdx] == shellIdx)
             volumes.push_back (volumeIdx);
@@ -344,7 +344,7 @@ namespace MR
 
 
 
-    size_t Shells::clusterBvalues (const BValueList& bvals, vector<size_t>& clusters) const
+    size_t Shells::clusterBvalues (const BValueList& bvals, std::vector<size_t>& clusters) const
     {
       BitSet visited (bvals.size(), false);
       size_t clusterIdx = 0;
@@ -362,7 +362,7 @@ namespace MR
 
           visited[ii] = true;
           const default_type b = bvals[ii];
-          vector<size_t> neighborIdx;
+          std::vector<size_t> neighborIdx;
           regionQuery (bvals, b, neighborIdx);
 
           if (b > bzero_threshold() && neighborIdx.size() < DWI_SHELLS_MIN_LINKAGE) {
@@ -375,7 +375,7 @@ namespace MR
             for (size_t i = 0; i < neighborIdx.size(); i++) {
               if (!visited[neighborIdx[i]]) {
                 visited[neighborIdx[i]] = true;
-                vector<size_t> neighborIdx2;
+                std::vector<size_t> neighborIdx2;
                 regionQuery (bvals, bvals[neighborIdx[i]], neighborIdx2);
                 if (neighborIdx2.size() >= DWI_SHELLS_MIN_LINKAGE)
                   for (size_t j = 0; j != neighborIdx2.size(); j++)
@@ -395,7 +395,7 @@ namespace MR
 
 
 
-    void Shells::regionQuery (const BValueList& bvals, const default_type b, vector<size_t>& idx) const
+    void Shells::regionQuery (const BValueList& bvals, const default_type b, std::vector<size_t>& idx) const
     {
       for (ssize_t i = 0; i < bvals.size(); i++) {
         if (bvals[i] > bzero_threshold() && abs (b - bvals[i]) < bvalue_epsilon())

--- a/core/dwi/shells.h
+++ b/core/dwi/shells.h
@@ -77,9 +77,9 @@ namespace MR
       public:
 
         Shell() : mean (0.0), stdev (0.0), min (0.0), max (0.0) { }
-        Shell (const Eigen::MatrixXd& grad, const vector<size_t>& indices);
+        Shell (const Eigen::MatrixXd& grad, const std::vector<size_t>& indices);
 
-        const vector<size_t>& get_volumes() const { return volumes; }
+        const std::vector<size_t>& get_volumes() const { return volumes; }
         size_t count() const { return volumes.size(); }
 
         default_type get_mean()  const { return mean; }
@@ -101,7 +101,7 @@ namespace MR
 
 
       protected:
-        vector<size_t> volumes;
+        std::vector<size_t> volumes;
         default_type mean, stdev, min, max;
 
     };
@@ -126,15 +126,15 @@ namespace MR
           return count;
         }
 
-        vector<size_t> get_counts() const {
-          vector<size_t> c (count());
+        std::vector<size_t> get_counts() const {
+          std::vector<size_t> c (count());
           for (size_t n = 0; n < count(); ++n)
             c[n] = shells[n].count();
           return c;
         }
 
-        vector<size_t> get_bvalues() const {
-          vector<size_t> b (count());
+        std::vector<size_t> get_bvalues() const {
+          std::vector<size_t> b (count());
           for (size_t n = 0; n < count(); ++n)
             b[n] = shells[n].get_mean();
           return b;
@@ -163,7 +163,7 @@ namespace MR
 
 
       protected:
-        vector<Shell> shells;
+        std::vector<Shell> shells;
 
 
       private:
@@ -171,8 +171,8 @@ namespace MR
         using BValueList = decltype(std::declval<const Eigen::MatrixXd>().col(0));
 
         // Functions for current b-value clustering implementation
-        size_t clusterBvalues (const BValueList&, vector<size_t>&) const;
-        void regionQuery (const BValueList&, const default_type, vector<size_t>&) const;
+        size_t clusterBvalues (const BValueList&, std::vector<size_t>&) const;
+        void regionQuery (const BValueList&, const default_type, std::vector<size_t>&) const;
 
 
     };

--- a/core/exception.h
+++ b/core/exception.h
@@ -109,7 +109,7 @@ namespace MR
 
       static void (*display_func) (const Exception& E, int log_level);
 
-      vector<std::string> description;
+      std::vector<std::string> description;
   };
 
   class InvalidImageException : public Exception { 

--- a/core/file/config.cpp
+++ b/core/file/config.cpp
@@ -138,7 +138,7 @@ namespace MR
       std::string value = get (key);
       if (value.size()) {
         try {
-          vector<default_type> V (parse_floats (value));
+          std::vector<default_type> V (parse_floats (value));
           if (V.size() < 3)
             throw Exception ("malformed RGB entry \"" + value + "\" for key \"" + key + "\" in configuration file - ignored");
           ret[0] = V[0];

--- a/core/file/dicom/csa_entry.h
+++ b/core/file/dicom/csa_entry.h
@@ -128,8 +128,8 @@ namespace MR {
                   v[m] = NaN;
               }
 
-            vector<std::string> get_string () const {
-              vector<std::string> result;
+            std::vector<std::string> get_string () const {
+              std::vector<std::string> result;
               const uint8_t* p = start + 84;
               for (uint32_t m = 0; m < nitems; m++) {
                 const uint32_t length = Raw::fetch_LE<uint32_t> (p);

--- a/core/file/dicom/element.cpp
+++ b/core/file/dicom/element.cpp
@@ -333,9 +333,9 @@ namespace MR {
 
 
 
-      vector<int32_t> Element::get_int () const
+      std::vector<int32_t> Element::get_int () const
       {
-        vector<int32_t> V;
+        std::vector<int32_t> V;
         if (VR == VR_SL)
           for (const uint8_t* p = data; p < data + size; p += sizeof (int32_t))
             V.push_back (Raw::fetch_<int32_t> (p, is_BE));
@@ -357,9 +357,9 @@ namespace MR {
 
 
 
-      vector<uint32_t> Element::get_uint () const
+      std::vector<uint32_t> Element::get_uint () const
       {
-        vector<uint32_t> V;
+        std::vector<uint32_t> V;
         if (VR == VR_UL)
           for (const uint8_t* p = data; p < data + size; p += sizeof (uint32_t))
             V.push_back (Raw::fetch_<uint32_t> (p, is_BE));
@@ -379,9 +379,9 @@ namespace MR {
 
 
 
-      vector<default_type> Element::get_float () const
+      std::vector<default_type> Element::get_float () const
       {
-        vector<default_type> V;
+        std::vector<default_type> V;
         if (VR == VR_FD)
           for (const uint8_t* p = data; p < data + size; p += sizeof (float64))
             V.push_back (Raw::fetch_<float64> (p, is_BE));
@@ -435,7 +435,7 @@ namespace MR {
 
 
 
-      vector<std::string> Element::get_string () const
+      std::vector<std::string> Element::get_string () const
       {
         if (VR == VR_AT)
           return { printf ("%04X %04X", Raw::fetch_<uint16_t> (data, is_BE), Raw::fetch_<uint16_t> (data+2, is_BE)) };
@@ -504,7 +504,7 @@ namespace MR {
 
       namespace {
         template <class T>
-          inline void print_vec (const vector<T>& V)
+          inline void print_vec (const std::vector<T>& V)
           {
             for (const auto& entry: V)
               fprintf (stdout, "%s ", str(entry).c_str());

--- a/core/file/dicom/element.h
+++ b/core/file/dicom/element.h
@@ -110,7 +110,7 @@ namespace MR {
           uint16_t group, element, VR;
           uint32_t size;
           uint8_t* data;
-          vector<Sequence> parents;
+          std::vector<Sequence> parents;
           bool transfer_syntax_supported;
 
           void set (const std::string& filename, bool force_read = false, bool read_write = false);
@@ -154,13 +154,13 @@ namespace MR {
           bool is_in_series_ref_sequence () const;
 
           Type type () const;
-          vector<int32_t> get_int () const;
-          vector<uint32_t> get_uint () const;
-          vector<default_type> get_float () const;
+          std::vector<int32_t> get_int () const;
+          std::vector<uint32_t> get_uint () const;
+          std::vector<default_type> get_float () const;
           Date get_date () const;
           Time get_time () const;
           std::pair<Date,Time> get_datetime () const;
-          vector<std::string> get_string () const;
+          std::vector<std::string> get_string () const;
 
           int32_t     get_int (size_t idx, int32_t default_value = 0)                    const { auto v (get_int());    return check_get (idx, v.size()) ? v[idx] : default_value; }
           uint32_t    get_uint (size_t idx, uint32_t default_value = 0)                  const { auto v (get_uint());   return check_get (idx, v.size()) ? v[idx] : default_value; }
@@ -194,7 +194,7 @@ namespace MR {
           uint8_t* start;
           bool is_explicit, is_BE, is_transfer_syntax_BE;
 
-          vector<uint8_t*>  end_seq;
+          std::vector<uint8_t*>  end_seq;
 
 
           uint16_t get_VR_from_tag_name (const std::string& name) {

--- a/core/file/dicom/image.cpp
+++ b/core/file/dicom/image.cpp
@@ -355,7 +355,7 @@ namespace MR {
             field = functor (it->second);
           }
         template <typename T>
-          void phoenix_vector (const KeyValues& keyval, const std::string& key, vector<T>& data) {
+          void phoenix_vector (const KeyValues& keyval, const std::string& key, std::vector<T>& data) {
             data.clear();
             for (size_t index = 0; ; ++index) {
               const auto it = keyval.find (key + "[" + str(index) + "]");
@@ -399,7 +399,7 @@ namespace MR {
             entry.get_float (mosaic_slices_timing);
           }
           else if (strcmp ("MrPhoenixProtocol", entry.key()) == 0) {
-            const vector<std::string> phoenix = entry.get_string();
+            const std::vector<std::string> phoenix = entry.get_string();
             const auto keyval = read_csa_ascii (phoenix);
             phoenix_scalar (keyval,
                 "sDiffusion.dsScheme",
@@ -444,7 +444,7 @@ namespace MR {
 
 
 
-      KeyValues Image::read_csa_ascii (const vector<std::string>& data)
+      KeyValues Image::read_csa_ascii (const std::vector<std::string>& data)
       {
 
         auto split_keyval = [] (const std::string& s) -> std::pair<std::string, std::string> {
@@ -528,7 +528,7 @@ namespace MR {
 
       namespace {
 
-        inline void update_count (size_t num, vector<size_t>& dim, vector<size_t>& index)
+        inline void update_count (size_t num, std::vector<size_t>& dim, std::vector<size_t>& index)
         {
           for (size_t n = 0; n < num; ++n) {
             if (dim[n] && index[n] != dim[n])
@@ -542,10 +542,10 @@ namespace MR {
       }
 
 
-      vector<size_t> Frame::count (const vector<Frame*>& frames)
+      std::vector<size_t> Frame::count (const std::vector<Frame*>& frames)
       {
-        vector<size_t> dim (3, 0);
-        vector<size_t> index (3, 1);
+        std::vector<size_t> dim (3, 0);
+        std::vector<size_t> index (3, 1);
         const Frame* previous = frames[0];
 
         for (auto frame_it = frames.cbegin()+1; frame_it != frames.cend(); ++frame_it) {
@@ -574,7 +574,7 @@ namespace MR {
 
 
 
-      default_type Frame::get_slice_separation (const vector<Frame*>& frames, size_t nslices)
+      default_type Frame::get_slice_separation (const std::vector<Frame*>& frames, size_t nslices)
       {
         default_type max_gap = 0.0;
         default_type min_separation = std::numeric_limits<default_type>::infinity();
@@ -606,7 +606,7 @@ namespace MR {
 
 
 
-      std::string Frame::get_DW_scheme (const vector<Frame*>& frames, const size_t nslices, const transform_type& image_transform)
+      std::string Frame::get_DW_scheme (const std::vector<Frame*>& frames, const size_t nslices, const transform_type& image_transform)
       {
         if (!std::isfinite (frames[0]->bvalue)) {
           DEBUG ("no DW encoding information found in DICOM frames");
@@ -653,7 +653,7 @@ namespace MR {
 
 
 
-      Eigen::MatrixXd Frame::get_PE_scheme (const vector<Frame*>& frames, const size_t nslices)
+      Eigen::MatrixXd Frame::get_PE_scheme (const std::vector<Frame*>& frames, const size_t nslices)
       {
         const size_t num_volumes = frames.size() / nslices;
         Eigen::MatrixXd pe_scheme = Eigen::MatrixXd::Zero (num_volumes, 4);

--- a/core/file/dicom/image.h
+++ b/core/file/dicom/image.h
@@ -69,8 +69,8 @@ namespace MR {
           default_type pixel_bandwidth, bandwidth_per_pixel_phase_encode, echo_time, inversion_time, repetition_time, flip_angle, partial_fourier, time_after_start;
           size_t echo_train_length;
           size_t bipolar_flag, readoutmode_flag;
-          vector<uint32_t> index;
-          vector<default_type> flip_angles;
+          std::vector<uint32_t> index;
+          std::vector<default_type> flip_angles;
 
           bool operator< (const Frame& frame) const {
             if (!ignore_series_num && series_num != frame.series_num)
@@ -125,10 +125,10 @@ namespace MR {
             return (philips_orientation == 'I' && bvalue > 0.0);
           }
 
-          static vector<size_t> count (const vector<Frame*>& frames);
-          static default_type get_slice_separation (const vector<Frame*>& frames, size_t nslices);
-          static std::string get_DW_scheme (const vector<Frame*>& frames, const size_t nslices, const transform_type& image_transform);
-          static Eigen::MatrixXd get_PE_scheme (const vector<Frame*>& frames, const size_t nslices);
+          static std::vector<size_t> count (const std::vector<Frame*>& frames);
+          static default_type get_slice_separation (const std::vector<Frame*>& frames, size_t nslices);
+          static std::string get_DW_scheme (const std::vector<Frame*>& frames, const size_t nslices, const transform_type& image_transform);
+          static Eigen::MatrixXd get_PE_scheme (const std::vector<Frame*>& frames, const size_t nslices);
 
           friend std::ostream& operator<< (std::ostream& stream, const Frame& item);
       };
@@ -156,15 +156,15 @@ namespace MR {
           size_t images_in_mosaic;
           std::string sequence_name, manufacturer;
           bool is_BE, in_frames;
-          vector<float> mosaic_slices_timing;
+          std::vector<float> mosaic_slices_timing;
 
-          vector<uint32_t> frame_dim;
-          vector<std::shared_ptr<Frame>> frames;
+          std::vector<uint32_t> frame_dim;
+          std::vector<std::shared_ptr<Frame>> frames;
 
           void read ();
           void parse_item (Element& item, const std::string& dirname = "");
           void decode_csa (const uint8_t* start, const uint8_t* end);
-          KeyValues read_csa_ascii (const vector<std::string>& data);
+          KeyValues read_csa_ascii (const std::vector<std::string>& data);
 
           bool operator< (const Image& ima) const {
             return Frame::operator< (ima);

--- a/core/file/dicom/mapper.cpp
+++ b/core/file/dicom/mapper.cpp
@@ -33,7 +33,7 @@ namespace MR {
     namespace Dicom {
 
 
-      std::unique_ptr<MR::ImageIO::Base> dicom_to_mapper (MR::Header& H, vector<std::shared_ptr<Series>>& series)
+      std::unique_ptr<MR::ImageIO::Base> dicom_to_mapper (MR::Header& H, std::vector<std::shared_ptr<Series>>& series)
       {
         //ENVVAR name: MRTRIX_PRESERVE_PHILIPS_ISO
         //ENVVAR Do not remove the synthetic isotropically-weighted diffusion
@@ -66,7 +66,7 @@ namespace MR {
         H.name() = sbuf;
 
         // build up sorted list of frames:
-        vector<Frame*> frames;
+        std::vector<Frame*> frames;
 
         // loop over series list:
         for (const auto& series_it : series) {
@@ -116,8 +116,8 @@ namespace MR {
           throw Exception ("missing image frames for DICOM image \"" + H.name() + "\"");
 
         if (dim[0] > 1) { // switch axes so slice dim is inner-most:
-          vector<Frame*> list (frames);
-          vector<Frame*>::iterator it = frames.begin();
+          std::vector<Frame*> list (frames);
+          std::vector<Frame*>::iterator it = frames.begin();
           for (size_t k = 0; k < dim[2]; ++k)
             for (size_t i = 0; i < dim[0]; ++i)
               for (size_t j = 0; j < dim[1]; ++j)
@@ -148,7 +148,7 @@ namespace MR {
                                      std::function<default_type(Frame*)> functor,
                                      const default_type multiplier) -> void
         {
-          vector<std::string> values;
+          std::vector<std::string> values;
           for (const auto f : frames) {
             const default_type value = functor (f);
             if (!std::isfinite (value))
@@ -308,8 +308,8 @@ namespace MR {
         }
 
         // Slice timing may come from a few different potential sources
-        vector<std::string> slices_timing_str;
-        vector<float> slices_timing_float;
+        std::vector<std::string> slices_timing_str;
+        std::vector<float> slices_timing_float;
         if (image.images_in_mosaic) {
           if (image.mosaic_slices_timing.size() < image.images_in_mosaic) {
             WARN ("Number of entries in mosaic slice timing (" + str(image.mosaic_slices_timing.size()) + ") is smaller than number of images in mosaic (" + str(image.images_in_mosaic) + "); omitting");

--- a/core/file/dicom/mapper.h
+++ b/core/file/dicom/mapper.h
@@ -31,7 +31,7 @@ namespace MR {
 
       class Series;
 
-      std::unique_ptr<MR::ImageIO::Base> dicom_to_mapper (MR::Header& H, vector<std::shared_ptr<Series>>& series);
+      std::unique_ptr<MR::ImageIO::Base> dicom_to_mapper (MR::Header& H, std::vector<std::shared_ptr<Series>>& series);
       
     }
   }

--- a/core/file/dicom/patient.h
+++ b/core/file/dicom/patient.h
@@ -26,7 +26,7 @@ namespace MR {
 
       class Study;
 
-      class Patient : public vector<std::shared_ptr<Study>> { 
+      class Patient : public std::vector<std::shared_ptr<Study>> { 
         public:
           Patient (const std::string& patient_name, const std::string& patient_ID,
               const std::string& patient_DOB) :

--- a/core/file/dicom/select_cmdline.cpp
+++ b/core/file/dicom/select_cmdline.cpp
@@ -24,9 +24,9 @@ namespace MR {
   namespace File {
     namespace Dicom {
 
-      vector<std::shared_ptr<Series>> select_cmdline (const Tree& tree)
+      std::vector<std::shared_ptr<Series>> select_cmdline (const Tree& tree)
       {
-        vector<std::shared_ptr<Series>> series;
+        std::vector<std::shared_ptr<Series>> series;
 
         if (tree.size() == 0)
           throw Exception ("DICOM tree its empty");
@@ -55,7 +55,7 @@ namespace MR {
 
           // select using environment variables:
 
-          vector<std::shared_ptr<Patient>> patient;
+          std::vector<std::shared_ptr<Patient>> patient;
           for (size_t i = 0; i < tree.size(); i++) {
             if ( (!patient_from_env || match (patient_from_env, tree[i]->name, true)) &&
                  (!patid_from_env || match (patid_from_env, tree[i]->ID, true)) )
@@ -66,7 +66,7 @@ namespace MR {
           if (patient.size() > 1)
             throw Exception ("too many matching patients in DICOM dataset \"" + tree.description + "\"");
 
-          vector<std::shared_ptr<Study>> study;
+          std::vector<std::shared_ptr<Study>> study;
           for (size_t i = 0; i < patient[0]->size(); i++) {
             if (!study_from_env || match (study_from_env, (*patient[0])[i]->name, true))
               study.push_back ((*patient[0])[i]);
@@ -191,7 +191,7 @@ namespace MR {
             if (buf[0] == 'q' || buf[0] == 'Q')
               throw CancelException();
             if (isdigit (buf[0])) {
-              vector<uint32_t> seq;
+              std::vector<uint32_t> seq;
               try {
                 seq = parse_ints<uint32_t> (buf);
                 for (size_t i = 0; i < seq.size(); i++) {
@@ -217,7 +217,7 @@ namespace MR {
 
 
 
-      vector<std::shared_ptr<Series>> (*select_func) (const Tree& tree) = select_cmdline;
+      std::vector<std::shared_ptr<Series>> (*select_func) (const Tree& tree) = select_cmdline;
 
 
 

--- a/core/file/dicom/series.cpp
+++ b/core/file/dicom/series.cpp
@@ -22,10 +22,10 @@ namespace MR {
   namespace File {
     namespace Dicom {
 
-      vector<int> Series::count () const
+      std::vector<int> Series::count () const
       {
-        vector<int> dim (3);
-        vector<int> current_dim(2);
+        std::vector<int> dim (3);
+        std::vector<int> current_dim(2);
         dim[0] = dim[1] = dim[2] = 0;
         current_dim[0] = current_dim[1] = 1;
 

--- a/core/file/dicom/series.h
+++ b/core/file/dicom/series.h
@@ -28,7 +28,7 @@ namespace MR {
       class Study;
       class Image;
 
-      class Series : public vector<std::shared_ptr<Image>> { 
+      class Series : public std::vector<std::shared_ptr<Image>> { 
         public:
           Series (Study* parent, const std::string& series_name, size_t series_number, const std::string& image_type,
               const std::string& series_ref_UID, const std::string& series_modality,
@@ -51,7 +51,7 @@ namespace MR {
             }
           }
 
-          vector<int> count () const;
+          std::vector<int> count () const;
           bool operator< (const Series& s) const {
             if (number != s.number)
               return number < s.number;

--- a/core/file/dicom/study.h
+++ b/core/file/dicom/study.h
@@ -27,7 +27,7 @@ namespace MR {
       class Patient;
       class Series;
 
-      class Study : public vector<std::shared_ptr<Series>> { 
+      class Study : public std::vector<std::shared_ptr<Series>> { 
         public:
           Study (Patient* parent, const std::string& study_name, const std::string& study_ID,
               const std::string& study_UID, const std::string& study_date, const std::string& study_time) :

--- a/core/file/dicom/tree.h
+++ b/core/file/dicom/tree.h
@@ -27,7 +27,7 @@ namespace MR {
       class Series;
       class Patient;
 
-      class Tree : public vector<std::shared_ptr<Patient>> { 
+      class Tree : public std::vector<std::shared_ptr<Patient>> { 
         public:
           std::string description;
           void read (const std::string& filename);
@@ -50,7 +50,7 @@ namespace MR {
 
       std::ostream& operator<< (std::ostream& stream, const Tree& item);
 
-      extern vector<std::shared_ptr<Series>> (*select_func) (const Tree& tree);
+      extern std::vector<std::shared_ptr<Series>> (*select_func) (const Tree& tree);
 
     }
   }

--- a/core/file/json_utils.cpp
+++ b/core/file/json_utils.cpp
@@ -93,12 +93,12 @@ namespace MR
                   all_numeric = false;
               }
               if (all_string) {
-                vector<std::string> lines;
+                std::vector<std::string> lines;
                 for (const auto& k : *i)
                   lines.push_back (unquote(k));
                 result.insert (std::make_pair (i.key(), join (lines, "\n")));
               } else if (all_numeric) {
-                vector<std::string> line;
+                std::vector<std::string> line;
                 for (const auto& k : *i)
                   line.push_back (str(k));
                 result.insert (std::make_pair (i.key(), join (line, ",")));
@@ -107,9 +107,9 @@ namespace MR
               }
             }
             else if (num_subarrays == i->size()) {
-              vector<std::string> s;
+              std::vector<std::string> s;
               for (const auto& j : *i) {
-                vector<std::string> line;
+                std::vector<std::string> line;
                 for (const auto& k : j)
                   line.push_back (unquote(str(k)));
                 s.push_back (join(line, ","));
@@ -195,7 +195,7 @@ namespace MR
             nlohmann::json temp;
             bool noninteger = false;
             for (ssize_t row = 0; row != M_float.rows(); ++row) {
-              vector<default_type> data (M_float.cols());
+              std::vector<default_type> data (M_float.cols());
               for (ssize_t i = 0; i != M_float.cols(); ++i) {
                 data[i] = M_float (row, i);
                 if (std::floor (data[i]) != data[i])
@@ -218,7 +218,7 @@ namespace MR
                 M_int.transposeInPlace();
               temp[kv.first] = nlohmann::json({});
               for (ssize_t row = 0; row != M_int.rows(); ++row) {
-                vector<int> data (M_int.cols());
+                std::vector<int> data (M_int.cols());
                 for (ssize_t i = 0; i != M_int.cols(); ++i)
                   data[i] = M_int (row, i);
                 if (row)
@@ -275,8 +275,8 @@ namespace MR
           return;
         }
 
-        vector<size_t> order;
-        vector<bool> flip;
+        std::vector<size_t> order;
+        std::vector<bool> flip;
         File::NIfTI::axes_on_write (header, order, flip);
         if (order[0] == 0 && order[1] == 1 && order[2] == 2 && !flip[0] && !flip[1] && !flip[2]) {
           INFO ("No need to transform orientation-based information written to JSON file to match image: image is already RAS");

--- a/core/file/mgh.h
+++ b/core/file/mgh.h
@@ -420,7 +420,7 @@ namespace MR
             const int32_t nentries = fetch<int32_t> (in);
             if (!nentries)
               throw Exception ("Error reading colour table from file \"" + H.name() + "\": No entries");
-            vector<std::string> table;
+            std::vector<std::string> table;
             const int32_t filename_length = fetch<int32_t> (in);
             std::string filename (filename_length, '\0');
             in.read (const_cast<char*> (filename.data()), filename_length);
@@ -559,7 +559,7 @@ namespace MR
           if (ndim > 4)
             throw Exception ("MGH file format does not support images of more than 4 dimensions");
 
-          vector<size_t> axes;
+          std::vector<size_t> axes;
           auto M = File::NIfTI::adjust_transform (H, axes);
 
           store<int32_t> (1, out); // version
@@ -662,7 +662,7 @@ namespace MR
               WARN ("Error writing MRI frame data to output image (image has " + str(nframes) + " volumes, frame data tables has " + str(lines.size()) + " rows); omitting information from output image");
               return;
             }
-            vector<mri_frame> frames (nframes);
+            std::vector<mri_frame> frames (nframes);
             for (size_t frame_index = 0; frame_index != nframes; ++frame_index) {
               const auto entries = split (lines[frame_index], ",", false);
               if (entries.size() != 24 && entries.size() != 45) {
@@ -885,12 +885,12 @@ namespace MR
           float32 ti = 0.0f;         /*!< milliseconds */
           float32 fov = 0.0f;        /*!< IGNORE THIS FIELD (data is inconsistent) */
           Tag transform_tag;
-          vector<Tag> tags;          /*!< variable length char strings */
+          std::vector<Tag> tags;          /*!< variable length char strings */
           std::unique_ptr<Eigen::Matrix<default_type, 4, 4>> auto_align_matrix;
           std::string pe_dir ("UNKNOWN");
           float32 field_strength = NaN;
           std::string mri_frames, colour_table;
-          vector<Tag> cmdline_tags;
+          std::vector<Tag> cmdline_tags;
 
           for (auto entry : H.keyval()) {
             if (entry.first == "command_history") {

--- a/core/file/name_parser.cpp
+++ b/core/file/name_parser.cpp
@@ -26,7 +26,7 @@ namespace MR
     namespace
     {
 
-      inline bool in_seq (const vector<uint32_t>& seq, uint32_t val)
+      inline bool in_seq (const std::vector<uint32_t>& seq, uint32_t val)
       {
         if (seq.size() == 0)
           return true;
@@ -129,7 +129,7 @@ namespace MR
 
 
 
-    bool NameParser::match (const std::string& file_name, vector<uint32_t>& indices) const
+    bool NameParser::match (const std::string& file_name, std::vector<uint32_t>& indices) const
     {
       uint32_t current = 0;
       size_t num = 0;
@@ -160,7 +160,7 @@ namespace MR
 
 
 
-    void NameParser::calculate_padding (const vector<uint32_t>& maxvals)
+    void NameParser::calculate_padding (const std::vector<uint32_t>& maxvals)
     {
       assert (maxvals.size() == seq_index.size());
       for (size_t n = 0; n < seq_index.size(); n++)
@@ -205,7 +205,7 @@ namespace MR
 
 
 
-    std::string NameParser::name (const vector<uint32_t>& indices)
+    std::string NameParser::name (const std::vector<uint32_t>& indices)
     {
       if (!seq_index.size())
         return Path::join (folder_name, array[0].string());
@@ -231,7 +231,7 @@ namespace MR
 
 
 
-    std::string NameParser::get_next_match (vector<uint32_t>& indices, bool return_seq_index)
+    std::string NameParser::get_next_match (std::vector<uint32_t>& indices, bool return_seq_index)
     {
       if (!folder)
         folder.reset (new Path::Dir (folder_name));
@@ -267,14 +267,14 @@ namespace MR
 
 
 
-    vector<uint32_t> ParsedName::List::parse_scan_check (const std::string& specifier, size_t max_num_sequences)
+    std::vector<uint32_t> ParsedName::List::parse_scan_check (const std::string& specifier, size_t max_num_sequences)
     {
       NameParser parser;
       parser.parse (specifier);
 
       scan (parser);
       std::sort (list.begin(), list.end(), compare_ptr_contents());
-      vector<uint32_t> dim = count();
+      std::vector<uint32_t> dim = count();
 
       for (size_t n = 0; n < dim.size(); n++)
         if (parser.sequence (n).size())
@@ -291,7 +291,7 @@ namespace MR
 
     void ParsedName::List::scan (NameParser& parser)
     {
-      vector<uint32_t> index;
+      std::vector<uint32_t> index;
       if (parser.ndim() == 0) {
         list.push_back (std::shared_ptr<ParsedName> (new ParsedName (parser.name (index), index)));
         return;
@@ -311,14 +311,14 @@ namespace MR
 
 
 
-    vector<uint32_t> ParsedName::List::count () const
+    std::vector<uint32_t> ParsedName::List::count () const
     {
       if (! list[0]->ndim()) {
-        if (size() == 1) return (vector<uint32_t>());
+        if (size() == 1) return (std::vector<uint32_t>());
         else throw Exception ("image number mismatch");
       }
 
-      vector<uint32_t> dim ( list[0]->ndim(), 0);
+      std::vector<uint32_t> dim ( list[0]->ndim(), 0);
       size_t current_entry = 0;
 
       count_dim (dim, current_entry, 0);
@@ -329,7 +329,7 @@ namespace MR
 
 
 
-    void ParsedName::List::count_dim (vector<uint32_t>& dim, size_t& current_entry, size_t current_dim) const
+    void ParsedName::List::count_dim (std::vector<uint32_t>& dim, size_t& current_entry, size_t current_dim) const
     {
       uint32_t n;
       bool stop = false;

--- a/core/file/name_parser.h
+++ b/core/file/name_parser.h
@@ -56,11 +56,11 @@ namespace MR
               return (str);
             }
 
-            const vector<uint32_t>& sequence () const {
+            const std::vector<uint32_t>& sequence () const {
               return (seq);
             }
 
-            vector<uint32_t>& sequence () {
+            std::vector<uint32_t>& sequence () {
               return (seq);
             }
 
@@ -83,7 +83,7 @@ namespace MR
           protected:
             size_t seq_length;
             std::string str;
-            vector<uint32_t> seq;
+            std::vector<uint32_t> seq;
         };
 
 
@@ -101,7 +101,7 @@ namespace MR
           return (array[i]);
         }
 
-        const vector<uint32_t>& sequence (size_t index) const {
+        const std::vector<uint32_t>& sequence (size_t index) const {
           return (array[seq_index[index]].sequence());
         }
 
@@ -113,16 +113,16 @@ namespace MR
           return (seq_index[number]);
         }
 
-        bool match (const std::string& file_name, vector<uint32_t>& indices) const;
-        void calculate_padding (const vector<uint32_t>& maxvals);
-        std::string name (const vector<uint32_t>& indices);
-        std::string get_next_match (vector<uint32_t>& indices, bool return_seq_index = false);
+        bool match (const std::string& file_name, std::vector<uint32_t>& indices) const;
+        void calculate_padding (const std::vector<uint32_t>& maxvals);
+        std::string name (const std::vector<uint32_t>& indices);
+        std::string get_next_match (std::vector<uint32_t>& indices, bool return_seq_index = false);
 
         friend std::ostream& operator<< (std::ostream& stream, const NameParser& parser);
 
       private:
-        vector<Item> array;
-        vector<size_t> seq_index;
+        std::vector<Item> array;
+        std::vector<size_t> seq_index;
         std::string folder_name, specification, current_name;
         std::unique_ptr<Path::Dir> folder;
 
@@ -150,17 +150,17 @@ namespace MR
     //! a class to hold a parsed image filename
     class ParsedName { 
       public:
-        ParsedName (const std::string& name, const vector<uint32_t>& index) : indices (index), filename (name) { }
+        ParsedName (const std::string& name, const std::vector<uint32_t>& index) : indices (index), filename (name) { }
 
         //! a class to hold a set of parsed image filenames
         class List { 
           public:
-            vector<uint32_t> parse_scan_check (const std::string& specifier,
+            std::vector<uint32_t> parse_scan_check (const std::string& specifier,
                                                size_t max_num_sequences = std::numeric_limits<size_t>::max());
 
             void scan (NameParser& parser);
 
-            vector<uint32_t> count () const;
+            std::vector<uint32_t> count () const;
 
             size_t biggest_filename_size () const {
               return max_name_size;
@@ -173,8 +173,8 @@ namespace MR
             friend std::ostream& operator<< (std::ostream& stream, const List& list);
 
           protected:
-            vector<std::shared_ptr<ParsedName>> list;
-            void count_dim (vector<uint32_t>& dim, size_t& current_entry, size_t current_dim) const;
+            std::vector<std::shared_ptr<ParsedName>> list;
+            void count_dim (std::vector<uint32_t>& dim, size_t& current_entry, size_t current_dim) const;
             size_t max_name_size;
         };
 
@@ -194,7 +194,7 @@ namespace MR
         friend std::ostream& operator<< (std::ostream& stream, const ParsedName& pin);
 
       protected:
-        vector<uint32_t> indices;
+        std::vector<uint32_t> indices;
         std::string filename;
 
     };

--- a/core/file/nifti_utils.cpp
+++ b/core/file/nifti_utils.cpp
@@ -65,7 +65,7 @@ namespace MR
           static char* regular (nifti_2_header& NH) { return nullptr; }
         };
 
-        const vector<std::string> suffixes { ".nii", ".img" };
+        const std::vector<std::string> suffixes { ".nii", ".img" };
       }
 
 
@@ -387,7 +387,7 @@ namespace MR
 
           bool is_BE = H.datatype().is_big_endian();
 
-          vector<size_t> axes;
+          std::vector<size_t> axes;
           auto M = File::NIfTI::adjust_transform (H, axes);
 
 
@@ -582,7 +582,7 @@ namespace MR
 
 
 
-      void axes_on_write (const Header& H, vector<size_t>& order, vector<bool>& flip)
+      void axes_on_write (const Header& H, std::vector<size_t>& order, std::vector<bool>& flip)
       {
         Stride::List strides = Stride::get (H);
         strides.resize (3);
@@ -593,9 +593,9 @@ namespace MR
 
 
 
-      transform_type adjust_transform (const Header& H, vector<size_t>& axes)
+      transform_type adjust_transform (const Header& H, std::vector<size_t>& axes)
       {
-        vector<bool> flip;
+        std::vector<bool> flip;
         axes_on_write (H, axes, flip);
 
         if (axes[0] == 0 && axes[1] == 1 && axes[2] == 2 &&
@@ -624,7 +624,7 @@ namespace MR
 
 
 
-      bool check (int VERSION, Header& H, const size_t num_axes, const vector<std::string>& suffixes)
+      bool check (int VERSION, Header& H, const size_t num_axes, const std::vector<std::string>& suffixes)
       {
         if (!Path::has_suffix (H.name(), suffixes))
           return false;

--- a/core/file/nifti_utils.h
+++ b/core/file/nifti_utils.h
@@ -34,10 +34,10 @@ namespace MR
     {
       extern bool right_left_warning_issued;
 
-      void axes_on_write (const Header& H, vector<size_t>& order, vector<bool>& flip);
-      transform_type adjust_transform (const Header& H, vector<size_t>& order);
+      void axes_on_write (const Header& H, std::vector<size_t>& order, std::vector<bool>& flip);
+      transform_type adjust_transform (const Header& H, std::vector<size_t>& order);
 
-      bool check (int VERSION, Header& H, const size_t num_axes, const vector<std::string>& suffixes);
+      bool check (int VERSION, Header& H, const size_t num_axes, const std::vector<std::string>& suffixes);
 
       template <int VERSION> std::unique_ptr<ImageIO::Base> read (Header& H);
       template <int VERSION> std::unique_ptr<ImageIO::Base> read_gz (Header& H);

--- a/core/file/path.h
+++ b/core/file/path.h
@@ -140,7 +140,7 @@ namespace MR
                           [&] (const std::string& suffix) { return has_suffix (name, suffix); });
     }
 
-    inline bool has_suffix (const std::string &name, const vector<std::string> &suffix_list)
+    inline bool has_suffix (const std::string &name, const std::vector<std::string> &suffix_list)
     {
       return std::any_of (suffix_list.begin(),
                           suffix_list.end(),

--- a/core/filter/connected_components.cpp
+++ b/core/filter/connected_components.cpp
@@ -34,8 +34,8 @@ namespace MR
       if (header.ndim() > enabled_axes.size())
         enabled_axes.resize (header.ndim(), false);
       // Begin by disabling adjacency offsets for those axes for which adjacency is not permitted
-      vector< vector<int> > offsets;
-      vector<int> o (header.ndim(), -1);
+      std::vector< std::vector<int> > offsets;
+      std::vector<int> o (header.ndim(), -1);
       size_t start_axis = 0;
       for (size_t axis = 0; axis != header.ndim(); ++axis) {
         if (!enabled_axes[axis]) {
@@ -71,12 +71,12 @@ namespace MR
       }
       // Now we can generate, for each element in the image, a list of adjacent elements
       // This may appear different to previous code, given the use of the Voxel2Vector class
-      vector<index_t> pos (header.ndim());
-      vector<int> neighbour (header.ndim());
+      std::vector<index_t> pos (header.ndim());
+      std::vector<int> neighbour (header.ndim());
       data.reserve (v2v.size());
       for (size_t i = 0; i != v2v.size(); ++i) {
         pos = v2v[i];
-        vector<index_t> indices;
+        std::vector<index_t> indices;
         for (auto o : offsets) {
           for (size_t axis = 0; axis != header.ndim(); ++axis)
             neighbour[axis] = pos[axis] + o[axis];
@@ -94,8 +94,8 @@ namespace MR
 
 
 
-    void Connector::run (vector<Cluster>& clusters,
-                         vector<uint32_t>& labels) const
+    void Connector::run (std::vector<Cluster>& clusters,
+                         std::vector<uint32_t>& labels) const
     {
       assert (adjacency.size());
       labels.resize (adjacency.size(), 0);
@@ -114,7 +114,7 @@ namespace MR
 
 
 
-    bool Connector::next_neighbour (uint32_t& node, vector<uint32_t>& labels) const
+    bool Connector::next_neighbour (uint32_t& node, std::vector<uint32_t>& labels) const
     {
       for (auto n : adjacency[node]) {
         if (!labels[n]) {
@@ -129,7 +129,7 @@ namespace MR
 
     void Connector::depth_first_search (const uint32_t root,
                                         Cluster& cluster,
-                                        vector<uint32_t>& labels) const
+                                        std::vector<uint32_t>& labels) const
     {
       uint32_t node = root;
       std::stack<uint32_t> stack;

--- a/core/filter/connected_components.h
+++ b/core/filter/connected_components.h
@@ -64,14 +64,14 @@ namespace MR
               data.clear();
             }
 
-            void set_axes (const vector<bool>& i) {
+            void set_axes (const std::vector<bool>& i) {
               enabled_axes = i;
               data.clear();
             }
 
             void initialise (const Header&, const Voxel2Vector&);
 
-            const vector<index_t>& operator[] (const size_t index) const {
+            const std::vector<index_t>& operator[] (const size_t index) const {
               assert (size());
               assert (index < size());
               return data[index];
@@ -86,8 +86,8 @@ namespace MR
 
           private:
             bool use_26_neighbours;
-            vector<bool> enabled_axes;
-            vector<vector<index_t>> data;
+            std::vector<bool> enabled_axes;
+            std::vector<std::vector<index_t>> data;
         } adjacency;
 
 
@@ -115,9 +115,9 @@ namespace MR
         Connector () { }
 
         // Perform connected components on vectorized binary data
-        void run (vector<Cluster>&, vector<uint32_t>&) const;
+        void run (std::vector<Cluster>&, std::vector<uint32_t>&) const;
         template <class VectorType>
-        void run (vector<Cluster>&, vector<uint32_t>&,
+        void run (std::vector<Cluster>&, std::vector<uint32_t>&,
                   const VectorType&, const float) const;
 
 
@@ -125,14 +125,14 @@ namespace MR
 
         // Utility functions that perform the actual connected
         //   components functionality
-        bool next_neighbour (uint32_t&, vector<uint32_t>&) const;
+        bool next_neighbour (uint32_t&, std::vector<uint32_t>&) const;
         template <class VectorType>
-        bool next_neighbour (uint32_t&, vector<uint32_t>&,
+        bool next_neighbour (uint32_t&, std::vector<uint32_t>&,
                              const VectorType&, const float) const;
 
-        void depth_first_search (const uint32_t, Cluster&, vector<uint32_t>&) const;
+        void depth_first_search (const uint32_t, Cluster&, std::vector<uint32_t>&) const;
         template <class VectorType>
-        void depth_first_search (const uint32_t, Cluster&, vector<uint32_t>&,
+        void depth_first_search (const uint32_t, Cluster&, std::vector<uint32_t>&,
                                  const VectorType&, const float) const;
 
 
@@ -141,8 +141,8 @@ namespace MR
 
 
     template <class VectorType>
-    void Connector::run (vector<Cluster>& clusters,
-                         vector<uint32_t>& labels,
+    void Connector::run (std::vector<Cluster>& clusters,
+                         std::vector<uint32_t>& labels,
                          const VectorType& data,
                          const float threshold) const
     {
@@ -165,7 +165,7 @@ namespace MR
 
     template <class VectorType>
     bool Connector::next_neighbour (uint32_t& node,
-                                    vector<uint32_t>& labels,
+                                    std::vector<uint32_t>& labels,
                                     const VectorType& data,
                                     const float threshold) const
     {
@@ -183,7 +183,7 @@ namespace MR
     template <class VectorType>
     void Connector::depth_first_search (const uint32_t root,
                                         Cluster& cluster,
-                                        vector<uint32_t>& labels,
+                                        std::vector<uint32_t>& labels,
                                         const VectorType& data,
                                         const float threshold) const
     {
@@ -266,8 +266,8 @@ namespace MR
           connector.adjacency.initialise (in, v2v);
           if (progress) ++(*progress);
 
-          vector<Connector::Cluster> clusters;
-          vector<uint32_t> labels;
+          std::vector<Connector::Cluster> clusters;
+          std::vector<uint32_t> labels;
           connector.run (clusters, labels);
           // Sort clusters in order from largest to smallest
           std::sort (clusters.begin(), clusters.end(), Connector::largest);
@@ -275,7 +275,7 @@ namespace MR
 
           // Generate a lookup table to map input cluster index to
           //   output cluster index following cluster-size sorting
-          vector<uint32_t> index_lookup (clusters.size() + 1, 0);
+          std::vector<uint32_t> index_lookup (clusters.size() + 1, 0);
           for (uint32_t c = 0; c < clusters.size(); c++) {
             if (clusters[c].size < minsize) break;
             index_lookup[clusters[c].label] = c + 1;
@@ -299,7 +299,7 @@ namespace MR
 
 
 
-        void set_axes (const vector<int>& i)
+        void set_axes (const std::vector<int>& i)
         {
           const size_t max_axis = *std::max_element (i.begin(), i.end());
           if (max_axis >= ndim())
@@ -313,7 +313,7 @@ namespace MR
         }
 
 
-        void set_axes (const vector<bool>& i)
+        void set_axes (const std::vector<bool>& i)
         {
           if (i.size() != ndim())
             throw Exception ("Length of axis selection flag vector (" + str(i.size()) + ") does not match dimensionality of connected-component filter (" + str(ndim()) + "D)");
@@ -340,7 +340,7 @@ namespace MR
 
 
       protected:
-        vector<bool> enabled_axes;
+        std::vector<bool> enabled_axes;
         bool largest_only;
         bool do_26_connectivity;
         uint32_t minsize;

--- a/core/filter/fill.h
+++ b/core/filter/fill.h
@@ -64,7 +64,7 @@ namespace MR
           set_message (message);
         }
 
-        void set_axes (const vector<int>& i)
+        void set_axes (const std::vector<int>& i)
         {
           const size_t max_axis = *std::max_element (i.begin(), i.end());
           if (max_axis >= ndim())
@@ -104,7 +104,7 @@ namespace MR
 
 
       protected:
-        vector<bool> enabled_axes;
+        std::vector<bool> enabled_axes;
         bool do_26_connectivity;
 
     };

--- a/core/filter/gradient.h
+++ b/core/filter/gradient.h
@@ -84,7 +84,7 @@ namespace MR
           wrt_scanner = do_wrt_scanner;
         }
 
-        void set_stdev (const vector<default_type>& stdevs) {
+        void set_stdev (const std::vector<default_type>& stdevs) {
           stdev = stdevs;
         }
 
@@ -153,7 +153,7 @@ namespace MR
         Filter::Smooth smoother;
         bool wrt_scanner;
         const bool magnitude;
-        vector<default_type> stdev;
+        std::vector<default_type> stdev;
     };
     //! @}
   }

--- a/core/filter/median.h
+++ b/core/filter/median.h
@@ -58,14 +58,14 @@ namespace MR
             }
 
         template <class HeaderType>
-        Median (const HeaderType& in, const vector<uint32_t>& extent) :
+        Median (const HeaderType& in, const std::vector<uint32_t>& extent) :
             Base (in),
             extent (extent) {
           datatype() = DataType::Float32;
         }
 
         template <class HeaderType>
-          Median (const HeaderType& in, const std::string& message, const vector<uint32_t>& extent) :
+          Median (const HeaderType& in, const std::string& message, const std::vector<uint32_t>& extent) :
             Base (in, message),
             extent (extent) {
               datatype() = DataType::Float32;
@@ -74,7 +74,7 @@ namespace MR
         //! Set the extent of median filtering neighbourhood in voxels.
         //! This must be set as a single value for all three dimensions
         //! or three values, one for each dimension. Default 3x3x3.
-        void set_extent (const vector<uint32_t>& ext) {
+        void set_extent (const std::vector<uint32_t>& ext) {
           for (size_t i = 0; i < ext.size(); ++i) {
             if (!(ext[i] & int (1)))
               throw Exception ("expected odd number for extent");
@@ -92,7 +92,7 @@ namespace MR
         }
 
     protected:
-        vector<uint32_t> extent;
+        std::vector<uint32_t> extent;
     };
     //! @}
   }

--- a/core/filter/normalise.h
+++ b/core/filter/normalise.h
@@ -58,14 +58,14 @@ namespace MR
             }
 
         template <class HeaderType>
-        Normalise (const HeaderType& in, const vector<uint32_t>& extent) :
+        Normalise (const HeaderType& in, const std::vector<uint32_t>& extent) :
             Base (in),
             extent (extent) {
           datatype() = DataType::Float32;
         }
 
         template <class HeaderType>
-          Normalise (const HeaderType& in, const std::string& message, const vector<uint32_t>& extent) :
+          Normalise (const HeaderType& in, const std::string& message, const std::vector<uint32_t>& extent) :
             Base (in, message),
             extent (extent) {
               datatype() = DataType::Float32;
@@ -74,7 +74,7 @@ namespace MR
         //! Set the extent of normalise filtering neighbourhood in voxels.
         //! This must be set as a single value for all three dimensions
         //! or three values, one for each dimension. Default 3x3x3.
-        void set_extent (const vector<uint32_t>& ext) {
+        void set_extent (const std::vector<uint32_t>& ext) {
           for (size_t i = 0; i < ext.size(); ++i) {
             if (!(ext[i] & uint32_t(1)))
               throw Exception ("expected odd number for extent");
@@ -92,7 +92,7 @@ namespace MR
         }
 
     protected:
-        vector<uint32_t> extent;
+        std::vector<uint32_t> extent;
     };
     //! @}
   }

--- a/core/filter/resize.h
+++ b/core/filter/resize.h
@@ -69,12 +69,12 @@ namespace MR
         ~Resize () { delete out_of_bounds_value; }
 
         void set_voxel_size (default_type size) {
-          vector<default_type> voxel_size (3, size);
+          std::vector<default_type> voxel_size (3, size);
           set_voxel_size (voxel_size);
         }
 
 
-        void set_voxel_size (const vector<default_type>& voxel_size) {
+        void set_voxel_size (const std::vector<default_type>& voxel_size) {
           if (voxel_size.size() != 3)
             throw Exception ("the voxel size must be defined using a value for all three dimensions.");
 
@@ -93,10 +93,10 @@ namespace MR
         }
 
 
-        void set_size (const vector<uint32_t>& image_res) {
+        void set_size (const std::vector<uint32_t>& image_res) {
           if (image_res.size() != 3)
             throw Exception ("the image resolution must be defined for 3 spatial dimensions");
-          vector<default_type> new_voxel_size (3);
+          std::vector<default_type> new_voxel_size (3);
           for (size_t d = 0; d < 3; ++d) {
             if (image_res[d] <= 0)
               throw Exception ("the image resolution must be larger than zero for all 3 spatial dimensions");
@@ -107,14 +107,14 @@ namespace MR
 
 
         void set_scale_factor (default_type scale) {
-          set_scale_factor (vector<default_type> (3, scale));
+          set_scale_factor (std::vector<default_type> (3, scale));
         }
 
 
-        void set_scale_factor (const vector<default_type> & scale) {
+        void set_scale_factor (const std::vector<default_type> & scale) {
           if (scale.size() != 3)
             throw Exception ("a scale factor for each spatial dimension is required");
-          vector<default_type> new_voxel_size (3);
+          std::vector<default_type> new_voxel_size (3);
           for (size_t d = 0; d < 3; ++d) {
             if (scale[d] <= 0.0)
               throw Exception ("the scale factor must be larger than zero");
@@ -123,7 +123,7 @@ namespace MR
           set_voxel_size (new_voxel_size);
         }
 
-        void set_oversample (vector<uint32_t> oversample) {
+        void set_oversample (std::vector<uint32_t> oversample) {
           if (oversample.size() == 1)
             oversample.resize (3, oversample[0]);
           else if (oversample.size() != 3 and oversample.size() != 0)
@@ -175,7 +175,7 @@ namespace MR
       protected:
         int interp_type;
         transform_type transformation;
-        vector<uint32_t> oversampling;
+        std::vector<uint32_t> oversampling;
         default_type *out_of_bounds_value;
     };
     //! @}

--- a/core/filter/reslice.h
+++ b/core/filter/reslice.h
@@ -49,7 +49,7 @@ namespace MR
           ImageTypeSource& source,
           ImageTypeDestination& destination,
           const transform_type& transform = Adapter::NoTransform,
-          const vector<uint32_t>& oversampling = Adapter::AutoOverSample,
+          const std::vector<uint32_t>& oversampling = Adapter::AutoOverSample,
           const typename ImageTypeDestination::value_type value_when_out_of_bounds = Interp::Base<ImageTypeDestination>::default_out_of_bounds_value())
       {
         Adapter::Reslice<Interpolator, ImageTypeSource> interp (source, destination, transform, oversampling, value_when_out_of_bounds);

--- a/core/filter/smooth.h
+++ b/core/filter/smooth.h
@@ -62,7 +62,7 @@ namespace MR
         }
 
         template <class HeaderType>
-        Smooth (const HeaderType& in, const vector<default_type>& stdev_in):
+        Smooth (const HeaderType& in, const std::vector<default_type>& stdev_in):
             Base (in),
             extent (3, 0),
             stdev (3, 0.0),
@@ -75,7 +75,7 @@ namespace MR
         //! Set the extent of smoothing kernel in voxels.
         //! This can be set as a single value to be used for the first 3 dimensions
         //! or separate values, one for each dimension. (Default: 4 standard deviations)
-        void set_extent (const vector<uint32_t>& new_extent)
+        void set_extent (const std::vector<uint32_t>& new_extent)
         {
           if (new_extent.size() != 1 && new_extent.size() != 3)
             throw Exception ("Please supply a single kernel extent value, or three values (one for each spatial dimension)");
@@ -91,7 +91,7 @@ namespace MR
         }
 
         void set_stdev (default_type stdev_in) {
-          set_stdev (vector<default_type> (3, stdev_in));
+          set_stdev (std::vector<default_type> (3, stdev_in));
         }
 
         //! ensure the image boundary remains zero. Used to constrain displacement fields during image registration
@@ -102,7 +102,7 @@ namespace MR
         //! Set the standard deviation of the Gaussian defined in mm.
         //! This must be set as a single value to be used for the first 3 dimensions
         //! or separate values, one for each dimension. (Default: 1 voxel)
-        void set_stdev (const vector<default_type>& std_dev)
+        void set_stdev (const std::vector<default_type>& std_dev)
         {
           for (size_t i = 0; i < std_dev.size(); ++i)
             if (stdev[i] < 0.0)
@@ -129,7 +129,7 @@ namespace MR
           std::unique_ptr<ProgressBar> progress;
           if (message.size()) {
             size_t axes_to_smooth = 0;
-            for (vector<default_type>::const_iterator i = stdev.begin(); i != stdev.end(); ++i)
+            for (std::vector<default_type>::const_iterator i = stdev.begin(); i != stdev.end(); ++i)
               if (*i)
                 ++axes_to_smooth;
             progress.reset (new ProgressBar (message, axes_to_smooth + 1));
@@ -156,7 +156,7 @@ namespace MR
           std::unique_ptr<ProgressBar> progress;
           if (message.size()) {
             size_t axes_to_smooth = 0;
-            for (vector<default_type>::const_iterator i = stdev.begin(); i != stdev.end(); ++i)
+            for (std::vector<default_type>::const_iterator i = stdev.begin(); i != stdev.end(); ++i)
               if (*i)
                 ++axes_to_smooth;
             progress.reset (new ProgressBar (message, axes_to_smooth + 1));
@@ -164,7 +164,7 @@ namespace MR
 
           for (size_t dim = 0; dim < 3; dim++) {
             if (stdev[dim] > 0) {
-              vector<size_t> axes (in_and_output.ndim(), dim);
+              std::vector<size_t> axes (in_and_output.ndim(), dim);
               size_t axdim = 1;
               for (size_t i = 0; i < in_and_output.ndim(); ++i) {
                 if (stride_order[i] == dim)
@@ -181,9 +181,9 @@ namespace MR
         }
 
       protected:
-        vector<uint32_t> extent;
-        vector<default_type> stdev;
-        const vector<size_t> stride_order;
+        std::vector<uint32_t> extent;
+        std::vector<default_type> stdev;
+        const std::vector<size_t> stride_order;
         bool zero_boundary;
 
         template <class ImageType>

--- a/core/filter/warp.h
+++ b/core/filter/warp.h
@@ -67,7 +67,7 @@ namespace MR
           ImageTypeDestination& destination,
           WarpType& warp,
           const typename ImageTypeDestination::value_type value_when_out_of_bounds = Interpolator<ImageTypeSource>::default_out_of_bounds_value(),
-          const vector<uint32_t> oversample = Adapter::AutoOverSample,
+          const std::vector<uint32_t> oversample = Adapter::AutoOverSample,
           const bool jacobian_modulate = false )
       {
 

--- a/core/filter/zclean.h
+++ b/core/filter/zclean.h
@@ -303,7 +303,7 @@ namespace MR
 
         template <typename ImageType, typename MaskType>
         void calculate_median_mad (ImageType& image, MaskType& mask, size_t nvoxels, float& median, float& mad) {
-          MR::vector<float> vals (nvoxels);
+          std::vector<float> vals (nvoxels);
           size_t idx = 0;
           for (auto l = Loop (0,3) (mask, image); l; ++l) {
             if (mask.value())

--- a/core/fixel/helpers.h
+++ b/core/fixel/helpers.h
@@ -232,11 +232,11 @@ namespace MR
     }
 
 
-    FORCE_INLINE vector<Header> find_data_headers (const std::string &fixel_directory_path, const Header &index_header, const bool include_directions = false)
+    FORCE_INLINE std::vector<Header> find_data_headers (const std::string &fixel_directory_path, const Header &index_header, const bool include_directions = false)
     {
       check_index_image (index_header);
       auto dir_walker = Path::Dir (fixel_directory_path);
-      vector<std::string> file_names;
+      std::vector<std::string> file_names;
       {
         std::string temp;
         while ((temp = dir_walker.read_name()).size())
@@ -244,7 +244,7 @@ namespace MR
       }
       std::sort (file_names.begin(), file_names.end());
 
-      vector<Header> data_headers;
+      std::vector<Header> data_headers;
       for (auto fname : file_names) {
         if (Path::has_suffix (fname, supported_sparse_formats)) {
           try {

--- a/core/formats/mrtrix_utils.cpp
+++ b/core/formats/mrtrix_utils.cpp
@@ -24,9 +24,9 @@ namespace MR
 
 
 
-    vector<ssize_t> parse_axes (size_t ndim, const std::string& specifier)
+    std::vector<ssize_t> parse_axes (size_t ndim, const std::string& specifier)
     {
-      vector<ssize_t> parsed (ndim);
+      std::vector<ssize_t> parsed (ndim);
 
       size_t sub = 0;
       size_t lim = 0;

--- a/core/formats/mrtrix_utils.h
+++ b/core/formats/mrtrix_utils.h
@@ -55,7 +55,7 @@ namespace MR
       void write_mrtrix_header (const Header&, StreamType&);
 
 
-    vector<ssize_t> parse_axes (size_t ndim, const std::string& specifier);
+    std::vector<ssize_t> parse_axes (size_t ndim, const std::string& specifier);
 
 
 
@@ -64,9 +64,9 @@ namespace MR
       void read_mrtrix_header (Header& H, SourceType& kv)
       {
         std::string dtype, layout;
-        vector<uint64_t> dim;
-        vector<default_type> vox, scaling;
-        vector<vector<default_type>> transform;
+        std::vector<uint64_t> dim;
+        std::vector<default_type> vox, scaling;
+        std::vector<std::vector<default_type>> transform;
 
         std::string key, value;
         while (next_keyvalue (kv, key, value)) {

--- a/core/formats/par.cpp
+++ b/core/formats/par.cpp
@@ -149,7 +149,7 @@ namespace MR
 
       float version = NaN;
       ParCols cols;
-      vector<SliceData> slices;
+      std::vector<SliceData> slices;
 
       while (in.good()) {
         std::string line;
@@ -190,7 +190,7 @@ namespace MR
         }
       }
 
-      vector<std::array<float,4>> G;
+      std::vector<std::array<float,4>> G;
 
       int nslices = 0;
       int nvols = 0;

--- a/core/header.cpp
+++ b/core/header.cpp
@@ -74,8 +74,8 @@ namespace MR
     {
       if (one == "variable" || two == "variable")
         return "variable";
-      vector<std::string> one_split = split (one, ",");
-      vector<std::string> two_split = split (two, ",");
+      std::vector<std::string> one_split = split (one, ",");
+      std::vector<std::string> two_split = split (two, ",");
       if (one_split.size() != two_split.size()) {
         DEBUG ("Slice timing vectors of inequal length");
         return "invalid";
@@ -148,10 +148,10 @@ namespace MR
 
     std::string short_description (const Header& H)
     {
-      vector<std::string> dims;
+      std::vector<std::string> dims;
       for (size_t n = 0; n < H.ndim(); ++n)
         dims.push_back (str(H.size(n)));
-      vector<std::string> vox;
+      std::vector<std::string> vox;
       for (size_t n = 0; n < H.ndim(); ++n)
         vox.push_back (str(H.spacing(n)));
 
@@ -197,7 +197,7 @@ namespace MR
 
         // Convenient to know a priori which loop index corresponds to which image axis
         // This needs to detect unity-sized axes and flag the loop to concatenate data along that axis
-        vector<size_t> loopindex2axis;
+        std::vector<size_t> loopindex2axis;
         size_t axis;
         for (axis = 0; axis != H.ndim(); ++axis) {
           if (H.size (axis) == 1) {
@@ -212,13 +212,13 @@ namespace MR
 
         // Reimplemented support for [] notation using recursive function calls
         // Note that the very first image header has already been opened before this function is
-        //   invoked for the first time; "vector<Header>& this_data" is used to propagate this
+        //   invoked for the first time; "std::vector<Header>& this_data" is used to propagate this
         //   data to deeper layers when necessary
-        std::function<void(Header&, vector<Header>&, const size_t)>
-        import = [&] (Header& result, vector<Header>& this_data, const size_t loop_index) -> void
+        std::function<void(Header&, std::vector<Header>&, const size_t)>
+        import = [&] (Header& result, std::vector<Header>& this_data, const size_t loop_index) -> void
         {
           if (loop_index == num.size()-1) {
-            vector<std::unique_ptr<ImageIO::Base>> ios;
+            std::vector<std::unique_ptr<ImageIO::Base>> ios;
             if (this_data.size())
               ios.push_back (std::move (this_data[0].io));
             for (size_t i = this_data.size(); i != size_t(num[loop_index]); ++i) {
@@ -241,7 +241,7 @@ namespace MR
           } // End branch for when loop_index is the maximum, ie. innermost loop
           // For each coordinate along this axis, need to concatenate headers from the
           //   next lower axis
-          vector<Header> nested_data;
+          std::vector<Header> nested_data;
           // The nested concatenation may still include the very first header that has already been read;
           //   this needs to be propagated through to the nested call
           if (this_data.size()) {
@@ -261,7 +261,7 @@ namespace MR
             result.io->merge (*this_data[i].io);
         };
 
-        vector<Header> headers;
+        std::vector<Header> headers;
         headers.push_back (std::move (H));
         import (H, headers, 0);
         H.name() = image_name;
@@ -283,7 +283,7 @@ namespace MR
 
 
   namespace {
-    inline bool check_strides_match (const vector<ssize_t>& a, const vector<ssize_t>& b)
+    inline bool check_strides_match (const std::vector<ssize_t>& a, const std::vector<ssize_t>& b)
     {
       size_t n = 0;
       for (; n < std::min (a.size(), b.size()); ++n)
@@ -324,15 +324,15 @@ namespace MR
 
       File::NameParser parser;
       parser.parse (image_name);
-      vector<uint32_t> Pdim (parser.ndim());
+      std::vector<uint32_t> Pdim (parser.ndim());
 
-      vector<int> Hdim (H.ndim());
+      std::vector<int> Hdim (H.ndim());
       for (size_t i = 0; i < H.ndim(); ++i)
         Hdim[i] = H.size(i);
 
       H.name() = image_name;
 
-      const vector<ssize_t> strides (Stride::get_symbolic (H));
+      const std::vector<ssize_t> strides (Stride::get_symbolic (H));
       const Formats::Base** format_handler = Formats::handlers;
       for (; *format_handler; format_handler++)
         if ((*format_handler)->check (H, H.ndim() - Pdim.size()))
@@ -347,7 +347,7 @@ namespace MR
           throw Exception ("unknown format for image \"" + image_name + "\" (unsupported file extension: " + basename.substr (extension_index) + ")");
       }
 
-      const vector<ssize_t> strides_aftercheck (Stride::get_symbolic (H));
+      const std::vector<ssize_t> strides_aftercheck (Stride::get_symbolic (H));
       if (!check_strides_match (strides, strides_aftercheck)) {
         INFO("output strides for image " + image_name + " modified to " + str(strides_aftercheck) +
             " - requested strides " + str(strides) + " are not supported in " + (*format_handler)->description + " format");
@@ -394,7 +394,7 @@ namespace MR
 
 
       Header header (H);
-      vector<uint32_t> num (Pdim.size());
+      std::vector<uint32_t> num (Pdim.size());
 
       if (!is_dash (image_name))
         H.name() = parser.name (num);
@@ -743,7 +743,7 @@ namespace MR
 
 
 
-  Header concatenate (const vector<Header>& headers, const size_t axis_to_concat, const bool permit_datatype_mismatch)
+  Header concatenate (const std::vector<Header>& headers, const size_t axis_to_concat, const bool permit_datatype_mismatch)
   {
     Exception e ("Unable to concatenate " + str(headers.size()) + " images along axis " + str(axis_to_concat) + ": ");
 

--- a/core/header.h
+++ b/core/header.h
@@ -214,7 +214,7 @@ namespace MR
 
       class NDimProxy {
         public:
-          NDimProxy (vector<Axis>& axes) : axes (axes) { }
+          NDimProxy (std::vector<Axis>& axes) : axes (axes) { }
           NDimProxy (NDimProxy&&) = default;
           NDimProxy (const NDimProxy&) = delete;
           NDimProxy& operator=(NDimProxy&&) = delete;
@@ -227,7 +227,7 @@ namespace MR
             return stream;
           }
         private:
-          vector<Axis>& axes;
+          std::vector<Axis>& axes;
       };
 
       //! return the number of dimensions (axes) of image
@@ -358,7 +358,7 @@ namespace MR
       friend std::ostream& operator<< (std::ostream& stream, const Header& H);
 
     protected:
-      vector<Axis> axes_;
+      std::vector<Axis> axes_;
       transform_type transform_;
       std::string name_;
       KeyValues keyval_;
@@ -393,8 +393,8 @@ namespace MR
 
 
 
-  // Can't be a static member function due to memory alignment requirements of vector<>
-  Header concatenate (const vector<Header>& headers, const size_t axis, const bool permit_datatype_mismatch);
+  // Can't be a static member function due to memory alignment requirements of std::vector<>
+  Header concatenate (const std::vector<Header>& headers, const size_t axis, const bool permit_datatype_mismatch);
 
 
 

--- a/core/image.h
+++ b/core/image.h
@@ -202,7 +202,7 @@ namespace MR
         //! pointer to data address whether in RAM or MMap
         void* data_pointer;
         //! voxel indices
-        vector<ssize_t> x;
+        std::vector<ssize_t> x;
         //! voxel indices
         Stride::List strides;
         //! offset to currently pointed-to voxel
@@ -277,12 +277,12 @@ namespace MR
         using value_type = ValueType;
 
       TmpImage (const typename Image<ValueType>::Buffer& b, void* const data,
-          vector<ssize_t> x, const Stride::List& strides, size_t offset) :
+          std::vector<ssize_t> x, const Stride::List& strides, size_t offset) :
         b (b), data (data), x (x), strides (strides), offset (offset) { }
 
         const typename Image<ValueType>::Buffer& b;
         void* const data;
-        vector<ssize_t> x;
+        std::vector<ssize_t> x;
         const Stride::List& strides;
         size_t offset;
 
@@ -393,7 +393,7 @@ namespace MR
         if (buffer->get_io()) {
           if (buffer->get_io()->is_image_readwrite() && buffer->data_buffer) {
             auto data_buffer = std::move (buffer->data_buffer);
-            TmpImage<ValueType> src = { *buffer, data_buffer.get(), vector<ssize_t> (ndim(), 0), strides, Stride::offset (*this) };
+            TmpImage<ValueType> src = { *buffer, data_buffer.get(), std::vector<ssize_t> (ndim(), 0), strides, Stride::offset (*this) };
             Image<ValueType> dest (buffer);
             threaded_copy_with_progress_message ("writing back direct IO buffer for \"" + name() + "\"", src, dest);
           }
@@ -437,7 +437,7 @@ namespace MR
       }
       else {
         auto src (*this);
-        TmpImage<ValueType> dest = { *buffer, buffer->data_buffer.get(), vector<ssize_t> (ndim(), 0), with_strides, Stride::offset (with_strides, *this) };
+        TmpImage<ValueType> dest = { *buffer, buffer->data_buffer.get(), std::vector<ssize_t> (ndim(), 0), with_strides, Stride::offset (with_strides, *this) };
         threaded_copy_with_progress_message ("preloading data for \"" + name() + "\"", src, dest);
       }
 

--- a/core/image_helpers.h
+++ b/core/image_helpers.h
@@ -107,7 +107,7 @@ namespace MR
               MR::apply (__assign<DestImageType...> (a, __get_index (ref, a)), std::tie (dest...));
           }
         const ImageType& ref;
-        const vector<IntType> axes;
+        const std::vector<IntType> axes;
       };
   }
 
@@ -200,7 +200,7 @@ namespace MR
   //! returns a functor to set the position in ref to other voxels
   /*! this can be used as follows:
    * \code
-   * vector<int> axes = { 0, 3, 4 };
+   * std::vector<int> axes = { 0, 3, 4 };
    * assign_pos (src_image, axes) (dest_image1, dest_image2);
    * \endcode
    *
@@ -209,14 +209,14 @@ namespace MR
    * operator[](size_t) methods). */
   template <class ImageType, typename IntType>
     FORCE_INLINE __assign_pos_axes<ImageType, IntType>
-    assign_pos_of (const ImageType& reference, const vector<IntType>& axes)
+    assign_pos_of (const ImageType& reference, const std::vector<IntType>& axes)
     {
       return { reference, axes };
     }
 
   template <class ImageType, typename IntType>
     FORCE_INLINE __assign_pos_axes<ImageType, IntType>
-    assign_pos_of (const ImageType& reference, const vector<IntType>&& axes)
+    assign_pos_of (const ImageType& reference, const std::vector<IntType>&& axes)
     {
       return assign_pos_of (reference, axes);
     }
@@ -301,7 +301,7 @@ namespace MR
 
   //! returns the number of voxel in the relevant subvolume of the data set
   template <class HeaderType>
-    inline int64_t voxel_count (const HeaderType& in, const vector<size_t>& axes)
+    inline int64_t voxel_count (const HeaderType& in, const std::vector<size_t>& axes)
     {
       int64_t fp = 1;
       for (size_t n = 0; n < axes.size(); ++n) {
@@ -359,7 +359,7 @@ namespace MR
     }
 
   template <class HeaderType1, class HeaderType2>
-    inline bool spacings_match (const HeaderType1& in1, const HeaderType2& in2, const vector<size_t>& axes, const double tol=0.0)
+    inline bool spacings_match (const HeaderType1& in1, const HeaderType2& in2, const std::vector<size_t>& axes, const double tol=0.0)
     {
       for (size_t n = 0; n < axes.size(); ++n) {
         if (in1.ndim() <= axes[n] || in2.ndim() <= axes[n]) return false;
@@ -390,7 +390,7 @@ namespace MR
     }
 
   template <class HeaderType1, class HeaderType2>
-    inline bool dimensions_match (const HeaderType1& in1, const HeaderType2& in2, const vector<size_t>& axes)
+    inline bool dimensions_match (const HeaderType1& in1, const HeaderType2& in2, const std::vector<size_t>& axes)
     {
       for (size_t n = 0; n < axes.size(); ++n) {
         if (in1.ndim() <= axes[n] || in2.ndim() <= axes[n]) return false;
@@ -428,7 +428,7 @@ namespace MR
     }
 
   template <class HeaderType1, class HeaderType2>
-    inline void check_dimensions (const HeaderType1& in1, const HeaderType2& in2, const vector<size_t>& axes)
+    inline void check_dimensions (const HeaderType1& in1, const HeaderType2& in2, const std::vector<size_t>& axes)
     {
       if (!dimensions_match (in1, in2, axes))
         throw Exception ("dimension mismatch between \"" + in1.name() + "\" and \"" + in2.name() + "\" for axes [" + join(axes, ",") + "]" +

--- a/core/image_io/base.h
+++ b/core/image_io/base.h
@@ -85,7 +85,7 @@ namespace MR
           return segsize;
         }
 
-        vector<File::Entry> files;
+        std::vector<File::Entry> files;
 
         void merge (const Base& B) {
           assert (addresses.empty());
@@ -102,7 +102,7 @@ namespace MR
 
       protected:
         size_t segsize;
-        vector<std::unique_ptr<uint8_t[]>> addresses;
+        std::vector<std::unique_ptr<uint8_t[]>> addresses;
         bool is_new, writable;
 
         void check () const {

--- a/core/image_io/default.h
+++ b/core/image_io/default.h
@@ -36,7 +36,7 @@ namespace MR
         Default& operator=(Default&&) = delete;
 
       protected:
-        vector<std::shared_ptr<File::MMap> > mmaps;
+        std::vector<std::shared_ptr<File::MMap> > mmaps;
         int64_t bytes_per_segment;
 
         virtual void load (const Header&, size_t);

--- a/core/image_io/variable_scaling.h
+++ b/core/image_io/variable_scaling.h
@@ -40,7 +40,7 @@ namespace MR
             default_type offset, scale;
         };
 
-        vector<ScaleFactor> scale_factors;
+        std::vector<ScaleFactor> scale_factors;
 
       protected:
         virtual void load (const Header&, size_t);

--- a/core/interp/sinc.h
+++ b/core/interp/sinc.h
@@ -158,7 +158,7 @@ namespace MR
         const size_t window_size;
         const int kernel_width;
         Math::Sinc<value_type> Sinc_x, Sinc_y, Sinc_z;
-        vector<value_type> y_values, z_values;
+        std::vector<value_type> y_values, z_values;
 
     };
 

--- a/core/math/SH.h
+++ b/core/math/SH.h
@@ -391,7 +391,7 @@ namespace MR
         public:
           PrecomputedFraction () : f1 (0.0), f2 (0.0) { }
           ValueType f1, f2;
-          typename vector<ValueType>::const_iterator p1, p2;
+          typename std::vector<ValueType>::const_iterator p1, p2;
       };
 
 
@@ -422,7 +422,7 @@ namespace MR
             Eigen::Matrix<value_type,Eigen::Dynamic,1,0,64> buf (lmax+1);
 
             for (int n = 0; n < ndir; n++) {
-              typename vector<value_type>::iterator p = AL.begin() + n*nAL;
+              typename std::vector<value_type>::iterator p = AL.begin() + n*nAL;
               value_type cos_el = std::cos (n*inc);
               for (int m = 0; m <= lmax; m++) {
                 Legendre::Plm_sph (buf, lmax, m, cos_el);
@@ -497,7 +497,7 @@ namespace MR
         protected:
           int lmax, ndir, nAL;
           ValueType inc;
-          vector<ValueType> AL;
+          std::vector<ValueType> AL;
       };
 
 

--- a/core/math/Sn_scale_estimator.h
+++ b/core/math/Sn_scale_estimator.h
@@ -45,7 +45,7 @@ namespace MR {
             }
 
         protected:
-          vector<value_type> diff, med_diff;
+          std::vector<value_type> diff, med_diff;
 
       };
 

--- a/core/math/average_space.cpp
+++ b/core/math/average_space.cpp
@@ -21,7 +21,7 @@ namespace MR
 {
    namespace Math
    {
-      double matrix_average (vector<Eigen::MatrixXd> const &mat_in, Eigen::MatrixXd& mat_avg, bool verbose) {
+      double matrix_average (std::vector<Eigen::MatrixXd> const &mat_in, Eigen::MatrixXd& mat_avg, bool verbose) {
         const size_t rows = mat_in[0].rows();
         const size_t cols = mat_in[0].cols();
         const size_t N = mat_in.size();
@@ -166,13 +166,13 @@ namespace MR
   void compute_average_voxel2scanner (Eigen::Transform<default_type, 3, Eigen::Projective>& average_v2s_trafo,
                                       Eigen::Vector3d& average_space_extent,
                                       Eigen::Vector3d& projected_voxel_sizes,
-                                      const vector<Header>& input_headers,
+                                      const std::vector<Header>& input_headers,
                                       const Eigen::Matrix<default_type, 4, 1>& padding,
-                                      const vector<Eigen::Transform<default_type, 3, Eigen::Projective>>& transform_header_with,
+                                      const std::vector<Eigen::Transform<default_type, 3, Eigen::Projective>>& transform_header_with,
                                       int voxel_subsampling) {
     const size_t num_images = input_headers.size();
     DEBUG ("compute_average_voxel2scanner num_images:" + str(num_images));
-    vector<Eigen::Transform<default_type, 3, Eigen::Projective>> transformation_matrices;
+    std::vector<Eigen::Transform<default_type, 3, Eigen::Projective>> transformation_matrices;
     Eigen::MatrixXd bounding_box_corners = Eigen::MatrixXd::Zero (8 * num_images, 4);
 
     for (size_t iFile = 0; iFile < num_images; iFile++) {
@@ -262,8 +262,8 @@ namespace MR
     }
   }
 
-  Header compute_minimum_average_header (const vector<Header>& input_headers,
-                                         const vector<Eigen::Transform<default_type, 3, Eigen::Projective>>& transform_header_with,
+  Header compute_minimum_average_header (const std::vector<Header>& input_headers,
+                                         const std::vector<Eigen::Transform<default_type, 3, Eigen::Projective>>& transform_header_with,
                                          int voxel_subsampling,
                                          Eigen::Matrix<default_type, 4, 1> padding) {
     Eigen::Transform<default_type, 3, Eigen::Projective> average_v2s_trafo;

--- a/core/math/average_space.h
+++ b/core/math/average_space.h
@@ -28,7 +28,7 @@ namespace MR
 {
    namespace Math
    {
-      double matrix_average (vector<Eigen::MatrixXd> const &mat_in, Eigen::MatrixXd& mat_avg, bool verbose = false);
+      double matrix_average (std::vector<Eigen::MatrixXd> const &mat_in, Eigen::MatrixXd& mat_avg, bool verbose = false);
    }
  }
 
@@ -37,8 +37,8 @@ namespace MR
   Eigen::Matrix<default_type, 8, 4> get_cuboid_corners (const Eigen::Matrix<default_type, 4, 1>& xzx1);
   Eigen::Matrix<default_type, 8, 4> get_bounding_box (const Header& header, const Eigen::Transform<default_type, 3, Eigen::Projective>& voxel2scanner);
 
-  Header compute_minimum_average_header (const vector<Header>& input_headers,
-                                         const vector<Eigen::Transform<default_type, 3, Eigen::Projective>>& transform_header_with,
+  Header compute_minimum_average_header (const std::vector<Header>& input_headers,
+                                         const std::vector<Eigen::Transform<default_type, 3, Eigen::Projective>>& transform_header_with,
                                          int voxel_subsampling = 1,
                                          Eigen::Matrix<default_type, 4, 1> padding = Eigen::Matrix<default_type, 4, 1>(1.0, 1.0, 1.0, 1.0));
 
@@ -50,8 +50,8 @@ namespace MR
         Eigen::Transform<default_type, 3, Eigen::Projective> transform_2 = Eigen::Transform<default_type, 3, Eigen::Projective>::Identity(),
         Eigen::Matrix<default_type, 4, 1> padding = Eigen::Matrix<default_type, 4, 1>(1.0, 1.0, 1.0, 1.0),
         int voxel_subsampling = 1) {
-      vector<Eigen::Transform<default_type, 3, Eigen::Projective>> init_transforms {transform_1, transform_2};
-      vector<Header> headers {im1,im2};
+      std::vector<Eigen::Transform<default_type, 3, Eigen::Projective>> init_transforms {transform_1, transform_2};
+      std::vector<Header> headers {im1,im2};
       return compute_minimum_average_header (headers, init_transforms, voxel_subsampling, padding);
     }
  }

--- a/core/math/constrained_least_squares.h
+++ b/core/math/constrained_least_squares.h
@@ -362,7 +362,7 @@ namespace MR
             const Problem<value_type>& P;
             matrix_type BtB, B;
             vector_type y_u, c, c_u, lambda, lambda_prev, l;
-            vector<bool> active;
+            std::vector<bool> active;
         };
 
 

--- a/core/math/erfinv.cpp
+++ b/core/math/erfinv.cpp
@@ -124,8 +124,8 @@ namespace MR
 
         private:
           const size_t N;
-          vector<default_type> m_Y;
-          vector<Eigen::Array<default_type, Eigen::Dynamic, 1>> m_P, m_Q;
+          std::vector<default_type> m_Y;
+          std::vector<Eigen::Array<default_type, Eigen::Dynamic, 1>> m_P, m_Q;
       };
       static const Shared shared;
 

--- a/core/math/math.h
+++ b/core/math/math.h
@@ -128,12 +128,12 @@ namespace MR
 
   //! read matrix data into a 2D vector \a filename
   template <class ValueType = default_type>
-    vector<vector<ValueType>> load_matrix_2D_vector (const std::string& filename, vector<std::string>* comments = nullptr)
+    std::vector<std::vector<ValueType>> load_matrix_2D_vector (const std::string& filename, std::vector<std::string>* comments = nullptr)
     {
       std::ifstream stream (filename, std::ios_base::in | std::ios_base::binary);
       if (!stream)
         throw Exception ("Unable to open numerical data text file \"" + filename + "\": " + strerror(errno));
-      vector<vector<ValueType>> V;
+      std::vector<std::vector<ValueType>> V;
       std::string sbuf, cbuf;
       size_t hash;
 
@@ -150,7 +150,7 @@ namespace MR
           continue;
 
         const auto elements = MR::split (sbuf, " ,;\t", true);
-        V.push_back (vector<ValueType>());
+        V.push_back (std::vector<ValueType>());
         try {
           for (const auto& entry : elements)
             V.back().push_back (to<ValueType> (entry));
@@ -179,7 +179,7 @@ namespace MR
     Eigen::Matrix<ValueType, Eigen::Dynamic, Eigen::Dynamic> load_matrix (const std::string& filename)
     {
       DEBUG ("loading matrix file \"" + filename + "\"...");
-      const vector<vector<ValueType>> V = load_matrix_2D_vector<ValueType> (filename);
+      const std::vector<std::vector<ValueType>> V = load_matrix_2D_vector<ValueType> (filename);
 
       Eigen::Matrix<ValueType, Eigen::Dynamic, Eigen::Dynamic> M (V.size(), V[0].size());
       for (ssize_t i = 0; i < M.rows(); i++)
@@ -214,8 +214,8 @@ namespace MR
   {
     DEBUG ("loading transform file \"" + filename + "\"...");
 
-    vector<std::string> comments;
-    const vector<vector<default_type>> V = load_matrix_2D_vector<> (filename, &comments);
+    std::vector<std::string> comments;
+    const std::vector<std::vector<default_type>> V = load_matrix_2D_vector<> (filename, &comments);
 
     if (V.empty())
       throw Exception ("transform in file " + filename + " is empty");
@@ -237,7 +237,7 @@ namespace MR
       centre[0] = NaN;
       centre[1] = NaN;
       centre[2] = NaN;
-      vector<std::string> elements;
+      std::vector<std::string> elements;
       for (auto & line : comments) {
         if (strncmp(line.c_str(), key.c_str(), key.size()) == 0)
           elements = split (strip (line.substr (key.size())), " ,;\t", true);

--- a/core/math/median.h
+++ b/core/math/median.h
@@ -89,7 +89,7 @@ namespace MR
       }
 
       bool convergence = false;
-      vector<default_type> dist(numIter);
+      std::vector<default_type> dist(numIter);
 
       // Minimizing the sum of the squares of the distances between each point in 'X' and the median.
       size_t i = 0;

--- a/core/math/sinc.h
+++ b/core/math/sinc.h
@@ -124,8 +124,8 @@ namespace MR
 
       private:
         const size_t window_size, max_offset_from_kernel_centre;
-        vector<size_t> indices;
-        vector<value_type> weights;
+        std::vector<size_t> indices;
+        std::vector<value_type> weights;
         value_type current_pos;
 
     };

--- a/core/math/stats/fwe.cpp
+++ b/core/math/stats/fwe.cpp
@@ -36,7 +36,7 @@ namespace MR
         assert (null_distributions.cols() == 1 || null_distributions.cols() == statistics.cols());
         matrix_type pvalues (statistics.rows(), statistics.cols());
 
-        auto s2p = [] (const vector<value_type>& null_dist, const matrix_type::ConstColXpr in, matrix_type::ColXpr out)
+        auto s2p = [] (const std::vector<value_type>& null_dist, const matrix_type::ConstColXpr in, matrix_type::ColXpr out)
         {
           for (ssize_t element = 0; element != in.size(); ++element) {
             if (in[element] > 0.0) {
@@ -56,7 +56,7 @@ namespace MR
 
         if (null_distributions.cols() == 1) { // strong fwe control
 
-          vector<value_type> sorted_null_dist;
+          std::vector<value_type> sorted_null_dist;
           sorted_null_dist.reserve (null_distributions.rows());
           for (ssize_t shuffle = 0; shuffle != null_distributions.rows(); ++shuffle)
             sorted_null_dist.push_back (null_distributions (shuffle, 0));
@@ -67,7 +67,7 @@ namespace MR
         } else { // weak fwe control
 
           for (ssize_t hypothesis = 0; hypothesis != statistics.cols(); ++hypothesis) {
-            vector<value_type> sorted_null_dist;
+            std::vector<value_type> sorted_null_dist;
             sorted_null_dist.reserve (null_distributions.rows());
             for (ssize_t shuffle = 0; shuffle != null_distributions.rows(); ++shuffle)
               sorted_null_dist.push_back (null_distributions (shuffle, hypothesis));

--- a/core/math/stats/glm.cpp
+++ b/core/math/stats/glm.cpp
@@ -121,7 +121,7 @@ namespace MR
               WARN ("Only a single variance group is defined in file \"" + opt[0][0] + "\"; variance groups will not be used");
               return index_array_type();
             }
-            vector<size_t> count_per_group (max_coeff + 1, 0);
+            std::vector<size_t> count_per_group (max_coeff + 1, 0);
             for (size_t i = 0; i != size_t(data.size()); ++i)
               count_per_group[data[i]]++;
             for (size_t vg_index = min_coeff; vg_index <= size_t(max_coeff); ++vg_index) {
@@ -139,9 +139,9 @@ namespace MR
 
 
 
-        vector<Hypothesis> load_hypotheses (const std::string& file_path)
+        std::vector<Hypothesis> load_hypotheses (const std::string& file_path)
         {
-          vector<Hypothesis> hypotheses;
+          std::vector<Hypothesis> hypotheses;
           const matrix_type contrast_matrix = load_matrix (file_path);
           for (ssize_t row = 0; row != contrast_matrix.rows(); ++row)
             hypotheses.emplace_back (Hypothesis (contrast_matrix.row (row), row));
@@ -164,7 +164,7 @@ namespace MR
               hypotheses.emplace_back (Hypothesis (this_f_matrix, ftest_index));
             }
             if (App::get_options ("fonly").size()) {
-              vector<Hypothesis> new_hypotheses;
+              std::vector<Hypothesis> new_hypotheses;
               for (size_t index = contrast_matrix.rows(); index != hypotheses.size(); ++index)
                 new_hypotheses.push_back (std::move (hypotheses[index]));
               std::swap (hypotheses, new_hypotheses);
@@ -195,7 +195,7 @@ namespace MR
             return hypothesis.matrix() * solve_betas (measurements, design);
         }
 
-        matrix_type abs_effect_size (const matrix_type& measurements, const matrix_type& design, const vector<Hypothesis>& hypotheses)
+        matrix_type abs_effect_size (const matrix_type& measurements, const matrix_type& design, const std::vector<Hypothesis>& hypotheses)
         {
           matrix_type result (measurements.cols(), hypotheses.size());
           for (size_t ic = 0; ic != hypotheses.size(); ++ic)
@@ -252,7 +252,7 @@ namespace MR
           return abs_effect_size (measurements, design, hypothesis).array() / stdev (measurements, design).array().col(0);
         }
 
-        matrix_type std_effect_size (const matrix_type& measurements, const matrix_type& design, const vector<Hypothesis>& hypotheses)
+        matrix_type std_effect_size (const matrix_type& measurements, const matrix_type& design, const std::vector<Hypothesis>& hypotheses)
         {
           const vector_type stdev_reciprocal = vector_type::Ones (measurements.cols()) / stdev (measurements, design).array().col(0);
           matrix_type result (measurements.cols(), hypotheses.size());
@@ -268,7 +268,7 @@ namespace MR
 
         void all_stats (const matrix_type& measurements,
                         const matrix_type& design,
-                        const vector<Hypothesis>& hypotheses,
+                        const std::vector<Hypothesis>& hypotheses,
                         const index_array_type& variance_groups,
                         matrix_type& betas,
                         matrix_type& abs_effect_size,
@@ -333,8 +333,8 @@ namespace MR
 
         void all_stats (const matrix_type& measurements,
                         const matrix_type& fixed_design,
-                        const vector<CohortDataImport>& extra_data,
-                        const vector<Hypothesis>& hypotheses,
+                        const std::vector<CohortDataImport>& extra_data,
+                        const std::vector<Hypothesis>& hypotheses,
                         const index_array_type& variance_groups,
                         vector_type& cond,
                         matrix_type& betas,
@@ -374,7 +374,7 @@ namespace MR
           class Functor
           {
             public:
-              Functor (const matrix_type& data, const matrix_type& design_fixed, const vector<CohortDataImport>& extra_data, const vector<Hypothesis>& hypotheses, const index_array_type& variance_groups,
+              Functor (const matrix_type& data, const matrix_type& design_fixed, const std::vector<CohortDataImport>& extra_data, const std::vector<Hypothesis>& hypotheses, const index_array_type& variance_groups,
                        vector_type& cond, matrix_type& betas, matrix_type& abs_effect_size, matrix_type& std_effect_size, matrix_type& stdev) :
                   data (data),
                   design_fixed (design_fixed),
@@ -453,8 +453,8 @@ namespace MR
             private:
               const matrix_type& data;
               const matrix_type& design_fixed;
-              const vector<CohortDataImport>& extra_data;
-              const vector<Hypothesis>& hypotheses;
+              const std::vector<CohortDataImport>& extra_data;
+              const std::vector<Hypothesis>& hypotheses;
               const index_array_type& variance_groups;
               vector_type& global_cond;
               matrix_type& global_betas;
@@ -564,7 +564,7 @@ namespace MR
 
 
 
-        TestFixedHomoscedastic::TestFixedHomoscedastic (const matrix_type& measurements, const matrix_type& design, const vector<Hypothesis>& hypotheses) :
+        TestFixedHomoscedastic::TestFixedHomoscedastic (const matrix_type& measurements, const matrix_type& design, const std::vector<Hypothesis>& hypotheses) :
             TestBase (measurements, design, hypotheses),
             pinvM (Math::pinv (M)),
             Rm (matrix_type::Identity (num_inputs(), num_inputs()) - (M*pinvM))
@@ -669,7 +669,7 @@ namespace MR
 
 
 
-        TestFixedHeteroscedastic::TestFixedHeteroscedastic (const matrix_type& measurements, const matrix_type& design, const vector<Hypothesis>& hypotheses, const index_array_type& variance_groups) :
+        TestFixedHeteroscedastic::TestFixedHeteroscedastic (const matrix_type& measurements, const matrix_type& design, const std::vector<Hypothesis>& hypotheses, const index_array_type& variance_groups) :
             TestFixedHomoscedastic (measurements, design, hypotheses),
             VG (variance_groups),
             num_vgs (VG.maxCoeff() + 1),
@@ -828,10 +828,10 @@ namespace MR
 
 
 
-        TestVariableHomoscedastic::TestVariableHomoscedastic (const vector<CohortDataImport>& importers,
+        TestVariableHomoscedastic::TestVariableHomoscedastic (const std::vector<CohortDataImport>& importers,
                                                               const matrix_type& measurements,
                                                               const matrix_type& design,
-                                                              const vector<Hypothesis>& hypotheses,
+                                                              const std::vector<Hypothesis>& hypotheses,
                                                               const bool nans_in_data,
                                                               const bool nans_in_columns) :
             TestBase (measurements, design, hypotheses),
@@ -1078,10 +1078,10 @@ namespace MR
 
 
 
-        TestVariableHeteroscedastic::TestVariableHeteroscedastic (const vector<CohortDataImport>& importers,
+        TestVariableHeteroscedastic::TestVariableHeteroscedastic (const std::vector<CohortDataImport>& importers,
                                                                   const matrix_type& measurements,
                                                                   const matrix_type& design,
-                                                                  const vector<Hypothesis>& hypotheses,
+                                                                  const std::vector<Hypothesis>& hypotheses,
                                                                   const index_array_type& variance_groups,
                                                                   const bool nans_in_data,
                                                                   const bool nans_in_columns) :

--- a/core/math/stats/glm.h
+++ b/core/math/stats/glm.h
@@ -117,7 +117,7 @@ namespace MR
 
         index_array_type load_variance_groups (const size_t num_inputs);
 
-        vector<Hypothesis> load_hypotheses (const std::string& file_path);
+        std::vector<Hypothesis> load_hypotheses (const std::string& file_path);
 
 
 
@@ -139,7 +139,7 @@ namespace MR
          * @return the matrix containing the output absolute effect sizes (one column of element effect sizes per contrast)
          */
         vector_type abs_effect_size (const matrix_type& measurements, const matrix_type& design, const Hypothesis& hypothesis);
-        matrix_type abs_effect_size (const matrix_type& measurements, const matrix_type& design, const vector<Hypothesis>& hypotheses);
+        matrix_type abs_effect_size (const matrix_type& measurements, const matrix_type& design, const std::vector<Hypothesis>& hypotheses);
 
 
 
@@ -168,7 +168,7 @@ namespace MR
          * @return the matrix containing the output standardised effect sizes (one column of element effect sizes per contrast)
          */
         vector_type std_effect_size (const matrix_type& measurements, const matrix_type& design, const Hypothesis& hypothesis);
-        matrix_type std_effect_size (const matrix_type& measurements, const matrix_type& design, const vector<Hypothesis>& hypotheses);
+        matrix_type std_effect_size (const matrix_type& measurements, const matrix_type& design, const std::vector<Hypothesis>& hypotheses);
 
 
 
@@ -183,7 +183,7 @@ namespace MR
          * @param std_effect_size the matrix containing the output standardised effect size
          * @param stdev the matrix containing the output standard deviation
          */
-        void all_stats (const matrix_type& measurements, const matrix_type& design, const vector<Hypothesis>& hypotheses, const index_array_type& variance_groups,
+        void all_stats (const matrix_type& measurements, const matrix_type& design, const std::vector<Hypothesis>& hypotheses, const index_array_type& variance_groups,
                         matrix_type& betas, matrix_type& abs_effect_size, matrix_type& std_effect_size, matrix_type& stdev);
 
         /*! Compute all GLM-related statistics
@@ -198,7 +198,7 @@ namespace MR
          * @param std_effect_size the matrix containing the output standardised effect size
          * @param stdev the matrix containing the output standard deviation
          */
-        void all_stats (const matrix_type& measurements, const matrix_type& design, const vector<CohortDataImport>& extra_columns, const vector<Hypothesis>& hypotheses, const index_array_type& variance_groups,
+        void all_stats (const matrix_type& measurements, const matrix_type& design, const std::vector<CohortDataImport>& extra_columns, const std::vector<Hypothesis>& hypotheses, const index_array_type& variance_groups,
                         vector_type& cond, matrix_type& betas, matrix_type& abs_effect_size, matrix_type& std_effect_size, matrix_type& stdev);
 
         //! @}
@@ -212,7 +212,7 @@ namespace MR
         class TestBase
         { 
           public:
-            TestBase (const matrix_type& measurements, const matrix_type& design, const vector<Hypothesis>& hypotheses) :
+            TestBase (const matrix_type& measurements, const matrix_type& design, const std::vector<Hypothesis>& hypotheses) :
                 y (measurements),
                 M (design),
                 c (hypotheses),
@@ -251,7 +251,7 @@ namespace MR
 
           protected:
             const matrix_type& y, M;
-            const vector<Hypothesis>& c;
+            const std::vector<Hypothesis>& c;
             std::shared_ptr<Math::Zstatistic> stat2z;
 
         };
@@ -280,7 +280,7 @@ namespace MR
              */
             TestFixedHomoscedastic (const matrix_type& measurements,
                                     const matrix_type& design,
-                                    const vector<Hypothesis>& hypotheses);
+                                    const std::vector<Hypothesis>& hypotheses);
 
             /*! Compute the statistics
              * @param shuffling_matrix a matrix to permute / sign flip the residuals (for permutation testing)
@@ -291,11 +291,11 @@ namespace MR
 
           protected:
             // New classes to store information relevant to Freedman-Lane implementation
-            vector<Hypothesis::Partition> partitions;
+            std::vector<Hypothesis::Partition> partitions;
             const matrix_type pinvM;
             const matrix_type Rm;
-            vector<matrix_type> XtX;
-            vector<default_type> one_over_dof;
+            std::vector<matrix_type> XtX;
+            std::vector<default_type> one_over_dof;
 
         };
         //! @}
@@ -323,7 +323,7 @@ namespace MR
              */
             TestFixedHeteroscedastic (const matrix_type& measurements,
                                       const matrix_type& design,
-                                      const vector<Hypothesis>& hypotheses,
+                                      const std::vector<Hypothesis>& hypotheses,
                                       const index_array_type& variance_groups);
 
             size_t num_variance_groups() const { return num_vgs; }
@@ -341,7 +341,7 @@ namespace MR
             // Total number of variance groups
             const size_t num_vgs;
             // Number of inputs that are part of each variance group
-            vector<size_t> inputs_per_vg;
+            std::vector<size_t> inputs_per_vg;
             // Might as well construct this in the functor rather than here,
             //   given 1 value for each VG is computed
             vector_type Rnn_sums;
@@ -373,10 +373,10 @@ namespace MR
         class TestVariableHomoscedastic : public TestBase
         { 
           public:
-            TestVariableHomoscedastic (const vector<CohortDataImport>& importers,
+            TestVariableHomoscedastic (const std::vector<CohortDataImport>& importers,
                                        const matrix_type& measurements,
                                        const matrix_type& design,
-                                       const vector<Hypothesis>& hypotheses,
+                                       const std::vector<Hypothesis>& hypotheses,
                                        const bool nans_in_data,
                                        const bool nans_in_columns);
 
@@ -393,7 +393,7 @@ namespace MR
             size_t num_factors() const override { return M.cols() + importers.size(); }
 
           protected:
-            const vector<CohortDataImport>& importers;
+            const std::vector<CohortDataImport>& importers;
             const bool nans_in_data, nans_in_columns;
 
             void get_mask (const size_t ie, BitSet&, const matrix_type& extra_columns) const;
@@ -427,10 +427,10 @@ namespace MR
         class TestVariableHeteroscedastic : public TestVariableHomoscedastic
         { 
           public:
-            TestVariableHeteroscedastic (const vector<CohortDataImport>& importers,
+            TestVariableHeteroscedastic (const std::vector<CohortDataImport>& importers,
                                          const matrix_type& measurements,
                                          const matrix_type& design,
-                                         const vector<Hypothesis>& hypotheses,
+                                         const std::vector<Hypothesis>& hypotheses,
                                          const index_array_type& variance_groups,
                                          const bool nans_in_data,
                                          const bool nans_in_columns);

--- a/core/math/stats/import.h
+++ b/core/math/stats/import.h
@@ -112,7 +112,7 @@ namespace MR
           bool allFinite() const;
 
         protected:
-          vector<std::shared_ptr<SubjectDataImportBase>> files;
+          std::vector<std::shared_ptr<SubjectDataImportBase>> files;
       };
 
 
@@ -132,7 +132,7 @@ namespace MR
         //   current working directory
         // Only once a directory is selected that contains all inputs listed in the
         //   text file is an attempt made to load all of those files
-        vector<std::string> lines;
+        std::vector<std::string> lines;
         {
           std::ifstream ifs (listpath.c_str());
           if (!ifs)
@@ -147,7 +147,7 @@ namespace MR
           }
         }
 
-        vector<std::string> directories { Path::dirname (listpath) };
+        std::vector<std::string> directories { Path::dirname (listpath) };
         if (directories[0].empty())
           directories[0] = ".";
         else if (directories[0] != ".")

--- a/core/math/stats/shuffle.cpp
+++ b/core/math/stats/shuffle.cpp
@@ -257,7 +257,7 @@ namespace MR
 
         size_t max_num_permutations;
         if (eb_within.size()) {
-          vector<size_t> counts (eb_within.maxCoeff()+1, 0);
+          std::vector<size_t> counts (eb_within.maxCoeff()+1, 0);
           for (ssize_t i = 0; i != eb_within.size(); ++i)
             counts[eb_within[i]]++;
           max_num_permutations = 1;
@@ -324,7 +324,7 @@ namespace MR
             if (nshuffles == max_shuffles) {
               generate_all_permutations (rows, eb_within, eb_whole);
               assert (permutations.size() == max_num_permutations);
-              vector<PermuteLabels> duplicated_permutations;
+              std::vector<PermuteLabels> duplicated_permutations;
               duplicated_permutations.reserve (max_shuffles);
               for (const auto& p : permutations) {
                 for (size_t i = 0; i != max_num_signflips; ++i)
@@ -354,7 +354,7 @@ namespace MR
             if (nshuffles == max_shuffles) {
               generate_all_signflips (rows, eb_whole);
               assert (signflips.size() == max_num_signflips);
-              vector<BitSet> duplicated_signflips;
+              std::vector<BitSet> duplicated_signflips;
               duplicated_signflips.reserve (max_shuffles);
               for (size_t i = 0; i != max_num_permutations; ++i)
                 duplicated_signflips.insert (duplicated_signflips.end(), signflips.begin(), signflips.end());
@@ -394,7 +394,7 @@ namespace MR
           data.array() -= 1;
           max_coeff--;
         }
-        vector<size_t> counts (max_coeff+1, 0);
+        std::vector<size_t> counts (max_coeff+1, 0);
         for (size_t i = 0; i != size_t(data.size()); ++i)
           counts[data[i]]++;
         for (size_t i = 0; i <= max_coeff; ++i) {
@@ -471,7 +471,7 @@ namespace MR
           return;
         }
 
-        vector<vector<size_t>> blocks;
+        std::vector<std::vector<size_t>> blocks;
 
         // Within-block exchangeability
         if (eb_within.size()) {
@@ -482,7 +482,7 @@ namespace MR
               permuted_labelling = default_labelling;
               // Random permutation within each block independently
               for (size_t ib = 0; ib != blocks.size(); ++ib) {
-                vector<size_t> permuted_block (blocks[ib]);
+                std::vector<size_t> permuted_block (blocks[ib]);
                 std::shuffle (permuted_block.begin(), permuted_block.end(), rng);
                 for (size_t i = 0; i != permuted_block.size(); ++i)
                   permuted_labelling[blocks[ib][i]] = permuted_block[i];
@@ -538,14 +538,14 @@ namespace MR
           return;
         }
 
-        vector<vector<size_t>> original;
+        std::vector<std::vector<size_t>> original;
 
         // Within-block exchangeability
         if (eb_within.size()) {
 
           original = indices2blocks (eb_within);
 
-          auto write = [&] (const vector<vector<size_t>>& data)
+          auto write = [&] (const std::vector<std::vector<size_t>>& data)
           {
             PermuteLabels temp (num_rows);
             for (size_t block = 0; block != data.size(); ++block) {
@@ -555,7 +555,7 @@ namespace MR
             permutations.push_back (std::move (temp));
           };
 
-          vector<vector<size_t>> blocks (original);
+          std::vector<std::vector<size_t>> blocks (original);
           write (blocks);
           do {
             size_t ib = 0;
@@ -602,7 +602,7 @@ namespace MR
 
       void Shuffler::load_permutations (const std::string& filename)
       {
-        vector<vector<size_t> > temp = load_matrix_2D_vector<size_t> (filename);
+        std::vector<std::vector<size_t> > temp = load_matrix_2D_vector<size_t> (filename);
         if (!temp.size())
           throw Exception ("no data found in permutations file: " + str(filename));
 
@@ -737,10 +737,10 @@ namespace MR
 
 
 
-      vector<vector<size_t>> Shuffler::indices2blocks (const index_array_type& indices) const
+      std::vector<std::vector<size_t>> Shuffler::indices2blocks (const index_array_type& indices) const
       {
         const size_t num_blocks = indices.maxCoeff()+1;
-        vector<vector<size_t>> result;
+        std::vector<std::vector<size_t>> result;
         result.resize (num_blocks);
         for (ssize_t i = 0; i != indices.size(); ++i)
           result[indices[i]].push_back (i);

--- a/core/math/stats/shuffle.h
+++ b/core/math/stats/shuffle.h
@@ -63,7 +63,7 @@ namespace MR
       class Shuffler
       { 
         public:
-          typedef vector<size_t> PermuteLabels;
+          typedef std::vector<size_t> PermuteLabels;
           enum class error_t { EE, ISE, BOTH };
 
           // First version reads command-line options in order to determine parameters prior to running initialise();
@@ -98,8 +98,8 @@ namespace MR
 
         private:
           const size_t rows;
-          vector<PermuteLabels> permutations;
-          vector<BitSet> signflips;
+          std::vector<PermuteLabels> permutations;
+          std::vector<BitSet> signflips;
           size_t nshuffles, counter;
           std::unique_ptr<ProgressBar> progress;
 
@@ -149,7 +149,7 @@ namespace MR
                                        const index_array_type& blocks);
 
 
-          vector<vector<size_t>> indices2blocks (const index_array_type&) const;
+          std::vector<std::vector<size_t>> indices2blocks (const index_array_type&) const;
 
       };
 

--- a/core/misc/voxel2vector.h
+++ b/core/misc/voxel2vector.h
@@ -53,7 +53,7 @@ namespace MR
 
       size_t size() const { return reverse.size(); }
 
-      const vector<index_t>& operator[] (const size_t index) const {
+      const std::vector<index_t>& operator[] (const size_t index) const {
         assert (index < reverse.size());
         return reverse[index];
       }
@@ -69,7 +69,7 @@ namespace MR
 
     private:
       Image<index_t> forward;
-      vector< vector<index_t> > reverse;
+      std::vector< std::vector<index_t> > reverse;
   };
 
 
@@ -89,7 +89,7 @@ namespace MR
     for (auto l = Loop(data) (r_mask, forward); l; ++l) {
       if (r_mask.value()) {
         forward.value() = counter++;
-        vector<index_t> pos;
+        std::vector<index_t> pos;
         for (size_t index = 0; index != data.ndim(); ++index)
           pos.push_back (forward.index(index));
         reverse.push_back (pos);

--- a/core/mrtrix.cpp
+++ b/core/mrtrix.cpp
@@ -24,9 +24,9 @@ namespace MR
    *                       Miscellaneous functions                        *
    ************************************************************************/
 
-  vector<default_type> parse_floats (const std::string& spec)
+  std::vector<default_type> parse_floats (const std::string& spec)
   {
-    vector<default_type> V;
+    std::vector<default_type> V;
     if (!spec.size()) throw Exception ("floating-point sequence specifier is empty");
     std::string::size_type start = 0, end;
     default_type range_spec[3];
@@ -68,9 +68,9 @@ namespace MR
 
 
 
-  vector<std::string> split (const std::string& string, const char* delimiters, bool ignore_empty_fields, size_t num)
+  std::vector<std::string> split (const std::string& string, const char* delimiters, bool ignore_empty_fields, size_t num)
   {
-    vector<std::string> V;
+    std::vector<std::string> V;
     if (!string.size())
       return V;
     std::string::size_type start = 0, end;

--- a/core/mrtrix.h
+++ b/core/mrtrix.h
@@ -170,13 +170,13 @@ namespace MR
   }
 
 
-  vector<std::string> split (
+  std::vector<std::string> split (
     const std::string& string,
     const char* delimiters = " \t\n",
     bool ignore_empty_fields = false,
     size_t num = std::numeric_limits<size_t>::max());
 
-  inline vector<std::string> split_lines (
+  inline std::vector<std::string> split_lines (
       const std::string& string,
       bool ignore_empty_fields = true,
       size_t num = std::numeric_limits<size_t>::max())
@@ -311,7 +311,7 @@ namespace MR
       throw Exception ("cannot convert empty string to complex float");
 
     const std::string stripped = strip (string);
-    vector<cfloat> candidates;
+    std::vector<cfloat> candidates;
     for (ssize_t i = -1; i <= ssize_t(stripped.size()); ++i) {
       std::string first, second;
       if (i == -1) {
@@ -369,7 +369,7 @@ namespace MR
       throw Exception ("cannot convert empty string to complex double");
 
     const std::string stripped = strip (string);
-    vector<cdouble> candidates;
+    std::vector<cdouble> candidates;
     for (ssize_t i = -1; i <= ssize_t(stripped.size()); ++i) {
       std::string first, second;
       if (i == -1) {
@@ -414,12 +414,12 @@ namespace MR
 
 
 
-  vector<default_type> parse_floats (const std::string& spec);
+  std::vector<default_type> parse_floats (const std::string& spec);
 
 
 
   template <typename IntType>
-  vector<IntType> parse_ints (const std::string& spec, const IntType last = std::numeric_limits<IntType>::max())
+  std::vector<IntType> parse_ints (const std::string& spec, const IntType last = std::numeric_limits<IntType>::max())
   {
     typedef typename std::make_signed<IntType>::type SignedIntType;
     if (!spec.size()) throw Exception ("integer sequence specifier is empty");
@@ -431,7 +431,7 @@ namespace MR
       return IntType(value);
     };
 
-    vector<IntType> V;
+    std::vector<IntType> V;
     std::string::size_type start = 0, end;
     std::array<SignedIntType, 3> num;
     size_t i = 0;
@@ -495,25 +495,25 @@ namespace MR
 
 
 
-  inline std::string join (const vector<std::string>& V, const std::string& delimiter)
+  inline std::string join (const std::vector<std::string>& V, const std::string& delimiter)
   {
     std::string ret;
     if (V.empty())
       return ret;
     ret = V[0];
-    for (vector<std::string>::const_iterator i = V.begin() +1; i != V.end(); ++i)
+    for (std::vector<std::string>::const_iterator i = V.begin() +1; i != V.end(); ++i)
       ret += delimiter + *i;
     return ret;
   }
 
   template <typename T>
-  inline std::string join (const vector<T>& V, const std::string& delimiter)
+  inline std::string join (const std::vector<T>& V, const std::string& delimiter)
   {
     std::string ret;
     if (V.empty())
       return ret;
     ret = str(V[0]);
-    for (typename vector<T>::const_iterator i = V.begin() +1; i != V.end(); ++i)
+    for (typename std::vector<T>::const_iterator i = V.begin() +1; i != V.end(); ++i)
       ret += delimiter + str(*i);
     return ret;
   }

--- a/core/ordered_thread_queue.h
+++ b/core/ordered_thread_queue.h
@@ -202,7 +202,7 @@ namespace MR {
 
        template <class Item> struct Type<__Ordered<__Batch<Item>>> { 
          using item = Item;
-         using queue = Queue<__Ordered<vector<Item>>>;
+         using queue = Queue<__Ordered<std::vector<Item>>>;
          using reader = typename queue::Reader;
          using writer = typename queue::Writer;
          using read_item = typename reader::Item;
@@ -215,7 +215,7 @@ namespace MR {
          struct __Source<__Ordered<__Batch<Item>>,Functor> {
            
 
-           using queued_t = __Ordered<vector<Item>>;
+           using queued_t = __Ordered<std::vector<Item>>;
            using passed_t = __Ordered<__Batch<Item>>;
            using queue_t = typename Type<queued_t>::queue;
            using writer_t = typename Type<queued_t>::writer;
@@ -258,8 +258,8 @@ namespace MR {
          struct __Pipe<__Ordered<__Batch<Item1>>,Functor,__Ordered<__Batch<Item2>>> {
            
 
-           using queued1_t = __Ordered<vector<Item1>>;
-           using queued2_t = __Ordered<vector<Item2>>;
+           using queued1_t = __Ordered<std::vector<Item1>>;
+           using queued2_t = __Ordered<std::vector<Item2>>;
            using passed2_t = __Ordered<__Batch<Item2>>;
            using queue1_t = typename Type<queued1_t>::queue;
            using queue2_t = typename Type<queued2_t>::queue;
@@ -306,7 +306,7 @@ namespace MR {
          struct __Sink<__Ordered<__Batch<Item>>,Functor> {
            
 
-           using queued_t = __Ordered<vector<Item>>;
+           using queued_t = __Ordered<std::vector<Item>>;
            using queue_t = typename Type<queued_t>::queue;
            using reader_t = typename Type<queued_t>::reader;
            using functor_t = typename __job<Functor>::member_type;

--- a/core/phase_encoding.h
+++ b/core/phase_encoding.h
@@ -226,8 +226,8 @@ namespace MR
     template <class MatrixType, class HeaderType>
     Eigen::MatrixXd transform_for_nifti_write (const MatrixType& pe_scheme, const HeaderType& H)
     {
-      vector<size_t> order;
-      vector<bool> flip;
+      std::vector<size_t> order;
+      std::vector<bool> flip;
       File::NIfTI::axes_on_write (H, order, flip);
       if (order[0] == 0 && order[1] == 1 && order[2] == 2 && !flip[0] && !flip[1] && !flip[2]) {
         INFO ("No transformation of phase encoding data required for export to file");

--- a/core/stats.h
+++ b/core/stats.h
@@ -69,7 +69,7 @@ namespace MR
           }
         }
 
-        template <class ImageType> void print (ImageType& ima, const vector<std::string>& fields) {
+        template <class ImageType> void print (ImageType& ima, const std::vector<std::string>& fields) {
 
           if (count > 1) {
             std = complex_type(sqrt (m2.real() / value_type (count - 1)), sqrt (m2.imag() / value_type (count - 1)));
@@ -132,7 +132,7 @@ namespace MR
         complex_type mean, delta, delta2, m2, std, std_rv, min, max;
         size_t count;
         const bool is_complex, ignore_zero;
-        vector<float> values;
+        std::vector<float> values;
     };
 
 

--- a/core/stride.cpp
+++ b/core/stride.cpp
@@ -39,7 +39,7 @@ namespace MR
 
 
 
-    List& sanitise (List& current, const List& desired, const vector<ssize_t>& dims)
+    List& sanitise (List& current, const List& desired, const std::vector<ssize_t>& dims)
     {
       // remove duplicates
       for (size_t i = 0; i < current.size()-1; ++i) {

--- a/core/stride.h
+++ b/core/stride.h
@@ -60,7 +60,7 @@ namespace MR
   namespace Stride
   {
 
-    using List = vector<ssize_t>;
+    using List = std::vector<ssize_t>;
 
     extern const App::OptionGroup Options;
 
@@ -120,7 +120,7 @@ namespace MR
 
 
 
-    //! return the strides of \a header as a vector<ssize_t>
+    //! return the strides of \a header as a std::vector<ssize_t>
     template <class HeaderType> 
       List get (const HeaderType& header)
       {
@@ -130,7 +130,7 @@ namespace MR
         return ret;
       }
 
-    //! set the strides of \a header from a vector<ssize_t>
+    //! set the strides of \a header from a std::vector<ssize_t>
     template <class HeaderType>
       void set (HeaderType& header, const List& stride)
       {
@@ -156,11 +156,11 @@ namespace MR
      * absolute stride.
      * \note all strides should be valid (i.e. non-zero). */
     template <class HeaderType> 
-      vector<size_t> order (const HeaderType& header, size_t from_axis = 0, size_t to_axis = std::numeric_limits<size_t>::max())
+      std::vector<size_t> order (const HeaderType& header, size_t from_axis = 0, size_t to_axis = std::numeric_limits<size_t>::max())
       {
         to_axis = std::min<size_t> (to_axis, header.ndim());
         assert (to_axis > from_axis);
-        vector<size_t> ret (to_axis-from_axis);
+        std::vector<size_t> ret (to_axis-from_axis);
         for (size_t i = 0; i < ret.size(); ++i) 
           ret[i] = from_axis+i;
         Compare<HeaderType> compare (header);
@@ -173,7 +173,7 @@ namespace MR
      * absolute stride.
      * \note all strides should be valid (i.e. non-zero). */
     template <> inline 
-      vector<size_t> order<List> (const List& strides, size_t from_axis, size_t to_axis)
+      std::vector<size_t> order<List> (const List& strides, size_t from_axis, size_t to_axis)
       {
         const Wrapper wrapper (const_cast<List&> (strides));
         return order (wrapper, from_axis, to_axis);
@@ -231,7 +231,7 @@ namespace MR
      * zero) or duplicate (absolute) strides, and assigning to each a
      * suitable value. The value chosen for each sanitised stride is the
      * lowest number greater than any of the currently valid strides. */
-    List& sanitise (List& current, const List& desired, const vector<ssize_t>& header);
+    List& sanitise (List& current, const List& desired, const std::vector<ssize_t>& header);
 
 
     //! convert strides from symbolic to actual strides
@@ -239,7 +239,7 @@ namespace MR
       void actualise (HeaderType& header)
       {
         sanitise (header);
-        vector<size_t> x (order (header));
+        std::vector<size_t> x (order (header));
         ssize_t skip = 1;
         for (size_t i = 0; i < header.ndim(); ++i) {
           header.stride (x[i]) = header.stride (x[i]) < 0 ? -skip : skip;
@@ -280,7 +280,7 @@ namespace MR
     template <class HeaderType> 
       void symbolise (HeaderType& header)
       {
-        vector<size_t> p (order (header));
+        std::vector<size_t> p (order (header));
         for (ssize_t i = 0; i < ssize_t (p.size()); ++i)
           if (header.stride (p[i]) != 0)
             header.stride (p[i]) = header.stride (p[i]) < 0 ? -(i+1) : i+1;
@@ -366,7 +366,7 @@ namespace MR
         List in (get_symbolic (current)), out (desired);
         out.resize (in.size(), 0);
 
-        vector<ssize_t> dims (current.ndim());
+        std::vector<ssize_t> dims (current.ndim());
         for (size_t n = 0; n < dims.size(); ++n)
           dims[n] = current.size(n);
 

--- a/core/thread.h
+++ b/core/thread.h
@@ -198,8 +198,8 @@ namespace MR
               }
             }
           protected:
-            vector<std::future<void>> threads;
-            vector<typename std::remove_reference<Functor>::type> functors;
+            std::vector<std::future<void>> threads;
+            std::vector<typename std::remove_reference<Functor>::type> functors;
 
         };
 

--- a/core/thread_queue.h
+++ b/core/thread_queue.h
@@ -529,8 +529,8 @@ namespace MR
          T** back;
          size_t capacity;
          size_t writer_count, reader_count;
-         std::stack<T*,vector<T*> > item_stack;
-         vector<std::unique_ptr<T>> items;
+         std::stack<T*,std::vector<T*> > item_stack;
+         std::vector<std::unique_ptr<T>> items;
          std::string name;
 
          void register_writer ()   {
@@ -667,7 +667,7 @@ namespace MR
 
        template <class Item> struct Type<__Batch<Item>> { 
          using item = Item;
-         using queue = Queue<vector<Item>>;
+         using queue = Queue<std::vector<Item>>;
          using reader = typename queue::Reader;
          using writer = typename queue::Writer;
          using read_item = typename reader::Item;

--- a/core/types.h
+++ b/core/types.h
@@ -109,7 +109,7 @@ namespace MR {
 
 #ifdef MRTRIX_NO_VLA
 # define VLA(name, type, num) \
-  vector<type> __vla__ ## name(num); \
+  std::vector<type> __vla__ ## name(num); \
   type* name = &__vla__ ## name[0]
 # define VLA_MAX(name, type, num, max) type name[max]
 #else
@@ -138,7 +138,7 @@ namespace MR {
 
 #ifdef MRTRIX_NO_NON_POD_VLA
 # define NON_POD_VLA(name, type, num) \
-  vector<type> __vla__ ## name(num); \
+  std::vector<type> __vla__ ## name(num); \
   type* name = &__vla__ ## name[0]
 # define NON_POD_VLA_MAX(name, type, num, max) type name[max]
 #else
@@ -200,21 +200,6 @@ namespace MR
 
 
   template <typename X, int N=(alignof(X)>::MR::malloc_align)>
-    class vector : public ::std::vector<X, Eigen::aligned_allocator<X>> {
-      public:
-        using ::std::vector<X,Eigen::aligned_allocator<X>>::vector;
-        vector() { }
-    };
-
-  template <typename X>
-    class vector<X,0> : public ::std::vector<X> {
-      public:
-        using ::std::vector<X>::vector;
-        vector() { }
-    };
-
-
-  template <typename X, int N=(alignof(X)>::MR::malloc_align)>
     class deque : public ::std::deque<X, Eigen::aligned_allocator<X>> {
       public:
         using ::std::deque<X,Eigen::aligned_allocator<X>>::deque;
@@ -252,7 +237,7 @@ namespace MR
 namespace std
 {
 
-  template <class T> inline ostream& operator<< (ostream& stream, const vector<T>& V)
+  template <class T> inline ostream& operator<< (ostream& stream, const std::vector<T>& V)
   {
     stream << "[ ";
     for (size_t n = 0; n < V.size(); n++)

--- a/src/connectome/enhance.cpp
+++ b/src/connectome/enhance.cpp
@@ -45,7 +45,7 @@ namespace MR {
 
             visited.clear();
             visited[seed] = true;
-            vector<size_t> to_expand (1, seed);
+            std::vector<size_t> to_expand (1, seed);
             size_t cluster_size = 0;
 
             while (to_expand.size()) {
@@ -54,7 +54,7 @@ namespace MR {
               to_expand.pop_back();
               cluster_size++;
 
-              for (vector<size_t>::const_iterator i = (*adjacency)[index].begin(); i != (*adjacency)[index].end(); ++i) {
+              for (std::vector<size_t>::const_iterator i = (*adjacency)[index].begin(); i != (*adjacency)[index].end(); ++i) {
                 if (!visited[*i] && std::isfinite(in[*i]) && in[*i] >= T) {
                   visited[*i] = true;
                   to_expand.push_back (*i);
@@ -77,12 +77,12 @@ namespace MR {
         const Mat2Vec mat2vec (num_nodes);
         const size_t num_edges = mat2vec.vec_size();
         ProgressBar progress ("Pre-computing statistical correlation matrix...", num_edges);
-        adjacency.reset (new vector< vector<size_t> > (num_edges, vector<size_t>()));
+        adjacency.reset (new std::vector< std::vector<size_t> > (num_edges, std::vector<size_t>()));
         for (node_t row = 0; row != num_nodes; ++row) {
           for (node_t column = row; column != num_nodes; ++column) {
 
             const size_t index = mat2vec (row, column);
-            vector<size_t>& vector = (*adjacency)[index];
+            std::vector<size_t>& vector = (*adjacency)[index];
             vector.reserve (2 * (num_nodes-1));
             // Should be able to expand from this edge to any other edge connected to either row or column
             for (node_t r = 0; r != num_nodes; ++r) {

--- a/src/connectome/enhance.h
+++ b/src/connectome/enhance.h
@@ -71,7 +71,7 @@ namespace MR {
           void operator() (in_column_type, const value_type, out_column_type) const override;
 
         protected:
-          std::shared_ptr< vector< vector<size_t> > > adjacency;
+          std::shared_ptr< std::vector< std::vector<size_t> > > adjacency;
           value_type threshold;
 
         private:

--- a/src/connectome/lut.cpp
+++ b/src/connectome/lut.cpp
@@ -125,7 +125,7 @@ LUT::file_format LUT::guess_file_format (const std::string& path)
   std::ifstream in_lut (path, std::ios_base::in);
   if (!in_lut)
     throw Exception ("Unable to open lookup table file");
-  vector<Column> columns;
+  std::vector<Column> columns;
   std::string line;
   size_t line_counter = 0;
   while (std::getline (in_lut, line)) {
@@ -305,18 +305,18 @@ void LUT::check_and_insert (const node_t index, const LUT_node& data)
 
 
 
-vector<node_t> get_lut_mapping (const LUT& in, const LUT& out)
+std::vector<node_t> get_lut_mapping (const LUT& in, const LUT& out)
 {
   if (in.empty())
-    return vector<node_t>();
-  vector<node_t> map (in.rbegin()->first + 1, 0);
+    return std::vector<node_t>();
+  std::vector<node_t> map (in.rbegin()->first + 1, 0);
   for (const auto& node_in : in) {
     node_t target = 0;
     for (const auto& node_out : out) {
       if (node_out.second.get_name() == node_in.second.get_name()) {
         if (target) {
           throw Exception ("Cannot perform LUT conversion: Node " + str(node_in.first) + " (" + node_in.second.get_name() + ") has multiple possible targets");
-          return vector<node_t> ();
+          return std::vector<node_t> ();
         }
         target = node_out.first;
         break;

--- a/src/connectome/lut.h
+++ b/src/connectome/lut.h
@@ -121,7 +121,7 @@ class LUT : public std::multimap<node_t, LUT_node>
 // Convenience function for constructing a mapping from one lookup table to another
 // NOTE: If the TARGET LUT contains multiple entries for a particular index, and a
 //   mapping TO that index is required, the conversion is ill-formed.
-vector<node_t> get_lut_mapping (const LUT&, const LUT&);
+std::vector<node_t> get_lut_mapping (const LUT&, const LUT&);
 
 
 

--- a/src/degibbs/unring1d.h
+++ b/src/degibbs/unring1d.h
@@ -145,7 +145,7 @@ namespace MR {
       private:
         Math::FFT1D& fft;
         Eigen::MatrixXcd shifted;
-        vector<int> shifts;
+        std::vector<int> shifts;
     };
 
 

--- a/src/degibbs/unring2d.h
+++ b/src/degibbs/unring2d.h
@@ -131,8 +131,8 @@ namespace MR {
     class Unring2DFunctor
     { 
       public:
-        Unring2DFunctor (const vector<size_t>& outer_axes,
-            const vector<size_t>& slice_axes,
+        Unring2DFunctor (const std::vector<size_t>& outer_axes,
+            const std::vector<size_t>& slice_axes,
             const int& nsh,
             const int& minW,
             const int& maxW,
@@ -162,8 +162,8 @@ namespace MR {
 
 
       protected:
-        const vector<size_t>& outer_axes;
-        const vector<size_t>& slice_axes;
+        const std::vector<size_t>& outer_axes;
+        const std::vector<size_t>& slice_axes;
         Image<value_type> in, out;
         Eigen::MatrixXcd slice;
         Unring2D unring2d;

--- a/src/degibbs/unring3d.h
+++ b/src/degibbs/unring3d.h
@@ -153,7 +153,7 @@ namespace MR {
           OutputImageType output;
           const int minW, maxW, num_shifts;
           Math::FFT1D fft;
-          vector<Math::FFT1D> ifft;
+          std::vector<Math::FFT1D> ifft;
 
 
           int optimumshift(int n, int lsize) {
@@ -192,7 +192,7 @@ namespace MR {
 
 
 
-      inline vector<size_t> strides_for_axis (int axis)
+      inline std::vector<size_t> strides_for_axis (int axis)
       {
         switch (axis) {
           case 0: return { 0, 1, 2 };

--- a/src/dwi/bootstrap.h
+++ b/src/dwi/bootstrap.h
@@ -77,7 +77,7 @@ namespace MR {
         {
           voxels.clear(); 
           if (voxel_buffer.empty())
-            voxel_buffer.push_back (vector<value_type> (NUM_VOX_PER_CHUNK * size(3)));
+            voxel_buffer.push_back (std::vector<value_type> (NUM_VOX_PER_CHUNK * size(3)));
           next_voxel = &voxel_buffer[0][0];
           last_voxel = next_voxel + NUM_VOX_PER_CHUNK * size(3);
           current_chunk = 0;
@@ -86,7 +86,7 @@ namespace MR {
       protected:
         Functor func;
         std::map<Eigen::Vector3i,value_type*,IndexCompare> voxels;
-        vector<vector<value_type>> voxel_buffer;
+        std::vector<std::vector<value_type>> voxel_buffer;
         value_type* next_voxel;
         value_type* last_voxel;
         size_t current_chunk;
@@ -96,7 +96,7 @@ namespace MR {
           if (next_voxel == last_voxel) {
             ++current_chunk;
             if (current_chunk >= voxel_buffer.size()) 
-              voxel_buffer.push_back (vector<value_type> (NUM_VOX_PER_CHUNK * size(3)));
+              voxel_buffer.push_back (std::vector<value_type> (NUM_VOX_PER_CHUNK * size(3)));
             assert (current_chunk < voxel_buffer.size());
             next_voxel = &voxel_buffer.back()[0];
             last_voxel = next_voxel + NUM_VOX_PER_CHUNK * size(3);

--- a/src/dwi/directions/mask.cpp
+++ b/src/dwi/directions/mask.cpp
@@ -30,7 +30,7 @@ namespace MR {
           Mask temp (*this);
           for (size_t d = 0; d != size(); ++d) {
             if (!temp[d]) {
-              for (vector<index_type>::const_iterator i = dirs->get_adj_dirs(d).begin(); i != dirs->get_adj_dirs(d).end(); ++i)
+              for (std::vector<index_type>::const_iterator i = dirs->get_adj_dirs(d).begin(); i != dirs->get_adj_dirs(d).end(); ++i)
                 reset (*i);
             }
           }
@@ -45,7 +45,7 @@ namespace MR {
           Mask temp (*this);
           for (size_t d = 0; d != size(); ++d) {
             if (temp[d]) {
-              for (vector<index_type>::const_iterator i = dirs->get_adj_dirs(d).begin(); i != dirs->get_adj_dirs(d).end(); ++i)
+              for (std::vector<index_type>::const_iterator i = dirs->get_adj_dirs(d).begin(); i != dirs->get_adj_dirs(d).end(); ++i)
                 set (*i);
             }
           }
@@ -66,7 +66,7 @@ namespace MR {
 
       bool Mask::is_adjacent (const size_t d) const
       {
-        for (vector<index_type>::const_iterator i = dirs->get_adj_dirs (d).begin(); i != dirs->get_adj_dirs (d).end(); ++i) {
+        for (std::vector<index_type>::const_iterator i = dirs->get_adj_dirs (d).begin(); i != dirs->get_adj_dirs (d).end(); ++i) {
           if (test (*i))
             return true;
         }

--- a/src/dwi/directions/set.cpp
+++ b/src/dwi/directions/set.cpp
@@ -38,14 +38,14 @@ namespace MR {
         if (one == two)
           return 0;
 
-        vector<bool> processed (size(), 0);
-        vector<index_type> to_expand;
+        std::vector<bool> processed (size(), 0);
+        std::vector<index_type> to_expand;
         processed[one] = true;
         to_expand.push_back (one);
         index_type min_linkage = 0;
         do {
           ++min_linkage;
-          vector<index_type> next_to_expand;
+          std::vector<index_type> next_to_expand;
           for (const auto& i : to_expand) {
             for (const auto& j : adj_dirs[i]) {
               if (j == two) {
@@ -82,7 +82,7 @@ namespace MR {
 
       void Set::initialise_adjacency()
       {
-        adj_dirs.assign (size(), vector<index_type>());
+        adj_dirs.assign (size(), std::vector<index_type>());
 
         // New algorithm for determining direction adjacency
         // * Duplicate all directions to get a full spherical set
@@ -109,7 +109,7 @@ namespace MR {
 
         class Plane { 
           public:
-            Plane (const vector<Vertex>& vertices, const index_type one, const index_type two, const index_type three) :
+            Plane (const std::vector<Vertex>& vertices, const index_type one, const index_type two, const index_type three) :
                 indices {{ one, two, three }},
                 normal (((vertices[two].dir-vertices[one].dir).cross (vertices[three].dir-vertices[two].dir)).normalized()),
                 dist (std::max ( { vertices[one].dir.dot (normal), vertices[two].dir.dot (normal), vertices[three].dir.dot (normal) } ) ) { }
@@ -126,7 +126,7 @@ namespace MR {
             }
         };
 
-        vector<Vertex> vertices;
+        std::vector<Vertex> vertices;
         // Generate antipodal vertices
         for (index_type i = 0; i != size(); ++i) {
           vertices.push_back (Vertex (*this, i, false));
@@ -149,7 +149,7 @@ namespace MR {
         }
 
         // Find the two most distant points out of these six
-        vector<index_type> all_extrema;
+        std::vector<index_type> all_extrema;
         for (size_t axis = 0; axis != 3; ++axis) {
           all_extrema.push_back (extremum_indices[axis][0]);
           all_extrema.push_back (extremum_indices[axis][1]);
@@ -203,7 +203,7 @@ namespace MR {
         planes.push_back (Plane (vertices, base_plane.indices[1], fourth_point, base_plane.indices[2]));
         planes.push_back (Plane (vertices, base_plane.indices[2], fourth_point, base_plane.indices[0]));
 
-        vector<Plane> hull;
+        std::vector<Plane> hull;
 
         // Speedup: Only test those directions that have not yet been incorporated into any plane
         BitSet assigned (vertices.size());
@@ -238,7 +238,7 @@ namespace MR {
 
             // TODO Using an alternative data structure, where both faces connected to each
             //   edge are stored and tracked, would speed this up considerably
-            vector< std::list<Plane>::iterator > all_planes;
+            std::vector< std::list<Plane>::iterator > all_planes;
             for (std::list<Plane>::iterator p = planes.begin(); p != planes.end(); ++p) {
               if (!p->includes (max_index) && vertices[max_index].dir.dot (p->normal) > p->dist)
                 all_planes.push_back (p);
@@ -374,7 +374,7 @@ namespace MR {
         default_type adj_dot_product_sum = 0.0;
         size_t adj_dot_product_count = 0;
         for (size_t i = 0; i != size(); ++i) {
-          for (vector<index_type>::const_iterator j = adj_dirs[i].begin(); j != adj_dirs[i].end(); ++j) {
+          for (std::vector<index_type>::const_iterator j = adj_dirs[i].begin(); j != adj_dirs[i].end(); ++j) {
             if (*j > i) {
               adj_dot_product_sum += abs (unit_vectors[i].dot (unit_vectors[*j]));
               ++adj_dot_product_count;
@@ -395,7 +395,7 @@ namespace MR {
         az_begin = -Math::pi;
         el_begin = 0.0;
 
-        grid_lookup.assign (total_num_angle_grids, vector<index_type>());
+        grid_lookup.assign (total_num_angle_grids, std::vector<index_type>());
         for (size_t i = 0; i != size(); ++i) {
           const size_t grid_index = dir2gridindex (get_dir(i));
           grid_lookup[grid_index].push_back (i);
@@ -420,7 +420,7 @@ namespace MR {
             const Eigen::Vector3d p (cos(az) * sin(el), sin(az) * sin(el), cos (el));
             const index_type nearest_dir = select_direction_slow (p);
             bool dir_present = false;
-            for (vector<index_type>::const_iterator d = grid_lookup[i].begin(); !dir_present && d != grid_lookup[i].end(); ++d)
+            for (std::vector<index_type>::const_iterator d = grid_lookup[i].begin(); !dir_present && d != grid_lookup[i].end(); ++d)
               dir_present = (*d == nearest_dir);
             if (!dir_present)
               grid_lookup[i].push_back (nearest_dir);
@@ -430,16 +430,16 @@ namespace MR {
         }
 
         for (size_t grid_index = 0; grid_index != total_num_angle_grids; ++grid_index) {
-          vector<index_type>& this_grid (grid_lookup[grid_index]);
+          std::vector<index_type>& this_grid (grid_lookup[grid_index]);
           const size_t num_to_expand = this_grid.size();
           for (size_t index_to_expand = 0; index_to_expand != num_to_expand; ++index_to_expand) {
             const index_type dir_to_expand = this_grid[index_to_expand];
-            for (vector<index_type>::const_iterator adj = get_adj_dirs(dir_to_expand).begin(); adj != get_adj_dirs(dir_to_expand).end(); ++adj) {
+            for (std::vector<index_type>::const_iterator adj = get_adj_dirs(dir_to_expand).begin(); adj != get_adj_dirs(dir_to_expand).end(); ++adj) {
 
               // Size of lookup tables could potentially be reduced by being more prohibitive of adjacent direction inclusion in the lookup table for this grid
 
               bool is_present = false;
-              for (vector<index_type>::const_iterator i = this_grid.begin(); !is_present && i != this_grid.end(); ++i)
+              for (std::vector<index_type>::const_iterator i = this_grid.begin(); !is_present && i != this_grid.end(); ++i)
                 is_present = (*i == *adj);
               if (!is_present)
                 this_grid.push_back (*adj);

--- a/src/dwi/directions/set.h
+++ b/src/dwi/directions/set.h
@@ -85,7 +85,7 @@ namespace MR {
 
           size_t size () const { return unit_vectors.size(); }
           const Eigen::Vector3d& get_dir (const size_t i) const { assert (i < size()); return unit_vectors[i]; }
-          const vector<index_type>& get_adj_dirs (const size_t i) const { assert (i < size()); return adj_dirs[i]; }
+          const std::vector<index_type>& get_adj_dirs (const size_t i) const { assert (i < size()); return adj_dirs[i]; }
           bool dirs_are_adjacent (const index_type one, const index_type two) const {
             assert (one < size());
             assert (two < size());
@@ -98,14 +98,14 @@ namespace MR {
 
           index_type get_min_linkage (const index_type one, const index_type two) const;
 
-          const vector<Eigen::Vector3d>& get_dirs() const { return unit_vectors; }
+          const std::vector<Eigen::Vector3d>& get_dirs() const { return unit_vectors; }
           const Eigen::Vector3d& operator[] (const size_t i) const { assert (i < size()); return unit_vectors[i]; }
 
 
         protected:
 
-          vector<Eigen::Vector3d> unit_vectors;
-          vector< vector<index_type> > adj_dirs; // Note: not self-inclusive
+          std::vector<Eigen::Vector3d> unit_vectors;
+          std::vector< std::vector<index_type> > adj_dirs; // Note: not self-inclusive
 
 
         private:
@@ -185,7 +185,7 @@ namespace MR {
 
         private:
 
-          vector< vector<index_type> > grid_lookup;
+          std::vector< std::vector<index_type> > grid_lookup;
           unsigned int num_az_grids, num_el_grids, total_num_angle_grids;
           default_type az_grid_step, el_grid_step;
           default_type az_begin, el_begin;

--- a/src/dwi/fixel_map.h
+++ b/src/dwi/fixel_map.h
@@ -79,7 +79,7 @@ namespace MR
         const ::MR::Header& header() const { return _header; }
 
       protected:
-        vector<Fixel> fixels;
+        std::vector<Fixel> fixels;
 
       private:
         const class HeaderHelper : public ::MR::Header { 

--- a/src/dwi/fmls.cpp
+++ b/src/dwi/fmls.cpp
@@ -184,11 +184,11 @@ namespace MR {
         if (data_in_order.begin()->first <= 0.0)
           return true;
 
-        vector< std::pair<index_type, uint32_t> > retrospective_assignments;
+        std::vector< std::pair<index_type, uint32_t> > retrospective_assignments;
 
         for (const auto& i : data_in_order) {
 
-          vector<uint32_t> adj_lobes;
+          std::vector<uint32_t> adj_lobes;
           for (uint32_t l = 0; l != out.size(); ++l) {
             if ((((i.first <= 0.0) &&  out[l].is_negative())
                   || ((i.first >  0.0) && !out[l].is_negative()))
@@ -237,7 +237,7 @@ namespace MR {
                 }
               }
               for (size_t j = adj_lobes.size() - 1; j; --j) {
-                vector<FOD_lobe>::iterator ptr = out.begin();
+                std::vector<FOD_lobe>::iterator ptr = out.begin();
                 advance (ptr, adj_lobes[j]);
                 out.erase (ptr);
               }
@@ -319,15 +319,15 @@ namespace MR {
           if (dilate_lookup_table && out.size()) {
 
             DWI::Directions::Mask processed (dirs);
-            for (vector<FOD_lobe>::iterator i = out.begin(); i != out.end(); ++i)
+            for (std::vector<FOD_lobe>::iterator i = out.begin(); i != out.end(); ++i)
               processed |= i->get_mask();
 
-            NON_POD_VLA (new_assignments, vector<uint32_t>, dirs.size());
+            NON_POD_VLA (new_assignments, std::vector<uint32_t>, dirs.size());
             while (!processed.full()) {
 
               for (index_type dir = 0; dir != dirs.size(); ++dir) {
                 if (!processed[dir]) {
-                  for (vector<index_type>::const_iterator neighbour = dirs.get_adj_dirs (dir).begin(); neighbour != dirs.get_adj_dirs (dir).end(); ++neighbour) {
+                  for (std::vector<index_type>::const_iterator neighbour = dirs.get_adj_dirs (dir).begin(); neighbour != dirs.get_adj_dirs (dir).end(); ++neighbour) {
                     if (processed[*neighbour])
                       new_assignments[dir].push_back (out.lut[*neighbour]);
                   }
@@ -344,7 +344,7 @@ namespace MR {
 
                   uint32_t best_lobe = 0;
                   default_type max_integral = 0.0;
-                  for (vector<uint32_t>::const_iterator lobe_no = new_assignments[dir].begin(); lobe_no != new_assignments[dir].end(); ++lobe_no) {
+                  for (std::vector<uint32_t>::const_iterator lobe_no = new_assignments[dir].begin(); lobe_no != new_assignments[dir].end(); ++lobe_no) {
                     if (out[*lobe_no].get_integral() > max_integral) {
                       best_lobe = *lobe_no;
                       max_integral = out[*lobe_no].get_integral();
@@ -365,7 +365,7 @@ namespace MR {
 
         if (create_null_lobe) {
           DWI::Directions::Mask null_mask (dirs, true);
-          for (vector<FOD_lobe>::iterator i = out.begin(); i != out.end(); ++i)
+          for (std::vector<FOD_lobe>::iterator i = out.begin(); i != out.end(); ++i)
             null_mask &= i->get_mask();
           out.push_back (FOD_lobe (null_mask));
         }

--- a/src/dwi/fmls.h
+++ b/src/dwi/fmls.h
@@ -152,7 +152,7 @@ namespace MR
           DWI::Directions::Mask mask;
           Eigen::Array<default_type, Eigen::Dynamic, 1> values;
           default_type max_peak_value;
-          vector<Eigen::Vector3d> peak_dirs;
+          std::vector<Eigen::Vector3d> peak_dirs;
           Eigen::Vector3d mean_dir;
           default_type integral;
           bool neg;
@@ -161,10 +161,10 @@ namespace MR
 
 
 
-      class FOD_lobes : public vector<FOD_lobe> { 
+      class FOD_lobes : public std::vector<FOD_lobe> { 
         public:
           Eigen::Array3i vox;
-          vector<uint8_t> lut;
+          std::vector<uint8_t> lut;
       };
 
 

--- a/src/dwi/sdeconv/csd.h
+++ b/src/dwi/sdeconv/csd.h
@@ -205,7 +205,7 @@ namespace MR
             Eigen::MatrixXd DW_dirs, HR_dirs;
             Eigen::MatrixXd rconv, HR_trans, M, Mt_M;
             default_type neg_lambda, norm_lambda, threshold;
-            vector<size_t> dwis;
+            std::vector<size_t> dwis;
             uint32_t lmax_response, lmax_data, lmax_cmdline, lmax;
             size_t niter;
         };
@@ -276,7 +276,7 @@ namespace MR
         Eigen::MatrixXd work, HR_T;
         Eigen::VectorXd F, init_F, HR_amps, Mt_b;
         Eigen::LLT<Eigen::MatrixXd> llt;
-        vector<int> neg, old_neg;
+        std::vector<int> neg, old_neg;
     };
 
 

--- a/src/dwi/sdeconv/msmt_csd.h
+++ b/src/dwi/sdeconv/msmt_csd.h
@@ -73,7 +73,7 @@ namespace MR
 
 
 
-              void set_responses (const vector<std::string>& files)
+              void set_responses (const std::vector<std::string>& files)
               {
                 lmax_response.clear();
                 for (const auto& s : files) {
@@ -89,7 +89,7 @@ namespace MR
                 response_files = files;
               }
 
-              void set_responses (const vector<Eigen::MatrixXd>& matrices)
+              void set_responses (const std::vector<Eigen::MatrixXd>& matrices)
               {
                 responses = matrices;
                 prepare_responses();
@@ -136,7 +136,7 @@ namespace MR
 
                 Eigen::MatrixXd C = Eigen::MatrixXd::Zero (grad.rows(), nparams);
 
-                vector<size_t> dwilist;
+                std::vector<size_t> dwilist;
                 for (size_t i = 0; i != size_t(grad.rows()); i++)
                   dwilist.push_back(i);
 
@@ -177,7 +177,7 @@ namespace MR
                       }
                       li++;
                     }
-                    vector<size_t> vols = shells[shell_idx].get_volumes();
+                    std::vector<size_t> vols = shells[shell_idx].get_volumes();
                     for (size_t idx = 0; idx < vols.size(); idx++) {
                       Eigen::VectorXd SHT_(SHT.row (vols[idx]).head (tissue_n));
                       SHT_ = (SHT_.array()*fconv.array()).matrix();
@@ -187,8 +187,8 @@ namespace MR
                   pbegin += tissue_n;
                 }
 
-                vector<size_t> m (num_tissues());
-                vector<size_t> n (num_tissues());
+                std::vector<size_t> m (num_tissues());
+                std::vector<size_t> n (num_tissues());
                 size_t M = 0;
                 size_t N = 0;
 
@@ -225,9 +225,9 @@ namespace MR
               const Eigen::MatrixXd grad;
               DWI::Shells shells;
               Eigen::MatrixXd HR_dirs;
-              vector<uint32_t> lmax, lmax_response;
-              vector<Eigen::MatrixXd> responses;
-              vector<std::string> response_files;
+              std::vector<uint32_t> lmax, lmax_response;
+              std::vector<Eigen::MatrixXd> responses;
+              std::vector<std::string> response_files;
               Math::ICLS::Problem<double> problem;
               double solution_min_norm_regularisation, constraint_min_norm_regularisation;
 

--- a/src/dwi/tractography/ACT/gmwmi.cpp
+++ b/src/dwi/tractography/ACT/gmwmi.cpp
@@ -43,7 +43,7 @@ namespace MR
 
 
 
-        Eigen::Vector3f GMWMI_finder::find_interface (const vector< Eigen::Vector3f >& tck, const bool end) const
+        Eigen::Vector3f GMWMI_finder::find_interface (const std::vector< Eigen::Vector3f >& tck, const bool end) const
         {
           Interp interp (interp_template);
           return find_interface (tck, end, interp);
@@ -52,7 +52,7 @@ namespace MR
 
 
 
-        void GMWMI_finder::crop_track (vector< Eigen::Vector3f >& tck) const
+        void GMWMI_finder::crop_track (std::vector< Eigen::Vector3f >& tck) const
         {
           if (tck.size() < 3)
             return;
@@ -192,7 +192,7 @@ namespace MR
 
 
 
-        Eigen::Vector3f GMWMI_finder::find_interface (const vector<Eigen::Vector3f>& tck, const bool end, Interp& interp) const
+        Eigen::Vector3f GMWMI_finder::find_interface (const std::vector<Eigen::Vector3f>& tck, const bool end, Interp& interp) const
         {
 
           if (tck.size() == 0)

--- a/src/dwi/tractography/ACT/gmwmi.h
+++ b/src/dwi/tractography/ACT/gmwmi.h
@@ -71,8 +71,8 @@ namespace MR
             Eigen::Vector3f normal (const Eigen::Vector3f&) const;
 
 
-            Eigen::Vector3f find_interface (const vector<Eigen::Vector3f>&, const bool) const;
-            void crop_track (vector<Eigen::Vector3f>&) const;
+            Eigen::Vector3f find_interface (const std::vector<Eigen::Vector3f>&, const bool) const;
+            void crop_track (std::vector<Eigen::Vector3f>&) const;
 
 
           protected:
@@ -90,7 +90,7 @@ namespace MR
             Eigen::Vector3f get_normal (const Eigen::Vector3f&, Interp&) const;
             Eigen::Vector3f get_cf_min_step (const Eigen::Vector3f&, Interp&) const;
 
-            Eigen::Vector3f find_interface (const vector<Eigen::Vector3f>&, const bool, Interp&) const;
+            Eigen::Vector3f find_interface (const std::vector<Eigen::Vector3f>&, const bool, Interp&) const;
 
 
             friend class Track_extender;

--- a/src/dwi/tractography/ACT/shared.h
+++ b/src/dwi/tractography/ACT/shared.h
@@ -48,7 +48,7 @@ namespace MR
             bool backtrack() const { return bt; }
 
             bool crop_at_gmwmi() const { return bool (gmwmi_finder); }
-            void crop_at_gmwmi (vector<Eigen::Vector3f>& tck) const
+            void crop_at_gmwmi (std::vector<Eigen::Vector3f>& tck) const
             {
               assert (gmwmi_finder);
               tck.back() = gmwmi_finder->find_interface (tck, true);

--- a/src/dwi/tractography/GT/externalenergy.h
+++ b/src/dwi/tractography/GT/externalenergy.h
@@ -88,10 +88,10 @@ namespace MR {
           
           Math::ICLS::Problem<double> nnls;
           
-          vector<Eigen::Vector3i > changes_vox;
-          vector<Eigen::VectorXd > changes_tod;
-          vector<Eigen::VectorXd > changes_fiso;
-          vector<double> changes_eext;
+          std::vector<Eigen::Vector3i > changes_vox;
+          std::vector<Eigen::VectorXd > changes_tod;
+          std::vector<Eigen::VectorXd > changes_fiso;
+          std::vector<double> changes_eext;
           
           
           void add(const Point_t& pos, const Point_t& dir, const double factor = 1.);

--- a/src/dwi/tractography/GT/gt.h
+++ b/src/dwi/tractography/GT/gt.h
@@ -58,7 +58,7 @@ namespace MR {
           double ppot;
 
           Eigen::MatrixXf resp_WM;
-          vector< Eigen::VectorXf > resp_ISO;
+          std::vector< Eigen::VectorXf > resp_ISO;
 
         };
 

--- a/src/dwi/tractography/GT/internalenergy.h
+++ b/src/dwi/tractography/GT/internalenergy.h
@@ -108,7 +108,7 @@ namespace MR {
         protected:
           ParticleGrid& pGrid;
           double cpot, dEint;
-          vector<ParticleEnd> neighbourhood;
+          std::vector<ParticleEnd> neighbourhood;
           double normalization;
           Math::RNG::Uniform<double> rng_uniform;
           

--- a/src/dwi/tractography/GT/mhsampler.h
+++ b/src/dwi/tractography/GT/mhsampler.h
@@ -78,7 +78,7 @@ namespace MR {
           EnergyComputer* E;      // Polymorphic copy requires call to EnergyComputer::clone(), hence references or smart pointers won't do.
           
           Transform T;
-          vector<size_t> dims;
+          std::vector<size_t> dims;
           Image<bool> mask;
           
           std::shared_ptr< SpatialLock<float> > lock;

--- a/src/dwi/tractography/GT/particlegrid.cpp
+++ b/src/dwi/tractography/GT/particlegrid.cpp
@@ -66,7 +66,7 @@ namespace MR {
           Particle* par;
           Particle* nextpar;
           int alpha = 0;
-          vector<Point_t> track;
+          std::vector<Point_t> track;
           // Loop through all unvisited particles
           for (ParticleVectorType& gridvox : grid)
           {

--- a/src/dwi/tractography/GT/particlegrid.h
+++ b/src/dwi/tractography/GT/particlegrid.h
@@ -40,7 +40,7 @@ namespace MR {
         { 
         public:
           
-          using ParticleVectorType = vector<Particle*>;
+          using ParticleVectorType = std::vector<Particle*>;
           
           template <class HeaderType>
           ParticleGrid(const HeaderType& image)
@@ -91,7 +91,7 @@ namespace MR {
         protected:
           std::mutex mutex;
           ParticlePool pool;
-          vector<ParticleVectorType> grid;
+          std::vector<ParticleVectorType> grid;
           Math::RNG rng;
           transform_type T_s2g;
           size_t dims[3];

--- a/src/dwi/tractography/GT/spatiallock.h
+++ b/src/dwi/tractography/GT/spatiallock.h
@@ -84,7 +84,7 @@ namespace MR {
 
         protected:
           std::mutex mutex;
-          vector< std::pair<point_type, bool> > lockcentres;
+          std::vector< std::pair<point_type, bool> > lockcentres;
           value_type _tx, _ty, _tz;
 
           bool try_lock(const point_type& pos, ssize_t& idx) {

--- a/src/dwi/tractography/SIFT/gradient_sort.h
+++ b/src/dwi/tractography/SIFT/gradient_sort.h
@@ -82,7 +82,7 @@ namespace MR
       class MT_gradient_vector_sorter
       { 
 
-          using VecType = vector<Cost_fn_gradient_sort>;
+          using VecType = std::vector<Cost_fn_gradient_sort>;
           using VecItType = VecType::iterator;
 
           class Comparator { 

--- a/src/dwi/tractography/SIFT/model.h
+++ b/src/dwi/tractography/SIFT/model.h
@@ -92,7 +92,7 @@ namespace MR
 
         protected:
           std::string tck_file_path;
-          vector<TrackContribution*> contributions;
+          std::vector<TrackContribution*> contributions;
 
           using Fixel_map<Fixel>::accessor;
           using Fixel_map<Fixel>::begin;
@@ -133,20 +133,20 @@ namespace MR
               Mapping::TrackMapperBase mapper;
               std::shared_ptr<std::mutex> mutex;
               double TD_sum;
-              vector<double> fixel_TDs;
-              vector<track_t> fixel_counts;
+              std::vector<double> fixel_TDs;
+              std::vector<track_t> fixel_counts;
           };
 
           class FixelRemapper
           { 
             public:
-              FixelRemapper (Model& i, vector<size_t>& r) :
+              FixelRemapper (Model& i, std::vector<size_t>& r) :
                 master   (i),
                 remapper (r) { }
               bool operator() (const TrackIndexRange&);
             private:
               Model& master;
-              vector<size_t>& remapper;
+              std::vector<size_t>& remapper;
           };
 
       };
@@ -158,7 +158,7 @@ namespace MR
       template <class Fixel>
       Model<Fixel>::~Model ()
       {
-        for (vector<TrackContribution*>::iterator i = contributions.begin(); i != contributions.end(); ++i) {
+        for (std::vector<TrackContribution*>::iterator i = contributions.begin(); i != contributions.end(); ++i) {
           if (*i) {
             delete *i;
             *i = nullptr;
@@ -221,10 +221,10 @@ namespace MR
         if (!remove_untracked_fixels && !min_fibre_density)
           return;
 
-        vector<size_t> fixel_index_mapping (fixels.size(), 0);
+        std::vector<size_t> fixel_index_mapping (fixels.size(), 0);
         VoxelAccessor v (accessor());
 
-        vector<Fixel> new_fixels;
+        std::vector<Fixel> new_fixels;
         new_fixels.push_back (Fixel());
         FOD_sum = 0.0;
 
@@ -260,7 +260,7 @@ namespace MR
         Thread::run_queue (writer, TrackIndexRange(), Thread::multi (remapper));
 
         TD_sum = 0.0;
-        for (typename vector<Fixel>::const_iterator i = fixels.begin(); i != fixels.end(); ++i)
+        for (typename std::vector<Fixel>::const_iterator i = fixels.begin(); i != fixels.end(); ++i)
           TD_sum += i->get_weight() * i->get_TD();
 
         INFO ("After fixel exclusion, the proportionality coefficient is " + str(mu()));
@@ -278,14 +278,14 @@ namespace MR
       {
         VAR (TD_sum);
         double sum_from_fixels = 0.0, sum_from_fixels_weighted = 0.0;
-        for (typename vector<Fixel>::const_iterator i = fixels.begin(); i != fixels.end(); ++i) {
+        for (typename std::vector<Fixel>::const_iterator i = fixels.begin(); i != fixels.end(); ++i) {
           sum_from_fixels          += i->get_TD();
           sum_from_fixels_weighted += i->get_TD() * i->get_weight();
         }
         VAR (sum_from_fixels);
         VAR (sum_from_fixels_weighted);
         double sum_from_tracks = 0.0;
-        for (vector<TrackContribution*>::const_iterator i = contributions.begin(); i != contributions.end(); ++i) {
+        for (std::vector<TrackContribution*>::const_iterator i = contributions.begin(); i != contributions.end(); ++i) {
           if (*i)
             sum_from_tracks += (*i)->get_total_contribution();
         }
@@ -362,7 +362,7 @@ namespace MR
           Mapping::SetDixel dixels;
           mapper (in, dixels);
 
-          vector<Track_fixel_contribution> masked_contributions;
+          std::vector<Track_fixel_contribution> masked_contributions;
           default_type total_contribution = 0.0, total_length = 0.0;
 
           for (Mapping::SetDixel::const_iterator i = dixels.begin(); i != dixels.end(); ++i) {
@@ -371,7 +371,7 @@ namespace MR
             if (fixel_index && (i->get_length() > Track_fixel_contribution::min())) {
               total_contribution += i->get_length() * master.fixels[fixel_index].get_weight();
               bool incremented = false;
-              for (vector<Track_fixel_contribution>::iterator c = masked_contributions.begin(); !incremented && c != masked_contributions.end(); ++c) {
+              for (std::vector<Track_fixel_contribution>::iterator c = masked_contributions.begin(); !incremented && c != masked_contributions.end(); ++c) {
                 if ((c->get_fixel_index() == fixel_index) && c->add (i->get_length()))
                   incremented = true;
               }
@@ -383,7 +383,7 @@ namespace MR
           master.contributions[in.get_index()] = new TrackContribution (masked_contributions, total_contribution, total_length);
 
           TD_sum += total_contribution;
-          for (vector<Track_fixel_contribution>::const_iterator i = masked_contributions.begin(); i != masked_contributions.end(); ++i) {
+          for (std::vector<Track_fixel_contribution>::const_iterator i = masked_contributions.begin(); i != masked_contributions.end(); ++i) {
             fixel_TDs [i->get_fixel_index()] += i->get_length();
             ++fixel_counts [i->get_fixel_index()];
           }
@@ -406,7 +406,7 @@ namespace MR
         for (track_t track_index = in.first; track_index != in.second; ++track_index) {
           if (master.contributions[track_index]) {
             TrackContribution& this_cont (*master.contributions[track_index]);
-            vector<Track_fixel_contribution> new_cont;
+            std::vector<Track_fixel_contribution> new_cont;
             double total_contribution = 0.0;
             for (size_t i = 0; i != this_cont.dim(); ++i) {
               const size_t new_index = remapper[this_cont[i].get_fixel_index()];

--- a/src/dwi/tractography/SIFT/output.h
+++ b/src/dwi/tractography/SIFT/output.h
@@ -231,7 +231,7 @@ namespace MR
         out << "# " << App::command_history_string << "\n";
         const default_type current_mu = mu();
         out << "#Fibre density,Track density (unscaled),Track density (scaled),Weight,\n";
-        for (typename vector<Fixel>::const_iterator i = fixels.begin(); i != fixels.end(); ++i)
+        for (typename std::vector<Fixel>::const_iterator i = fixels.begin(); i != fixels.end(); ++i)
           out << str (i->get_FOD()) << "," << str (i->get_TD()) << "," << str (i->get_TD() * current_mu) << "," << str (i->get_weight()) << ",\n";
         out.close();
       }

--- a/src/dwi/tractography/SIFT/sifter.cpp
+++ b/src/dwi/tractography/SIFT/sifter.cpp
@@ -57,7 +57,7 @@ namespace MR
 
         // For streamlines that do not contribute to the map, remove an equivalent proportion of length to those that do contribute
         double sum_contributing_length = 0.0, sum_noncontributing_length = 0.0;
-        vector<track_t> noncontributing_indices;
+        std::vector<track_t> noncontributing_indices;
         for (track_t i = 0; i != contributions.size(); ++i) {
           if (contributions[i]) {
             if (contributions[i]->get_total_contribution()) {
@@ -72,7 +72,7 @@ namespace MR
         // Randomise the order or removal here; faster than trying to select at random later
         std::shuffle (noncontributing_indices.begin(), noncontributing_indices.end(), Math::RNG());
 
-        vector<Cost_fn_gradient_sort> gradient_vector;
+        std::vector<Cost_fn_gradient_sort> gradient_vector;
         try {
           gradient_vector.assign (num_tracks(), Cost_fn_gradient_sort (num_tracks(), std::numeric_limits<double>::max(), std::numeric_limits<double>::max()));
         } catch (...) {
@@ -178,7 +178,7 @@ namespace MR
 
             } else { // Proceed as normal
 
-              const vector<Cost_fn_gradient_sort>::iterator candidate = sorter.get();
+              const std::vector<Cost_fn_gradient_sort>::iterator candidate = sorter.get();
               if (candidate == gradient_vector.end()) {
                 recalculate = POS_GRADIENT;
                 if (!removed_this_iteration)
@@ -359,7 +359,7 @@ namespace MR
 
 
 
-      void SIFTer::set_regular_outputs (const vector<uint32_t>& in, const std::string& dirpath)
+      void SIFTer::set_regular_outputs (const std::vector<uint32_t>& in, const std::string& dirpath)
       {
         for (auto i : in) {
           if (i > 0 && i <= contributions.size())
@@ -377,7 +377,7 @@ namespace MR
 
         Math::RNG::Normal<float> rng;
 
-        vector<Cost_fn_gradient_sort> gradient_vector;
+        std::vector<Cost_fn_gradient_sort> gradient_vector;
         gradient_vector.assign (num_tracks, Cost_fn_gradient_sort (num_tracks, 0.0, 0.0));
         // Fill the gradient vector with random Gaussian data
         for (track_t index = 0; index != num_tracks; ++index) {
@@ -385,16 +385,16 @@ namespace MR
           gradient_vector[index].set (index, value, value);
         }
 
-        vector<size_t> block_sizes;
+        std::vector<size_t> block_sizes;
         for (size_t i = 16; i < num_tracks; i *= 2)
           block_sizes.push_back (i);
         block_sizes.push_back (num_tracks);
 
-        for (vector<size_t>::const_iterator i = block_sizes.begin(); i != block_sizes.end(); ++i) {
+        for (std::vector<size_t>::const_iterator i = block_sizes.begin(); i != block_sizes.end(); ++i) {
           const size_t block_size = *i;
 
           // Make a copy of the gradient vector, so the same data is sorted each time
-          vector<Cost_fn_gradient_sort> temp_gv (gradient_vector);
+          std::vector<Cost_fn_gradient_sort> temp_gv (gradient_vector);
 
           Timer timer;
           // Simulate sorting and filtering
@@ -424,7 +424,7 @@ namespace MR
       {
         const double current_mu = mu();
         double roc_cost = 0.0;
-        vector<Fixel>::const_iterator i = fixels.begin();
+        std::vector<Fixel>::const_iterator i = fixels.begin();
         for (++i; i != fixels.end(); ++i)
           roc_cost += i->get_d_cost_d_mu (current_mu);
         return roc_cost;

--- a/src/dwi/tractography/SIFT/sifter.h
+++ b/src/dwi/tractography/SIFT/sifter.h
@@ -78,7 +78,7 @@ namespace MR
         void set_term_mu     (const float i)        { term_mu = i; }
         void set_csv_path    (const std::string& i) { csv_path = i; }
 
-        void set_regular_outputs (const vector<uint32_t>&, const std::string&);
+        void set_regular_outputs (const std::vector<uint32_t>&, const std::string&);
 
 
         // DEBUGGING
@@ -96,7 +96,7 @@ namespace MR
 
 
         // User-controllable settings
-        vector<track_t> output_at_counts;
+        std::vector<track_t> output_at_counts;
         std::string     debug_dir;
         track_t term_number;
         float   term_ratio;
@@ -115,12 +115,12 @@ namespace MR
         class TrackGradientCalculator
         { 
           public:
-            TrackGradientCalculator (const SIFTer& sifter, vector<Cost_fn_gradient_sort>& v, const double mu, const double r) :
+            TrackGradientCalculator (const SIFTer& sifter, std::vector<Cost_fn_gradient_sort>& v, const double mu, const double r) :
                 master (sifter), gradient_vector (v), current_mu (mu), current_roc_cost (r) { }
             bool operator() (const TrackIndexRange&) const;
           private:
             const SIFTer& master;
-            vector<Cost_fn_gradient_sort>& gradient_vector;
+            std::vector<Cost_fn_gradient_sort>& gradient_vector;
             const double current_mu, current_roc_cost;
         };
 

--- a/src/dwi/tractography/SIFT/track_contribution.h
+++ b/src/dwi/tractography/SIFT/track_contribution.h
@@ -132,7 +132,7 @@ class Track_fixel_contribution
       { 
 
         public:
-        TrackContribution (const vector<Track_fixel_contribution>& in, const float c, const float l) :
+        TrackContribution (const std::vector<Track_fixel_contribution>& in, const float c, const float l) :
             Min_mem_array<Track_fixel_contribution> (in),
             total_contribution (c),
             total_length       (l) { }

--- a/src/dwi/tractography/SIFT2/fixel_updater.h
+++ b/src/dwi/tractography/SIFT2/fixel_updater.h
@@ -46,9 +46,9 @@ namespace MR {
           TckFactor& master;
 
           // Each thread needs a local copy of these
-          vector<double> fixel_coeff_sums;
-          vector<double> fixel_TDs;
-          vector<SIFT::track_t> fixel_counts;
+          std::vector<double> fixel_coeff_sums;
+          std::vector<double> fixel_TDs;
+          std::vector<SIFT::track_t> fixel_counts;
 
       };
 

--- a/src/dwi/tractography/SIFT2/line_search.cpp
+++ b/src/dwi/tractography/SIFT2/line_search.cpp
@@ -58,7 +58,7 @@ namespace MR {
 
         Result data_result, tik_result, tv_result;
 
-        for (vector<Fixel>::const_iterator i = fixels.begin(); i != fixels.end(); ++i) {
+        for (std::vector<Fixel>::const_iterator i = fixels.begin(); i != fixels.end(); ++i) {
 
           const double contribution = i->length * factor;
           const double scaled_contribution = mu * contribution;
@@ -91,7 +91,7 @@ namespace MR {
       {
         double cf_data = 0.0;
         double cf_reg_tv = 0.0;
-        for (vector<Fixel>::const_iterator i = fixels.begin(); i != fixels.end(); ++i) {
+        for (std::vector<Fixel>::const_iterator i = fixels.begin(); i != fixels.end(); ++i) {
           cf_data   += i->cost_frac * i->PM * Math::pow2 ((mu * (i->TD + (i->length * std::exp (Fs+dFs)) + (i->dTD_dFs*dFs))) - i->FOD);
           cf_reg_tv += i->SL_eff * SIFT2::tvreg (Fs+dFs, i->meanFs);
         }

--- a/src/dwi/tractography/SIFT2/line_search.h
+++ b/src/dwi/tractography/SIFT2/line_search.h
@@ -79,7 +79,7 @@ namespace MR {
           const double Fs;
           const double reg_tik, reg_tv;
 
-          vector<Fixel> fixels;
+          std::vector<Fixel> fixels;
 
       };
 

--- a/src/dwi/tractography/SIFT2/tckfactor.cpp
+++ b/src/dwi/tractography/SIFT2/tckfactor.cpp
@@ -62,7 +62,7 @@ namespace MR {
 
       void TckFactor::store_orig_TDs()
       {
-        for (vector<Fixel>::iterator i = fixels.begin(); i != fixels.end(); ++i)
+        for (std::vector<Fixel>::iterator i = fixels.begin(); i != fixels.end(); ++i)
           i->store_orig_TD();
       }
 
@@ -81,7 +81,7 @@ namespace MR {
         const double cf = calc_cost_function();
         SIFT::track_t excluded_count = 0, zero_TD_count = 0;
         double zero_TD_cf_sum = 0.0, excluded_cf_sum = 0.0;
-        for (vector<Fixel>::iterator i = fixels.begin(); i != fixels.end(); ++i) {
+        for (std::vector<Fixel>::iterator i = fixels.begin(); i != fixels.end(); ++i) {
           if (!i->get_orig_TD()) {
             ++zero_TD_count;
             zero_TD_cf_sum += i->get_cost (fixed_mu);
@@ -107,7 +107,7 @@ namespace MR {
       {
         VAR (calc_cost_function());
 
-        for (vector<Fixel>::iterator i = fixels.begin(); i != fixels.end(); ++i)
+        for (std::vector<Fixel>::iterator i = fixels.begin(); i != fixels.end(); ++i)
           i->clear_TD();
 
         coefficients.resize (num_tracks(), 0.0);
@@ -187,7 +187,7 @@ namespace MR {
           Thread::run_queue (writer, SIFT::TrackIndexRange(), Thread::multi (functor));
         }
 
-        for (vector<Fixel>::iterator i = fixels.begin(); i != fixels.end(); ++i) {
+        for (std::vector<Fixel>::iterator i = fixels.begin(); i != fixels.end(); ++i) {
           i->clear_TD();
           i->clear_mean_coeff();
         }
@@ -251,7 +251,7 @@ namespace MR {
         // Initial estimates of how each weighting coefficient is going to change
         // The ProjectionCalculator classes overwrite these in place, so do an initial allocation but
         //   don't bother wiping it at every iteration
-        //vector<float> projected_steps (num_tracks(), 0.0);
+        //std::vector<float> projected_steps (num_tracks(), 0.0);
 
         // Logging which fixels need to be excluded from optimisation in subsequent iterations,
         //   due to driving streamlines to unwanted high weights
@@ -290,7 +290,7 @@ namespace MR {
           }
 
           // Multi-threaded calculation of updated streamline density, and mean weighting coefficient, in each fixel
-          for (vector<Fixel>::iterator i = fixels.begin(); i != fixels.end(); ++i) {
+          for (std::vector<Fixel>::iterator i = fixels.begin(); i != fixels.end(); ++i) {
             i->clear_TD();
             i->clear_mean_coeff();
           }
@@ -300,7 +300,7 @@ namespace MR {
             Thread::run_queue (writer, SIFT::TrackIndexRange(), Thread::multi (worker));
           }
           // Scale the fixel mean coefficient terms (each streamline in the fixel is weighted by its length)
-          for (vector<Fixel>::iterator i = fixels.begin(); i != fixels.end(); ++i)
+          for (std::vector<Fixel>::iterator i = fixels.begin(); i != fixels.end(); ++i)
             i->normalise_mean_coeff();
           indicate_progress();
 
@@ -422,10 +422,10 @@ namespace MR {
         if (!coefficients.size())
           return;
 
-        vector<double> mins   (fixels.size(), std::numeric_limits<double>::infinity());
-        vector<double> stdevs (fixels.size(), 0.0);
-        vector<double> maxs   (fixels.size(), -std::numeric_limits<double>::infinity());
-        vector<size_t> zeroed (fixels.size(), 0);
+        std::vector<double> mins   (fixels.size(), std::numeric_limits<double>::infinity());
+        std::vector<double> stdevs (fixels.size(), 0.0);
+        std::vector<double> maxs   (fixels.size(), -std::numeric_limits<double>::infinity());
+        std::vector<size_t> zeroed (fixels.size(), 0);
 
         {
           ProgressBar progress ("Generating streamline coefficient statistic images", num_tracks());

--- a/src/dwi/tractography/algorithms/calibrator.h
+++ b/src/dwi/tractography/algorithms/calibrator.h
@@ -32,10 +32,10 @@ namespace MR {
 
       using namespace MR::DWI::Tractography::Tracking;
 
-      FORCE_INLINE vector<Eigen::Vector3f> direction_grid (float max_angle, float spacing)
+      FORCE_INLINE std::vector<Eigen::Vector3f> direction_grid (float max_angle, float spacing)
       {
         const float maxR = Math::pow2 (max_angle / spacing);
-        vector<Eigen::Vector3f> list;
+        std::vector<Eigen::Vector3f> list;
         ssize_t extent = std::ceil (max_angle / spacing);
 
         for (ssize_t i = -extent; i <= extent; ++i) {
@@ -69,7 +69,7 @@ namespace MR {
           const float sqrt3 = std::sqrt (3.0);
           const float max_angle = std::isfinite (method.S.max_angle_ho) ? method.S.max_angle_ho : method.S.max_angle_1o;
 
-          vector<Pair> amps;
+          std::vector<Pair> amps;
           for (float el = 0.0; el < max_angle; el += 0.001) {
             amps.push_back (Pair (el, calibrate_func (el)));
             if (!std::isfinite (amps.back().amp) || amps.back().amp <= 0.0) break;

--- a/src/dwi/tractography/algorithms/iFOD1.h
+++ b/src/dwi/tractography/algorithms/iFOD1.h
@@ -241,7 +241,7 @@ namespace MR
       float calibrate_ratio;
       size_t mean_sample_num, num_sample_runs, num_truncations;
       float max_truncation;
-      vector< Eigen::Vector3f > calibrate_list;
+      std::vector< Eigen::Vector3f > calibrate_list;
 
       float FOD (const Eigen::Vector3f& d) const
       {

--- a/src/dwi/tractography/algorithms/iFOD2.h
+++ b/src/dwi/tractography/algorithms/iFOD2.h
@@ -341,11 +341,11 @@ end_init:
             float calibrate_ratio, half_log_prob0, last_half_log_probN, half_log_prob0_seed;
             size_t mean_sample_num, num_sample_runs, num_truncations;
             float max_truncation;
-            vector<Eigen::Vector3f> calibrate_list;
+            std::vector<Eigen::Vector3f> calibrate_list;
 
             // Store list of points in the currently-calculated arc
-            vector<Eigen::Vector3f> positions, calib_positions;
-            vector<Eigen::Vector3f> tangents, calib_tangents;
+            std::vector<Eigen::Vector3f> positions, calib_positions;
+            std::vector<Eigen::Vector3f> tangents, calib_tangents;
 
             // Generate an arc only when required, and on the majority of next() calls, simply return the next point
             //   in the arc - more dense structural image sampling
@@ -379,7 +379,7 @@ end_init:
 
 
 
-            float path_prob (vector<Eigen::Vector3f>& positions, vector<Eigen::Vector3f>& tangents)
+            float path_prob (std::vector<Eigen::Vector3f>& positions, std::vector<Eigen::Vector3f>& tangents)
             {
 
               // Early exit for ACT when path is not sensible
@@ -412,7 +412,7 @@ end_init:
 
 
           protected:
-            void get_path (vector<Eigen::Vector3f>& positions, vector<Eigen::Vector3f>& tangents, const Eigen::Vector3f& end_dir) const
+            void get_path (std::vector<Eigen::Vector3f>& positions, std::vector<Eigen::Vector3f>& tangents, const Eigen::Vector3f& end_dir) const
             {
               float cos_theta = end_dir.dot (dir);
               cos_theta = std::min (cos_theta, float(1.0));
@@ -490,7 +490,7 @@ end_init:
                 Eigen::VectorXf& fod;
                 const float vox;
                 float init_log_prob;
-                vector<Eigen::Vector3f> positions, tangents;
+                std::vector<Eigen::Vector3f> positions, tangents;
             };
 
             friend void calibrate<iFOD2> (iFOD2& method);

--- a/src/dwi/tractography/algorithms/nulldist.h
+++ b/src/dwi/tractography/algorithms/nulldist.h
@@ -163,7 +163,7 @@ namespace MR
       const Shared& S;
       Interpolator<Image<float>>::type source;
 
-      vector<Eigen::Vector3f> positions, tangents;
+      std::vector<Eigen::Vector3f> positions, tangents;
       size_t sample_idx;
 
     };

--- a/src/dwi/tractography/algorithms/tensor_prob.h
+++ b/src/dwi/tractography/algorithms/tensor_prob.h
@@ -125,7 +125,7 @@ namespace MR
                     raw_signals.push_back (Eigen::VectorXf (size(3)));
                 }
 
-                vector<Eigen::VectorXf> raw_signals;
+                std::vector<Eigen::VectorXf> raw_signals;
 
                 bool get (const Eigen::Vector3f& pos, Eigen::VectorXf& data) {
                   if (!scanner (pos)) {

--- a/src/dwi/tractography/connectome/exemplar.cpp
+++ b/src/dwi/tractography/connectome/exemplar.cpp
@@ -153,7 +153,7 @@ void Exemplar::finalize (const float step_size)
   // Start from the midpoint, resample backwards to the start of the exemplar,
   //   reverse the data, then do the second half of the exemplar
   int32_t index = (size() + 1) / 2;
-  vector<point_type> vertices (1, (*this)[index]);
+  std::vector<point_type> vertices (1, (*this)[index]);
   const float step_sq = Math::pow2 (step_size);
   for (int32_t step = -1; step <= 1; step += 2) {
     if (step == 1) {

--- a/src/dwi/tractography/connectome/extract.cpp
+++ b/src/dwi/tractography/connectome/extract.cpp
@@ -28,7 +28,7 @@ namespace Connectome {
 
 bool Selector::operator() (const node_t node) const
 {
-  for (vector<node_t>::const_iterator i = list.begin(); i != list.end(); ++i) {
+  for (std::vector<node_t>::const_iterator i = list.begin(); i != list.end(); ++i) {
     if (*i == node)
       return true;
   }
@@ -44,7 +44,7 @@ bool Selector::operator() (const NodePair& nodes) const
   if (exact_match && list.size() == 2)
     return ((nodes.first == list[0] && nodes.second == list[1]) || (nodes.first == list[1] && nodes.second == list[0]));
   bool found_first = false, found_second = false;
-  for (vector<node_t>::const_iterator i = list.begin(); i != list.end(); ++i) {
+  for (std::vector<node_t>::const_iterator i = list.begin(); i != list.end(); ++i) {
     if (*i == nodes.first)  found_first = true;
     if (*i == nodes.second) found_second = true;
   }
@@ -54,10 +54,10 @@ bool Selector::operator() (const NodePair& nodes) const
     return (found_first || found_second);
 }
 
-bool Selector::operator() (const vector<node_t>& nodes) const
+bool Selector::operator() (const std::vector<node_t>& nodes) const
 {
   BitSet found (list.size());
-  for (vector<node_t>::const_iterator n = nodes.begin(); n != nodes.end(); ++n) {
+  for (std::vector<node_t>::const_iterator n = nodes.begin(); n != nodes.end(); ++n) {
     for (size_t i = 0; i != list.size(); ++i)
       if (*n == list[i]) found[i] = true;
   }
@@ -74,7 +74,7 @@ bool Selector::operator() (const vector<node_t>& nodes) const
 
 
 
-WriterExemplars::WriterExemplars (const Tractography::Properties& properties, const vector<node_t>& nodes, const bool exclusive, const node_t first_node, const vector<Eigen::Vector3f>& COMs) :
+WriterExemplars::WriterExemplars (const Tractography::Properties& properties, const std::vector<node_t>& nodes, const bool exclusive, const node_t first_node, const std::vector<Eigen::Vector3f>& COMs) :
     step_size (properties.get_stepsize())
 {
   if (!std::isfinite (step_size))
@@ -138,7 +138,7 @@ bool WriterExemplars::operator() (const Tractography::Connectome::Streamline_nod
 void WriterExemplars::finalize()
 {
   ProgressBar progress ("finalizing exemplars", exemplars.size());
-  for (vector<Exemplar>::iterator i = exemplars.begin(); i != exemplars.end(); ++i) {
+  for (std::vector<Exemplar>::iterator i = exemplars.begin(); i != exemplars.end(); ++i) {
     i->finalize (step_size);
     ++progress;
   }
@@ -191,11 +191,11 @@ void WriterExemplars::write (const std::string& path, const std::string& weights
   Tractography::Properties properties;
   properties["step_size"] = str(step_size);
   Tractography::Writer<float> writer (path, properties);
-  for (vector<Exemplar>::const_iterator i = exemplars.begin(); i != exemplars.end(); ++i)
+  for (std::vector<Exemplar>::const_iterator i = exemplars.begin(); i != exemplars.end(); ++i)
     writer (i->get());
   if (weights_path.size()) {
     File::OFStream output (weights_path);
-    for (vector<Exemplar>::const_iterator i = exemplars.begin(); i != exemplars.end(); ++i)
+    for (std::vector<Exemplar>::const_iterator i = exemplars.begin(); i != exemplars.end(); ++i)
       output << str(i->get_weight()) << "\n";
   }
 }
@@ -209,7 +209,7 @@ void WriterExemplars::write (const std::string& path, const std::string& weights
 
 
 
-WriterExtraction::WriterExtraction (const Tractography::Properties& p, const vector<node_t>& nodes, const bool exclusive, const bool keep_self) :
+WriterExtraction::WriterExtraction (const Tractography::Properties& p, const std::vector<node_t>& nodes, const bool exclusive, const bool keep_self) :
     properties (p),
     node_list (nodes),
     exclusive (exclusive),
@@ -236,7 +236,7 @@ void WriterExtraction::add (const node_t node_one, const node_t node_two, const 
   }
 }
 
-void WriterExtraction::add (const vector<node_t>& list, const std::string& path, const std::string weights_path = "")
+void WriterExtraction::add (const std::vector<node_t>& list, const std::string& path, const std::string weights_path = "")
 {
   selectors.emplace_back (Selector (list, exclusive, keep_self));
   writers.emplace_back (new Tractography::WriterUnbuffered<float> (path, properties));
@@ -260,7 +260,7 @@ bool WriterExtraction::operator() (const Connectome::Streamline_nodepair& in) co
     // Make sure that both nodes are within the list of nodes of interest;
     //   if not, don't bother passing to any of the selectors
     bool first_in_list = false, second_in_list = false;
-    for (vector<node_t>::const_iterator i = node_list.begin(); i != node_list.end(); ++i) {
+    for (std::vector<node_t>::const_iterator i = node_list.begin(); i != node_list.end(); ++i) {
       if (*i == in.get_nodes().first)  first_in_list = true;
       if (*i == in.get_nodes().second) second_in_list = true;
     }
@@ -285,7 +285,7 @@ bool WriterExtraction::operator() (const Connectome::Streamline_nodelist& in) co
     // Make sure _all_ nodes are within the list of nodes of interest;
     //   if not, don't pass to any of the selectors
     BitSet in_list (in.get_nodes().size());
-    for (vector<node_t>::const_iterator i = node_list.begin(); i != node_list.end(); ++i) {
+    for (std::vector<node_t>::const_iterator i = node_list.begin(); i != node_list.end(); ++i) {
       for (size_t n = 0; n != in.get_nodes().size(); ++n)
         if (*i == in.get_nodes()[n]) in_list[n] = true;
     }

--- a/src/dwi/tractography/connectome/extract.h
+++ b/src/dwi/tractography/connectome/extract.h
@@ -46,7 +46,7 @@ class Selector
     Selector (const node_t node_one, const node_t node_two) :
       exact_match (true),
       keep_self (true) { list.push_back (node_one); list.push_back (node_two); }
-    Selector (const vector<node_t>& node_list, const bool both, const bool keep_self = false) :
+    Selector (const std::vector<node_t>& node_list, const bool both, const bool keep_self = false) :
       list (node_list),
       exact_match (both),
       keep_self (keep_self) { }
@@ -58,10 +58,10 @@ class Selector
     bool operator() (const node_t) const;
     bool operator() (const NodePair&) const;
     bool operator() (const node_t one, const node_t two) const { return (*this) (NodePair (one, two)); }
-    bool operator() (const vector<node_t>&) const;
+    bool operator() (const std::vector<node_t>&) const;
 
   private:
-    vector<node_t> list;
+    std::vector<node_t> list;
     bool exact_match, keep_self;
 
 };
@@ -74,7 +74,7 @@ class Selector
 class WriterExemplars
 { 
   public:
-    WriterExemplars (const Tractography::Properties&, const vector<node_t>&, const bool, const node_t, const vector<Eigen::Vector3f>&);
+    WriterExemplars (const Tractography::Properties&, const std::vector<node_t>&, const bool, const node_t, const std::vector<Eigen::Vector3f>&);
 
     bool operator() (const Tractography::Connectome::Streamline_nodepair&);
     bool operator() (const Tractography::Connectome::Streamline_nodelist&);
@@ -88,8 +88,8 @@ class WriterExemplars
 
   private:
     float step_size;
-    vector<Selector> selectors;
-    vector<Exemplar> exemplars;
+    std::vector<Selector> selectors;
+    std::vector<Exemplar> exemplars;
 };
 
 
@@ -104,11 +104,11 @@ class WriterExtraction
 { 
 
   public:
-    WriterExtraction (const Tractography::Properties&, const vector<node_t>&, const bool, const bool);
+    WriterExtraction (const Tractography::Properties&, const std::vector<node_t>&, const bool, const bool);
 
     void add (const node_t, const std::string&, const std::string);
     void add (const node_t, const node_t, const std::string&, const std::string);
-    void add (const vector<node_t>&, const std::string&, const std::string);
+    void add (const std::vector<node_t>&, const std::string&, const std::string);
 
     void clear();
 
@@ -120,11 +120,11 @@ class WriterExtraction
 
   private:
     const Tractography::Properties& properties;
-    const vector<node_t>& node_list;
+    const std::vector<node_t>& node_list;
     const bool exclusive;
     const bool keep_self;
-    vector< Selector > selectors;
-    vector< std::unique_ptr< Tractography::WriterUnbuffered<float> > > writers;
+    std::vector< Selector > selectors;
+    std::vector< std::unique_ptr< Tractography::WriterUnbuffered<float> > > writers;
     Tractography::Streamline<> empty_tck;
 
 };

--- a/src/dwi/tractography/connectome/mapped_track.h
+++ b/src/dwi/tractography/connectome/mapped_track.h
@@ -81,13 +81,13 @@ namespace MR {
               nodes () { }
 
             void add_node   (const node_t i)               { nodes.push_back (i);  }
-            void set_nodes  (const vector<node_t>& i) { nodes = i; }
-            void set_nodes  (vector<node_t>&& i)       { std::swap (nodes, i); }
+            void set_nodes  (const std::vector<node_t>& i) { nodes = i; }
+            void set_nodes  (std::vector<node_t>&& i)       { std::swap (nodes, i); }
 
-            const vector<node_t>& get_nodes() const { return nodes; }
+            const std::vector<node_t>& get_nodes() const { return nodes; }
 
           private:
-            vector<node_t> nodes;
+            std::vector<node_t> nodes;
 
         };
 

--- a/src/dwi/tractography/connectome/mapper.h
+++ b/src/dwi/tractography/connectome/mapper.h
@@ -58,7 +58,7 @@ class Mapper
     {
       assert (!tck2nodes.provides_pair());
       out.set_track_index (in.get_index());
-      vector<node_t> nodes;
+      std::vector<node_t> nodes;
       tck2nodes (in, nodes);
       out.set_nodes (std::move (nodes));
       out.set_factor (metric (in, out.get_nodes()));

--- a/src/dwi/tractography/connectome/matrix.cpp
+++ b/src/dwi/tractography/connectome/matrix.cpp
@@ -85,8 +85,8 @@ bool Matrix<T>::operator() (const Mapped_track_nodelist& in)
 {
   assert (assignments_single.empty());
   assert (assignments_pairs.empty());
-  vector<node_t> list (in.get_nodes());
-  for (vector<node_t>::const_iterator i = list.begin(); i != list.end(); ++i) {
+  std::vector<node_t> list (in.get_nodes());
+  for (std::vector<node_t>::const_iterator i = list.begin(); i != list.end(); ++i) {
     assert (*i < data.rows());
   }
   if (is_vector()) {
@@ -95,7 +95,7 @@ bool Matrix<T>::operator() (const Mapped_track_nodelist& in)
       inc_count (0, in.get_weight());
       list.push_back (0);
     } else {
-      for (vector<node_t>::const_iterator n = list.begin(); n != list.end(); ++n) {
+      for (std::vector<node_t>::const_iterator n = list.begin(); n != list.end(); ++n) {
         apply_data (*n, in.get_factor(), in.get_weight());
         inc_count (*n, in.get_weight());
       }
@@ -124,7 +124,7 @@ bool Matrix<T>::operator() (const Mapped_track_nodelist& in)
     } else if (in.get_track_index() < assignments_lists.size()) {
       assignments_lists[in.get_track_index()] = std::move (list);
     } else {
-      assignments_lists.resize (in.get_track_index() + 1, vector<node_t>());
+      assignments_lists.resize (in.get_track_index() + 1, std::vector<node_t>());
       assignments_lists[in.get_track_index()] = std::move (list);
     }
   }
@@ -178,7 +178,7 @@ void Matrix<T>::error_check (const std::set<node_t>& missing_nodes)
       visited[nodes.second] = true;
     }
   }
-  vector<std::string> empty_nodes;
+  std::vector<std::string> empty_nodes;
   for (node_t i = 1; i != visited.size(); ++i) {
     if (!visited[i] && missing_nodes.find (i) == missing_nodes.end())
       empty_nodes.push_back (str(i));

--- a/src/dwi/tractography/connectome/matrix.h
+++ b/src/dwi/tractography/connectome/matrix.h
@@ -97,9 +97,9 @@ class Matrix
     const std::unique_ptr<MR::Connectome::Mat2Vec> mat2vec;
 
     vector_type data, counts;
-    vector<node_t> assignments_single;
-    vector<NodePair> assignments_pairs;
-    vector< vector<node_t> > assignments_lists;
+    std::vector<node_t> assignments_single;
+    std::vector<NodePair> assignments_pairs;
+    std::vector< std::vector<node_t> > assignments_lists;
 
     FORCE_INLINE void apply_data (const size_t, const T, const T);
     FORCE_INLINE void apply_data (const size_t, const size_t, const T, const T);

--- a/src/dwi/tractography/connectome/metric.h
+++ b/src/dwi/tractography/connectome/metric.h
@@ -61,11 +61,11 @@ class Metric {
       return (*this)(tck);
     }
 
-    double operator() (const Streamline<>& tck, const vector<node_t>& nodes) const
+    double operator() (const Streamline<>& tck, const std::vector<node_t>& nodes) const
     {
       if (scale_by_invnodevol) {
         double sum_volumes = 0.0;
-        for (vector<node_t>::const_iterator n = nodes.begin(); n != nodes.end(); ++n) {
+        for (std::vector<node_t>::const_iterator n = nodes.begin(); n != nodes.end(); ++n) {
           assert (*n < node_volumes.size());
           sum_volumes += node_volumes[*n];
         }

--- a/src/dwi/tractography/connectome/streamline.h
+++ b/src/dwi/tractography/connectome/streamline.h
@@ -52,11 +52,11 @@ class Streamline_nodelist : public Tractography::Streamline<>
     Streamline_nodelist() : Tractography::Streamline<>(), nodes () { }
     Streamline_nodelist (const size_t i) : Tractography::Streamline<> (i), nodes () { }
 
-    void set_nodes (const vector<node_t>& i) { nodes = i; }
-    const vector<node_t>& get_nodes() const { return nodes; }
+    void set_nodes (const std::vector<node_t>& i) { nodes = i; }
+    const std::vector<node_t>& get_nodes() const { return nodes; }
 
   private:
-    vector<node_t> nodes;
+    std::vector<node_t> nodes;
 };
 
 

--- a/src/dwi/tractography/connectome/tck2nodes.cpp
+++ b/src/dwi/tractography/connectome/tck2nodes.cpp
@@ -76,7 +76,7 @@ node_t Tck2nodes_radial::select_node (const Tractography::Streamline<>& tck, Ima
   const Eigen::Vector3d v_float = transform->scanner2voxel * p;
   const voxel_type centre { int(std::round (v_float[0])), int(std::round (v_float[1])), int(std::round (v_float[2])) };
 
-  for (vector<voxel_type>::const_iterator offset = radial_search.begin(); offset != radial_search.end(); ++offset) {
+  for (std::vector<voxel_type>::const_iterator offset = radial_search.begin(); offset != radial_search.end(); ++offset) {
 
     const voxel_type this_voxel (centre + *offset);
     const Eigen::Vector3d p_voxel (transform->voxel2scanner * this_voxel.matrix().cast<default_type>());
@@ -230,7 +230,7 @@ default_type Tck2nodes_forwardsearch::get_cf (const Eigen::Vector3d& p, const Ei
 
 
 
-void Tck2nodes_all_voxels::select_nodes (const Streamline<>& tck, Image<node_t>& v, vector<node_t>& out) const
+void Tck2nodes_all_voxels::select_nodes (const Streamline<>& tck, Image<node_t>& v, std::vector<node_t>& out) const
 {
   std::set<node_t> result;
   for (Streamline<>::const_iterator p = tck.begin(); p != tck.end(); ++p) {

--- a/src/dwi/tractography/connectome/tck2nodes.h
+++ b/src/dwi/tractography/connectome/tck2nodes.h
@@ -59,7 +59,7 @@ class Tck2nodes_base {
       return std::make_pair (node_one, node_two);
     }
 
-    bool operator() (const Streamline<>& tck, vector<node_t>& out) const
+    bool operator() (const Streamline<>& tck, std::vector<node_t>& out) const
     {
       assert (!pair);
       Image<node_t> v (nodes);
@@ -79,7 +79,7 @@ class Tck2nodes_base {
       throw Exception ("Calling empty virtual function Tck2nodes_base::select_node()");
     }
 
-    virtual void select_nodes (const Streamline<>& tck, Image<node_t>& v, vector<node_t>& out) const {
+    virtual void select_nodes (const Streamline<>& tck, Image<node_t>& v, std::vector<node_t>& out) const {
       throw Exception ("Calling empty virtual function Tck2nodes_base::select_nodes()");
     }
 
@@ -144,7 +144,7 @@ class Tck2nodes_radial : public Tck2nodes_base {
     node_t select_node (const Tractography::Streamline<>&, Image<node_t>&, const bool) const override;
 
     void initialise_search ();
-    vector<voxel_type> radial_search;
+    std::vector<voxel_type> radial_search;
     const default_type max_dist;
     // Distances are sub-voxel from the precise streamline termination point, so the search order is imperfect.
     //   This parameter controls when to stop the radial search because no voxel within the search space can be closer
@@ -225,7 +225,7 @@ class Tck2nodes_all_voxels : public Tck2nodes_base
     ~Tck2nodes_all_voxels() { }
 
   private:
-    void select_nodes (const Streamline<>&, Image<node_t>&, vector<node_t>&) const override;
+    void select_nodes (const Streamline<>&, Image<node_t>&, std::vector<node_t>&) const override;
 
 };
 

--- a/src/dwi/tractography/editing/loader.h
+++ b/src/dwi/tractography/editing/loader.h
@@ -40,7 +40,7 @@ namespace MR {
         { 
 
           public:
-            Loader (const vector<std::string>& files) :
+            Loader (const std::vector<std::string>& files) :
               file_list (files),
               dummy_properties (),
               reader (new Reader<> (file_list[0], dummy_properties)),
@@ -50,7 +50,7 @@ namespace MR {
 
 
           private:
-            const vector<std::string>& file_list;
+            const std::vector<std::string>& file_list;
             Properties dummy_properties;
             std::unique_ptr<Reader<> > reader;
             size_t file_index;

--- a/src/dwi/tractography/editing/worker.cpp
+++ b/src/dwi/tractography/editing/worker.cpp
@@ -87,8 +87,8 @@ namespace MR {
           }
 
           // Split tck into separate tracks based on the mask
-          vector<vector<Eigen::Vector3f>> cropped_tracks;
-          vector<Eigen::Vector3f> temp;
+          std::vector<std::vector<Eigen::Vector3f>> cropped_tracks;
+          std::vector<Eigen::Vector3f> temp;
 
           for (const auto& p : in) {
             const bool contains = properties.mask.contains (p);

--- a/src/dwi/tractography/file_base.cpp
+++ b/src/dwi/tractography/file_base.cpp
@@ -35,7 +35,7 @@ namespace MR {
           const std::string key = lowercase (kv.key());
           if (key == "roi" || key == "prior_roi") {
             try {
-              vector<std::string> V (split (kv.value(), " \t", true, 2));
+              std::vector<std::string> V (split (kv.value(), " \t", true, 2));
               if (V.size() != 2)
                 throw 1;
               properties.prior_rois.insert (std::pair<std::string,std::string> (V[0], V[1]));

--- a/src/dwi/tractography/mapping/buffer_scratch_dump.h
+++ b/src/dwi/tractography/mapping/buffer_scratch_dump.h
@@ -99,7 +99,7 @@ namespace MR {
             for (const auto& i : H.keyval())
               out_header << "\n" << i.first << ": " << i.second;
 
-            for (vector<std::string>::const_iterator i = H.comments().begin(); i != H.comments().end(); i++)
+            for (std::vector<std::string>::const_iterator i = H.comments().begin(); i != H.comments().end(); i++)
               out_header << "\ncomments: " << *i;
 
 

--- a/src/dwi/tractography/mapping/gaussian/mapper.cpp
+++ b/src/dwi/tractography/mapping/gaussian/mapper.cpp
@@ -41,7 +41,7 @@ namespace MR {
           void TrackMapper::gaussian_smooth_factors (const Streamline<>& tck) const
           {
 
-            vector<default_type> unsmoothed (factors);
+            std::vector<default_type> unsmoothed (factors);
 
             for (size_t i = 0; i != unsmoothed.size(); ++i) {
 

--- a/src/dwi/tractography/mapping/mapper.cpp
+++ b/src/dwi/tractography/mapping/mapper.cpp
@@ -214,7 +214,7 @@ void TrackMapperTWI::add_twdfc_static_image (Image<float>& image)
   image_plugin.reset (new TWDFCStaticImagePlugin (image));
 }
 
-void TrackMapperTWI::add_twdfc_dynamic_image (Image<float>& image, const vector<float>& kernel, const ssize_t timepoint)
+void TrackMapperTWI::add_twdfc_dynamic_image (Image<float>& image, const std::vector<float>& kernel, const ssize_t timepoint)
 {
   if (image_plugin)
     throw Exception ("Cannot add more than one associated image to TWI");
@@ -254,7 +254,7 @@ void TrackMapperTWI::load_factors (const Streamline<>& tck) const
   if (contrast != CURVATURE)
     throw Exception ("Unsupported contrast in function TrackMapperTWI::load_factors()");
 
-  vector<Eigen::Vector3d> tangents;
+  std::vector<Eigen::Vector3d> tangents;
   tangents.reserve (tck.size());
 
   // Would like to be able to manipulate the length over which the tangent calculation is affected
@@ -267,7 +267,7 @@ void TrackMapperTWI::load_factors (const Streamline<>& tck) const
 
   // Need to know the distance along the spline between every point and every other point
   // Start by logging the length of each step
-  vector<default_type> step_sizes;
+  std::vector<default_type> step_sizes;
   step_sizes.reserve (tck.size());
 
   for (size_t i = 0; i != tck.size(); ++i) {
@@ -322,7 +322,7 @@ void TrackMapperTWI::load_factors (const Streamline<>& tck) const
   // Smooth both the tangent vectors and the principal normal vectors according to a Gaussuan kernel
   // Remember: tangent vectors are unit length, but for principal normal vectors length must be preserved!
 
-  vector<Eigen::Vector3d> smoothed_tangents;
+  std::vector<Eigen::Vector3d> smoothed_tangents;
   smoothed_tangents.reserve (tangents.size());
 
   static const default_type gaussian_theta = CURVATURE_TRACK_SMOOTHING_FWHM / (2.0 * sqrt (2.0 * log (2.0)));

--- a/src/dwi/tractography/mapping/mapper.h
+++ b/src/dwi/tractography/mapping/mapper.h
@@ -379,7 +379,7 @@ namespace MR {
             void set_backtrack();
             void add_fod_image    (const std::string&);
             void add_twdfc_static_image  (Image<float>&);
-            void add_twdfc_dynamic_image (Image<float>&, const vector<float>&, const ssize_t);
+            void add_twdfc_dynamic_image (Image<float>&, const std::vector<float>&, const ssize_t);
             void add_vector_data  (const std::string&);
 
 
@@ -388,7 +388,7 @@ namespace MR {
             const tck_stat_t track_statistic;
 
             // Members for when the contribution of a track is not constant along its length
-            mutable vector<default_type> factors;
+            mutable std::vector<default_type> factors;
             void load_factors (const Streamline<>&) const;
 
             // Member for incorporating additional information from an external image into the TWI process

--- a/src/dwi/tractography/mapping/mapper_plugins.cpp
+++ b/src/dwi/tractography/mapping/mapper_plugins.cpp
@@ -107,7 +107,7 @@ namespace MR {
 
 
 
-        void TWIScalarImagePlugin::load_factors (const Streamline<>& tck, vector<default_type>& factors) const
+        void TWIScalarImagePlugin::load_factors (const Streamline<>& tck, std::vector<default_type>& factors) const
         {
           if (statistic == ENDS_MIN || statistic == ENDS_MEAN || statistic == ENDS_MAX || statistic == ENDS_PROD) {
 
@@ -141,7 +141,7 @@ namespace MR {
 
 
 
-        void TWIFODImagePlugin::load_factors (const Streamline<>& tck, vector<default_type>& factors) const
+        void TWIFODImagePlugin::load_factors (const Streamline<>& tck, std::vector<default_type>& factors) const
         {
           assert (statistic != ENDS_CORR);
           if (statistic == ENDS_MAX || statistic == ENDS_MEAN || statistic == ENDS_MIN || statistic == ENDS_PROD) {
@@ -184,12 +184,12 @@ namespace MR {
 
 
 
-        void TWDFCStaticImagePlugin::load_factors (const Streamline<>& tck, vector<default_type>& factors) const
+        void TWDFCStaticImagePlugin::load_factors (const Streamline<>& tck, std::vector<default_type>& factors) const
         {
           // Use trilinear interpolation
           // Store values into local vectors, since it's a two-pass operation
           factors.assign (1, NaN);
-          vector<float> values[2];
+          std::vector<float> values[2];
           for (size_t tck_end_index = 0; tck_end_index != 2; ++tck_end_index) {
             const ssize_t index = get_end_index (tck, bool(tck_end_index));
             if (index < 0)
@@ -227,14 +227,14 @@ namespace MR {
 
 
 
-        void TWDFCDynamicImagePlugin::load_factors (const Streamline<>& tck, vector<default_type>& factors) const
+        void TWDFCDynamicImagePlugin::load_factors (const Streamline<>& tck, std::vector<default_type>& factors) const
         {
           assert (statistic == ENDS_CORR);
           factors.assign (1, NaN);
 
           // Use trilinear interpolation
           // Store values into local vectors, since it's a two-pass operation
-          vector<default_type> values[2];
+          std::vector<default_type> values[2];
           for (size_t tck_end_index = 0; tck_end_index != 2; ++tck_end_index) {
             const ssize_t index = get_end_index (tck, tck_end_index);
             if (index < 0)

--- a/src/dwi/tractography/mapping/mapper_plugins.h
+++ b/src/dwi/tractography/mapping/mapper_plugins.h
@@ -92,7 +92,7 @@ namespace MR {
 
             void set_backtrack();
 
-            virtual void load_factors (const Streamline<>&, vector<default_type>&) const = 0;
+            virtual void load_factors (const Streamline<>&, std::vector<default_type>&) const = 0;
 
 
           protected:
@@ -141,7 +141,7 @@ namespace MR {
               return new TWIScalarImagePlugin (*this);
             }
 
-            void load_factors (const Streamline<>&, vector<default_type>&) const override;
+            void load_factors (const Streamline<>&, std::vector<default_type>&) const override;
         };
 
 
@@ -168,7 +168,7 @@ namespace MR {
               return new TWIFODImagePlugin (*this);
             }
 
-            void load_factors (const Streamline<>&, vector<default_type>&) const override;
+            void load_factors (const Streamline<>&, std::vector<default_type>&) const override;
 
           private:
             mutable Eigen::Matrix<default_type, Eigen::Dynamic, 1> sh_coeffs;
@@ -191,7 +191,7 @@ namespace MR {
               return new TWDFCStaticImagePlugin (*this);
             }
 
-            void load_factors (const Streamline<>&, vector<default_type>&) const override;
+            void load_factors (const Streamline<>&, std::vector<default_type>&) const override;
         };
 
 
@@ -200,7 +200,7 @@ namespace MR {
         class TWDFCDynamicImagePlugin : public TWIImagePluginBase
         { 
           public:
-            TWDFCDynamicImagePlugin (Image<float>& input_image, const vector<float>& kernel, const ssize_t timepoint) :
+            TWDFCDynamicImagePlugin (Image<float>& input_image, const std::vector<float>& kernel, const ssize_t timepoint) :
                 TWIImagePluginBase (input_image, ENDS_CORR),
                 kernel (kernel),
                 kernel_centre ((kernel.size()-1) / 2),
@@ -213,10 +213,10 @@ namespace MR {
               return new TWDFCDynamicImagePlugin (*this);
             }
 
-            void load_factors (const Streamline<>&, vector<default_type>&) const override;
+            void load_factors (const Streamline<>&, std::vector<default_type>&) const override;
 
           protected:
-            const vector<float> kernel;
+            const std::vector<float> kernel;
             const ssize_t kernel_centre, sample_centre;
         };
 

--- a/src/dwi/tractography/mapping/mapping.cpp
+++ b/src/dwi/tractography/mapping/mapping.cpp
@@ -55,7 +55,7 @@ namespace MR {
 
 
 
-        void generate_header (Header& header, const std::string& tck_file_path, const vector<default_type>& voxel_size)
+        void generate_header (Header& header, const std::string& tck_file_path, const std::vector<default_type>& voxel_size)
         {
 
           Properties properties;
@@ -103,7 +103,7 @@ namespace MR {
 
 
 
-        void oversample_header (Header& header, const vector<default_type>& voxel_size)
+        void oversample_header (Header& header, const std::vector<default_type>& voxel_size)
         {
           INFO ("oversampling header...");
 

--- a/src/dwi/tractography/mapping/mapping.h
+++ b/src/dwi/tractography/mapping/mapping.h
@@ -39,9 +39,9 @@ namespace MR {
 
 
 #define MAX_TRACKS_READ_FOR_HEADER 1000000
-        void generate_header (Header&, const std::string&, const vector<default_type>&);
+        void generate_header (Header&, const std::string&, const std::vector<default_type>&);
 
-        void oversample_header (Header&, const vector<default_type>&);
+        void oversample_header (Header&, const std::vector<default_type>&);
 
 
 

--- a/src/dwi/tractography/properties.cpp
+++ b/src/dwi/tractography/properties.cpp
@@ -148,7 +148,7 @@ namespace MR
         for (KeyValues::const_iterator i = P.begin(); i != P.end(); ++i)
           stream << "[ " << i->first << ": " << i->second << " ], ";
         stream << "comments: ";
-        for (vector<std::string>::const_iterator i = P.comments.begin(); i != P.comments.end(); ++i)
+        for (std::vector<std::string>::const_iterator i = P.comments.begin(); i != P.comments.end(); ++i)
           stream << "\"" << *i << "\", ";
         return (stream);
       }

--- a/src/dwi/tractography/properties.h
+++ b/src/dwi/tractography/properties.h
@@ -70,7 +70,7 @@ namespace MR
           // As stored within the header of an existing .tck file
           std::multimap<std::string, std::string> prior_rois;
 
-          vector<std::string> comments;
+          std::vector<std::string> comments;
 
           friend std::ostream& operator<< (std::ostream& stream, const Properties& P);
       };

--- a/src/dwi/tractography/resampling/arc.h
+++ b/src/dwi/tractography/resampling/arc.h
@@ -51,7 +51,7 @@ namespace MR {
                 value_type d;
             };
 
-            vector<Plane> planes;
+            std::vector<Plane> planes;
 
           public:
             Arc (const size_t n, const point_type& s, const point_type& e) :

--- a/src/dwi/tractography/resampling/fixed_num_points.cpp
+++ b/src/dwi/tractography/resampling/fixed_num_points.cpp
@@ -38,7 +38,7 @@ namespace MR {
           if (in.size() < 2)
             return true;
           value_type length = 0.0;
-          vector<value_type> steps;
+          std::vector<value_type> steps;
           for (size_t i = 1; i != in.size(); ++i) {
             const value_type dist = (in[i] - in[i-1]).norm();
             length += dist;

--- a/src/dwi/tractography/resampling/resampling.cpp
+++ b/src/dwi/tractography/resampling/resampling.cpp
@@ -78,7 +78,7 @@ namespace MR {
           using value_type = float;
           using point_type = Eigen::Vector3f;
 
-          point_type get_pos (const vector<default_type>& s)
+          point_type get_pos (const std::vector<default_type>& s)
           {
             if (s.size() != 3)
               throw Exception ("position expected as a comma-seperated list of 3 values");

--- a/src/dwi/tractography/roi.cpp
+++ b/src/dwi/tractography/roi.cpp
@@ -87,7 +87,7 @@ namespace MR {
       Image<bool> Mask::__get_mask (const std::string& name)
       {
         auto data = Image<bool>::open (name);
-        vector<size_t> bottom (3, 0), top (3, 0);
+        std::vector<size_t> bottom (3, 0), top (3, 0);
         std::fill_n (bottom.begin(), 3, std::numeric_limits<size_t>::max());
 
         size_t sum = 0;

--- a/src/dwi/tractography/roi.h
+++ b/src/dwi/tractography/roi.h
@@ -149,7 +149,7 @@ namespace MR
 
           friend inline std::ostream& operator<< (std::ostream& stream, const ROISetBase& R) {
             if (R.R.empty()) return (stream);
-            vector<ROI>::const_iterator i = R.R.begin();
+            std::vector<ROI>::const_iterator i = R.R.begin();
             stream << *i;
             ++i;
             for (; i != R.R.end(); ++i) stream << ", " << *i;
@@ -157,7 +157,7 @@ namespace MR
           }
 
         protected:
-          vector<ROI> R;
+          std::vector<ROI> R;
       };
 
 

--- a/src/dwi/tractography/scalar_file.h
+++ b/src/dwi/tractography/scalar_file.h
@@ -209,7 +209,7 @@ namespace MR
             if (buffer_size + tck_scalar.size() > buffer_capacity)
               commit();
 
-            for (typename vector<value_type>::const_iterator i = tck_scalar.begin(); i != tck_scalar.end(); ++i) {
+            for (typename std::vector<value_type>::const_iterator i = tck_scalar.begin(); i != tck_scalar.end(); ++i) {
               assert (std::isfinite (*i));
               add_scalar (*i);
             }

--- a/src/dwi/tractography/seeding/basic.cpp
+++ b/src/dwi/tractography/seeding/basic.cpp
@@ -151,8 +151,8 @@ namespace MR
           auto vox = Image<float>::open (in);
           if (!(vox.ndim() == 3 || (vox.ndim() == 4 && vox.size(3) == 1)))
             throw Exception ("Seed image must be a 3D image");
-          vector<size_t> bottom (3, std::numeric_limits<size_t>::max());
-          vector<size_t> top    (3, 0);
+          std::vector<size_t> bottom (3, std::numeric_limits<size_t>::max());
+          std::vector<size_t> top    (3, 0);
 
           for (auto i = Loop (0,3) (vox); i; ++i) {
             const float value = vox.value();

--- a/src/dwi/tractography/seeding/dynamic.cpp
+++ b/src/dwi/tractography/seeding/dynamic.cpp
@@ -274,7 +274,7 @@ namespace MR
       {
         static std::mutex mutex;
         std::lock_guard<std::mutex> lock (mutex);
-        vector< Eigen::Vector3f > tck;
+        std::vector< Eigen::Vector3f > tck;
         tck.push_back (p);
         seed_output (tck);
       }

--- a/src/dwi/tractography/seeding/list.h
+++ b/src/dwi/tractography/seeding/list.h
@@ -69,7 +69,7 @@ namespace MR
 
 
         private:
-          vector<std::unique_ptr<Base>> seeders;
+          std::vector<std::unique_ptr<Base>> seeders;
           float total_volume;
           uint32_t total_count;
 

--- a/src/dwi/tractography/streamline.h
+++ b/src/dwi/tractography/streamline.h
@@ -57,25 +57,25 @@ namespace MR
 
       // A class for track scalars
       template <typename ValueType = float>
-      class TrackScalar : public vector<ValueType>, public DataIndex
+      class TrackScalar : public std::vector<ValueType>, public DataIndex
       { 
         public:
           using value_type = ValueType;
-          using vector<ValueType>::vector;
+          using std::vector<ValueType>::vector;
           TrackScalar () = default;
           TrackScalar (const TrackScalar&) = default;
           TrackScalar (TrackScalar&& that) :
-              vector<value_type> (std::move (that)),
+              std::vector<value_type> (std::move (that)),
               DataIndex (std::move (that)) { }
           TrackScalar& operator= (const TrackScalar& that) = default;
-          void clear() { vector<ValueType>::clear(); DataIndex::clear(); }
+          void clear() { std::vector<ValueType>::clear(); DataIndex::clear(); }
       };
 
 
 
 
       template <typename ValueType = float>
-        class Streamline : public vector<Eigen::Matrix<ValueType,3,1>>, public DataIndex
+        class Streamline : public std::vector<Eigen::Matrix<ValueType,3,1>>, public DataIndex
       { 
         public:
           using point_type = Eigen::Matrix<ValueType,3,1>;
@@ -84,31 +84,31 @@ namespace MR
           Streamline () : weight (1.0f) { }
 
           Streamline (size_t size) :
-            vector<point_type> (size),
+            std::vector<point_type> (size),
             weight (value_type (1.0)) { }
 
           Streamline (size_t size, const point_type& fill) :
-            vector<point_type> (size, fill),
+            std::vector<point_type> (size, fill),
             weight (value_type (1.0)) { }
 
           Streamline (const Streamline&) = default;
           Streamline& operator= (const Streamline& that) = default;
 
           Streamline (Streamline&& that) :
-            vector<point_type> (std::move (that)),
+            std::vector<point_type> (std::move (that)),
             DataIndex (std::move (that)),
             weight (that.weight) {
               that.weight = 1.0f;
             }
 
-          Streamline (const vector<point_type>& tck) :
-            vector<point_type> (tck),
+          Streamline (const std::vector<point_type>& tck) :
+            std::vector<point_type> (tck),
             DataIndex (),
             weight (1.0) { }
 
           Streamline& operator= (Streamline&& that)
           {
-            vector<point_type>::operator= (std::move (that));
+            std::vector<point_type>::operator= (std::move (that));
             DataIndex::operator= (std::move (that));
             weight = that.weight; that.weight = 0.0f;
             return *this;
@@ -117,7 +117,7 @@ namespace MR
 
           void clear()
           {
-            vector<point_type>::clear();
+            std::vector<point_type>::clear();
             DataIndex::clear();
             weight = 1.0;
           }
@@ -131,7 +131,7 @@ namespace MR
 
 
       template <typename PointType>
-      typename PointType::Scalar length (const vector<PointType>& tck)
+      typename PointType::Scalar length (const std::vector<PointType>& tck)
       {
         if (tck.empty())
           return std::numeric_limits<typename PointType::Scalar>::quiet_NaN();

--- a/src/dwi/tractography/tracking/exec.h
+++ b/src/dwi/tractography/tracking/exec.h
@@ -425,7 +425,7 @@ namespace MR
 
             }
 
-            bool satisfy_wm_requirement (const vector<Eigen::Vector3f>& tck)
+            bool satisfy_wm_requirement (const std::vector<Eigen::Vector3f>& tck)
             {
               // If using the Seed_test algorithm (indicated by max_num_points == 2), don't want to execute this check
               if (S.max_num_points_preds == 2)
@@ -451,7 +451,7 @@ namespace MR
 
 
 
-            void truncate_exit_sgm (vector<Eigen::Vector3f>& tck)
+            void truncate_exit_sgm (std::vector<Eigen::Vector3f>& tck)
             {
               const size_t sgm_start = tck.size() - method.act().sgm_depth;
               assert (sgm_start >= 0 && sgm_start < tck.size());

--- a/src/dwi/tractography/tracking/generated_track.h
+++ b/src/dwi/tractography/tracking/generated_track.h
@@ -34,13 +34,13 @@ namespace MR
 
 
 
-        class GeneratedTrack : public vector<Eigen::Vector3f>
+        class GeneratedTrack : public std::vector<Eigen::Vector3f>
         { 
 
 
           public:
 
-            using BaseType = vector<Eigen::Vector3f>;
+            using BaseType = std::vector<Eigen::Vector3f>;
 
             enum class status_t { INVALID, SEED_REJECTED, TRACK_REJECTED, ACCEPTED };
 

--- a/src/fixel/filter/connect.cpp
+++ b/src/fixel/filter/connect.cpp
@@ -56,14 +56,14 @@ namespace MR
 
         BitSet processed (input.size (0));
         using IndexAndSize = std::pair<size_t, size_t>;
-        vector<IndexAndSize> cluster_sizes;
+        std::vector<IndexAndSize> cluster_sizes;
         for (index_type seed = 0; seed != input.size (0); ++seed) {
           if (!processed[seed]) {
             input.index (0) = seed;
             if (input.value() >= value_threshold) {
               processed[seed] = true;
               size_t cluster_size = 1;
-              std::stack<index_type, vector<index_type>> to_expand;
+              std::stack<index_type, std::vector<index_type>> to_expand;
               to_expand.push (seed);
               const size_t cluster_index = cluster_sizes.size()+1;
               while (to_expand.size()) {
@@ -99,7 +99,7 @@ namespace MR
         // For a given value in the output image (as determined by the order in which the
         //   clusters were segmented), what should the new value be, such that the clusters
         //   are indexed sequentially according to size, with 1 being the biggest cluster?
-        vector<size_t> index_remapper (cluster_sizes.size() + 1);
+        std::vector<size_t> index_remapper (cluster_sizes.size() + 1);
         index_remapper[0] = 0;
         for (size_t index = 0; index != cluster_sizes.size(); ++index)
           index_remapper[cluster_sizes[index].first] = index + 1;

--- a/src/fixel/filter/smooth.h
+++ b/src/fixel/filter/smooth.h
@@ -76,7 +76,7 @@ namespace MR
         protected:
           Image<bool> mask_image;
           Matrix::Reader matrix;
-          vector<Eigen::Vector3f> fixel_positions;
+          std::vector<Eigen::Vector3f> fixel_positions;
           float stdev, gaussian_const1, gaussian_const2, threshold;
 
       };

--- a/src/fixel/index_remapper.h
+++ b/src/fixel/index_remapper.h
@@ -57,8 +57,8 @@ namespace MR
 
       private:
         bool mapping_is_default;
-        vector<index_type> external2internal;
-        vector<index_type> internal2external;
+        std::vector<index_type> external2internal;
+        std::vector<index_type> internal2external;
 
     };
 

--- a/src/fixel/matrix.cpp
+++ b/src/fixel/matrix.cpp
@@ -38,7 +38,7 @@ namespace MR
 
 
 
-      void InitFixel::add (const vector<index_type>& indices)
+      void InitFixel::add (const std::vector<index_type>& indices)
       {
         if ((*this).empty()) {
           (*this).reserve (indices.size());
@@ -144,7 +144,7 @@ namespace MR
                 angular_threshold_dp (std::cos (angular_threshold * (Math::pi/180.0))) { }
 
             bool operator() (const DWI::Tractography::Streamline<>& tck,
-                             vector<index_type>& out) const
+                             std::vector<index_type>& out) const
             {
               using direction_type = Eigen::Vector3d;
               using SetVoxelDir = DWI::Tractography::Mapping::SetVoxelDir;
@@ -210,10 +210,10 @@ namespace MR
         Thread::run_queue (loader,
                            Thread::batch (DWI::Tractography::Streamline<float>()),
                            track_processor,
-                           Thread::batch (vector<index_type>()),
+                           Thread::batch (std::vector<index_type>()),
                            // Inline lambda function for receiving streamline fixel visitations and
                            //   updating the connectivity matrix
-                           [&] (const vector<index_type>& fixels)
+                           [&] (const std::vector<index_type>& fixels)
                            {
                              try {
                                for (auto f : fixels)

--- a/src/fixel/matrix.h
+++ b/src/fixel/matrix.h
@@ -68,14 +68,14 @@ namespace MR
 
 
 
-      class InitFixel : public vector<InitElement>
+      class InitFixel : public std::vector<InitElement>
       { 
         public:
           using ElementType = InitElement;
-          using BaseType = vector<InitElement>;
+          using BaseType = std::vector<InitElement>;
           InitFixel() :
               track_count (0) { }
-          void add (const vector<fixel_index_type>& indices);
+          void add (const std::vector<fixel_index_type>& indices);
           count_type count() const { return track_count; }
         private:
           count_type track_count;
@@ -108,11 +108,11 @@ namespace MR
 
       // With the internally normalised CFE expression, want to store a
       //   multiplicative factor per fixel
-      class NormFixel : public vector<NormElement>
+      class NormFixel : public std::vector<NormElement>
       { 
         public:
           using ElementType = NormElement;
-          using BaseType = vector<NormElement>;
+          using BaseType = std::vector<NormElement>;
           NormFixel() :
             norm_multiplier (connectivity_value_type (1)) { }
           NormFixel (const BaseType& i) :
@@ -141,7 +141,7 @@ namespace MR
       // Different types are used depending on whether the connectivity matrix
       //   is in the process of being built, or whether it has been normalised
       // TODO Revise
-      using init_matrix_type = vector<InitFixel>;
+      using init_matrix_type = std::vector<InitFixel>;
 
 
 

--- a/src/gui/dialog/dicom.cpp
+++ b/src/gui/dialog/dicom.cpp
@@ -197,9 +197,9 @@ namespace MR
 
 
 
-      vector<std::shared_ptr<Series>> select_dicom (const Tree& tree)
+      std::vector<std::shared_ptr<Series>> select_dicom (const Tree& tree)
       {
-        vector<std::shared_ptr<Series> > ret;
+        std::vector<std::shared_ptr<Series> > ret;
         if (tree.size() == 1) {
           if (tree[0]->size() == 1) {
             if ((*tree[0])[0]->size() == 1) {

--- a/src/gui/dialog/dicom.h
+++ b/src/gui/dialog/dicom.h
@@ -29,7 +29,7 @@ namespace MR
 
       using namespace MR::File::Dicom;
 
-      vector<std::shared_ptr<Series>> select_dicom (const Tree& tree);
+      std::vector<std::shared_ptr<Series>> select_dicom (const Tree& tree);
 
     }
   }

--- a/src/gui/dialog/file.cpp
+++ b/src/gui/dialog/file.cpp
@@ -77,12 +77,12 @@ namespace MR
 
 
 
-        vector<std::string> get_files (QWidget* parent, const std::string& caption, const std::string& filter, std::string* folder)
+        std::vector<std::string> get_files (QWidget* parent, const std::string& caption, const std::string& filter, std::string* folder)
         {
           QStringList qlist = QFileDialog::getOpenFileNames (parent, qstr(caption),
               folder ? qstr(*folder) : QString(), qstr(filter), 0, FILE_DIALOG_OPTIONS);
 
-          vector<std::string> list;
+          std::vector<std::string> list;
           if (qlist.size()) {
             for (int n = 0; n < qlist.size(); ++n)
               list.push_back (qlist[n].toUtf8().data());

--- a/src/gui/dialog/file.h
+++ b/src/gui/dialog/file.h
@@ -34,14 +34,14 @@ namespace MR
 
         std::string get_folder (QWidget* parent, const std::string& caption, std::string* folder = nullptr);
         std::string get_file (QWidget* parent, const std::string& caption, const std::string& filter = std::string(), std::string* folder = nullptr);
-        vector<std::string> get_files (QWidget* parent, const std::string& caption, const std::string& filter = std::string(), std::string* folder = nullptr);
+        std::vector<std::string> get_files (QWidget* parent, const std::string& caption, const std::string& filter = std::string(), std::string* folder = nullptr);
         std::string get_save_name (QWidget* parent, const std::string& caption, const std::string& suggested_name = std::string(), const std::string& filter = std::string(), std::string* folder = nullptr);
 
         inline std::string get_image (QWidget* parent, const std::string& caption, std::string* folder = nullptr) {
           return get_file (parent, caption, image_filter_string, folder);
         }
 
-        inline vector<std::string> get_images (QWidget* parent, const std::string& caption, std::string* folder = nullptr) {
+        inline std::vector<std::string> get_images (QWidget* parent, const std::string& caption, std::string* folder = nullptr) {
           return get_files (parent, caption, image_filter_string, folder);
         }
 

--- a/src/gui/dwi/renderer.cpp
+++ b/src/gui/dwi/renderer.cpp
@@ -399,7 +399,7 @@ namespace MR
         QApplication::restoreOverrideCursor();
       }
 
-      void Renderer::SH::update_transform (const vector<Shapes::HalfSphere::Vertex>& vertices, int lmax)
+      void Renderer::SH::update_transform (const std::vector<Shapes::HalfSphere::Vertex>& vertices, int lmax)
       {
         // order is r, del, daz
 
@@ -608,8 +608,8 @@ namespace MR
 
       void Renderer::Dixel::update_dixels (const MR::DWI::Directions::Set& dirs)
       {
-        vector<Eigen::Vector3f> directions_data;
-        vector<std::array<GLint,3>> indices_data;
+        std::vector<Eigen::Vector3f> directions_data;
+        std::vector<std::array<GLint,3>> indices_data;
 
         for (size_t i = 0; i != dirs.size(); ++i) {
           directions_data.push_back (dirs[i].cast<float>());

--- a/src/gui/dwi/renderer.h
+++ b/src/gui/dwi/renderer.h
@@ -169,7 +169,7 @@ namespace MR
               GL::VertexBuffer surface_buffer;
               GL::VertexArrayObject VAO;
 
-              void update_transform (const vector<Shapes::HalfSphere::Vertex>&, int);
+              void update_transform (const std::vector<Shapes::HalfSphere::Vertex>&, int);
 
           } sh;
 

--- a/src/gui/mrview/colourmap_button.h
+++ b/src/gui/mrview/colourmap_button.h
@@ -53,7 +53,7 @@ public:
     void set_colourmap_index(size_t index);
     void set_scale_inverted(bool yesno);
     void set_fixed_colour();
-    vector<QAction*> colourmap_actions;
+    std::vector<QAction*> colourmap_actions;
     void open_menu (const QPoint& p) { colourmap_menu->exec (p); }
 private:
     void init_menu(bool create_shortcuts, bool use_special, bool customise_state);
@@ -62,8 +62,8 @@ private:
     void init_special_colour_menu_items(bool create_shortcuts);
     void init_customise_state_menu_items();
 
-    static const vector<ColourMap::Entry> core_colourmaps_entries;
-    static const vector<ColourMap::Entry> special_colourmaps_entries;
+    static const std::vector<ColourMap::Entry> core_colourmaps_entries;
+    static const std::vector<ColourMap::Entry> special_colourmaps_entries;
 
     ColourMapButtonObserver& observer;
     QActionGroup *core_colourmaps_actions;

--- a/src/gui/mrview/file_open.cpp
+++ b/src/gui/mrview/file_open.cpp
@@ -26,7 +26,7 @@ namespace MR
     {
       if (event->type() == QEvent::FileOpen) {
         QFileOpenEvent *openEvent = static_cast<QFileOpenEvent *>(event);
-        vector<std::unique_ptr<MR::Header>> list;
+        std::vector<std::unique_ptr<MR::Header>> list;
         try {
           list.push_back (make_unique<MR::Header> (MR::Header::open (openEvent->file().toUtf8().data())));
         }

--- a/src/gui/mrview/gui_image.cpp
+++ b/src/gui/mrview/gui_image.cpp
@@ -174,7 +174,7 @@ namespace MR
         const ssize_t xsize = header().size (x), ysize = header().size (y);
 
         type = gl::FLOAT;
-        vector<float> data;
+        std::vector<float> data;
 
         std::string cmap_name = ColourMap::maps[colourmap].name;
 
@@ -506,7 +506,7 @@ namespace MR
           } V (image);
 
           const size_t N = ( format == gl::RED ? 1 : 3 );
-          vector<ValueType> data (N * V.size(0) * V.size(1));
+          std::vector<ValueType> data (N * V.size(0) * V.size(1));
 
           ProgressBar progress ("loading image data", V.size(2));
 
@@ -577,7 +577,7 @@ namespace MR
 
       inline void Image::copy_texture_3D_complex ()
       {
-        vector<float> data (2 * image.size (0) * image.size (1));
+        std::vector<float> data (2 * image.size (0) * image.size (1));
 
         ProgressBar progress ("loading image data", image.size (2));
 

--- a/src/gui/mrview/gui_image.h
+++ b/src/gui/mrview/gui_image.h
@@ -63,7 +63,7 @@ namespace MR
 
         protected:
           GL::Texture texture2D[3];
-          vector<ssize_t> tex_positions;
+          std::vector<ssize_t> tex_positions;
 
       };
 
@@ -89,7 +89,7 @@ namespace MR
           cfloat nearest_neighbour_value (const Eigen::Vector3f&) const;
 
           const transform_type& transform() const { return image.transform(); }
-          const vector<std::string>& comments() const { return _comments; }
+          const std::vector<std::string>& comments() const { return _comments; }
 
           void reset_windowing (const int, const bool);
 
@@ -113,7 +113,7 @@ namespace MR
           void lookup_texture_4D_cache ();
           void update_texture_4D_cache ();
 
-          vector<std::string> _comments;
+          std::vector<std::string> _comments;
 
       };
 

--- a/src/gui/mrview/mode/ortho.h
+++ b/src/gui/mrview/mode/ortho.h
@@ -50,7 +50,7 @@ namespace MR
             void set_show_as_row_slot (bool state);
 
           protected:
-            vector<Projection> projections;
+            std::vector<Projection> projections;
             int current_plane;
             GL::VertexBuffer frame_VB;
             GL::VertexArrayObject frame_VAO;

--- a/src/gui/mrview/mode/volume.cpp
+++ b/src/gui/mrview/mode/volume.cpp
@@ -64,10 +64,10 @@ namespace MR
 
         std::string Volume::Shader::fragment_shader_source (const Displayable& object)
         {
-          vector< std::pair<GL::vec4,bool> > clip = mode.get_active_clip_planes();
+          std::vector< std::pair<GL::vec4,bool> > clip = mode.get_active_clip_planes();
           const bool AND = mode.get_clipintersectionmodestate();
           std::string clip_color_spec = File::Config::get ("MRViewClipPlaneColour");
-          vector<float> clip_color = { 1.0, 0.0, 0.0, 0.1 };
+          std::vector<float> clip_color = { 1.0, 0.0, 0.0, 0.1 };
           if (clip_color_spec.size()) {
             auto colour = parse_floats (clip_color_spec);
             if (colour.size() != 4)
@@ -481,7 +481,7 @@ namespace MR
           GL_CHECK_ERROR;
           gl::Uniform1i (gl::GetUniformLocation (volume_shader, "depth_sampler"), 1);
 
-          vector< std::pair<GL::vec4,bool> > clip = get_active_clip_planes();
+          std::vector< std::pair<GL::vec4,bool> > clip = get_active_clip_planes();
           GL_CHECK_ERROR;
 
           for (size_t n = 0; n < clip.size(); ++n) {
@@ -542,16 +542,16 @@ namespace MR
           return dynamic_cast<Tool::View*> (dock->tool);
         }
 
-        inline vector< std::pair<GL::vec4,bool> > Volume::get_active_clip_planes () const
+        inline std::vector< std::pair<GL::vec4,bool> > Volume::get_active_clip_planes () const
         {
           Tool::View* view = get_view_tool();
-          return view ? view->get_active_clip_planes() : vector< std::pair<GL::vec4,bool> >();
+          return view ? view->get_active_clip_planes() : std::vector< std::pair<GL::vec4,bool> >();
         }
 
-        inline vector<GL::vec4*> Volume::get_clip_planes_to_be_edited () const
+        inline std::vector<GL::vec4*> Volume::get_clip_planes_to_be_edited () const
         {
           Tool::View* view = get_view_tool();
-          return view ? view->get_clip_planes_to_be_edited() : vector<GL::vec4*>();
+          return view ? view->get_clip_planes_to_be_edited() : std::vector<GL::vec4*>();
         }
 
         inline bool Volume::get_cliphighlightstate () const

--- a/src/gui/mrview/mode/volume.h
+++ b/src/gui/mrview/mode/volume.h
@@ -49,7 +49,7 @@ namespace MR
             GL::VertexBuffer volume_VB, volume_VI;
             GL::VertexArrayObject volume_VAO;
             GL::Texture depth_texture;
-            vector<GL::vec4> clip;
+            std::vector<GL::vec4> clip;
 
             class Shader : public Displayable::Shader { 
               public:
@@ -65,8 +65,8 @@ namespace MR
             } volume_shader;
 
             Tool::View* get_view_tool () const;
-            vector< std::pair<GL::vec4,bool> > get_active_clip_planes () const;
-            vector<GL::vec4*> get_clip_planes_to_be_edited () const;
+            std::vector< std::pair<GL::vec4,bool> > get_active_clip_planes () const;
+            std::vector<GL::vec4*> get_clip_planes_to_be_edited () const;
             bool get_cliphighlightstate () const;
             bool get_clipintersectionmodestate () const;
         };

--- a/src/gui/mrview/sync/interprocesscommunicator.cpp
+++ b/src/gui/mrview/sync/interprocesscommunicator.cpp
@@ -111,7 +111,7 @@ namespace MR
         void InterprocessCommunicator::OnNewIncomingConnection()
         {
           LocalSocketReader* lsr = new LocalSocketReader(receiver->nextPendingConnection());
-          connect(lsr, SIGNAL(DataReceived(vector<std::shared_ptr<QByteArray>>)), this, SLOT(OnDataReceived(vector<std::shared_ptr<QByteArray>>)));
+          connect(lsr, SIGNAL(DataReceived(std::vector<std::shared_ptr<QByteArray>>)), this, SLOT(OnDataReceived(std::vector<std::shared_ptr<QByteArray>>)));
         }
 
         /**
@@ -158,9 +158,9 @@ namespace MR
         /**
         * Fires when 1+ messages are received from another process.
         */
-        void InterprocessCommunicator::OnDataReceived(vector<std::shared_ptr<QByteArray>> allMessages)
+        void InterprocessCommunicator::OnDataReceived(std::vector<std::shared_ptr<QByteArray>> allMessages)
         {
-          vector<std::shared_ptr<QByteArray>> toSync;
+          std::vector<std::shared_ptr<QByteArray>> toSync;
 
           for (size_t i = 0; i < allMessages.size(); i++)
           {

--- a/src/gui/mrview/sync/interprocesscommunicator.h
+++ b/src/gui/mrview/sync/interprocesscommunicator.h
@@ -50,14 +50,14 @@ namespace MR
 
         private slots:
           void OnNewIncomingConnection();
-          void OnDataReceived(vector<std::shared_ptr<QByteArray>> dat);
+          void OnDataReceived(std::vector<std::shared_ptr<QByteArray>> dat);
 
         signals:
-          void SyncDataReceived(vector<std::shared_ptr<QByteArray>> data); //fires when data is received which is for syncing. It is up to listeners to validate and store this value
+          void SyncDataReceived(std::vector<std::shared_ptr<QByteArray>> data); //fires when data is received which is for syncing. It is up to listeners to validate and store this value
 
         private:
           int id;//id which is unique between mrview processes
-          vector<std::shared_ptr<GUI::MRView::Sync::Client>> senders;//send information
+          std::vector<std::shared_ptr<GUI::MRView::Sync::Client>> senders;//send information
           QLocalServer *receiver;//listens for information
           void TryConnectTo(int connectToId);//tries to connect with another interprocesscommunicator
 

--- a/src/gui/mrview/sync/localsocketreader.cpp
+++ b/src/gui/mrview/sync/localsocketreader.cpp
@@ -36,7 +36,7 @@ namespace MR
         */
         void LocalSocketReader::OnDataReceived()
         {
-          vector<std::shared_ptr<QByteArray>> messagesReceived;
+          std::vector<std::shared_ptr<QByteArray>> messagesReceived;
           while (socket->bytesAvailable() > 0)
           {
             //First byte must always by an unsigned int32 stating how much data to read

--- a/src/gui/mrview/sync/localsocketreader.h
+++ b/src/gui/mrview/sync/localsocketreader.h
@@ -44,7 +44,7 @@ namespace MR
 
 
         signals:
-          void DataReceived(vector<std::shared_ptr<QByteArray>> dat);//emits every message currently available
+          void DataReceived(std::vector<std::shared_ptr<QByteArray>> dat);//emits every message currently available
 
 
         private slots:

--- a/src/gui/mrview/sync/syncmanager.cpp
+++ b/src/gui/mrview/sync/syncmanager.cpp
@@ -30,8 +30,8 @@ namespace MR
           try
           {
             ips = new InterprocessCommunicator();//will throw exception if it fails to set up a server
-            connect (ips, SIGNAL(SyncDataReceived(vector<std::shared_ptr<QByteArray>>)),
-                     this, SLOT(OnIPSDataReceived(vector<std::shared_ptr<QByteArray>>)));
+            connect (ips, SIGNAL(SyncDataReceived(std::vector<std::shared_ptr<QByteArray>>)),
+                     this, SLOT(OnIPSDataReceived(std::vector<std::shared_ptr<QByteArray>>)));
           }
           catch (...)
           {
@@ -78,7 +78,7 @@ namespace MR
         /**
         * Receives a signal from another process that a value to sync has changed
         */
-        void SyncManager::OnIPSDataReceived(vector<std::shared_ptr<QByteArray>> all_messages)
+        void SyncManager::OnIPSDataReceived(std::vector<std::shared_ptr<QByteArray>> all_messages)
         {
           //WARNING This code assumes that the order of syncing operations does not matter
 

--- a/src/gui/mrview/sync/syncmanager.h
+++ b/src/gui/mrview/sync/syncmanager.h
@@ -46,7 +46,7 @@ namespace MR
 
         private slots:
           void OnWindowFocusChanged();
-          void OnIPSDataReceived(vector<std::shared_ptr<QByteArray>> all_messages);
+          void OnIPSDataReceived(std::vector<std::shared_ptr<QByteArray>> all_messages);
 
         private:
           InterprocessCommunicator* ips;//used to communicate with other processes

--- a/src/gui/mrview/tool/connectome/connectome.cpp
+++ b/src/gui/mrview/tool/connectome/connectome.cpp
@@ -855,7 +855,7 @@ namespace MR
           }
           if (opt.opt->is ("connectome.load")) {
             try {
-              vector<std::string> list (1, opt[0]);
+              std::vector<std::string> list (1, opt[0]);
               add_matrices (list);
             } catch (Exception& e) { e.display(); }
             return true;
@@ -896,7 +896,7 @@ namespace MR
 
         void Connectome::matrix_open_slot ()
         {
-          vector<std::string> list = Dialog::File::get_files (&window(), "Select connectome file(s) to open", "", &current_folder);
+          std::vector<std::string> list = Dialog::File::get_files (&window(), "Select connectome file(s) to open", "", &current_folder);
           if (list.empty())
             return;
           add_matrices (list);
@@ -2235,9 +2235,9 @@ namespace MR
             buffer.reset (new MR::Image<node_t> (H.get_image<node_t>().with_direct_io()));
           }
           MR::Transform transform (H);
-          vector<Eigen::Vector3f> node_coms;
-          vector<size_t> node_volumes;
-          vector<Eigen::Array3i> node_lower_corners, node_upper_corners;
+          std::vector<Eigen::Vector3f> node_coms;
+          std::vector<size_t> node_volumes;
+          std::vector<Eigen::Array3i> node_lower_corners, node_upper_corners;
           size_t max_index = 0;
 
           {
@@ -2278,7 +2278,7 @@ namespace MR
             for (size_t node_index = 1; node_index <= max_index; ++node_index) {
               if (node_volumes[node_index]) {
 
-                vector<int> from (3), dim (3);
+                std::vector<int> from (3), dim (3);
                 for (size_t axis = 0; axis != 3; ++axis) {
                   from[axis] = node_lower_corners[node_index][axis];
                   dim[axis] = node_upper_corners[node_index][axis] - node_lower_corners[node_index][axis] + 1;
@@ -2322,9 +2322,9 @@ namespace MR
           dynamic_cast<Node_list*>(node_list->tool)->initialize();
         }
 
-        void Connectome::add_matrices (const vector<std::string>& list)
+        void Connectome::add_matrices (const std::vector<std::string>& list)
         {
-          vector<FileDataVector> data;
+          std::vector<FileDataVector> data;
           for (size_t i = 0; i < list.size(); ++i) {
             try {
               MR::Connectome::matrix_type matrix = MR::load_matrix<default_type> (list[i]);
@@ -2770,7 +2770,7 @@ namespace MR
                 nodes[node_index].set_name (lut.find(node_index)->second.get_name());
               } else if (count > 1) {
                 ++duplicate_entry_count;
-                vector<std::string> names;
+                std::vector<std::string> names;
                 const auto range = lut.equal_range (node_index);
                 for (auto i = range.first; i != range.second; ++i)
                   names.push_back (i->second.get_name());
@@ -3511,11 +3511,11 @@ namespace MR
 
 
 
-        void Connectome::node_selection_changed (const vector<node_t>& list)
+        void Connectome::node_selection_changed (const std::vector<node_t>& list)
         {
           selected_nodes.clear();
           selected_node_count = list.size();
-          for (vector<node_t>::const_iterator n = list.begin(); n != list.end(); ++n)
+          for (std::vector<node_t>::const_iterator n = list.begin(); n != list.end(); ++n)
             selected_nodes[*n] = true;
           if (node_visibility == node_visibility_t::CONNECTOME || node_visibility == node_visibility_t::MATRIX_FILE) {
             if (selected_node_count >= 2) {

--- a/src/gui/mrview/tool/connectome/connectome.h
+++ b/src/gui/mrview/tool/connectome/connectome.h
@@ -241,8 +241,8 @@ namespace MR
             std::unique_ptr< MR::Image<node_t> > buffer;
 
 
-            vector<Node> nodes;
-            vector<Edge> edges;
+            std::vector<Node> nodes;
+            std::vector<Edge> edges;
 
 
             // For converting connectome matrices to vectors
@@ -352,7 +352,7 @@ namespace MR
             void clear_all();
             void enable_all (const bool);
             void initialise (const std::string&);
-            void add_matrices (const vector<std::string>&);
+            void add_matrices (const std::vector<std::string>&);
 
             void draw_nodes (const Projection&);
             void draw_edges (const Projection&);
@@ -376,7 +376,7 @@ namespace MR
 
             // Helper functions for determining actual node / edge visual properties
             //   given current selection status
-            void           node_selection_changed          (const vector<node_t>&);
+            void           node_selection_changed          (const std::vector<node_t>&);
             bool           node_visibility_given_selection (const node_t);
             Eigen::Array3f node_colour_given_selection     (const node_t);
             float          node_size_given_selection       (const node_t);

--- a/src/gui/mrview/tool/connectome/edge.cpp
+++ b/src/gui/mrview/tool/connectome/edge.cpp
@@ -104,7 +104,7 @@ namespace MR
 
         Edge::Line::Line (const Edge& parent)
         {
-          vector<Eigen::Vector3f> data;
+          std::vector<Eigen::Vector3f> data;
           data.push_back (parent.get_node_centre (0));
           data.push_back (parent.get_node_centre (1));
 
@@ -254,10 +254,10 @@ namespace MR
 
           shared.check_num_points (count);
 
-          vector<Eigen::Vector3f> vertices;
+          std::vector<Eigen::Vector3f> vertices;
           const size_t N = shared.points_per_vertex();
           vertices.reserve (N * data.vertices.size());
-          for (vector<Eigen::Vector3f>::const_iterator i = data.vertices.begin(); i != data.vertices.end(); ++i) {
+          for (std::vector<Eigen::Vector3f>::const_iterator i = data.vertices.begin(); i != data.vertices.end(); ++i) {
             for (size_t j = 0; j != N; ++j)
               vertices.push_back (*i);
           }
@@ -266,9 +266,9 @@ namespace MR
           if (vertices.size())
             gl::BufferData (gl::ARRAY_BUFFER, vertices.size() * sizeof (Eigen::Vector3f), &vertices[0][0], gl::STATIC_DRAW);
 
-          vector<Eigen::Vector3f> tangents;
+          std::vector<Eigen::Vector3f> tangents;
           tangents.reserve (vertices.size());
-          for (vector<Eigen::Vector3f>::const_iterator i = data.tangents.begin(); i != data.tangents.end(); ++i) {
+          for (std::vector<Eigen::Vector3f>::const_iterator i = data.tangents.begin(); i != data.tangents.end(); ++i) {
             for (size_t j = 0; j != N; ++j)
               tangents.push_back (*i);
           }
@@ -277,14 +277,14 @@ namespace MR
           if (tangents.size())
             gl::BufferData (gl::ARRAY_BUFFER, tangents.size() * sizeof (Eigen::Vector3f), &tangents[0][0], gl::STATIC_DRAW);
 
-          vector< std::pair<float, float> > normal_multipliers;
+          std::vector< std::pair<float, float> > normal_multipliers;
           const float angle_multiplier = 2.0 * Math::pi / float(shared.points_per_vertex());
           for (size_t i = 0; i != shared.points_per_vertex(); ++i)
             normal_multipliers.push_back (std::make_pair (std::cos (i * angle_multiplier), std::sin (i * angle_multiplier)));
-          vector<Eigen::Vector3f> normals;
+          std::vector<Eigen::Vector3f> normals;
           normals.reserve (vertices.size());
           for (size_t i = 0; i != data.vertices.size(); ++i) {
-            for (vector< std::pair<float, float> >::const_iterator j = normal_multipliers.begin(); j != normal_multipliers.end(); ++j)
+            for (std::vector< std::pair<float, float> >::const_iterator j = normal_multipliers.begin(); j != normal_multipliers.end(); ++j)
               normals.push_back ((j->first * data.normals[i]) + (j->second * data.binormals[i]));
           }
           normal_buffer.gen();

--- a/src/gui/mrview/tool/connectome/edge.h
+++ b/src/gui/mrview/tool/connectome/edge.h
@@ -130,7 +130,7 @@ namespace MR
               Exemplar () = delete;
             private:
               const Eigen::Vector3f endpoints[2];
-              vector<Eigen::Vector3f> vertices, tangents, normals, binormals;
+              std::vector<Eigen::Vector3f> vertices, tangents, normals, binormals;
               friend class Streamline;
               friend class Streamtube;
           };

--- a/src/gui/mrview/tool/connectome/matrix_list.cpp
+++ b/src/gui/mrview/tool/connectome/matrix_list.cpp
@@ -38,7 +38,7 @@ namespace MR
 
 
 
-      void Matrix_list_model::add_items (vector<FileDataVector>& list) {
+      void Matrix_list_model::add_items (std::vector<FileDataVector>& list) {
         beginInsertRows (QModelIndex(), items.size(), items.size() + list.size());
         items.reserve (items.size() + list.size());
         std::move (std::begin (list), std::end (list), std::back_inserter (items));

--- a/src/gui/mrview/tool/connectome/matrix_list.h
+++ b/src/gui/mrview/tool/connectome/matrix_list.h
@@ -89,13 +89,13 @@ namespace MR
               endRemoveRows();
             }
 
-            void add_items (vector<FileDataVector>&);
+            void add_items (std::vector<FileDataVector>&);
 
             const FileDataVector& get (const size_t index) { assert (index < items.size()); return items[index]; }
             const FileDataVector& get (QModelIndex& index) { assert (size_t(index.row()) < items.size()); return items[index.row()]; }
 
           protected:
-            vector<FileDataVector> items;
+            std::vector<FileDataVector> items;
 
         };
 

--- a/src/gui/mrview/tool/connectome/node.cpp
+++ b/src/gui/mrview/tool/connectome/node.cpp
@@ -75,7 +75,7 @@ namespace MR
           GL::Context::Grab context;
           GL::assert_context_is_current();
 
-          vector<float> vertices;
+          std::vector<float> vertices;
           vertices.reserve (3 * in.num_vertices());
           for (size_t v = 0; v != in.num_vertices(); ++v) {
             for (size_t axis = 0; axis != 3; ++axis)
@@ -88,7 +88,7 @@ namespace MR
 
           if (!in.have_normals())
             in.calculate_normals();
-          vector<float> normals;
+          std::vector<float> normals;
           normals.reserve (3 * in.num_vertices());
           for (size_t n = 0; n != in.num_vertices(); ++n) {
             for (size_t axis = 0; axis != 3; ++axis)
@@ -108,7 +108,7 @@ namespace MR
           gl::EnableVertexAttribArray (1);
           gl::VertexAttribPointer (1, 3, gl::FLOAT, gl::FALSE_, 0, (void*)(0));
 
-          vector<unsigned int> indices;
+          std::vector<unsigned int> indices;
           indices.reserve (3 * in.num_triangles());
           for (size_t i = 0; i != in.num_triangles(); ++i) {
             for (size_t v = 0; v != 3; ++v)

--- a/src/gui/mrview/tool/connectome/node_list.cpp
+++ b/src/gui/mrview/tool/connectome/node_list.cpp
@@ -170,7 +170,7 @@ namespace MR
       void Node_list::clear_selection_slot()
       {
         node_list_view->clearSelection();
-        vector<node_t> empty_node_list;
+        std::vector<node_t> empty_node_list;
         connectome.node_selection_changed (empty_node_list);
       }
 
@@ -187,7 +187,7 @@ namespace MR
       void Node_list::node_selection_changed_slot (const QItemSelection&, const QItemSelection&)
       {
         QModelIndexList list = node_list_view->selectionModel()->selectedRows();
-        vector<node_t> nodes;
+        std::vector<node_t> nodes;
         for (int i = 0; i != list.size(); ++i)
           nodes.push_back (list[i].row());
         connectome.node_selection_changed (nodes);

--- a/src/gui/mrview/tool/connectome/node_overlay.cpp
+++ b/src/gui/mrview/tool/connectome/node_overlay.cpp
@@ -77,7 +77,7 @@ namespace MR
           get_axes (plane, x, y);
           const ssize_t xsize = data.size (x), ysize = data.size (y);
 
-          vector<float> texture_data;
+          std::vector<float> texture_data;
           texture_data.resize (4*xsize*ysize, 0.0f);
           if (tex_positions[plane] >= 0 && tex_positions[plane] < data.size (plane)) {
             data.index(plane) = slice;

--- a/src/gui/mrview/tool/fixel/base_fixel.cpp
+++ b/src/gui/mrview/tool/fixel/base_fixel.cpp
@@ -453,7 +453,7 @@ namespace MR
 
           set_colour_type_index (colour_index);
 
-          regular_grid_buffer_pos = vector<Eigen::Vector3f> (pos_buffer_store.size ());
+          regular_grid_buffer_pos = std::vector<Eigen::Vector3f> (pos_buffer_store.size ());
 
           regular_grid_vao.gen ();
 

--- a/src/gui/mrview/tool/fixel/base_fixel.h
+++ b/src/gui/mrview/tool/fixel/base_fixel.h
@@ -249,28 +249,28 @@ namespace MR
               }
 
               MR::Header header;
-              vector<std::string> colour_types;
-              vector<std::string> value_types;
-              vector<std::string> threshold_types;
+              std::vector<std::string> colour_types;
+              std::vector<std::string> value_types;
+              std::vector<std::string> threshold_types;
               mutable std::map<const std::string, FixelValue> fixel_values;
               mutable FixelValue dummy_fixel_val_state;
 
-              vector<Eigen::Vector3f> pos_buffer_store;
-              vector<Eigen::Vector3f> dir_buffer_store;
+              std::vector<Eigen::Vector3f> pos_buffer_store;
+              std::vector<Eigen::Vector3f> dir_buffer_store;
 
-              vector<Eigen::Vector3f> regular_grid_buffer_pos;
-              vector<Eigen::Vector3f> regular_grid_buffer_dir;
-              vector<float> regular_grid_buffer_colour;
-              vector<float> regular_grid_buffer_val;
-              vector<float> regular_grid_buffer_threshold;
+              std::vector<Eigen::Vector3f> regular_grid_buffer_pos;
+              std::vector<Eigen::Vector3f> regular_grid_buffer_dir;
+              std::vector<float> regular_grid_buffer_colour;
+              std::vector<float> regular_grid_buffer_val;
+              std::vector<float> regular_grid_buffer_threshold;
 
-              vector<vector<vector<GLint> > > slice_fixel_indices;
-              vector<vector<vector<GLsizei> > > slice_fixel_sizes;
-              vector<vector<GLsizei> > slice_fixel_counts;
+              std::vector<std::vector<std::vector<GLint> > > slice_fixel_indices;
+              std::vector<std::vector<std::vector<GLsizei> > > slice_fixel_sizes;
+              std::vector<std::vector<GLsizei> > slice_fixel_counts;
 
               // Flattened buffer used when cropping to slice
               // To support off-axis rendering, we maintain dict mapping voxels to buffer_pos indices
-              std::unordered_map <std::array<int, 3>, vector<GLint>, IntPointHasher> voxel_to_indices_map;
+              std::unordered_map <std::array<int, 3>, std::vector<GLint>, IntPointHasher> voxel_to_indices_map;
 
               FixelColourType colour_type;
               FixelScaleType scale_type;

--- a/src/gui/mrview/tool/fixel/fixel.cpp
+++ b/src/gui/mrview/tool/fixel/fixel.cpp
@@ -43,7 +43,7 @@ namespace MR
             Model (QObject* parent) :
               ListModelBase (parent) { }
 
-            void add_items (vector<std::string>& filenames, Fixel& fixel_tool) {
+            void add_items (std::vector<std::string>& filenames, Fixel& fixel_tool) {
 
               size_t old_size = items.size();
               for (size_t i = 0, N = filenames.size(); i < N; ++i) {
@@ -344,13 +344,13 @@ namespace MR
 
         void Fixel::fixel_open_slot ()
         {
-          vector<std::string> list = Dialog::File::get_files (this, "Select fixel images to open",
+          std::vector<std::string> list = Dialog::File::get_files (this, "Select fixel images to open",
               GUI::Dialog::File::image_filter_string, &current_folder);
           add_images (list);
         }
 
 
-        void Fixel::add_images (vector<std::string> &list)
+        void Fixel::add_images (std::vector<std::string> &list)
         {
           if (list.empty())
             return;
@@ -376,7 +376,7 @@ namespace MR
 
           const QMimeData* mimeData = event->mimeData();
           if (mimeData->hasUrls()) {
-            vector<std::string> list;
+            std::vector<std::string> list;
             QList<QUrl> urlList = mimeData->urls();
             for (int i = 0; i < urlList.size() && i < max_files; ++i) {
                 list.push_back (urlList.at (i).path().toUtf8().constData());
@@ -853,7 +853,7 @@ namespace MR
         bool Fixel::process_commandline_option (const MR::App::ParsedOption& opt)
         {
           if (opt.opt->is ("fixel.load")) {
-            vector<std::string> list (1, std::string(opt[0]));
+            std::vector<std::string> list (1, std::string(opt[0]));
             try { fixel_list_model->add_items (list , *this); }
             catch (Exception& E) { E.display(); }
             return true;

--- a/src/gui/mrview/tool/fixel/fixel.h
+++ b/src/gui/mrview/tool/fixel/fixel.h
@@ -108,7 +108,7 @@ namespace MR
             QSlider *opacity_slider;
 
 
-            void add_images (vector<std::string>& list);
+            void add_images (std::vector<std::string>& list);
             void dropEvent (QDropEvent* event) override;
 
           private:

--- a/src/gui/mrview/tool/fixel/image4D.cpp
+++ b/src/gui/mrview/tool/fixel/image4D.cpp
@@ -66,8 +66,8 @@ namespace MR
           fixel_val_store.clear();
 
           for (size_t axis = 0; axis < 3; ++axis) {
-            std::fill (slice_fixel_indices[axis].begin(), slice_fixel_indices[axis].end(), vector<GLint>());
-            std::fill (slice_fixel_sizes[axis].begin(), slice_fixel_sizes[axis].end(), vector<GLsizei>());
+            std::fill (slice_fixel_indices[axis].begin(), slice_fixel_indices[axis].end(), std::vector<GLint>());
+            std::fill (slice_fixel_sizes[axis].begin(), slice_fixel_sizes[axis].end(), std::vector<GLsizei>());
             std::fill (slice_fixel_counts[axis].begin(), slice_fixel_counts[axis].end(), 0);
           }
 

--- a/src/gui/mrview/tool/fixel/vector_structs.h
+++ b/src/gui/mrview/tool/fixel/vector_structs.h
@@ -34,7 +34,7 @@ namespace MR
           float value_max = std::numeric_limits<float>::min ();
           float lessthan = value_min, greaterthan = value_max;
           float current_min = value_min, current_max = value_max;
-          vector<float> buffer_store;
+          std::vector<float> buffer_store;
 
 
           void clear () {

--- a/src/gui/mrview/tool/list_model_base.h
+++ b/src/gui/mrview/tool/list_model_base.h
@@ -91,7 +91,7 @@ namespace MR
               if (count < 1 || row < 0 || row > rowCount () || count != swapped_rows.second)
                 return false;
 
-              vector<std::unique_ptr<Displayable>> swapped_items;
+              std::vector<std::unique_ptr<Displayable>> swapped_items;
 
               swapped_items.insert ( swapped_items.begin(),
                 std::make_move_iterator (items.begin() + row),
@@ -147,7 +147,7 @@ namespace MR
               endRemoveRows();
             }
 
-            vector<std::unique_ptr<Displayable>> items;
+            std::vector<std::unique_ptr<Displayable>> items;
           private:
             std::pair<int, int> swapped_rows;
         };

--- a/src/gui/mrview/tool/odf/item.cpp
+++ b/src/gui/mrview/tool/odf/item.cpp
@@ -114,7 +114,7 @@ namespace MR
           if (index >= shells->count())
             throw Exception ("Shell index is outside valid range");
           Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic> shell_dirs ((*shells)[index].count(), 3);
-          const vector<size_t>& volumes = (*shells)[index].get_volumes();
+          const std::vector<size_t>& volumes = (*shells)[index].get_volumes();
           for (size_t row = 0; row != volumes.size(); ++row)
             shell_dirs.row (row) = grad.row (volumes[row]).head<3>().cast<float>();
           auto new_dirs = MR::make_unique<MR::DWI::Directions::Set> (shell_dirs);
@@ -153,7 +153,7 @@ namespace MR
         Eigen::VectorXf ODF_Item::DixelPlugin::get_shell_data (const Eigen::VectorXf& values) const
         {
           assert (shells);
-          const vector<size_t>& volumes ((*shells)[shell_index].get_volumes());
+          const std::vector<size_t>& volumes ((*shells)[shell_index].get_volumes());
           Eigen::VectorXf result (volumes.size());
           for (size_t i = 0; i != volumes.size(); ++i)
             result[i] = values[volumes[i]];

--- a/src/gui/mrview/tool/odf/model.cpp
+++ b/src/gui/mrview/tool/odf/model.cpp
@@ -28,13 +28,13 @@ namespace MR
       {
 
 
-        size_t ODF_Model::add_items (const vector<std::string>& list,
+        size_t ODF_Model::add_items (const std::vector<std::string>& list,
                                      const odf_type_t type,
                                      const bool colour_by_direction,
                                      const bool hide_negative_lobes,
                                      const float scale)
         {
-          vector<std::unique_ptr<MR::Header>> hlist;
+          std::vector<std::unique_ptr<MR::Header>> hlist;
           for (size_t i = 0; i < list.size(); ++i) {
             try {
               auto header = make_unique<MR::Header> (MR::Header::open (list[i]));

--- a/src/gui/mrview/tool/odf/model.h
+++ b/src/gui/mrview/tool/odf/model.h
@@ -72,7 +72,7 @@ namespace MR
               return 1;
             }
 
-            size_t add_items (const vector<std::string>& list, const odf_type_t type, bool colour_by_direction, bool hide_negative_lobes, float scale);
+            size_t add_items (const std::vector<std::string>& list, const odf_type_t type, bool colour_by_direction, bool hide_negative_lobes, float scale);
 
             QModelIndex index (int row, int column, const QModelIndex& parent = QModelIndex()) const {
               (void ) parent; // to suppress warnings about unused parameters
@@ -89,7 +89,7 @@ namespace MR
               return index.isValid() ? dynamic_cast<ODF_Item*>(items[index.row()].get()) : NULL;
             }
 
-            vector<std::unique_ptr<ODF_Item>> items;
+            std::vector<std::unique_ptr<ODF_Item>> items;
         };
 
       }

--- a/src/gui/mrview/tool/odf/odf.cpp
+++ b/src/gui/mrview/tool/odf/odf.cpp
@@ -474,7 +474,7 @@ namespace MR
 
 
 
-        void ODF::add_images (vector<std::string>& list, const odf_type_t mode)
+        void ODF::add_images (std::vector<std::string>& list, const odf_type_t mode)
         {
           size_t previous_size = image_list_model->rowCount();
           if (!image_list_model->add_items (list, mode,
@@ -517,7 +517,7 @@ namespace MR
 
         void ODF::sh_open_slot ()
         {
-          vector<std::string> list = Dialog::File::get_images (&window(), "Select SH-based ODF images to open", &current_folder);
+          std::vector<std::string> list = Dialog::File::get_images (&window(), "Select SH-based ODF images to open", &current_folder);
           if (list.empty())
             return;
 
@@ -526,7 +526,7 @@ namespace MR
 
         void ODF::tensor_open_slot ()
         {
-          vector<std::string> list = Dialog::File::get_images (&window(), "Select tensor images to open", &current_folder);
+          std::vector<std::string> list = Dialog::File::get_images (&window(), "Select tensor images to open", &current_folder);
           if (list.empty())
             return;
 
@@ -535,7 +535,7 @@ namespace MR
 
         void ODF::dixel_open_slot ()
         {
-          vector<std::string> list = Dialog::File::get_images (&window(), "Select dixel-based ODF images to open", &current_folder);
+          std::vector<std::string> list = Dialog::File::get_images (&window(), "Select dixel-based ODF images to open", &current_folder);
           if (list.empty())
             return;
 
@@ -898,7 +898,7 @@ namespace MR
         {
           if (opt.opt->is ("odf.load_sh")) {
             try {
-              vector<std::string> list (1, opt[0]);
+              std::vector<std::string> list (1, opt[0]);
               add_images (list, odf_type_t::SH);
             }
             catch (Exception& e) {
@@ -909,7 +909,7 @@ namespace MR
 
           if (opt.opt->is ("odf.load_tensor")) {
             try {
-              vector<std::string> list (1, opt[0]);
+              std::vector<std::string> list (1, opt[0]);
               add_images (list, odf_type_t::TENSOR);
             }
             catch (Exception& e) {
@@ -920,7 +920,7 @@ namespace MR
 
           if (opt.opt->is ("odf.load_dixel")) {
             try {
-              vector<std::string> list (1, opt[0]);
+              std::vector<std::string> list (1, opt[0]);
               add_images (list, odf_type_t::DIXEL);
             }
             catch (Exception& e) {

--- a/src/gui/mrview/tool/odf/odf.h
+++ b/src/gui/mrview/tool/odf/odf.h
@@ -104,7 +104,7 @@ namespace MR
 
              int lmax;
 
-             void add_images (vector<std::string>& list, const odf_type_t mode);
+             void add_images (std::vector<std::string>& list, const odf_type_t mode);
 
              virtual void closeEvent (QCloseEvent* event) override;
 

--- a/src/gui/mrview/tool/overlay.cpp
+++ b/src/gui/mrview/tool/overlay.cpp
@@ -47,7 +47,7 @@ namespace MR
             Model (QObject* parent) :
               ListModelBase (parent) { }
 
-            void add_items (vector<std::unique_ptr<MR::Header>>& list);
+            void add_items (std::vector<std::unique_ptr<MR::Header>>& list);
 
             Item* get_image (QModelIndex& index) {
               return dynamic_cast<Item*>(items[index.row()].get());
@@ -55,7 +55,7 @@ namespace MR
         };
 
 
-        void Overlay::Model::add_items (vector<std::unique_ptr<MR::Header>>& list)
+        void Overlay::Model::add_items (std::vector<std::unique_ptr<MR::Header>>& list)
         {
           beginInsertRows (QModelIndex(), items.size(), items.size()+list.size());
           for (size_t i = 0; i < list.size(); ++i) {
@@ -192,10 +192,10 @@ namespace MR
 
         void Overlay::image_open_slot ()
         {
-          vector<std::string> overlay_names = Dialog::File::get_images (this, "Select overlay images to open", &current_folder);
+          std::vector<std::string> overlay_names = Dialog::File::get_images (this, "Select overlay images to open", &current_folder);
           if (overlay_names.empty())
             return;
-          vector<std::unique_ptr<MR::Header>> list;
+          std::vector<std::unique_ptr<MR::Header>> list;
           for (size_t n = 0; n < overlay_names.size(); ++n) {
             try {
               list.push_back (make_unique<MR::Header> (MR::Header::open (overlay_names[n])));
@@ -210,7 +210,7 @@ namespace MR
 
 
 
-        void Overlay::add_images (vector<std::unique_ptr<MR::Header>>& list)
+        void Overlay::add_images (std::vector<std::unique_ptr<MR::Header>>& list)
         {
           size_t previous_size = image_list_model->rowCount();
           image_list_model->add_items (list);
@@ -229,7 +229,7 @@ namespace MR
 
           const QMimeData* mimeData = event->mimeData();
           if (mimeData->hasUrls()) {
-            vector<std::unique_ptr<MR::Header>> list;
+            std::vector<std::unique_ptr<MR::Header>> list;
             QList<QUrl> urlList = mimeData->urls();
             for (int i = 0; i < urlList.size() && i < max_files; ++i) {
               try {
@@ -752,7 +752,7 @@ namespace MR
         bool Overlay::process_commandline_option (const MR::App::ParsedOption& opt)
         {
           if (opt.opt->is ("overlay.load")) {
-            vector<std::unique_ptr<MR::Header>> list;
+            std::vector<std::unique_ptr<MR::Header>> list;
             try { list.push_back (make_unique<MR::Header> (MR::Header::open (opt[0]))); }
             catch (Exception& e) { e.display(); }
             add_images (list);

--- a/src/gui/mrview/tool/overlay.h
+++ b/src/gui/mrview/tool/overlay.h
@@ -106,7 +106,7 @@ namespace MR
                window().updateGL();
              }
 
-             void add_images (vector<std::unique_ptr<MR::Header>>& list);
+             void add_images (std::vector<std::unique_ptr<MR::Header>>& list);
              void dropEvent (QDropEvent* event) override;
         };
 

--- a/src/gui/mrview/tool/roi_editor/item.cpp
+++ b/src/gui/mrview/tool/roi_editor/item.cpp
@@ -94,7 +94,7 @@ namespace MR
           GL::Context::Grab context;
           GL::assert_context_is_current();
           bind();
-          vector<GLubyte> data (header().size(0)*header().size(1));
+          std::vector<GLubyte> data (header().size(0)*header().size(1));
           for (int n = 0; n < header().size(2); ++n)
             upload_data ({ { 0, 0, n } }, { { header().size(0), header().size(1), 1 } }, reinterpret_cast<void*> (&data[0]));
           GL::assert_context_is_current();
@@ -107,7 +107,7 @@ namespace MR
           GL::assert_context_is_current();
           bind();
           auto image = header().get_image<bool>();
-          vector<GLubyte> data (image.size(0)*image.size(1));
+          std::vector<GLubyte> data (image.size(0)*image.size(1));
           ProgressBar progress ("loading ROI image \"" + header().name() + "\"");
           for (auto outer = MR::Loop(2) (image); outer; ++outer) {
             auto p = data.begin();

--- a/src/gui/mrview/tool/roi_editor/item.h
+++ b/src/gui/mrview/tool/roi_editor/item.h
@@ -74,7 +74,7 @@ namespace MR
             float min_brush_size, max_brush_size, brush_size;
 
           private:
-            vector<ROI_UndoEntry> undo_list;
+            std::vector<ROI_UndoEntry> undo_list;
             int current_undo;
 
             static int number_of_undos;

--- a/src/gui/mrview/tool/roi_editor/model.cpp
+++ b/src/gui/mrview/tool/roi_editor/model.cpp
@@ -31,7 +31,7 @@ namespace MR
 
 
 
-        void ROI_Model::load (vector<std::unique_ptr<MR::Header>>& list)
+        void ROI_Model::load (std::vector<std::unique_ptr<MR::Header>>& list)
         {
           beginInsertRows (QModelIndex(), items.size(), items.size()+list.size());
           for (size_t i = 0; i < list.size(); ++i) {

--- a/src/gui/mrview/tool/roi_editor/model.h
+++ b/src/gui/mrview/tool/roi_editor/model.h
@@ -41,7 +41,7 @@ namespace MR
             ROI_Model (QObject* parent) : 
               ListModelBase (parent) { }
 
-            void load (vector<std::unique_ptr<MR::Header>>&);
+            void load (std::vector<std::unique_ptr<MR::Header>>&);
             void create (MR::Header&&);
 
             ROI_Item* get (QModelIndex& index) {

--- a/src/gui/mrview/tool/roi_editor/roi.cpp
+++ b/src/gui/mrview/tool/roi_editor/roi.cpp
@@ -296,10 +296,10 @@ namespace MR
 
         void ROI::open_slot ()
         {
-          vector<std::string> names = Dialog::File::get_images (this, "Select ROI images to open", &current_folder);
+          std::vector<std::string> names = Dialog::File::get_images (this, "Select ROI images to open", &current_folder);
           if (names.empty())
             return;
-          vector<std::unique_ptr<MR::Header>> list;
+          std::vector<std::unique_ptr<MR::Header>> list;
           for (size_t n = 0; n < names.size(); ++n)
             list.push_back (make_unique<MR::Header> (MR::Header::open (names[n])));
 
@@ -317,7 +317,7 @@ namespace MR
 
           const QMimeData* mimeData = event->mimeData();
           if (mimeData->hasUrls()) {
-            vector<std::unique_ptr<MR::Header>> list;
+            std::vector<std::unique_ptr<MR::Header>> list;
             QList<QUrl> urlList = mimeData->urls();
             for (int i = 0; i < urlList.size() && i < max_files; ++i) {
               try {
@@ -341,7 +341,7 @@ namespace MR
 
         void ROI::save (ROI_Item* roi)
         {
-          vector<GLubyte> data (roi->header().size(0) * roi->header().size(1) * roi->header().size(2));
+          std::vector<GLubyte> data (roi->header().size(0) * roi->header().size(1) * roi->header().size(2));
           {
             GL::Context::Grab context;
             GL::assert_context_is_current();
@@ -399,7 +399,7 @@ namespace MR
 
 
 
-        void ROI::load (vector<std::unique_ptr<MR::Header>>& list)
+        void ROI::load (std::vector<std::unique_ptr<MR::Header>>& list)
         {
           list_model->load (list);
           list_view->selectionModel()->clear();
@@ -902,7 +902,7 @@ namespace MR
         bool ROI::process_commandline_option (const MR::App::ParsedOption& opt)
         {
           if (opt.opt->is ("roi.load")) {
-            vector<std::unique_ptr<MR::Header>> list;
+            std::vector<std::unique_ptr<MR::Header>> list;
             try { list.push_back (make_unique<MR::Header> (MR::Header::open (opt[0]))); }
             catch (Exception& e) { e.display(); }
             load (list);

--- a/src/gui/mrview/tool/roi_editor/roi.h
+++ b/src/gui/mrview/tool/roi_editor/roi.h
@@ -105,7 +105,7 @@ namespace MR
                window().updateGL();
              }
 
-             void load (vector<std::unique_ptr<MR::Header>>& list);
+             void load (std::vector<std::unique_ptr<MR::Header>>& list);
              void save (ROI_Item*);
 
              int normal2axis (const Eigen::Vector3f&, const ROI_Item&) const;

--- a/src/gui/mrview/tool/roi_editor/undoentry.cpp
+++ b/src/gui/mrview/tool/roi_editor/undoentry.cpp
@@ -371,7 +371,7 @@ namespace MR
           const bool existing_value = after[seed_index];
           if (existing_value == insert_mode_value) return;
           after[seed_index] = fill_value;
-          vector<std::array<int,3>> buffer (1, seed_voxel);
+          std::vector<std::array<int,3>> buffer (1, seed_voxel);
           while (buffer.size()) {
             const std::array<int,3> v (buffer.back());
             buffer.pop_back();

--- a/src/gui/mrview/tool/roi_editor/undoentry.h
+++ b/src/gui/mrview/tool/roi_editor/undoentry.h
@@ -61,7 +61,7 @@ namespace MR
 
           std::array<GLint,3> from, size;
           std::array<GLint,2> tex_size, slice_axes;
-          vector<GLubyte> before, after;
+          std::vector<GLubyte> before, after;
 
           class Shared
           { 

--- a/src/gui/mrview/tool/tractography/tractogram.cpp
+++ b/src/gui/mrview/tool/tractography/tractogram.cpp
@@ -611,9 +611,9 @@ namespace MR
 
           DWI::Tractography::Reader<float> file (filename, properties);
           DWI::Tractography::Streamline<float> tck;
-          vector<Eigen::Vector3f> buffer;
-          vector<GLint> starts;
-          vector<GLint> sizes;
+          std::vector<Eigen::Vector3f> buffer;
+          std::vector<GLint> starts;
+          std::vector<GLint> sizes;
           size_t tck_count = 0;
 
           on_FOV_changed();
@@ -671,7 +671,7 @@ namespace MR
           for (size_t buffer_index = 0, N = vertex_buffers.size(); buffer_index < N; ++buffer_index) {
 
             const size_t num_tracks = num_tracks_per_buffer[buffer_index];
-            vector<Eigen::Vector3f> buffer;
+            std::vector<Eigen::Vector3f> buffer;
             for (size_t buffer_tck_counter = 0; buffer_tck_counter != num_tracks; ++buffer_tck_counter) {
 
               const Eigen::Vector3f& tangent (endpoint_tangents[total_tck_counter++]);
@@ -705,7 +705,7 @@ namespace MR
           erase_intensity_scalar_data ();
           value_min = std::numeric_limits<float>::infinity();
           value_max = -std::numeric_limits<float>::infinity();
-          vector<float> buffer;
+          std::vector<float> buffer;
           DWI::Tractography::TrackScalar<float> tck_scalar;
 
           if (Path::has_suffix (filename, ".tsf")) {
@@ -746,7 +746,7 @@ namespace MR
           } else {
             const Eigen::VectorXf scalars = MR::load_vector<float> (filename);
             size_t total_num_tracks = 0;
-            for (vector<size_t>::const_iterator i = num_tracks_per_buffer.begin(); i != num_tracks_per_buffer.end(); ++i)
+            for (std::vector<size_t>::const_iterator i = num_tracks_per_buffer.begin(); i != num_tracks_per_buffer.end(); ++i)
               total_num_tracks += *i;
             if (size_t(scalars.size()) != total_num_tracks)
               throw Exception ("The scalar text file does not contain the same number of elements as the selected tractogram");
@@ -755,7 +755,7 @@ namespace MR
             for (size_t buffer_index = 0; buffer_index != vertex_buffers.size(); ++buffer_index) {
 
               size_t num_tracks = num_tracks_per_buffer[buffer_index];
-              vector<GLint>& track_lengths (original_track_sizes[buffer_index]);
+              std::vector<GLint>& track_lengths (original_track_sizes[buffer_index]);
 
               for (size_t index = 0; index != num_tracks; ++index, ++running_index) {
                 const float value = scalars[running_index];
@@ -800,7 +800,7 @@ namespace MR
           erase_threshold_scalar_data ();
           threshold_min = std::numeric_limits<float>::infinity();
           threshold_max = -std::numeric_limits<float>::infinity();
-          vector<float> buffer;
+          std::vector<float> buffer;
           DWI::Tractography::TrackScalar<float> tck_scalar;
 
           if (Path::has_suffix (filename, ".tsf")) {
@@ -841,7 +841,7 @@ namespace MR
           } else {
             const Eigen::VectorXf scalars = MR::load_vector<float> (filename);
             size_t total_num_tracks = 0;
-            for (vector<size_t>::const_iterator i = num_tracks_per_buffer.begin(); i != num_tracks_per_buffer.end(); ++i)
+            for (std::vector<size_t>::const_iterator i = num_tracks_per_buffer.begin(); i != num_tracks_per_buffer.end(); ++i)
               total_num_tracks += *i;
             if (size_t(scalars.size()) != total_num_tracks)
               throw Exception ("The scalar text file does not contain the same number of elements as the selected tractogram");
@@ -850,7 +850,7 @@ namespace MR
             for (size_t buffer_index = 0; buffer_index != vertex_buffers.size(); ++buffer_index) {
 
               size_t num_tracks = num_tracks_per_buffer[buffer_index];
-              vector<GLint>& track_lengths (original_track_sizes[buffer_index]);
+              std::vector<GLint>& track_lengths (original_track_sizes[buffer_index]);
 
               for (size_t index = 0; index != num_tracks; ++index, ++running_index) {
                 const float value = scalars[running_index];
@@ -961,9 +961,9 @@ namespace MR
         }
 
 
-        void Tractogram::load_tracks_onto_GPU (vector<Eigen::Vector3f>& buffer,
-            vector<GLint>& starts,
-            vector<GLint>& sizes,
+        void Tractogram::load_tracks_onto_GPU (std::vector<Eigen::Vector3f>& buffer,
+            std::vector<GLint>& starts,
+            std::vector<GLint>& sizes,
             size_t& tck_count)
         {
           GL::assert_context_is_current();
@@ -992,7 +992,7 @@ namespace MR
           GL::assert_context_is_current();
         }
 
-        void Tractogram::load_end_colours_onto_GPU (vector<Eigen::Vector3f>& buffer)
+        void Tractogram::load_end_colours_onto_GPU (std::vector<Eigen::Vector3f>& buffer)
         {
           GL::assert_context_is_current();
 
@@ -1012,7 +1012,7 @@ namespace MR
 
 
 
-        void Tractogram::load_intensity_scalars_onto_GPU (vector<float>& buffer, size_t& tck_count)
+        void Tractogram::load_intensity_scalars_onto_GPU (std::vector<float>& buffer, size_t& tck_count)
         {
           GL::assert_context_is_current();
 
@@ -1035,7 +1035,7 @@ namespace MR
 
 
 
-        void Tractogram::load_threshold_scalars_onto_GPU (vector<float>& buffer, size_t& tck_count)
+        void Tractogram::load_threshold_scalars_onto_GPU (std::vector<float>& buffer, size_t& tck_count)
         {
           GL::assert_context_is_current();
 

--- a/src/gui/mrview/tool/tractography/tractogram.h
+++ b/src/gui/mrview/tool/tractography/tractogram.h
@@ -134,19 +134,19 @@ namespace MR
             //   streamline tangents and store them; then, if colour by
             //   endpoint is requested, generate the buffer based on these
             //   and the known track sizes
-            vector<Eigen::Vector3f> endpoint_tangents;
+            std::vector<Eigen::Vector3f> endpoint_tangents;
 
-            vector<GLuint> vertex_buffers;
-            vector<GLuint> vertex_array_objects;
-            vector<GLuint> colour_buffers;
-            vector<GLuint> intensity_scalar_buffers;
-            vector<GLuint> threshold_scalar_buffers;
+            std::vector<GLuint> vertex_buffers;
+            std::vector<GLuint> vertex_array_objects;
+            std::vector<GLuint> colour_buffers;
+            std::vector<GLuint> intensity_scalar_buffers;
+            std::vector<GLuint> threshold_scalar_buffers;
             DWI::Tractography::Properties properties;
-            vector<vector<GLint> > track_starts;
-            vector<vector<GLint> > track_sizes;
-            vector<vector<GLint> > original_track_sizes;
-            vector<vector<GLint> > original_track_starts;
-            vector<size_t> num_tracks_per_buffer;
+            std::vector<std::vector<GLint> > track_starts;
+            std::vector<std::vector<GLint> > track_sizes;
+            std::vector<std::vector<GLint> > original_track_sizes;
+            std::vector<std::vector<GLint> > original_track_starts;
+            std::vector<size_t> num_tracks_per_buffer;
             GLint sample_stride;
             bool vao_dirty;
 
@@ -155,15 +155,15 @@ namespace MR
             float threshold_min, threshold_max;
 
 
-            void load_tracks_onto_GPU (vector<Eigen::Vector3f>& buffer,
-                                       vector<GLint>& starts,
-                                       vector<GLint>& sizes,
+            void load_tracks_onto_GPU (std::vector<Eigen::Vector3f>& buffer,
+                                       std::vector<GLint>& starts,
+                                       std::vector<GLint>& sizes,
                                        size_t& tck_count);
 
-            void load_end_colours_onto_GPU (vector<Eigen::Vector3f>&);
+            void load_end_colours_onto_GPU (std::vector<Eigen::Vector3f>&);
 
-            void load_intensity_scalars_onto_GPU (vector<float>& buffer, size_t& tck_count);
-            void load_threshold_scalars_onto_GPU (vector<float>& buffer, size_t& tck_count);
+            void load_intensity_scalars_onto_GPU (std::vector<float>& buffer, size_t& tck_count);
+            void load_threshold_scalars_onto_GPU (std::vector<float>& buffer, size_t& tck_count);
 
             void render_streamlines ();
 

--- a/src/gui/mrview/tool/tractography/tractography.cpp
+++ b/src/gui/mrview/tool/tractography/tractography.cpp
@@ -66,7 +66,7 @@ namespace MR
             Model (QObject* parent) :
               ListModelBase (parent) { }
 
-            void add_items (vector<std::string>& filenames,
+            void add_items (std::vector<std::string>& filenames,
                             Tractography& tractography_tool) {
 
               for (size_t i = 0; i < filenames.size(); ++i) {
@@ -359,7 +359,7 @@ namespace MR
         void Tractography::tractogram_open_slot ()
         {
 
-          vector<std::string> list = Dialog::File::get_files (this, "Select tractograms to open", "Tractograms (*.tck)", &current_folder);
+          std::vector<std::string> list = Dialog::File::get_files (this, "Select tractograms to open", "Tractograms (*.tck)", &current_folder);
           add_tractogram(list);
         }
 
@@ -367,7 +367,7 @@ namespace MR
 
 
 
-        void Tractography::add_tractogram (vector<std::string>& list)
+        void Tractography::add_tractogram (std::vector<std::string>& list)
         {
           if (list.empty())
           { return; }
@@ -391,7 +391,7 @@ namespace MR
 
           const QMimeData* mimeData = event->mimeData();
           if (mimeData->hasUrls()) {
-            vector<std::string> list;
+            std::vector<std::string> list;
             QList<QUrl> urlList = mimeData->urls();
             for (int i = 0; i < urlList.size() && i < max_files; ++i) {
                 list.push_back (urlList.at (i).path().toUtf8().constData());
@@ -886,7 +886,7 @@ namespace MR
 
           if (opt.opt->is ("tractography.load"))
           {
-            vector<std::string> list (1, std::string(opt[0]));
+            std::vector<std::string> list (1, std::string(opt[0]));
             add_tractogram(list);
             return true;
           }
@@ -920,7 +920,7 @@ namespace MR
           {
             try {
               //Set the tsf visualisation range
-              vector<default_type> range;
+              std::vector<default_type> range;
               if (process_commandline_option_tsf_option(opt,2, range))
                 scalar_file_options->set_scaling (range[0], range[1]);
             }
@@ -933,7 +933,7 @@ namespace MR
           {
             try {
               //Set the tsf visualisation threshold
-              vector<default_type> range;
+              std::vector<default_type> range;
               if (process_commandline_option_tsf_option(opt,2, range))
                 scalar_file_options->set_threshold (TrackThresholdType::UseColourFile,range[0], range[1]);
             }
@@ -1096,7 +1096,7 @@ namespace MR
 
 
       /*Checks whether legal to apply tsf options and prepares the scalar_file_options to do so. Returns the vector of floats parsed from the options, or null on fail*/
-        bool Tractography::process_commandline_option_tsf_option(const MR::App::ParsedOption& opt, uint reqArgSize, vector<default_type>& range)
+        bool Tractography::process_commandline_option_tsf_option(const MR::App::ParsedOption& opt, uint reqArgSize, std::vector<default_type>& range)
         {
           if(process_commandline_option_tsf_check_tracto_loaded()){
             QModelIndexList indices = tractogram_list_view->selectionModel()->selectedIndexes();

--- a/src/gui/mrview/tool/tractography/tractography.h
+++ b/src/gui/mrview/tool/tractography/tractography.h
@@ -119,10 +119,10 @@ namespace MR
 
             void dropEvent (QDropEvent* event) override;
             void update_scalar_options();
-            void add_tractogram (vector<std::string>& list);
+            void add_tractogram (std::vector<std::string>& list);
             void select_last_added_tractogram();
             bool process_commandline_option_tsf_check_tracto_loaded ();
-            bool process_commandline_option_tsf_option (const MR::App::ParsedOption&, uint, vector<default_type>& range);
+            bool process_commandline_option_tsf_option (const MR::App::ParsedOption&, uint, std::vector<default_type>& range);
             void update_geometry_type_gui();
         };
       }

--- a/src/gui/mrview/tool/view.cpp
+++ b/src/gui/mrview/tool/view.cpp
@@ -153,7 +153,7 @@ namespace MR
               endInsertRows();
             }
 
-            vector<ClipPlane> planes;
+            std::vector<ClipPlane> planes;
         };
 
 
@@ -929,9 +929,9 @@ namespace MR
 
 
 
-        vector< std::pair<GL::vec4,bool> > View::get_active_clip_planes () const
+        std::vector< std::pair<GL::vec4,bool> > View::get_active_clip_planes () const
         {
-          vector< std::pair<GL::vec4,bool> > ret;
+          std::vector< std::pair<GL::vec4,bool> > ret;
           QItemSelectionModel* selection = clip_planes_list_view->selectionModel();
           if (clip_box->isChecked()) {
             for (int i = 0; i < clip_planes_model->rowCount(); ++i) {
@@ -947,9 +947,9 @@ namespace MR
           return ret;
         }
 
-        vector<GL::vec4*> View::get_clip_planes_to_be_edited () const
+        std::vector<GL::vec4*> View::get_clip_planes_to_be_edited () const
         {
-          vector<GL::vec4*> ret;
+          std::vector<GL::vec4*> ret;
           if (clip_box->isChecked()) {
             QModelIndexList indices = clip_planes_list_view->selectionModel()->selectedIndexes();
             for (int i = 0; i < indices.size(); ++i)
@@ -1101,7 +1101,7 @@ namespace MR
           reset_light_box_gui_controls();
         }
 
-        void View::move_clip_planes_in_out (const ModelViewProjection& projection, vector<GL::vec4*>& clip, float distance)
+        void View::move_clip_planes_in_out (const ModelViewProjection& projection, std::vector<GL::vec4*>& clip, float distance)
         {
           Eigen::Vector3f d = projection.screen_normal();
           for (size_t n = 0; n < clip.size(); ++n) {
@@ -1112,7 +1112,7 @@ namespace MR
         }
 
 
-        void View::rotate_clip_planes (vector<GL::vec4*>& clip, const Eigen::Quaternionf& rot)
+        void View::rotate_clip_planes (std::vector<GL::vec4*>& clip, const Eigen::Quaternionf& rot)
         {
           const auto& focus (window().focus());
           for (size_t n = 0; n < clip.size(); ++n) {
@@ -1137,7 +1137,7 @@ namespace MR
 
         bool View::slice_move_event (const ModelViewProjection& projection, float x)
         {
-          vector<GL::vec4*> clip = get_clip_planes_to_be_edited();
+          std::vector<GL::vec4*> clip = get_clip_planes_to_be_edited();
           if (!clip.size()) return false;
           const auto &header = window().image()->header();
           float increment = x * std::pow (header.spacing (0) * header.spacing (1) * header.spacing (2), 1.0f/3.0f);
@@ -1149,7 +1149,7 @@ namespace MR
 
         bool View::pan_event (const ModelViewProjection& projection)
         {
-          vector<GL::vec4*> clip = get_clip_planes_to_be_edited();
+          std::vector<GL::vec4*> clip = get_clip_planes_to_be_edited();
           if (!clip.size()) return false;
           Eigen::Vector3f move = projection.screen_to_model_direction (window().mouse_displacement(), window().target());
           for (size_t n = 0; n < clip.size(); ++n) {
@@ -1163,7 +1163,7 @@ namespace MR
 
         bool View::panthrough_event (const ModelViewProjection& projection)
         {
-          vector<GL::vec4*> clip = get_clip_planes_to_be_edited();
+          std::vector<GL::vec4*> clip = get_clip_planes_to_be_edited();
           if (!clip.size()) return false;
           move_clip_planes_in_out (projection, clip, MOVE_IN_OUT_FOV_MULTIPLIER * window().mouse_displacement().y() * window().FOV());
           return true;
@@ -1173,7 +1173,7 @@ namespace MR
 
         bool View::tilt_event (const ModelViewProjection& projection)
         {
-          vector<GL::vec4*> clip = get_clip_planes_to_be_edited();
+          std::vector<GL::vec4*> clip = get_clip_planes_to_be_edited();
           if (!clip.size()) return false;
           const Eigen::Quaternionf rot = window().get_current_mode()->get_tilt_rotation (projection);
           if (!rot.coeffs().allFinite())
@@ -1186,7 +1186,7 @@ namespace MR
 
         bool View::rotate_event (const ModelViewProjection& projection)
         {
-          vector<GL::vec4*> clip = get_clip_planes_to_be_edited();
+          std::vector<GL::vec4*> clip = get_clip_planes_to_be_edited();
           if (!clip.size()) return false;
           const Eigen::Quaternionf rot = window().get_current_mode()->get_rotate_rotation (projection);
           if (rot.coeffs().allFinite())

--- a/src/gui/mrview/tool/view.h
+++ b/src/gui/mrview/tool/view.h
@@ -51,8 +51,8 @@ namespace MR
 
             QPushButton *clip_on_button[3], *clip_edit_button[3], *clip_modify_button;
 
-            vector< std::pair<GL::vec4,bool> > get_active_clip_planes () const;
-            vector<GL::vec4*> get_clip_planes_to_be_edited () const;
+            std::vector< std::pair<GL::vec4,bool> > get_active_clip_planes () const;
+            std::vector<GL::vec4*> get_clip_planes_to_be_edited () const;
             bool get_cliphighlightstate () const;
             bool get_clipintersectionmodestate () const;
 
@@ -143,8 +143,8 @@ namespace MR
             void reset_light_box_gui_controls ();
             void set_transparency_from_image ();
 
-            void move_clip_planes_in_out (const ModelViewProjection& projection, vector<GL::vec4*>& clip, float distance);
-            void rotate_clip_planes (vector<GL::vec4*>& clip, const Eigen::Quaternionf& rot);
+            void move_clip_planes_in_out (const ModelViewProjection& projection, std::vector<GL::vec4*>& clip, float distance);
+            void rotate_clip_planes (std::vector<GL::vec4*>& clip, const Eigen::Quaternionf& rot);
         };
 
       }

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -136,7 +136,7 @@ namespace MR
         //CONF Initial window size of MRView in pixels.
         //CONF default: 512,512
         std::string init_size_string = lowercase (MR::File::Config::get ("MRViewInitWindowSize"));
-        vector<uint32_t> init_window_size;
+        std::vector<uint32_t> init_window_size;
         if (init_size_string.length())
           init_window_size = parse_ints<uint32_t> (init_size_string);
         if (init_window_size.size() == 2)
@@ -156,7 +156,7 @@ namespace MR
       void Window::GLArea::dropEvent (QDropEvent* event) {
         const QMimeData* mimeData = event->mimeData();
         if (mimeData->hasUrls()) {
-          vector<std::unique_ptr<MR::Header>> list;
+          std::vector<std::unique_ptr<MR::Header>> list;
           QList<QUrl> urlList = mimeData->urls();
           for (int i = 0; i < urlList.size() && i < 32; ++i) {
             try {
@@ -781,7 +781,7 @@ namespace MR
             }
           }
 
-          vector<std::unique_ptr<MR::Header>> list;
+          std::vector<std::unique_ptr<MR::Header>> list;
           for (size_t n = 0; n < MR::App::argument.size(); ++n) {
             try { list.push_back (make_unique<MR::Header> (MR::Header::open (MR::App::argument[n]))); }
             catch (CancelException& e) {
@@ -842,11 +842,11 @@ namespace MR
 
       void Window::image_open_slot ()
       {
-        vector<std::string> image_list = Dialog::File::get_images (this, "Select images to open", &current_folder);
+        std::vector<std::string> image_list = Dialog::File::get_images (this, "Select images to open", &current_folder);
         if (image_list.empty())
           return;
 
-        vector<std::unique_ptr<MR::Header>> list;
+        std::vector<std::unique_ptr<MR::Header>> list;
         for (size_t n = 0; n < image_list.size(); ++n) {
           try {
             list.push_back (make_unique<MR::Header> (MR::Header::open (image_list[n])));
@@ -868,7 +868,7 @@ namespace MR
 
 
         try {
-          vector<std::unique_ptr<MR::Header>> list;
+          std::vector<std::unique_ptr<MR::Header>> list;
           list.push_back (make_unique<MR::Header> (MR::Header::open (folder)));
           add_images (list);
         }
@@ -883,7 +883,7 @@ namespace MR
 
 
 
-      void Window::add_images (vector<std::unique_ptr<MR::Header>>& list)
+      void Window::add_images (std::vector<std::unique_ptr<MR::Header>>& list)
       {
         if (list.empty())
           return;
@@ -1887,7 +1887,7 @@ namespace MR
           }
 
           if (opt.opt->is ("size")) {
-            vector<uint32_t> glsize = parse_ints<uint32_t> (opt[0]);
+            std::vector<uint32_t> glsize = parse_ints<uint32_t> (opt[0]);
             if (glsize.size() != 2)
               throw Exception ("invalid argument \"" + std::string(opt.args[0]) + "\" to -size batch command");
             if (glsize[0] < 1 || glsize[1] < 1)
@@ -1931,7 +1931,7 @@ namespace MR
 
           if (opt.opt->is ("target")) {
             if (image()) {
-              vector<default_type> pos = parse_floats (opt[0]);
+              std::vector<default_type> pos = parse_floats (opt[0]);
               if (pos.size() != 3)
                 throw Exception ("-target option expects a comma-separated list of 3 floating-point values");
               set_target (Eigen::Vector3f { float(pos[0]), float(pos[1]), float(pos[2]) });
@@ -1942,7 +1942,7 @@ namespace MR
 
           if (opt.opt->is ("orientation")) {
             if (image()) {
-              vector<default_type> pos = parse_floats (opt[0]);
+              std::vector<default_type> pos = parse_floats (opt[0]);
               if (pos.size() != 4)
                 throw Exception ("-orientation option expects a comma-separated list of 4 floating-point values");
               set_orientation ({ float(pos[0]), float(pos[1]), float(pos[2]), float(pos[3]) });
@@ -1953,7 +1953,7 @@ namespace MR
 
           if (opt.opt->is ("voxel")) {
             if (image()) {
-              vector<default_type> pos = parse_floats (opt[0]);
+              std::vector<default_type> pos = parse_floats (opt[0]);
               if (pos.size() != 3)
                 throw Exception ("-voxel option expects a comma-separated list of 3 floating-point values");
               set_focus (image()->voxel2scanner() *  Eigen::Vector3f { float(pos[0]), float(pos[1]), float(pos[2]) });
@@ -2006,7 +2006,7 @@ namespace MR
           }
 
           if (opt.opt->is ("load")) {
-            vector<std::unique_ptr<MR::Header>> list;
+            std::vector<std::unique_ptr<MR::Header>> list;
             try { list.push_back (make_unique<MR::Header> (MR::Header::open (opt[0]))); }
             catch (Exception& e) { e.display(); }
             add_images (list);
@@ -2039,7 +2039,7 @@ namespace MR
 
           if (opt.opt->is ("intensity_range")) {
             if (image()) {
-              vector<default_type> param = parse_floats (opt[0]);
+              std::vector<default_type> param = parse_floats (opt[0]);
               if (param.size() != 2)
                 throw Exception ("-intensity_range options expects comma-separated list of two floating-point values");
               image()->set_windowing (param[0], param[1]);
@@ -2049,7 +2049,7 @@ namespace MR
           }
 
           if (opt.opt->is ("position")) {
-            vector<int> pos = parse_ints<int> (opt[0]);
+            std::vector<int> pos = parse_ints<int> (opt[0]);
             if (pos.size() != 2)
               throw Exception ("invalid argument \"" + std::string(opt[0]) + "\" to -position option");
             move (pos[0], pos[1]);

--- a/src/gui/mrview/window.h
+++ b/src/gui/mrview/window.h
@@ -84,7 +84,7 @@ namespace MR
           ~Window();
 
           void parse_arguments ();
-          void add_images (vector<std::unique_ptr<MR::Header>>& list);
+          void add_images (std::vector<std::unique_ptr<MR::Header>>& list);
 
           const QPoint& mouse_position () const { return mouse_position_; }
           const QPoint& mouse_displacement () const { return mouse_displacement_; }
@@ -340,7 +340,7 @@ namespace MR
 
           Tool::Base* tool_has_focus;
 
-          vector<double> render_times;
+          std::vector<double> render_times;
           double best_FPS, best_FPS_time;
           bool show_FPS;
           size_t current_option;

--- a/src/gui/projection.cpp
+++ b/src/gui/projection.cpp
@@ -41,7 +41,7 @@ namespace MR
 
     void Projection::draw_orientation_labels () const
     {
-      vector<OrientationLabel> labels;
+      std::vector<OrientationLabel> labels;
       labels.push_back (OrientationLabel (model_to_screen_direction (Eigen::Vector3f {-1.0,  0.0,  0.0}), 'L'));
       labels.push_back (OrientationLabel (model_to_screen_direction (Eigen::Vector3f { 1.0,  0.0,  0.0}), 'R'));
       labels.push_back (OrientationLabel (model_to_screen_direction (Eigen::Vector3f { 0.0, -1.0,  0.0}), 'P'));

--- a/src/gui/shapes/cylinder.cpp
+++ b/src/gui/shapes/cylinder.cpp
@@ -33,8 +33,8 @@ namespace MR
     void Cylinder::LOD (const size_t level_of_detail)
     {
 
-      vector<Eigen::Vector3f> vertices, normals;
-      vector<Eigen::Array3i> indices;
+      std::vector<Eigen::Vector3f> vertices, normals;
+      std::vector<Eigen::Array3i> indices;
 
       // Want to be able to display using a single DrawElements call; not worth faffing about
       //   with combinations of GL_TRIANGLES and GL_TRIANGLE_FAN

--- a/src/gui/shapes/halfsphere.cpp
+++ b/src/gui/shapes/halfsphere.cpp
@@ -115,9 +115,9 @@ namespace MR
 
     void HalfSphere::LOD (const size_t level_of_detail)
     {
-      //vector<Vertex> vertices;
+      //std::vector<Vertex> vertices;
       vertices.clear();
-      vector<Triangle> indices;
+      std::vector<Triangle> indices;
 
       for (size_t n = 0; n < NUM_VERTICES; n++)
         vertices.push_back (initial_vertices[n]);

--- a/src/gui/shapes/halfsphere.h
+++ b/src/gui/shapes/halfsphere.h
@@ -65,7 +65,7 @@ namespace MR
 
         };
 
-        vector<Vertex> vertices;
+        std::vector<Vertex> vertices;
     };
 
 

--- a/src/gui/shapes/sphere.cpp
+++ b/src/gui/shapes/sphere.cpp
@@ -149,9 +149,9 @@ namespace MR
 
     void Sphere::LOD (const size_t level_of_detail)
     {
-      //vector<Vertex> vertices;
+      //std::vector<Vertex> vertices;
       vertices.clear();
-      vector<Triangle> indices;
+      std::vector<Triangle> indices;
 
       for (size_t n = 0; n < NUM_VERTICES; n++)
         vertices.push_back (initial_vertices[n]);

--- a/src/gui/shapes/sphere.h
+++ b/src/gui/shapes/sphere.h
@@ -65,7 +65,7 @@ namespace MR
 
         };
 
-        vector<Vertex> vertices;
+        std::vector<Vertex> vertices;
 
     };
 

--- a/src/min_mem_array.h
+++ b/src/min_mem_array.h
@@ -31,8 +31,8 @@ namespace MR {
 
 // This class allows for construction and management of a c-style array, where the
 //   memory overhead is minimal (a pointer and a size_t)
-// vector<>'s have some amount of overhead, which can add up if many are being stored
-// Typical usage is to gather the required data using a vector<>, and use that vector
+// std::vector<>'s have some amount of overhead, which can add up if many are being stored
+// Typical usage is to gather the required data using a std::vector<>, and use that vector
 //   to construct a Min_mem_array<>
 
 template <class T>

--- a/src/registration/linear.cpp
+++ b/src/registration/linear.cpp
@@ -42,7 +42,7 @@ namespace MR
       if (get_options("init_rotation.search.run_global").size()) registration.init.init_rotation.search.run_global = true;
       auto opt = get_options("init_rotation.search.angles");
       if (opt.size()) {
-        vector<default_type> angles = parse_floats (opt[0][0]);
+        std::vector<default_type> angles = parse_floats (opt[0][0]);
         for (auto& a: angles) {
           if (a < 0.0 or a > 180.0)
             throw Exception ("init_rotation.search.angles have to be between 0 and 180 degree.");
@@ -122,7 +122,7 @@ namespace MR
         const auto iterations = parse_ints<uint32_t> (opt[0][0]);
         registration.set_stage_iterations (iterations);
       } else {
-        registration.set_stage_iterations (vector<uint32_t> {1});
+        registration.set_stage_iterations (std::vector<uint32_t> {1});
       }
 
       opt = get_options("linstage.diagnostics.prefix");

--- a/src/registration/linear.h
+++ b/src/registration/linear.h
@@ -90,11 +90,11 @@ namespace MR
       }
       size_t stage_iterations, gd_max_iter;
       default_type scale_factor;
-      vector<OptimiserAlgoType> optimisers;
+      std::vector<OptimiserAlgoType> optimisers;
       OptimiserAlgoType optimiser_default, optimiser_first, optimiser_last;
       default_type loop_density;
       ssize_t fod_lmax;
-      vector<std::string> diagnostics_images;
+      std::vector<std::string> diagnostics_images;
     } ;
 
     class Linear { 
@@ -127,7 +127,7 @@ namespace MR
         }
 
         // set_scale_factor needs to be the first option that is set as it overwrites the stage vector
-        void set_scale_factor (const vector<default_type>& scalefactor) {
+        void set_scale_factor (const std::vector<default_type>& scalefactor) {
           stages.resize (scalefactor.size());
           for (size_t level = 0; level < scalefactor.size(); ++level) {
             if (scalefactor[level] <= 0 || scalefactor[level] > 1.0)
@@ -154,7 +154,7 @@ namespace MR
             stage.optimiser_last = type;
         }
 
-        void set_stage_iterations (const vector<uint32_t>& it) {
+        void set_stage_iterations (const std::vector<uint32_t>& it) {
           for (size_t i = 0; i < it.size (); ++i)
             if (!it[i])
               throw Exception ("the number of stage iterations must be positive");
@@ -174,7 +174,7 @@ namespace MR
           }
         }
 
-        void set_max_iter (const vector<uint32_t>& maxiter) {
+        void set_max_iter (const std::vector<uint32_t>& maxiter) {
           if (maxiter.size() == stages.size()) {
             for (size_t i = 0; i < stages.size (); ++i)
               stages[i].gd_max_iter = maxiter[i];
@@ -191,7 +191,7 @@ namespace MR
           do_reorientation = true;
         }
 
-        void set_lmax (const vector<uint32_t>& lmax) {
+        void set_lmax (const std::vector<uint32_t>& lmax) {
           for (size_t i = 0; i < lmax.size (); ++i)
             if (lmax[i] % 2)
               throw Exception ("the input lmax must be even");
@@ -206,11 +206,11 @@ namespace MR
         }
 
         // needs to be set after set_lmax
-        void set_mc_parameters (const vector<MultiContrastSetting>& mcs) {
+        void set_mc_parameters (const std::vector<MultiContrastSetting>& mcs) {
           contrasts = mcs;
         }
 
-        void set_loop_density (const vector<default_type>& loop_density_){
+        void set_loop_density (const std::vector<default_type>& loop_density_){
           for (size_t d = 0; d < loop_density_.size(); ++d)
             if (loop_density_[d] < 0.0 or loop_density_[d] > 1.0 )
               throw Exception ("loop density must be between 0.0 and 1.0");
@@ -237,7 +237,7 @@ namespace MR
           }
         }
 
-        void set_extent (const vector<size_t> extent) {
+        void set_extent (const std::vector<size_t> extent) {
           for (size_t d = 0; d < extent.size(); ++d) {
             if (extent[d] < 1)
               throw Exception ("the neighborhood kernel extent must be at least 1 voxel");
@@ -574,9 +574,9 @@ namespace MR
           // }
 
       protected:
-        vector<StageSetting> stages;
-        vector<MultiContrastSetting> contrasts, stage_contrasts;
-        vector<size_t> kernel_extent;
+        std::vector<StageSetting> stages;
+        std::vector<MultiContrastSetting> contrasts, stage_contrasts;
+        std::vector<size_t> kernel_extent;
         default_type grad_tolerance;
         default_type step_tolerance;
         std::streambuf* log_stream;

--- a/src/registration/metric/cc_helper.h
+++ b/src/registration/metric/cc_helper.h
@@ -40,7 +40,7 @@ namespace MR
                             DerivedImageType& C,
                             DerivedImageType& im1_meansubtr,
                             DerivedImageType& im2_meansubtr,
-                            const vector<size_t>& extent) {
+                            const std::vector<size_t>& extent) {
           // TODO check extent
           int nmax = extent[0] * extent[1] * extent[2];
           Eigen::VectorXd n1 = Eigen::VectorXd(nmax);

--- a/src/registration/metric/demons4D.h
+++ b/src/registration/metric/demons4D.h
@@ -35,7 +35,7 @@ namespace MR
         public:
           Demons4D (default_type& global_energy, size_t& global_voxel_count,
                      const Im1ImageType& im1_image, const Im2ImageType& im2_image, const Im1MaskType im1_mask, const Im2MaskType im2_mask,
-                     const vector<MultiContrastSetting>* contrast_settings = nullptr) :
+                     const std::vector<MultiContrastSetting>* contrast_settings = nullptr) :
                        global_cost (global_energy),
                        global_voxel_count (global_voxel_count),
                        thread_cost (0.0),
@@ -166,7 +166,7 @@ namespace MR
             Im1MaskType im1_mask;
             Im2MaskType im2_mask;
 
-            const vector<MultiContrastSetting>* contrast_settings;
+            const std::vector<MultiContrastSetting>* contrast_settings;
             const ssize_t nvols;
             Eigen::VectorXd weight;
 

--- a/src/registration/metric/evaluate.h
+++ b/src/registration/metric/evaluate.h
@@ -254,7 +254,7 @@ namespace MR
           protected:
             MetricType metric;
             ParamType params;
-            vector<size_t> extent;
+            std::vector<size_t> extent;
             size_t iteration;
             Eigen::MatrixXd directions;
             ssize_t overlap_count;

--- a/src/registration/metric/local_cross_correlation.h
+++ b/src/registration/metric/local_cross_correlation.h
@@ -112,13 +112,13 @@ namespace MR
           out.row(3) = ( Eigen::Matrix<default_type,5,1>() << value_in1 - m1, value_in2 - m2, n1.adjoint() * n2, n1.adjoint() * n1, n2.adjoint() * n2 ).finished();
         }
 
-        LCCPrecomputeFunctorMasked_Naive (const vector<size_t>& ext, ImageType1& adapter1, ImageType2& adapter2) :
+        LCCPrecomputeFunctorMasked_Naive (const std::vector<size_t>& ext, ImageType1& adapter1, ImageType2& adapter2) :
           extent(ext),
           in1(adapter1),
           in2(adapter2) { /* TODO check dimensions and extent */ }
 
         protected:
-          vector<size_t> extent;
+          std::vector<size_t> extent;
           ImageType1 in1; // store reslice adapter in functor to avoid iterating over it when mask is false
           ImageType2 in2; // TODO: cache interpolated values for neighbourhood iteration
       };
@@ -163,7 +163,7 @@ namespace MR
                 auto cc_mask_header = Header::scratch (parameters.midway_image);
 
                 auto cc_image = cc_image_header.template get_image <ProcessedImageValueType>().with_direct_io(Stride::contiguous_along_axis(3));
-                vector<uint32_t> NoOversample;
+                std::vector<uint32_t> NoOversample;
                 {
                   LogLevelLatch log_level (0);
                   if (parameters.im1_mask.valid() or parameters.im2_mask.valid())

--- a/src/registration/metric/params.h
+++ b/src/registration/metric/params.h
@@ -85,9 +85,9 @@ namespace MR
                       update_control_points();
           }
 
-          void set_extent (vector<size_t> extent_vector) { extent=std::move(extent_vector); }
+          void set_extent (std::vector<size_t> extent_vector) { extent=std::move(extent_vector); }
 
-          void set_mc_settings (const vector<MultiContrastSetting>& mc_vector) {
+          void set_mc_settings (const std::vector<MultiContrastSetting>& mc_vector) {
             mc_settings = mc_vector;
 
             // set multi contrast weights
@@ -139,7 +139,7 @@ namespace MR
             control_points.block<3,4>(0,0).colwise() += centre;
           }
 
-          const vector<size_t>& get_extent() const { return extent; }
+          const std::vector<size_t>& get_extent() const { return extent; }
 
           template <class OptimiserType>
             void optimiser_update (OptimiserType& optim, const ssize_t overlap_count) {
@@ -170,7 +170,7 @@ namespace MR
               header.keyval()["trafo2"] = str(trafo2.matrix());
               auto check = Image<default_type>::create (image_path, header);
 
-              vector<uint32_t> no_oversampling (3,1);
+              std::vector<uint32_t> no_oversampling (3,1);
               Adapter::Reslice<Interp::Linear, Im1ImageType > im1_reslicer (
                 im1_image, midway_image, trafo1, no_oversampling, NAN);
               Adapter::Reslice<Interp::Linear, Im2ImageType > im2_reslicer (
@@ -237,15 +237,15 @@ namespace MR
 
           bool robust_estimate_subset;
           bool robust_estimate_use_score;
-          MR::vector<int> robust_estimate_subset_from;
-          MR::vector<int> robust_estimate_subset_size;
+          std::vector<int> robust_estimate_subset_from;
+          std::vector<int> robust_estimate_subset_size;
           Image<float> robust_estimate_score1, robust_estimate_score2;
           MR::copy_ptr<Interp::Linear<Image<float>>> robust_estimate_score1_interp;
           MR::copy_ptr<Interp::Linear<Image<float>>> robust_estimate_score2_interp;
 
           Eigen::Matrix<default_type, Eigen::Dynamic, Eigen::Dynamic> control_points;
-          vector<size_t> extent;
-          vector<MultiContrastSetting> mc_settings;
+          std::vector<size_t> extent;
+          std::vector<MultiContrastSetting> mc_settings;
 
           ProcImageType processed_image;
           MR::copy_ptr<ProcImageInterpolatorType> processed_image_interp;

--- a/src/registration/metric/thread_kernel.h
+++ b/src/registration/metric/thread_kernel.h
@@ -331,7 +331,7 @@ namespace MR
       struct StochasticThreadKernel { 
         public:
           StochasticThreadKernel (
-              const vector<size_t>& inner_axes,
+              const std::vector<size_t>& inner_axes,
               const default_type density,
               const MetricType& metric,
               const ParamType& parameters,
@@ -372,7 +372,7 @@ namespace MR
               }
           }
         protected:
-          vector<size_t> inner_axes;
+          std::vector<size_t> inner_axes;
           default_type density;
           MetricType metric;
           ParamType params;

--- a/src/registration/multi_contrast.cpp
+++ b/src/registration/multi_contrast.cpp
@@ -61,7 +61,7 @@ namespace MR
     };
 
 
-    void preload_data(vector<Header>& input, Image<default_type>& images, const vector<MultiContrastSetting>& mc_params) {
+    void preload_data(std::vector<Header>& input, Image<default_type>& images, const std::vector<MultiContrastSetting>& mc_params) {
       const size_t n_images = input.size();
       assert (mc_params.size() == input.size());
       size_t sumvols (0);
@@ -85,8 +85,8 @@ namespace MR
       } else {
         for (size_t idx = 0; idx < n_images; idx++) {
           size_t ndim = input[idx].ndim();
-          vector<size_t> from (ndim, 0);
-          vector<size_t> size (ndim, 1);
+          std::vector<size_t> from (ndim, 0);
+          std::vector<size_t> size (ndim, 1);
           for (size_t dim = 0; dim < 3; ++dim)
             size[dim] = input[idx].size(dim);
           if (ndim==4)

--- a/src/registration/multi_contrast.h
+++ b/src/registration/multi_contrast.h
@@ -37,7 +37,7 @@ namespace MR
   {
 
     FORCE_INLINE void check_image_output (const std::string& image_name, const Header& reference) {
-      vector<std::string> V;
+      std::vector<std::string> V;
       if (!image_name.size()) throw Exception ("image output path is empty");
         if (Path::exists (image_name) && !App::overwrite_files)
           throw Exception ("output image \"" + image_name + "\" already exists (use -force option to force overwrite)");
@@ -45,7 +45,7 @@ namespace MR
         Header H = reference;
         File::NameParser parser;
         parser.parse (image_name);
-        vector<int> Pdim (parser.ndim());
+        std::vector<int> Pdim (parser.ndim());
 
         H.name() = image_name;
 
@@ -105,7 +105,7 @@ namespace MR
       return o;
     }
 
-    void preload_data(vector<Header>& input, Image<default_type>& images, const vector<MultiContrastSetting>& mc_params);
+    void preload_data(std::vector<Header>& input, Image<default_type>& images, const std::vector<MultiContrastSetting>& mc_params);
 
   }
 }

--- a/src/registration/multi_resolution_lmax.h
+++ b/src/registration/multi_resolution_lmax.h
@@ -33,15 +33,15 @@ namespace MR
                                                   const bool do_reorientation = false,
                                                   const uint32_t lmax = 0)
     {
-      vector<uint32_t> from (input.ndim(), 0);
-      vector<uint32_t> size (input.ndim());
+      std::vector<uint32_t> from (input.ndim(), 0);
+      std::vector<uint32_t> size (input.ndim());
       for (size_t dim = 0; dim < input.ndim(); ++dim)
         size[dim] = input.size(dim);
       if (do_reorientation)
         size[3] = Math::SH::NforL (lmax);
       Adapter::Subset<ImageType> subset (input, from, size);
       Filter::Smooth smooth_filter (subset);
-      vector<default_type> stdev(3);
+      std::vector<default_type> stdev(3);
       for (size_t dim = 0; dim < 3; ++dim)
         stdev[dim] = input.spacing(dim) / (2.0 * scale_factor);
 
@@ -60,10 +60,10 @@ namespace MR
     FORCE_INLINE ImageType multi_resolution_lmax (ImageType& input,
                                                   const default_type scale_factor,
                                                   const bool do_reorientation,
-                                                  const vector<MultiContrastSetting>& contrast,
-                                                  vector<MultiContrastSetting>* contrast_updated = nullptr)
+                                                  const std::vector<MultiContrastSetting>& contrast,
+                                                  std::vector<MultiContrastSetting>* contrast_updated = nullptr)
     {
-      vector<uint32_t> volume_indices;
+      std::vector<uint32_t> volume_indices;
       size_t start = 0;
       for (size_t ic = 0; ic < contrast.size(); ic++) {
         const auto & mc = contrast[ic];
@@ -78,7 +78,7 @@ namespace MR
       Adapter::Extract1D<ImageType> subset (input, 3, volume_indices);
 
       Filter::Smooth smooth_filter (subset);
-      vector<default_type> stdev(3);
+      std::vector<default_type> stdev(3);
       for (size_t dim = 0; dim < 3; ++dim)
         stdev[dim] = input.spacing(dim) / (2.0 * scale_factor);
 

--- a/src/registration/nonlinear.h
+++ b/src/registration/nonlinear.h
@@ -81,7 +81,7 @@ namespace MR
               im2_to_mid_linear = linear_transform.get_transform_half_inverse();
 
               INFO ("Estimating halfway space");
-              vector<Eigen::Transform<double, 3, Eigen::Projective>> init_transforms;
+              std::vector<Eigen::Transform<double, 3, Eigen::Projective>> init_transforms;
               // define transfomations that will be applied to the image header when the common space is calculated
               midway_image_header = compute_minimum_average_header (im1_image, im2_image, linear_transform.get_transform_half_inverse(), linear_transform.get_transform_half());
             } else {
@@ -394,12 +394,12 @@ namespace MR
             is_initialised = true;
           }
 
-          void set_max_iter (const vector<uint32_t>& maxiter) {
+          void set_max_iter (const std::vector<uint32_t>& maxiter) {
             max_iter = maxiter;
           }
 
 
-          void set_scale_factor (const vector<default_type>& scalefactor) {
+          void set_scale_factor (const std::vector<default_type>& scalefactor) {
             for (size_t level = 0; level < scalefactor.size(); ++level) {
               if (scalefactor[level] <= 0 || scalefactor[level] > 1)
                 throw Exception ("the non-linear registration scale factor for each multi-resolution level must be between 0 and 1");
@@ -407,7 +407,7 @@ namespace MR
             scale_factor = scalefactor;
           }
 
-          vector<default_type> get_scale_factor () const {
+          std::vector<default_type> get_scale_factor () const {
             return scale_factor;
           }
 
@@ -428,7 +428,7 @@ namespace MR
             disp_smoothing = voxel_fwhm;
           }
 
-          void set_lmax (const vector<uint32_t>& lmax) {
+          void set_lmax (const std::vector<uint32_t>& lmax) {
             for (size_t i = 0; i < lmax.size (); ++i)
               if (lmax[i] % 2)
                 throw Exception ("the input nonlinear lmax must be even");
@@ -436,7 +436,7 @@ namespace MR
           }
 
           // needs to be set after set_lmax
-          void set_mc_parameters (const vector<MultiContrastSetting>& mcs) {
+          void set_mc_parameters (const std::vector<MultiContrastSetting>& mcs) {
             contrasts = mcs;
           }
 
@@ -519,7 +519,7 @@ namespace MR
               throw Exception ("CC radius needs to be larger than 1");
             use_cc = true;
             INFO("Cross correlation radius: " + str(radius));
-            cc_extent = vector<size_t>(3, radius * 2 + 1);
+            cc_extent = std::vector<size_t>(3, radius * 2 + 1);
           }
 
           void set_diagnostics_image (const std::basic_string<char>& path) {
@@ -547,24 +547,24 @@ namespace MR
 
 
           bool is_initialised;
-          vector<uint32_t> max_iter;
-          vector<default_type> scale_factor;
+          std::vector<uint32_t> max_iter;
+          std::vector<default_type> scale_factor;
           default_type update_smoothing;
           default_type disp_smoothing;
           default_type gradient_step;
           Eigen::MatrixXd aPSF_directions;
           bool do_reorientation;
-          vector<uint32_t> fod_lmax;
+          std::vector<uint32_t> fod_lmax;
           bool use_cc;
           std::basic_string<char> diagnostics_image_prefix;
 
-          vector<size_t> cc_extent;
+          std::vector<size_t> cc_extent;
 
           transform_type im1_to_mid_linear;
           transform_type im2_to_mid_linear;
           Header midway_image_header;
 
-          vector<MultiContrastSetting> contrasts, stage_contrasts;
+          std::vector<MultiContrastSetting> contrasts, stage_contrasts;
 
           // Internally the warp is stored as a displacement field to enable easy smoothing near the boundaries
           std::shared_ptr<Image<default_type> > im1_to_mid_new;

--- a/src/registration/transform/affine.cpp
+++ b/src/registration/transform/affine.cpp
@@ -278,7 +278,7 @@ namespace MR
 
           bool Affine::robust_estimate (
             Eigen::Matrix<default_type, Eigen::Dynamic, 1>& gradient,
-            vector<Eigen::Matrix<default_type, Eigen::Dynamic, 1>>& grad_estimates,
+            std::vector<Eigen::Matrix<default_type, Eigen::Dynamic, 1>>& grad_estimates,
             const Eigen::Matrix<default_type, 4, 4>& control_points,
             const Eigen::Matrix<default_type, Eigen::Dynamic, 1>& parameter_vector,
             const default_type& weiszfeld_precision = 1.0e-6,

--- a/src/registration/transform/affine.h
+++ b/src/registration/transform/affine.h
@@ -124,7 +124,7 @@ namespace MR
 
           bool robust_estimate (
             Eigen::Matrix<default_type, Eigen::Dynamic, 1>& gradient,
-            vector<Eigen::Matrix<default_type, Eigen::Dynamic, 1>>& grad_estimates,
+            std::vector<Eigen::Matrix<default_type, Eigen::Dynamic, 1>>& grad_estimates,
             const Eigen::Matrix<default_type, 4, 4>& control_points,
             const Eigen::Matrix<default_type, Eigen::Dynamic, 1>& parameter_vector,
             const default_type& weiszfeld_precision,

--- a/src/registration/transform/base.h
+++ b/src/registration/transform/base.h
@@ -237,7 +237,7 @@ namespace MR
 
           template <class ParamType, class VectorType>
           bool robust_estimate (VectorType& gradient,
-                                vector<VectorType>& grad_estimates,
+                                std::vector<VectorType>& grad_estimates,
                                 const ParamType& params,
                                 const VectorType& parameter_vector,
                                 const default_type& weiszfeld_precision,

--- a/src/registration/transform/initialiser.cpp
+++ b/src/registration/transform/initialiser.cpp
@@ -33,7 +33,7 @@ namespace MR
           Image<default_type>& mask2,
           Registration::Transform::Base& transform,
           Registration::Transform::Init::LinearInitialisationParams& init,
-          const vector<MultiContrastSetting>& contrast_settings) {
+          const std::vector<MultiContrastSetting>& contrast_settings) {
 
           CONSOLE ("initialising centre of rotation using centre of mass");
           Eigen::Vector3d im1_centre_mass, im2_centre_mass;
@@ -101,7 +101,7 @@ namespace MR
           Image<default_type>& mask2,
           Registration::Transform::Base& transform,
           Registration::Transform::Init::LinearInitialisationParams& init,
-          const vector<MultiContrastSetting>& contrast_settings) {
+          const std::vector<MultiContrastSetting>& contrast_settings) {
 
           Image<default_type> bogus_mask;
           CONSOLE ("initialising using image moments");
@@ -145,7 +145,7 @@ namespace MR
           Image<default_type>& mask2,
           Registration::Transform::Base& transform,
           Registration::Transform::Init::LinearInitialisationParams& init,
-          const vector<MultiContrastSetting>& contrast_settings);
+          const std::vector<MultiContrastSetting>& contrast_settings);
 
         void initialise_using_image_mass (
           Image<default_type>& im1,
@@ -154,7 +154,7 @@ namespace MR
           Image<default_type>& mask2,
           Registration::Transform::Base& transform,
           Registration::Transform::Init::LinearInitialisationParams& init,
-          const vector<MultiContrastSetting>& contrast_settings);
+          const std::vector<MultiContrastSetting>& contrast_settings);
       }
     }
   }

--- a/src/registration/transform/initialiser.h
+++ b/src/registration/transform/initialiser.h
@@ -44,7 +44,7 @@ namespace MR
             bool unmasked1;
             bool unmasked2;
             struct rot_search { 
-              vector<default_type> angles;
+              std::vector<default_type> angles;
               default_type scale;
               size_t directions;
               bool run_global;
@@ -84,7 +84,7 @@ namespace MR
           Image<default_type>& mask2,
           Registration::Transform::Base& transform,
           Registration::Transform::Init::LinearInitialisationParams& init,
-          const vector<MultiContrastSetting>& contrast_settings);
+          const std::vector<MultiContrastSetting>& contrast_settings);
 
         extern void set_centre_via_image_centres (
           const Image<default_type>& im1,
@@ -109,7 +109,7 @@ namespace MR
           Image<default_type>& mask2,
           Registration::Transform::Base& transform,
           Registration::Transform::Init::LinearInitialisationParams& init,
-          const vector<MultiContrastSetting>& contrast_settings);
+          const std::vector<MultiContrastSetting>& contrast_settings);
 
         extern void initialise_using_FOD (
           Image<default_type>& im1,
@@ -127,7 +127,7 @@ namespace MR
           Image<default_type>& mask2,
           Registration::Transform::Base& transform,
           Registration::Transform::Init::LinearInitialisationParams& init,
-          const vector<MultiContrastSetting>& contrast_settings);
+          const std::vector<MultiContrastSetting>& contrast_settings);
 
         extern void initialise_using_image_mass (
           Image<default_type>& im1,
@@ -136,7 +136,7 @@ namespace MR
           Image<default_type>& mask2,
           Registration::Transform::Base& transform,
           Registration::Transform::Init::LinearInitialisationParams& init,
-          const vector<MultiContrastSetting>& contrast_settings);
+          const std::vector<MultiContrastSetting>& contrast_settings);
       }
     }
   }

--- a/src/registration/transform/initialiser_helpers.cpp
+++ b/src/registration/transform/initialiser_helpers.cpp
@@ -49,7 +49,7 @@ namespace MR
           eigenvals.resize(eval.size());
 
           // sort eigenvectors by eigenvalue, largest first
-          vector<std::pair<default_type, ssize_t>> eval_idx_vec;
+          std::vector<std::pair<default_type, ssize_t>> eval_idx_vec;
           for(ssize_t i = 0; i < eval.size(); ++i ) {
               eval_idx_vec.emplace_back(eval[i], i);
           }
@@ -70,7 +70,7 @@ namespace MR
                                     const Eigen::Matrix<default_type, 3, 1>& centre,
                                     Eigen::VectorXd& weighted_m,
                                     Eigen::VectorXd& weighted_mu,
-                                    const vector<MultiContrastSetting>& contrast_settings) :
+                                    const std::vector<MultiContrastSetting>& contrast_settings) :
               transform (image), mask (mask),
               centre (centre),
               global_m (weighted_m), global_mu (weighted_mu) {
@@ -141,8 +141,8 @@ namespace MR
             Eigen::VectorXd& global_mu;
             Eigen::VectorXd local_m;
             Eigen::VectorXd local_mu;
-            vector<size_t> start_vol;
-            vector<default_type> weight;
+            std::vector<size_t> start_vol;
+            std::vector<default_type> weight;
             Eigen::Vector3d voxel_pos, scanner_pos;
           };
 
@@ -221,7 +221,7 @@ namespace MR
             const MaskType& mask,
             default_type& weighted_mass,
             Eigen::Vector3d& weighted_centre_of_mass,
-            const vector<MultiContrastSetting>& contrast_settings) :
+            const std::vector<MultiContrastSetting>& contrast_settings) :
             transform (image), mask (mask), mass (0.0), global_mass (weighted_mass), global_centre_of_mass (weighted_centre_of_mass) {
               centre_of_mass.setZero();
               start_vol.resize (std::max(contrast_settings.size(), size_t(1)), 0);
@@ -265,15 +265,15 @@ namespace MR
           default_type& global_mass;
           Eigen::Vector3d& global_centre_of_mass;
           Eigen::Vector3d centre_of_mass;
-          vector<size_t> start_vol;
-          vector<default_type> weight;
+          std::vector<size_t> start_vol;
+          std::vector<default_type> weight;
           Eigen::Vector3d voxel_pos, scanner;
         };
 
         void get_centre_of_mass (Image<default_type>& im,
                                  Image<default_type>& mask,
                                  Eigen::Vector3d& centre_of_mass,
-                                 const vector<MultiContrastSetting>& contrast_settings) {
+                                 const std::vector<MultiContrastSetting>& contrast_settings) {
           centre_of_mass.setZero();
           default_type mass (0.0);
 
@@ -292,7 +292,7 @@ namespace MR
           Image<default_type>& mask2,
           Registration::Transform::Base& transform,
           Registration::Transform::Init::LinearInitialisationParams& init,
-          const vector<MultiContrastSetting>& contrast_settings) {
+          const std::vector<MultiContrastSetting>& contrast_settings) {
 
           CONSOLE ("searching for best rotation");
           Registration::Metric::MeanSquaredNoGradient metric; // replace with CrossCorrelationNoGradient?
@@ -315,7 +315,7 @@ namespace MR
                                           Image<default_type>& mask2,
                                           Registration::Transform::Base& transform,
                                           Registration::Transform::Init::LinearInitialisationParams& init,
-                                          const vector<MultiContrastSetting>& contrast_settings) {
+                                          const std::vector<MultiContrastSetting>& contrast_settings) {
 
           CONSOLE ("initialising translation and centre of rotation using centre of mass");
           Image<default_type> bogus_mask;

--- a/src/registration/transform/initialiser_helpers.h
+++ b/src/registration/transform/initialiser_helpers.h
@@ -48,7 +48,7 @@ namespace MR
         void get_centre_of_mass (Image<default_type>& im,
                                  Image<default_type>& mask,
                                  Eigen::Vector3d& centre_of_mass,
-                                 const vector<MultiContrastSetting>& contrast_settings);
+                                 const std::vector<MultiContrastSetting>& contrast_settings);
 
         bool get_sorted_eigen_vecs_vals (const Eigen::Matrix<default_type, 3, 3>& mat,
           Eigen::Matrix<default_type, Eigen::Dynamic, Eigen::Dynamic>& eigenvectors,
@@ -106,7 +106,7 @@ namespace MR
                                 Image<default_type>& mask1,
                                 Image<default_type>& mask2,
                                 Registration::Transform::Base& transform,
-                                const vector<MultiContrastSetting>& contrast):
+                                const std::vector<MultiContrastSetting>& contrast):
               im1 (image1),
               im2 (image2),
               transform (transform),
@@ -131,7 +131,7 @@ namespace MR
             Registration::Transform::Base& transform;
             Image<default_type>& mask1;
             Image<default_type>& mask2;
-            const vector<MultiContrastSetting>& contrast_settings;
+            const std::vector<MultiContrastSetting>& contrast_settings;
             Eigen::Vector3d im1_centre, im2_centre;
             Eigen::Matrix<default_type, 3, 1> im1_centre_of_mass, im2_centre_of_mass;
             Eigen::Matrix<default_type, 3, 3> im1_covariance_matrix, im2_covariance_matrix;

--- a/src/registration/transform/reorient.h
+++ b/src/registration/transform/reorient.h
@@ -40,10 +40,10 @@ namespace MR
         return delta_matrix.transpose();
       }
 
-      FORCE_INLINE vector<vector<ssize_t>> multiContrastSetting2start_nvols (const vector<MultiContrastSetting>& mcsettings, size_t& max_n_SH)
+      FORCE_INLINE std::vector<std::vector<ssize_t>> multiContrastSetting2start_nvols (const std::vector<MultiContrastSetting>& mcsettings, size_t& max_n_SH)
       {
         max_n_SH = 0;
-        vector<vector<ssize_t>> start_nvols;
+        std::vector<std::vector<ssize_t>> start_nvols;
         if (mcsettings.size() != 0) {
           for (const auto & mc : mcsettings) {
             if (mc.do_reorientation && mc.lmax > 0) {
@@ -65,7 +65,7 @@ namespace MR
                         ssize_t max_n_SH,
                         const transform_type& linear_transform,
                         const Eigen::MatrixXd& directions,
-                        const vector<vector<ssize_t>>& vstart_nvols,
+                        const std::vector<std::vector<ssize_t>>& vstart_nvols,
                         const bool modulate) : fod (n_vol), max_n_SH (max_n_SH), start_nvols (vstart_nvols)
           {
             assert (n_vol > max_n_SH);
@@ -100,7 +100,7 @@ namespace MR
         protected:
           Eigen::VectorXd fod;
           ssize_t max_n_SH;
-          vector<vector<ssize_t>> start_nvols;
+          std::vector<std::vector<ssize_t>> start_nvols;
           Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> transform;
       };
 
@@ -155,10 +155,10 @@ namespace MR
                      const transform_type& transform,
                      const Eigen::MatrixXd& directions,
                      bool modulate = false,
-                     vector<MultiContrastSetting> multi_contrast_settings = vector<MultiContrastSetting>())
+                     std::vector<MultiContrastSetting> multi_contrast_settings = std::vector<MultiContrastSetting>())
       {
         assert (directions.cols() > directions.rows());
-        vector<vector<ssize_t>> start_nvols;
+        std::vector<std::vector<ssize_t>> start_nvols;
         size_t max_n_SH (0);
         if (multi_contrast_settings.size())
           start_nvols = multiContrastSetting2start_nvols (multi_contrast_settings, max_n_SH);
@@ -187,10 +187,10 @@ namespace MR
                      const transform_type& transform,
                      const Eigen::MatrixXd& directions,
                      bool modulate = false,
-                     vector<MultiContrastSetting> multi_contrast_settings = vector<MultiContrastSetting>())
+                     std::vector<MultiContrastSetting> multi_contrast_settings = std::vector<MultiContrastSetting>())
       {
         assert (directions.cols() > directions.rows());
-        vector<vector<ssize_t>> start_nvols;
+        std::vector<std::vector<ssize_t>> start_nvols;
         size_t max_n_SH (0);
         if (multi_contrast_settings.size())
           start_nvols = multiContrastSetting2start_nvols (multi_contrast_settings, max_n_SH);
@@ -215,7 +215,7 @@ namespace MR
                         ssize_t max_n_SH,
                         Image<default_type>& warp,
                         const Eigen::MatrixXd& directions,
-                        const vector<vector<ssize_t>>& vstart_nvols,
+                        const std::vector<std::vector<ssize_t>>& vstart_nvols,
                         const bool modulate) :
           max_n_SH (max_n_SH), n_dirs (directions.cols()), jacobian_adapter (warp), directions (directions),
           modulate (modulate), start_nvols (vstart_nvols), fod (n_vol)
@@ -277,7 +277,7 @@ namespace MR
             Adapter::Jacobian<Image<default_type> > jacobian_adapter;
             const Eigen::MatrixXd& directions;
             const bool modulate;
-            const vector<vector<ssize_t>> start_nvols;
+            const std::vector<std::vector<ssize_t>> start_nvols;
             Eigen::VectorXd fod;
             std::map<ssize_t, Eigen::MatrixXd> map_FOD_to_aPSF_transform;
             ssize_t max_n_SHvox;
@@ -342,11 +342,11 @@ namespace MR
                           Image<default_type>& warp,
                           const Eigen::MatrixXd& directions,
                           const bool modulate = false,
-                          vector<MultiContrastSetting> multi_contrast_settings = vector<MultiContrastSetting>())
+                          std::vector<MultiContrastSetting> multi_contrast_settings = std::vector<MultiContrastSetting>())
       {
         assert (directions.cols() > directions.rows());
         check_dimensions (fod_image, warp, 0, 3);
-        vector<vector<ssize_t>> start_nvols;
+        std::vector<std::vector<ssize_t>> start_nvols;
         size_t max_n_SH (0);
         if (multi_contrast_settings.size())
           start_nvols = multiContrastSetting2start_nvols (multi_contrast_settings, max_n_SH);
@@ -366,11 +366,11 @@ namespace MR
                           Image<default_type>& warp,
                           const Eigen::MatrixXd& directions,
                           const bool modulate = false,
-                          vector<MultiContrastSetting> multi_contrast_settings = vector<MultiContrastSetting>())
+                          std::vector<MultiContrastSetting> multi_contrast_settings = std::vector<MultiContrastSetting>())
       {
         assert (directions.cols() > directions.rows());
         check_dimensions (fod_image, warp, 0, 3);
-        vector<vector<ssize_t>> start_nvols;
+        std::vector<std::vector<ssize_t>> start_nvols;
         size_t max_n_SH (0);
         if (multi_contrast_settings.size())
           start_nvols = multiContrastSetting2start_nvols (multi_contrast_settings, max_n_SH);

--- a/src/registration/transform/rigid.cpp
+++ b/src/registration/transform/rigid.cpp
@@ -264,7 +264,7 @@ namespace MR
 
           bool Rigid::robust_estimate (
             Eigen::Matrix<default_type, Eigen::Dynamic, 1>& gradient,
-            vector<Eigen::Matrix<default_type, Eigen::Dynamic, 1>>& grad_estimates,
+            std::vector<Eigen::Matrix<default_type, Eigen::Dynamic, 1>>& grad_estimates,
             const Eigen::Matrix<default_type, 4, 4>& control_points,
             const Eigen::Matrix<default_type, Eigen::Dynamic, 1>& parameter_vector,
             const default_type& weiszfeld_precision = 1.0e-6,

--- a/src/registration/transform/rigid.h
+++ b/src/registration/transform/rigid.h
@@ -111,7 +111,7 @@ namespace MR
 
           bool robust_estimate (
             Eigen::Matrix<default_type, Eigen::Dynamic, 1>& gradient,
-            vector<Eigen::Matrix<default_type, Eigen::Dynamic, 1>>& grad_estimates,
+            std::vector<Eigen::Matrix<default_type, Eigen::Dynamic, 1>>& grad_estimates,
             const Eigen::Matrix<default_type, 4, 4>& control_points,
             const Eigen::Matrix<default_type, Eigen::Dynamic, 1>& parameter_vector,
             const default_type& weiszfeld_precision,

--- a/src/registration/transform/robust.cpp
+++ b/src/registration/transform/robust.cpp
@@ -18,8 +18,8 @@ namespace MR
 {
   namespace Registration
   {
-    void calc_median_trafo (const MR::vector<transform_type>& candid_trafo, const Eigen::Matrix<default_type, 4, 4> & vertices_4,
-      const transform_type & trafo_before, transform_type & median_trafo, MR::vector<default_type> & scores) {
+    void calc_median_trafo (const std::vector<transform_type>& candid_trafo, const Eigen::Matrix<default_type, 4, 4> & vertices_4,
+      const transform_type & trafo_before, transform_type & median_trafo, std::vector<default_type> & scores) {
       DEBUG("calc_median_trafo");
       const int n_vertices = 4;
       int weiszfeld_iterations = 100;
@@ -28,7 +28,7 @@ namespace MR
 
       transform_type trafo;
       const Eigen::Matrix<default_type, 3, n_vertices> vertices = vertices_4.template block<3,4>(0,0);
-      MR::vector<Eigen::Matrix<default_type, 3, Eigen::Dynamic>> candid_vertices (n_vertices);
+      std::vector<Eigen::Matrix<default_type, 3, Eigen::Dynamic>> candid_vertices (n_vertices);
       Eigen::Matrix<default_type, 3, Eigen::Dynamic> start_vertices = trafo_before * vertices;
 
       for (size_t i = 0; i < n_vertices; ++i)

--- a/src/registration/transform/search.h
+++ b/src/registration/transform/search.h
@@ -235,7 +235,7 @@ namespace MR
           private:
             FORCE_INLINE ParamType get_parameters () {
               // create resized midway image
-              // vector<Eigen::Transform<default_type, 3, Eigen::Projective>> init_transforms;
+              // std::vector<Eigen::Transform<default_type, 3, Eigen::Projective>> init_transforms;
               // {
               //   Eigen::Transform<default_type, 3, Eigen::Projective> init_trafo_1 = ;
               //   Eigen::Transform<default_type, 3, Eigen::Projective> init_trafo_2 = local_trafo.get_transform_half();
@@ -244,7 +244,7 @@ namespace MR
               // }
               // auto padding = Eigen::Matrix<default_type, 4, 1>(1.0, 1.0, 1.0, 1.0);
               // int subsample = 1;
-              // vector<Header> headers;
+              // std::vector<Header> headers;
               // headers.push_back (Header (im1));
               // headers.push_back (Header (im2));
               midway_image_header = compute_minimum_average_header (im1, im2, local_trafo.get_transform_half_inverse(), local_trafo.get_transform_half());
@@ -330,10 +330,10 @@ namespace MR
             transform_type best_trafo;
             Header midway_image_header;
             default_type min_cost;
-            vector<default_type> vec_cost;
-            vector<size_t> vec_overlap;
+            std::vector<default_type> vec_cost;
+            std::vector<size_t> vec_overlap;
             size_t global_search_iterations;
-            vector<default_type> rot_angles;
+            std::vector<default_type> rot_angles;
             size_t local_search_directions;
             default_type image_scale_factor;
             bool global_search;
@@ -343,7 +343,7 @@ namespace MR
             Eigen::Matrix<default_type, Eigen::Dynamic, 2> az_el;
             Eigen::Matrix<default_type, Eigen::Dynamic, 3> xyz;
             Eigen::Matrix<default_type, Eigen::Dynamic, 1> overlap_it, cost_it;
-            vector<transform_type> trafo_it;
+            std::vector<transform_type> trafo_it;
           };
     } // namespace RotationSearch
   }

--- a/src/registration/warp/compose.h
+++ b/src/registration/warp/compose.h
@@ -247,7 +247,7 @@ namespace MR
         WarpType deformation = WarpType::scratch (midway_header);
 
         transform_type linear;
-        vector<uint32_t> index (1);
+        std::vector<uint32_t> index (1);
         if (from == 1) {
           linear = Registration::Warp::parse_linear_transform (warp, "linear1");
           index[0] = 0;
@@ -270,7 +270,7 @@ namespace MR
         transform_type linear1 = Registration::Warp::parse_linear_transform (warp, "linear1");
         transform_type linear2 = Registration::Warp::parse_linear_transform (warp, "linear2");
 
-        vector<uint32_t> index (1);
+        std::vector<uint32_t> index (1);
         if (from == 1) {
           index[0] = 0;
           Adapter::Extract1D<Image<default_type>> im1_to_mid (warp, 4, index);

--- a/src/stats/cfe.cpp
+++ b/src/stats/cfe.cpp
@@ -41,7 +41,7 @@ namespace MR
     void CFE::operator() (in_column_type stats, out_column_type enhanced_stats) const
     {
       enhanced_stats.setZero();
-      vector<default_type> connected_stats;
+      std::vector<default_type> connected_stats;
       for (size_t fixel = 0; fixel < matrix.size(); ++fixel) {
         if (stats[fixel] < dh)
           continue;
@@ -59,7 +59,7 @@ namespace MR
         //   divide statistic by dh to determine the number of cluster sizes that should
         //   be incremented, and dynamically increment all cluster sizes for that
         //   particular connected fixel
-        vector<Fixel::Matrix::connectivity_value_type> extents (std::floor (stats[fixel]/dh), Fixel::Matrix::connectivity_value_type(0));
+        std::vector<Fixel::Matrix::connectivity_value_type> extents (std::floor (stats[fixel]/dh), Fixel::Matrix::connectivity_value_type(0));
         for (const auto& connection : connections) {
           const default_type connection_stat = stats[connection.index()];
           if (connection_stat > dh) {

--- a/src/stats/cfe.h
+++ b/src/stats/cfe.h
@@ -46,7 +46,7 @@ namespace MR
         const value_type dh, E, H, C;
         const bool normalise;
 
-        mutable vector<value_type> h_pow_H;
+        mutable std::vector<value_type> h_pow_H;
 
         void operator() (in_column_type, out_column_type) const override;
     };

--- a/src/stats/cluster.cpp
+++ b/src/stats/cluster.cpp
@@ -27,8 +27,8 @@ namespace MR
 
       void ClusterSize::operator() (in_column_type input, const value_type T, out_column_type output) const
       {
-        vector<Filter::Connector::Cluster> clusters;
-        vector<uint32_t> labels (input.size(), 0);
+        std::vector<Filter::Connector::Cluster> clusters;
+        std::vector<uint32_t> labels (input.size(), 0);
         connector.run (clusters, labels, input, T);
         output.resize (input.size());
         for (size_t i = 0; i < size_t(input.size()); ++i)

--- a/src/stats/permstack.cpp
+++ b/src/stats/permstack.cpp
@@ -33,7 +33,7 @@ namespace MR
         Math::Stats::Permutation::generate (num_permutations, num_samples, permutations, include_default);
       }
 
-      PermutationStack::PermutationStack (vector <vector<size_t> >& permutations, const std::string msg) :
+      PermutationStack::PermutationStack (std::vector <std::vector<size_t> >& permutations, const std::string msg) :
           num_permutations (permutations.size()),
           permutations (permutations),
           counter (0),

--- a/src/stats/permstack.h
+++ b/src/stats/permstack.h
@@ -36,7 +36,7 @@ namespace MR
       { 
         public:
           size_t index;
-          vector<size_t> data;
+          std::vector<size_t> data;
       };
 
 
@@ -45,18 +45,18 @@ namespace MR
         public:
           PermutationStack (const size_t num_permutations, const size_t num_samples, const std::string msg, const bool include_default = true);
 
-          PermutationStack (vector <vector<size_t> >& permutations, const std::string msg);
+          PermutationStack (std::vector <std::vector<size_t> >& permutations, const std::string msg);
 
           bool operator() (Permutation&);
 
-          const vector<size_t>& operator[] (size_t index) const {
+          const std::vector<size_t>& operator[] (size_t index) const {
             return permutations[index];
           }
 
           const size_t num_permutations;
 
         protected:
-          vector< vector<size_t> > permutations;
+          std::vector< std::vector<size_t> > permutations;
           size_t counter;
           ProgressBar progress;
       };

--- a/src/surface/algo/image2mesh.h
+++ b/src/surface/algo/image2mesh.h
@@ -106,7 +106,7 @@ namespace MR
                 // Break this voxel face into two triangles
 
                 // Get the integer positions of the four vertices
-                vector<Vox> voxels (4, p);
+                std::vector<Vox> voxels (4, p);
                 voxels[1][plane_axes[adj][0]]++;
                 voxels[2][plane_axes[adj][0]]++; voxels[2][plane_axes[adj][1]]++;
                 voxels[3][plane_axes[adj][1]]++;

--- a/src/surface/filter/smooth.cpp
+++ b/src/surface/filter/smooth.cpp
@@ -51,7 +51,7 @@ namespace MR
 
         // Pre-compute polygon centroids and areas
         VertexList centroids;
-        vector<default_type> areas;
+        std::vector<default_type> areas;
         for (TriangleList::const_iterator p = in.triangles.begin(); p != in.triangles.end(); ++p) {
           centroids.push_back ((in.vertices[(*p)[0]] + in.vertices[(*p)[1]] + in.vertices[(*p)[2]]) * (1.0/3.0));
           areas.push_back (area (in, *p));
@@ -67,10 +67,10 @@ namespace MR
         //
         // Initialisation is different to iterations: Need a single pass to find those
         //   polygons that actually use the vertex
-        vector< std::set<uint32_t> > vert_polys (V, std::set<uint32_t>());
+        std::vector< std::set<uint32_t> > vert_polys (V, std::set<uint32_t>());
         // For each vertex, don't just want to store the polygons within the neighbourhood;
         //   also want to store those that will be expanded from in the next iteration
-        vector< vector<uint32_t> > vert_polys_to_expand (V, vector<uint32_t>());
+        std::vector< std::vector<uint32_t> > vert_polys_to_expand (V, std::vector<uint32_t>());
 
         for (uint32_t t = 0; t != T; ++t) {
           for (uint32_t i = 0; i != 3; ++i) {
@@ -83,7 +83,7 @@ namespace MR
         // Now, we want to expand this selection outwards for each vertex
         // To do this, also want to produce a list for each polygon: containing those polygons
         //   that share a common edge (i.e. two vertices)
-        vector< vector<uint32_t> > poly_neighbours (T, vector<uint32_t>());
+        std::vector< std::vector<uint32_t> > poly_neighbours (T, std::vector<uint32_t>());
         for (uint32_t i = 0; i != T; ++i) {
           for (uint32_t j = i+1; j != T; ++j) {
             if (in.triangles[i].shares_edge (in.triangles[j])) {
@@ -100,9 +100,9 @@ namespace MR
           for (uint32_t v = 0; v != V; ++v) {
 
             // Find polygons at the outer edge of this expanding front, and add them to the neighbourhood for this vertex
-            vector<uint32_t> next_front;
-            for (vector<uint32_t>::const_iterator front = vert_polys_to_expand[v].begin(); front != vert_polys_to_expand[v].end(); ++front) {
-              for (vector<uint32_t>::const_iterator expansion = poly_neighbours[*front].begin(); expansion != poly_neighbours[*front].end(); ++expansion) {
+            std::vector<uint32_t> next_front;
+            for (std::vector<uint32_t>::const_iterator front = vert_polys_to_expand[v].begin(); front != vert_polys_to_expand[v].end(); ++front) {
+              for (std::vector<uint32_t>::const_iterator expansion = poly_neighbours[*front].begin(); expansion != poly_neighbours[*front].end(); ++expansion) {
                 const std::set<uint32_t>::const_iterator existing = vert_polys[v].find (*expansion);
                 if (existing == vert_polys[v].end()) {
                   vert_polys[v].insert (*expansion);

--- a/src/surface/filter/vertex_transform.cpp
+++ b/src/surface/filter/vertex_transform.cpp
@@ -91,7 +91,7 @@ namespace MR
             break;
 
           case transform_t::FS2REAL:
-            vector<size_t> axes( 3 );
+            std::vector<size_t> axes( 3 );
             auto M = File::NIfTI::adjust_transform( header, axes );
             Eigen::Vector3d cras( 3, 1 );
             for ( size_t i = 0; i < 3; i++ )

--- a/src/surface/freesurfer.cpp
+++ b/src/surface/freesurfer.cpp
@@ -34,7 +34,7 @@ namespace MR
           throw Exception ("Error opening input file!");
 
         const int32_t num_vertices = get_BE<int32_t> (in);
-        vector<int32_t> vertices, vertex_labels;
+        std::vector<int32_t> vertices, vertex_labels;
         vertices.reserve (num_vertices);
         vertex_labels.reserve (num_vertices);
         for (int32_t i = 0; i != num_vertices; ++i) {

--- a/src/surface/mesh.cpp
+++ b/src/surface/mesh.cpp
@@ -209,7 +209,7 @@ namespace MR
               if (vertex_count != 3 && vertex_count != 4)
                 throw Exception ("Could not parse file \"" + path + "\";  only suppport 3- and 4-vertex polygons");
 
-              vector<unsigned int> t (vertex_count, 0);
+              std::vector<unsigned int> t (vertex_count, 0);
 
               if (is_ascii) {
                 for (int index = 0; index != vertex_count; ++index) {
@@ -292,7 +292,7 @@ namespace MR
           if (attribute_byte_count)
             warn_attribute = true;
 
-          triangles.push_back ( vector<uint32_t> { uint32_t(vertices.size()-3), uint32_t(vertices.size()-2), uint32_t(vertices.size()-1) } );
+          triangles.push_back ( std::vector<uint32_t> { uint32_t(vertices.size()-3), uint32_t(vertices.size()-2), uint32_t(vertices.size()-1) } );
           const Eigen::Vector3d computed_normal = Surface::normal (*this, triangles.back());
           if (computed_normal.dot (normal.cast<default_type>()) < 0.0)
             warn_right_hand_rule = true;
@@ -355,7 +355,7 @@ namespace MR
             inside_facet = false;
             if (vertex_index != 3)
               throw Exception ("Error parsing STL file " + Path::basename (path) + ": facet ended with " + str(vertex_index) + " vertices");
-            triangles.push_back ( vector<uint32_t> { uint32_t(vertices.size()-3), uint32_t(vertices.size()-2), uint32_t(vertices.size()-1) } );
+            triangles.push_back ( std::vector<uint32_t> { uint32_t(vertices.size()-3), uint32_t(vertices.size()-2), uint32_t(vertices.size()-1) } );
             vertex_index = 0;
             const Eigen::Vector3d computed_normal = Surface::normal (*this, triangles.back());
             if (computed_normal.dot (normal) < 0.0)
@@ -433,7 +433,7 @@ namespace MR
           // Need to handle:
           // * Either 3 or 4 vertices - write to either triangles or quads
           // * Vertices only, vertices & texture coordinates, vertices & normals, all 3
-          vector<std::string> elements;
+          std::vector<std::string> elements;
           do {
             const size_t first_space = data.find_first_of (' ');
             if (first_space == data.npos) {
@@ -447,9 +447,9 @@ namespace MR
           } while (data.size());
           if (elements.size() != 3 && elements.size() != 4)
             throw Exception ("Malformed face information in input OBJ file (face with neither 3 nor 4 vertices; line " + str(counter) + ")");
-          vector<FaceData> face_data;
+          std::vector<FaceData> face_data;
           size_t values_per_element = 0;
-          for (vector<std::string>::iterator i = elements.begin(); i != elements.end(); ++i) {
+          for (std::vector<std::string>::iterator i = elements.begin(); i != elements.end(); ++i) {
             FaceData temp;
             temp.vertex = 0; temp.texture = 0; temp.normal = 0;
             const size_t first_slash = i->find_first_of ('/');
@@ -476,10 +476,10 @@ namespace MR
             face_data.push_back (temp);
           }
           if (face_data.size() == 3) {
-            vector<uint32_t> temp { face_data[0].vertex, face_data[1].vertex, face_data[2].vertex };
+            std::vector<uint32_t> temp { face_data[0].vertex, face_data[1].vertex, face_data[2].vertex };
             triangles.push_back (Triangle (temp));
           } else {
-            vector<uint32_t> temp { face_data[0].vertex, face_data[1].vertex, face_data[2].vertex, face_data[3].vertex };
+            std::vector<uint32_t> temp { face_data[0].vertex, face_data[1].vertex, face_data[2].vertex, face_data[3].vertex };
             quads.push_back (Quad (temp));
           }
           // The OBJ format allows defining different vertex-based normals for different faces that reference the same vertex

--- a/src/surface/mesh_multi.cpp
+++ b/src/surface/mesh_multi.cpp
@@ -74,7 +74,7 @@ namespace MR
         } else if (prefix == "f") {
           if (index < 0)
             throw Exception ("Malformed OBJ file; face outside object (line " + str(counter) + ")");
-          vector<std::string> elements;
+          std::vector<std::string> elements;
           do {
             const size_t first_space = data.find_first_of (' ');
             if (first_space == data.npos) {
@@ -88,9 +88,9 @@ namespace MR
           } while (data.size());
           if (elements.size() != 3 && elements.size() != 4)
             throw Exception ("Malformed face information in input OBJ file (face with neither 3 nor 4 vertices; line " + str(counter) + ")");
-          vector<FaceData> face_data;
+          std::vector<FaceData> face_data;
           size_t values_per_element = 0;
-          for (vector<std::string>::iterator i = elements.begin(); i != elements.end(); ++i) {
+          for (std::vector<std::string>::iterator i = elements.begin(); i != elements.end(); ++i) {
             FaceData temp;
             temp.vertex = 0; temp.texture = 0; temp.normal = 0;
             const size_t first_slash = i->find_first_of ('/');
@@ -116,10 +116,10 @@ namespace MR
             face_data.push_back (temp);
           }
           if (face_data.size() == 3) {
-            vector<uint32_t> temp { face_data[0].vertex, face_data[1].vertex, face_data[2].vertex };
+            std::vector<uint32_t> temp { face_data[0].vertex, face_data[1].vertex, face_data[2].vertex };
             triangles.push_back (Triangle (temp));
           } else {
-            vector<uint32_t> temp { face_data[0].vertex, face_data[1].vertex, face_data[2].vertex, face_data[3].vertex };
+            std::vector<uint32_t> temp { face_data[0].vertex, face_data[1].vertex, face_data[2].vertex, face_data[3].vertex };
             quads.push_back (Quad (temp));
           }
         } else if (prefix == "g") {

--- a/src/surface/mesh_multi.h
+++ b/src/surface/mesh_multi.h
@@ -37,10 +37,10 @@ namespace MR
     //   (would allow embedding binary data within the file, rather than
     //   everything being ASCII as in .obj)
 
-    class MeshMulti : public vector<Mesh>
+    class MeshMulti : public std::vector<Mesh>
     { 
       public:
-        using vector<Mesh>::vector;
+        using std::vector<Mesh>::vector;
 
         void load (const std::string&);
         void save (const std::string&) const;

--- a/src/surface/types.h
+++ b/src/surface/types.h
@@ -30,11 +30,11 @@ namespace MR
 
 
     using Vertex = Eigen::Vector3d;
-    using VertexList = vector<Vertex>;
+    using VertexList = std::vector<Vertex>;
     using Triangle = Polygon<3>;
-    using TriangleList = vector<Triangle>;
+    using TriangleList = std::vector<Triangle>;
     using Quad = Polygon<4>;
-    using QuadList = vector<Quad>;
+    using QuadList = std::vector<Quad>;
 
     class Vox : public Eigen::Array3i
     { 

--- a/testing/cmd/testing_diff_tck.cpp
+++ b/testing/cmd/testing_diff_tck.cpp
@@ -77,7 +77,7 @@ inline bool within_haussdorf (const DWI::Tractography::Streamline<>& tck1, const
   return true;
 }
 
-inline bool within_haussdorf (const DWI::Tractography::Streamline<>& tck, const vector<DWI::Tractography::Streamline<>>& list, float tol)
+inline bool within_haussdorf (const DWI::Tractography::Streamline<>& tck, const std::vector<DWI::Tractography::Streamline<>>& list, float tol)
 {
   for (auto& tck2 : list) {
     if (within_haussdorf (tck, tck2, tol))
@@ -101,7 +101,7 @@ void run ()
 
   if (get_options ("unordered").size()) {
 
-    vector<DWI::Tractography::Streamline<>> ref_list;
+    std::vector<DWI::Tractography::Streamline<>> ref_list;
     DWI::Tractography::Streamline<> tck;
 
     while (reader2 (tck))

--- a/testing/cmd/testing_gen_data.cpp
+++ b/testing/cmd/testing_gen_data.cpp
@@ -43,7 +43,7 @@ void usage ()
 
 void run ()
 {
-  vector<int> dim = argument[0];
+  std::vector<int> dim = argument[0];
 
   Header header;
 

--- a/testing/cmd/testing_unit_tests_bitset.cpp
+++ b/testing/cmd/testing_unit_tests_bitset.cpp
@@ -33,7 +33,7 @@ void usage ()
 
 void run ()
 {
-  vector<std::string> failed_tests;
+  std::vector<std::string> failed_tests;
   auto test = [&] (const bool result, const std::string msg) {
     if (!result)
       failed_tests.push_back (msg);

--- a/testing/cmd/testing_unit_tests_parse_ints.cpp
+++ b/testing/cmd/testing_unit_tests_parse_ints.cpp
@@ -35,7 +35,7 @@ void usage ()
 }
 
 
-vector<std::string> failures;
+std::vector<std::string> failures;
 
 
 

--- a/testing/cmd/testing_unit_tests_shuffle.cpp
+++ b/testing/cmd/testing_unit_tests_shuffle.cpp
@@ -34,7 +34,7 @@ using MR::Math::Stats::index_array_type;
 #define ROWS size_t(6)
 #define BLOCK_INDICES 0,1,0,1,2,2 // Must increment from zero, and must be equal number in each
 enum exchange_t { NONE, WITHIN, WHOLE };
-vector<std::string> exchange_strings { "Unrestricted", "within-block", "whole-block" };
+std::vector<std::string> exchange_strings { "Unrestricted", "within-block", "whole-block" };
 
 void usage ()
 {
@@ -47,7 +47,7 @@ void usage ()
 
 void run ()
 {
-  vector<std::string> failed_tests;
+  std::vector<std::string> failed_tests;
 
   vector_type dummy_data (ROWS);
   for (ssize_t row = 0; row != ROWS; ++row)
@@ -56,7 +56,7 @@ void run ()
   index_array_type block_indices (ROWS);
   block_indices << BLOCK_INDICES;
   assert (block_indices.size() == ROWS);
-  vector<std::set<size_t>> blocks (block_indices.maxCoeff()+1);
+  std::vector<std::set<size_t>> blocks (block_indices.maxCoeff()+1);
   for (ssize_t i = 0; i != block_indices.size(); ++i)
     blocks[block_indices[i]].insert (i);
 
@@ -138,7 +138,7 @@ void run ()
   auto test_unique = [&] (Shuffler& in, const std::string& msg)
   {
     in.reset();
-    vector<Shuffle> matrices;
+    std::vector<Shuffle> matrices;
     Shuffle temp;
     bool duplicate_index = false, duplicate_data = false;
     while (in (temp)) {

--- a/testing/cmd/testing_unit_tests_to.cpp
+++ b/testing/cmd/testing_unit_tests_to.cpp
@@ -35,11 +35,11 @@ void usage ()
 }
 
 
-vector<std::string> failures;
+std::vector<std::string> failures;
 
 
 template <class T>
-void test (const vector<std::string>& strings, const vector<bool>& results)
+void test (const std::vector<std::string>& strings, const std::vector<bool>& results)
 {
   for (size_t i = 0; i != strings.size(); ++i) {
     try {
@@ -57,7 +57,7 @@ void test (const vector<std::string>& strings, const vector<bool>& results)
 
 void run ()
 {
-  const vector<std::string> data = {
+  const std::vector<std::string> data = {
     "0",
     "1",
     "2",
@@ -111,7 +111,7 @@ void run ()
     "inf+infi",
     " -inf+-nani " };
 
-  const vector<bool> bool_tests = {
+  const std::vector<bool> bool_tests = {
     true,  // "0"
     true,  // "1"
     true,  // "2"
@@ -166,7 +166,7 @@ void run ()
     false  // " -inf+-nani "
   };
 
-  const vector<bool> int_tests = {
+  const std::vector<bool> int_tests = {
       true,  // "0"
       true,  // "1"
       true,  // "2"
@@ -221,7 +221,7 @@ void run ()
       false  // " -inf+-nani "
   };
 
-  const vector<bool> float_tests = {
+  const std::vector<bool> float_tests = {
       true,  // "0"
       true,  // "1"
       true,  // "2"
@@ -276,7 +276,7 @@ void run ()
       false  // " -inf+-nani "
   };
 
-  const vector<bool> complex_tests = {
+  const std::vector<bool> complex_tests = {
       true,  // "0"
       true,  // "1"
       true,  // "2"


### PR DESCRIPTION
As the title suggests, this contains changes to replace all instances of `MR::vector` with `std::vector` in light of our coming switch to C++17.
This was one of the objectives identified in #2585.