### PR TITLE
Experimental include-what-you-use support

### DIFF
--- a/.github/workflows/iwyu.yml
+++ b/.github/workflows/iwyu.yml
@@ -1,0 +1,43 @@
+name: include-what-you-use
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    env:
+      CFLAGS: -Werror
+      QT_SELECT: qt5
+      
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install dependencies
+      # Note that we need to install clang-13, since iwyu on latest Ubuntu is built with clang-13.
+      run: |
+        sudo apt-get update
+        sudo apt install -y bear iwyu clang-13 libqt5opengl5-dev libqt5svg5-dev libglvnd-dev libeigen3-dev zlib1g-dev libfftw3-dev 
+
+    - name: configure
+      run: |
+        export CXX_COMPILER_LAUNCHER="bear --append --"
+        export CXX="clang++-13"
+        ./configure || { cat configure.log; false; }
+
+    - name: build
+      run: ./build -nowarnings -nopaginate || { cat build.log; false; }
+    
+    - name: list files in workspace
+      run: ls ${{ github.workspace }}
+
+    - name: cat compile_commands.json
+      run: cat ${{ github.workspace }}/compile_commands.json
+      
+    - name: Download IWYU script
+      run: |
+        wget https://raw.githubusercontent.com/include-what-you-use/include-what-you-use/clang_13/iwyu_tool.py
+        chmod +x iwyu_tool.py
+
+    - name: Run IWYU script
+      run: |
+        ./iwyu_tool.py -p ${{ github.workspace }} -- -Xiwyu --mapping_file=${{ github.workspace }}/iwyu/mapping.imp

--- a/iwyu/eigen.imp
+++ b/iwyu/eigen.imp
@@ -1,0 +1,11 @@
+[
+    { include: ["@<Eigen/src/Core/.*>", "private", "<Eigen/Core>", "public"] },
+    { include: ["@<Eigen/src/Core/.*>", "private", "<Eigen/Core>", "public"] },
+    { include: ["@<Eigen/src/Dense/.*>", "private", "<Eigen/Dense>", "public"] },
+    { include: ["@<Eigen/src/Eigen/.*>", "private", "<Eigen/Eigen>", "public"] },
+    { include: ["@<Eigen/src/Eigenvalues/.*>", "private", "<Eigen/Eigenvalues>", "public"] },
+    { include: ["@<Eigen/src/Geometry/.*>", "private", "<Eigen/Geometry>", "public"] },
+    { include: ["@<Eigen/src/Jacobi/.*>", "private", "<Eigen/Jacobi>", "public"] },
+
+    { include: ["@\"src/Core/.*\"", "private", "<Eigen/Dense>", "public"] }
+]

--- a/iwyu/mapping.imp
+++ b/iwyu/mapping.imp
@@ -1,0 +1,3 @@
+[
+    { ref: "eigen.imp" }
+]


### PR DESCRIPTION
This is a preliminary attempt at incorporating [include-what-you-use](https://github.com/include-what-you-use/include-what-you-use) in our workflow. The scope is to figure out whether it makes sense to follow the strategy outlined in #2579. 
It remains to be seen how IWYU should be incorporated, whether as a simple hinting mechanism for contributors or as an enforcing CI check that blocks PRs (possibly after running the [automatic fixing script](https://github.com/include-what-you-use/include-what-you-use#how-to-correct-iwyu-mistakes) on the entire codebase). 

The benefit of IWYU are the removal of unnecessary includes and an avoidance of relying on transitive includes.