### PR TITLE
Add support for multiple arguments to CXX_COMPILER_LAUNCHER

### DIFF
--- a/configure
+++ b/configure
@@ -1481,8 +1481,9 @@ with open (config_filename, 'w', encoding='utf-8') as config_file:
   commit (config_file, 'lib_suffix', lib_suffix)
 
   if "CXX_COMPILER_LAUNCHER" in os.environ:
-    print("\n USING COMPILER PREFIX", os.environ["CXX_COMPILER_LAUNCHER"])
-    cpp.insert(0, os.environ["CXX_COMPILER_LAUNCHER"])
+    cpp_launcher = os.environ["CXX_COMPILER_LAUNCHER"].split()
+    print("\n USING CXX_COMPILER_LAUNCHER", cpp_launcher)
+    cpp = cpp_launcher + cpp
 
   commit (config_file, 'cpp', cpp)
   commit (config_file, 'cpp_flags', cpp_flags)


### PR DESCRIPTION
Currently, we have a way to specify a compiler prefix in the configure script using the `CXX_COMPILER_LAUNCHER` environment variable. This is useful to use tools like `ccache` or `sccache`. This pull requests add supports to specify a compiler prefix with multiple arguments, which can sometimes can be handy for other tools like [bear](https://github.com/rizsotto/Bear) (e.g. you can use `CXX_COMPILER_LAUNCHER="bear --append --" ./configure` to generate a compilation database).