### PR TITLE
tcksift2 weights: move save operation outside of allocation try block

### DIFF
--- a/src/dwi/tractography/SIFT2/tckfactor.cpp
+++ b/src/dwi/tractography/SIFT2/tckfactor.cpp
@@ -350,10 +350,10 @@ namespace MR {
             weights[i] = (coefficients[i] == min_coeff || !std::isfinite(coefficients[i])) ?
                          0.0 :
                          std::exp (coefficients[i]);
-          save_vector (weights, path);
         } catch (...) {
           WARN ("Unable to assign memory for output factor file: \"" + Path::basename(path) + "\" not created");
         }
+        save_vector (weights, path);
       }
 
 


### PR DESCRIPTION
Fix #2668

Issue what that allocation and writing of weights were both contained within the same `try{}` block, and the `catch()` block produces an error message related to allocation only. Simplest fix is to move the write stage outside that `try{}` block, and rely on its own error handling, which should be clear enough here (should produce a message like `error opening file "XYZ": reason` in this case). 