### PR TITLE
Remove MR::make_shared and MR::make_unique

### DIFF
--- a/check_syntax
+++ b/check_syntax
@@ -72,13 +72,6 @@ for f in $(find cmd core src -type f -name '*.h' -o -name '*.cpp' | $grep -v '_m
   )
 
 
-# detect any instances of std::make_shared:
-  res="$res"$(
-    cat .check_syntax.tmp | \
-# match for the parts we're interested in and output just the bits that match:
-    $grep -Po '(?<!::)std::make_shared\b'
-  )
-
 # detect any instances of "using namespace std;":
   res="$res"$(
     cat .check_syntax.tmp | \
@@ -127,7 +120,6 @@ else
   echo "Please check the following syntax requirements:
   - Add MEMALIGN() or NOMEMALIGN macro to any class declarations identified above;
   - Replace all occurrences of std::vector<> with MR::vector<> (or just vector<>);
-  - Avoid use of std::make_shared();
   - Replace all instances of std::abs() with MR::abs() (or just abs());
   - Replace all instances of %zu in print() calls with PRI_SIZET." >> $LOG
   exit 1

--- a/cmd/fod2fixel.cpp
+++ b/cmd/fod2fixel.cpp
@@ -197,7 +197,7 @@ void Segmented_FOD_receiver::commit ()
   index_header.size(3) = 2;
   index_header.datatype() = DataType::from<index_type>();
   index_header.datatype().set_byte_order_native();
-  index_image = make_unique<IndexImage> (IndexImage::create (index_filepath, index_header));
+  index_image = std::make_unique<IndexImage> (IndexImage::create (index_filepath, index_header));
 
   auto fixel_data_header (H);
   fixel_data_header.ndim() = 3;
@@ -211,7 +211,7 @@ void Segmented_FOD_receiver::commit ()
   if (dir_path.size()) {
     auto dir_header (fixel_data_header);
     dir_header.size(1) = 3;
-    dir_image = make_unique<DataImage> (DataImage::create (Path::join(fixel_directory_path, dir_path), dir_header));
+    dir_image = std::make_unique<DataImage> (DataImage::create (Path::join(fixel_directory_path, dir_path), dir_header));
     dir_image->index(1) = 0;
     Fixel::check_fixel_size (*index_image, *dir_image);
   }
@@ -219,7 +219,7 @@ void Segmented_FOD_receiver::commit ()
   if (afd_path.size()) {
     auto afd_header (fixel_data_header);
     afd_header.size(1) = 1;
-    afd_image = make_unique<DataImage> (DataImage::create (Path::join(fixel_directory_path, afd_path), afd_header));
+    afd_image = std::make_unique<DataImage> (DataImage::create (Path::join(fixel_directory_path, afd_path), afd_header));
     afd_image->index(1) = 0;
     Fixel::check_fixel_size (*index_image, *afd_image);
   }
@@ -227,7 +227,7 @@ void Segmented_FOD_receiver::commit ()
   if (peak_amp_path.size()) {
     auto peak_amp_header (fixel_data_header);
     peak_amp_header.size(1) = 1;
-    peak_amp_image = make_unique<DataImage> (DataImage::create (Path::join(fixel_directory_path, peak_amp_path), peak_amp_header));
+    peak_amp_image = std::make_unique<DataImage> (DataImage::create (Path::join(fixel_directory_path, peak_amp_path), peak_amp_header));
     peak_amp_image->index(1) = 0;
     Fixel::check_fixel_size (*index_image, *peak_amp_image);
   }
@@ -235,7 +235,7 @@ void Segmented_FOD_receiver::commit ()
   if (disp_path.size()) {
     auto disp_header (fixel_data_header);
     disp_header.size(1) = 1;
-    disp_image = make_unique<DataImage> (DataImage::create (Path::join(fixel_directory_path, disp_path), disp_header));
+    disp_image = std::make_unique<DataImage> (DataImage::create (Path::join(fixel_directory_path, disp_path), disp_header));
     disp_image->index(1) = 0;
     Fixel::check_fixel_size (*index_image, *disp_image);
   }

--- a/cmd/meshconvert.cpp
+++ b/cmd/meshconvert.cpp
@@ -74,7 +74,7 @@ void run ()
   auto opt = get_options ("transform");
   if (opt.size()) {
     auto H = Header::open (opt[0][1]);
-    auto transform = make_unique<Surface::Filter::VertexTransform> (H);
+    auto transform = std::make_unique<Surface::Filter::VertexTransform> (H);
     switch (int(opt[0][0])) {
       case 0: transform->set_first2real(); break;
       case 1: transform->set_real2first(); break;

--- a/cmd/mrclusterstats.cpp
+++ b/cmd/mrclusterstats.cpp
@@ -194,7 +194,7 @@ void run() {
   auto mask_header = Header::open (argument[3]);
   check_effective_dimensionality (mask_header, 3);
   auto mask_image = mask_header.get_image<bool>();
-  std::shared_ptr<Voxel2Vector> v2v = make_shared<Voxel2Vector> (mask_image, mask_header);
+  std::shared_ptr<Voxel2Vector> v2v = std::make_shared<Voxel2Vector> (mask_image, mask_header);
   SubjectVoxelImport::set_mapping (v2v);
   Filter::Connector connector;
   connector.adjacency.set_26_adjacency (do_26_connectivity);

--- a/core/file/json.h
+++ b/core/file/json.h
@@ -6083,7 +6083,7 @@ NLOHMANN_JSON_NAMESPACE_END
 #include <cstddef> // size_t
 #include <cstring> // strlen
 #include <iterator> // begin, end, iterator_traits, random_access_iterator_tag, distance, next
-#include <memory> // shared_ptr, make_shared, addressof
+#include <memory> // shared_ptr, std::make_shared, addressof
 #include <numeric> // accumulate
 #include <string> // string, char_traits
 #include <type_traits> // enable_if, is_base_of, is_pointer, is_integral, remove_pointer
@@ -14838,7 +14838,7 @@ NLOHMANN_JSON_NAMESPACE_END
 #include <algorithm> // copy
 #include <cstddef> // size_t
 #include <iterator> // back_inserter
-#include <memory> // shared_ptr, make_shared
+#include <memory> // shared_ptr, std::make_shared
 #include <string> // basic_string
 #include <vector> // vector
 

--- a/core/filter/dilate.h
+++ b/core/filter/dilate.h
@@ -75,7 +75,7 @@ namespace MR
           std::shared_ptr<ProgressBar> progress (message.size() ? new ProgressBar (message, npass + 1) : nullptr);
 
           for (unsigned int pass = 0; pass < npass; pass++) {
-            out = make_shared<Image<bool>> (Image<bool>::scratch (input));
+            out = std::make_shared<Image<bool>> (Image<bool>::scratch (input));
             for (auto l = Loop (*in) (*in, *out); l; ++l)
               out->value() = dilate (*in);
             if (pass < npass - 1)

--- a/core/filter/erode.h
+++ b/core/filter/erode.h
@@ -71,13 +71,13 @@ namespace MR
         template <class InputImageType, class OutputImageType>
         void operator() (InputImageType& input, OutputImageType& output)
         {
-          std::shared_ptr <Image<bool> > in = make_shared<Image<bool> > (Image<bool>::scratch (input));
+          std::shared_ptr <Image<bool> > in = std::make_shared<Image<bool> > (Image<bool>::scratch (input));
           copy (input, *in);
           std::shared_ptr <Image<bool> > out;
           std::shared_ptr<ProgressBar> progress (message.size() ? new ProgressBar (message, npass + 1) : nullptr);
 
           for (unsigned int pass = 0; pass < npass; pass++) {
-            out = make_shared<Image<bool> > (Image<bool>::scratch (input));
+            out = std::make_shared<Image<bool> > (Image<bool>::scratch (input));
             for (auto l = Loop (*in) (*in, *out); l; ++l)
              out->value() = erode (*in);
 

--- a/core/filter/smooth.h
+++ b/core/filter/smooth.h
@@ -122,7 +122,7 @@ namespace MR
         template <class InputImageType, class OutputImageType, typename ValueType = float>
         void operator() (InputImageType& input, OutputImageType& output)
         {
-          std::shared_ptr <Image<ValueType> > in (make_shared<Image<ValueType> > (Image<ValueType>::scratch (input)));
+          std::shared_ptr <Image<ValueType> > in (std::make_shared<Image<ValueType> > (Image<ValueType>::scratch (input)));
           threaded_copy (input, *in);
           std::shared_ptr <Image<ValueType> > out;
 
@@ -138,7 +138,7 @@ namespace MR
           for (size_t dim = 0; dim < 3; dim++) {
             if (stdev[dim] > 0) {
               DEBUG ("creating scratch image for smoothing image along dimension " + str(dim));
-              out = make_shared<Image<ValueType> > (Image<ValueType>::scratch (input));
+              out = std::make_shared<Image<ValueType> > (Image<ValueType>::scratch (input));
               Adapter::Gaussian1D<Image<ValueType> > gaussian (*in, stdev[dim], dim, extent[dim], zero_boundary);
               threaded_copy (gaussian, *out, 0, input.ndim(), 2);
               in = out;

--- a/core/header.cpp
+++ b/core/header.cpp
@@ -492,7 +492,7 @@ namespace MR
     H.reset_intensity_scaling();
     H.sanitise();
     H.format_ = "scratch image";
-    H.io = make_unique<ImageIO::Scratch> (H);
+    H.io = std::make_unique<ImageIO::Scratch> (H);
     return H;
   }
 

--- a/core/types.h
+++ b/core/types.h
@@ -229,10 +229,6 @@ namespace MR
     };
 
 
-  template <typename X, typename... Args>
-    inline std::shared_ptr<X> make_shared (Args&&... args) {
-      return std::shared_ptr<X> (new X (std::forward<Args> (args)...));
-    }
 
   template <typename X, typename... Args>
     inline std::unique_ptr<X> make_unique (Args&&... args) {

--- a/core/types.h
+++ b/core/types.h
@@ -230,12 +230,6 @@ namespace MR
 
 
 
-  template <typename X, typename... Args>
-    inline std::unique_ptr<X> make_unique (Args&&... args) {
-      return std::unique_ptr<X> (new X (std::forward<Args> (args)...));
-    }
-
-
   // required to allow use of abs() call on unsigned integers in template
   // functions, etc, since the standard labels such calls ill-formed:
   // http://en.cppreference.com/w/cpp/numeric/math/abs

--- a/src/dwi/tractography/GT/mhsampler.h
+++ b/src/dwi/tractography/GT/mhsampler.h
@@ -44,7 +44,7 @@ namespace MR {
                     EnergyComputer* e, Image<bool>& m)
             : props(p), stats(s), pGrid(pgrid), E(e), T(dwi), 
               dims{size_t(dwi.size(0)), size_t(dwi.size(1)), size_t(dwi.size(2))}, 
-              mask(m), lock(make_shared<SpatialLock<float>>(5*Particle::L)), 
+              mask(m), lock(std::make_shared<SpatialLock<float>>(5*Particle::L)), 
               sigpos(Particle::L / 8.), sigdir(0.2)
           {
             DEBUG("Initialise Metropolis Hastings sampler.");

--- a/src/gui/mrview/file_open.cpp
+++ b/src/gui/mrview/file_open.cpp
@@ -28,7 +28,7 @@ namespace MR
         QFileOpenEvent *openEvent = static_cast<QFileOpenEvent *>(event);
         vector<std::unique_ptr<MR::Header>> list;
         try {
-          list.push_back (make_unique<MR::Header> (MR::Header::open (openEvent->file().toUtf8().data())));
+          list.push_back (std::make_unique<MR::Header> (MR::Header::open (openEvent->file().toUtf8().data())));
         }
         catch (Exception& E) {
           E.display();

--- a/src/gui/mrview/tool/odf/item.cpp
+++ b/src/gui/mrview/tool/odf/item.cpp
@@ -117,7 +117,7 @@ namespace MR
           const vector<size_t>& volumes = (*shells)[index].get_volumes();
           for (size_t row = 0; row != volumes.size(); ++row)
             shell_dirs.row (row) = grad.row (volumes[row]).head<3>().cast<float>();
-          auto new_dirs = MR::make_unique<MR::DWI::Directions::Set> (shell_dirs);
+          auto new_dirs = std::make_unique<MR::DWI::Directions::Set> (shell_dirs);
           std::swap (dirs, new_dirs);
           shell_index = index;
           dir_type = DixelPlugin::dir_t::DW_SCHEME;
@@ -126,13 +126,13 @@ namespace MR
         void ODF_Item::DixelPlugin::set_header() {
           if (!header_dirs.rows())
             throw Exception ("No direction scheme defined in header");
-          auto new_dirs = MR::make_unique<MR::DWI::Directions::Set> (header_dirs);
+          auto new_dirs = std::make_unique<MR::DWI::Directions::Set> (header_dirs);
           std::swap (dirs, new_dirs);
           dir_type = DixelPlugin::dir_t::HEADER;
         }
 
         void ODF_Item::DixelPlugin::set_internal (const size_t n) {
-          auto new_dirs = MR::make_unique<MR::DWI::Directions::Set> (n);
+          auto new_dirs = std::make_unique<MR::DWI::Directions::Set> (n);
           std::swap (dirs, new_dirs);
           dir_type = DixelPlugin::dir_t::INTERNAL;
         }
@@ -145,7 +145,7 @@ namespace MR
 
         void ODF_Item::DixelPlugin::set_from_file (const std::string& path)
         {
-          auto new_dirs = MR::make_unique<MR::DWI::Directions::Set> (path);
+          auto new_dirs = std::make_unique<MR::DWI::Directions::Set> (path);
           std::swap (dirs, new_dirs);
           dir_type = DixelPlugin::dir_t::FILE;
         }

--- a/src/gui/mrview/tool/odf/model.cpp
+++ b/src/gui/mrview/tool/odf/model.cpp
@@ -37,7 +37,7 @@ namespace MR
           vector<std::unique_ptr<MR::Header>> hlist;
           for (size_t i = 0; i < list.size(); ++i) {
             try {
-              auto header = make_unique<MR::Header> (MR::Header::open (list[i]));
+              auto header = std::make_unique<MR::Header> (MR::Header::open (list[i]));
               switch (type) {
                 case odf_type_t::SH:
                   Math::SH::check (*header);
@@ -63,7 +63,7 @@ namespace MR
           if (hlist.size()) {
             beginInsertRows (QModelIndex(), items.size(), items.size()+hlist.size());
             for (size_t i = 0; i < hlist.size(); ++i)
-              items.push_back (make_unique<ODF_Item> (std::move (*hlist[i]), type, scale, hide_negative_lobes, colour_by_direction));
+              items.push_back (std::make_unique<ODF_Item> (std::move (*hlist[i]), type, scale, hide_negative_lobes, colour_by_direction));
             endInsertRows();
           }
 

--- a/src/gui/mrview/tool/overlay.cpp
+++ b/src/gui/mrview/tool/overlay.cpp
@@ -198,7 +198,7 @@ namespace MR
           vector<std::unique_ptr<MR::Header>> list;
           for (size_t n = 0; n < overlay_names.size(); ++n) {
             try {
-              list.push_back (make_unique<MR::Header> (MR::Header::open (overlay_names[n])));
+              list.push_back (std::make_unique<MR::Header> (MR::Header::open (overlay_names[n])));
             } catch (Exception& e) {
               e.display();
             }
@@ -233,7 +233,7 @@ namespace MR
             QList<QUrl> urlList = mimeData->urls();
             for (int i = 0; i < urlList.size() && i < max_files; ++i) {
               try {
-                list.push_back (make_unique<MR::Header> (MR::Header::open (urlList.at (i).path().toUtf8().constData())));
+                list.push_back (std::make_unique<MR::Header> (MR::Header::open (urlList.at (i).path().toUtf8().constData())));
               }
               catch (Exception& e) {
                 e.display();
@@ -753,7 +753,7 @@ namespace MR
         {
           if (opt.opt->is ("overlay.load")) {
             vector<std::unique_ptr<MR::Header>> list;
-            try { list.push_back (make_unique<MR::Header> (MR::Header::open (opt[0]))); }
+            try { list.push_back (std::make_unique<MR::Header> (MR::Header::open (opt[0]))); }
             catch (Exception& e) { e.display(); }
             add_images (list);
             return true;

--- a/src/gui/mrview/tool/roi_editor/roi.cpp
+++ b/src/gui/mrview/tool/roi_editor/roi.cpp
@@ -301,7 +301,7 @@ namespace MR
             return;
           vector<std::unique_ptr<MR::Header>> list;
           for (size_t n = 0; n < names.size(); ++n)
-            list.push_back (make_unique<MR::Header> (MR::Header::open (names[n])));
+            list.push_back (std::make_unique<MR::Header> (MR::Header::open (names[n])));
 
           load (list);
           in_insert_mode = false;
@@ -321,7 +321,7 @@ namespace MR
             QList<QUrl> urlList = mimeData->urls();
             for (int i = 0; i < urlList.size() && i < max_files; ++i) {
               try {
-                list.push_back (make_unique<MR::Header> (MR::Header::open (urlList.at (i).path().toUtf8().constData())));
+                list.push_back (std::make_unique<MR::Header> (MR::Header::open (urlList.at (i).path().toUtf8().constData())));
               }
               catch (Exception& e) {
                 e.display();
@@ -903,7 +903,7 @@ namespace MR
         {
           if (opt.opt->is ("roi.load")) {
             vector<std::unique_ptr<MR::Header>> list;
-            try { list.push_back (make_unique<MR::Header> (MR::Header::open (opt[0]))); }
+            try { list.push_back (std::make_unique<MR::Header> (MR::Header::open (opt[0]))); }
             catch (Exception& e) { e.display(); }
             load (list);
             return true;

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -160,7 +160,7 @@ namespace MR
           QList<QUrl> urlList = mimeData->urls();
           for (int i = 0; i < urlList.size() && i < 32; ++i) {
             try {
-              list.push_back (make_unique<MR::Header> (MR::Header::open (urlList.at (i).path().toUtf8().constData())));
+              list.push_back (std::make_unique<MR::Header> (MR::Header::open (urlList.at (i).path().toUtf8().constData())));
             }
             catch (Exception& e) {
               e.display();
@@ -783,7 +783,7 @@ namespace MR
 
           vector<std::unique_ptr<MR::Header>> list;
           for (size_t n = 0; n < MR::App::argument.size(); ++n) {
-            try { list.push_back (make_unique<MR::Header> (MR::Header::open (MR::App::argument[n]))); }
+            try { list.push_back (std::make_unique<MR::Header> (MR::Header::open (MR::App::argument[n]))); }
             catch (CancelException& e) {
               for (const auto& msg : e.description)
                 CONSOLE (msg);
@@ -849,7 +849,7 @@ namespace MR
         vector<std::unique_ptr<MR::Header>> list;
         for (size_t n = 0; n < image_list.size(); ++n) {
           try {
-            list.push_back (make_unique<MR::Header> (MR::Header::open (image_list[n])));
+            list.push_back (std::make_unique<MR::Header> (MR::Header::open (image_list[n])));
           }
           catch (Exception& E) {
             E.display();
@@ -869,7 +869,7 @@ namespace MR
 
         try {
           vector<std::unique_ptr<MR::Header>> list;
-          list.push_back (make_unique<MR::Header> (MR::Header::open (folder)));
+          list.push_back (std::make_unique<MR::Header> (MR::Header::open (folder)));
           add_images (list);
         }
         catch (CancelException& E) {
@@ -2007,7 +2007,7 @@ namespace MR
 
           if (opt.opt->is ("load")) {
             vector<std::unique_ptr<MR::Header>> list;
-            try { list.push_back (make_unique<MR::Header> (MR::Header::open (opt[0]))); }
+            try { list.push_back (std::make_unique<MR::Header> (MR::Header::open (opt[0]))); }
             catch (Exception& e) { e.display(); }
             add_images (list);
             return;

--- a/src/registration/metric/evaluate.h
+++ b/src/registration/metric/evaluate.h
@@ -96,8 +96,8 @@ namespace MR
                 DEBUG ("Reorienting FODs...");
                 std::shared_ptr<Image<default_type> > im1_image_reoriented;
                 std::shared_ptr<Image<default_type> > im2_image_reoriented;
-                im1_image_reoriented = make_shared<Image<default_type>>(Image<default_type>::scratch (params.im1_image));
-                im2_image_reoriented = make_shared<Image<default_type>>(Image<default_type>::scratch (params.im2_image));
+                im1_image_reoriented = std::make_shared<Image<default_type>>(Image<default_type>::scratch (params.im1_image));
+                im2_image_reoriented = std::make_shared<Image<default_type>>(Image<default_type>::scratch (params.im2_image));
 
                 {
                   if (params.mc_settings.size()) {
@@ -177,8 +177,8 @@ namespace MR
                 DEBUG ("Reorienting FODs...");
                 std::shared_ptr<Image<default_type> > im1_image_reoriented;
                 std::shared_ptr<Image<default_type> > im2_image_reoriented;
-                im1_image_reoriented = make_shared<Image<default_type>>(Image<default_type>::scratch (params.im1_image));
-                im2_image_reoriented = make_shared<Image<default_type>>(Image<default_type>::scratch (params.im2_image));
+                im1_image_reoriented = std::make_shared<Image<default_type>>(Image<default_type>::scratch (params.im1_image));
+                im2_image_reoriented = std::make_shared<Image<default_type>>(Image<default_type>::scratch (params.im2_image));
 
                 {
                   if (params.mc_settings.size()) {

--- a/src/registration/nonlinear.h
+++ b/src/registration/nonlinear.h
@@ -175,19 +175,19 @@ namespace MR
               field_header.ndim() = 4;
               field_header.size(3) = 3;
 
-              im1_to_mid_new = make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
-              im2_to_mid_new = make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
-              im1_update = make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
-              im2_update = make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
-              im1_update_new = make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
-              im2_update_new = make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
+              im1_to_mid_new = std::make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
+              im2_to_mid_new = std::make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
+              im1_update = std::make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
+              im2_update = std::make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
+              im1_update_new = std::make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
+              im2_update_new = std::make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
 
               if (!is_initialised) {
                 if (level == 0) {
-                  im1_to_mid = make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
-                  im2_to_mid = make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
-                  mid_to_im1 = make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
-                  mid_to_im2 = make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
+                  im1_to_mid = std::make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
+                  im2_to_mid = std::make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
+                  mid_to_im1 = std::make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
+                  mid_to_im2 = std::make_shared<Image<default_type>>(Image<default_type>::scratch (field_header));
                 } else {
                   DEBUG ("Upsampling fields");
                   {
@@ -372,22 +372,22 @@ namespace MR
             field_header.ndim() = 4;
             field_header.size(3) = 3;
 
-            im1_to_mid = make_shared<Image<default_type>> (Image<default_type>::scratch (field_header));
+            im1_to_mid = std::make_shared<Image<default_type>> (Image<default_type>::scratch (field_header));
             input_warps.index(4) = 0;
             threaded_copy (input_warps, *im1_to_mid, 0, 4);
             Registration::Warp::deformation2displacement (*im1_to_mid, *im1_to_mid);
 
-            mid_to_im1 = make_shared<Image<default_type>> (Image<default_type>::scratch (field_header));
+            mid_to_im1 = std::make_shared<Image<default_type>> (Image<default_type>::scratch (field_header));
             input_warps.index(4) = 1;
             threaded_copy (input_warps, *mid_to_im1, 0, 4);
             Registration::Warp::deformation2displacement (*mid_to_im1, *mid_to_im1);
 
-            im2_to_mid = make_shared<Image<default_type>> (Image<default_type>::scratch (field_header));
+            im2_to_mid = std::make_shared<Image<default_type>> (Image<default_type>::scratch (field_header));
             input_warps.index(4) = 2;
             threaded_copy (input_warps, *im2_to_mid, 0, 4);
             Registration::Warp::deformation2displacement (*im2_to_mid, *im2_to_mid);
 
-            mid_to_im2 = make_shared<Image<default_type>> (Image<default_type>::scratch (field_header));
+            mid_to_im2 = std::make_shared<Image<default_type>> (Image<default_type>::scratch (field_header));
             input_warps.index(4) = 3;
             threaded_copy (input_warps, *mid_to_im2, 0, 4);
             Registration::Warp::deformation2displacement (*mid_to_im2, *mid_to_im2);
@@ -530,7 +530,7 @@ namespace MR
         protected:
 
           std::shared_ptr<Image<default_type> > reslice (Image<default_type>& image, Header& header) {
-            std::shared_ptr<Image<default_type> > temp = make_shared<Image<default_type> > (Image<default_type>::scratch (header));
+            std::shared_ptr<Image<default_type> > temp = std::make_shared<Image<default_type> > (Image<default_type>::scratch (header));
             Filter::reslice<Interp::Linear> (image, *temp);
             return temp;
           }

--- a/src/registration/warp/compose.h
+++ b/src/registration/warp/compose.h
@@ -177,8 +177,8 @@ namespace MR
         } else {
           scale_factor = std::pow (2, std::ceil (std::log ((max_norm * step) / (min_vox_size / 2.0)) / std::log (2.0)));
 
-          std::shared_ptr<Image<default_type>> scaled_update = make_shared<Image<default_type> >(Image<default_type>::scratch (update));
-          std::shared_ptr<Image<default_type>> composed = make_shared<Image<default_type> >(Image<default_type>::scratch (update));
+          std::shared_ptr<Image<default_type>> scaled_update = std::make_shared<Image<default_type> >(Image<default_type>::scratch (update));
+          std::shared_ptr<Image<default_type>> composed = std::make_shared<Image<default_type> >(Image<default_type>::scratch (update));
 
           // Scaling
           default_type scaled_step = step / scale_factor; // apply the step size and scale factor at once


### PR DESCRIPTION
This removes all instances of `MR::make_shared` and `MR::make_unique` and replaces with `std::make_shared` and `std::make_unique` respectively, as they're no longer necessary with C++17.

Partially fulfils #2585.