### PR TITLE
tcksift2: Fix check for allocation of memory for weights vector

### DIFF
--- a/src/dwi/tractography/SIFT2/tckfactor.cpp
+++ b/src/dwi/tractography/SIFT2/tckfactor.cpp
@@ -344,17 +344,20 @@ namespace MR {
       {
         if (size_t(coefficients.size()) != contributions.size())
           throw Exception ("Cannot output weighting factors if they have not first been estimated!");
+        decltype(coefficients) weights;
         try {
-          decltype(coefficients) weights (coefficients.size());
-          for (SIFT::track_t i = 0; i != num_tracks(); ++i)
-            weights[i] = (coefficients[i] == min_coeff || !std::isfinite(coefficients[i])) ?
-                         0.0 :
-                         std::exp (coefficients[i]);
-          save_vector (weights, path);
+          weights.resize (coefficients.size());
         } catch (...) {
           WARN ("Unable to assign memory for output factor file: \"" + Path::basename(path) + "\" not created");
+          return;
         }
+        for (SIFT::track_t i = 0; i != num_tracks(); ++i)
+          weights[i] = (coefficients[i] == min_coeff || !std::isfinite(coefficients[i])) ?
+                        0.0 :
+                        std::exp (coefficients[i]);
+        save_vector (weights, path);
       }
+
 
 
       void TckFactor::output_coefficients (const std::string& path) const


### PR DESCRIPTION
If path to output weights file is erroneous, do not issue a misleading warning message claiming that the issue relates to an inability to allocate memory. 

Fixes bug introduced in #626.
Solves #2668.
Replaces #2671.

-----

Classic case of why you should not catch exceptions in a manner that is broad in both scope of exception type and length of code.

Note that even though the output weights vector is the primary output of the `tcksift2` command, there was nevertheless a conscious decision in the past to nevertheless allow the rest of the command to complete even if there were a memory failure at this point. There might be other outputs that could be of use. Or for instance, the user may have requested that the streamline weighting coefficients be exported, which don't require allocation of additional memory to write, and the weighting factors can be computed from those after the fact.