### PR TITLE
tckmap: Support fixel templates

### DIFF
--- a/src/dwi/tractography/mapping/gaussian/mapper.h
+++ b/src/dwi/tractography/mapping/gaussian/mapper.h
@@ -107,6 +107,7 @@ namespace MR {
             inline void add_to_set (SetVoxelDEC&, const Eigen::Vector3i&, const Eigen::Vector3d&, const default_type, const default_type) const;
             inline void add_to_set (SetDixel&   , const Eigen::Vector3i&, const Eigen::Vector3d&, const default_type, const default_type) const;
             inline void add_to_set (SetVoxelTOD&, const Eigen::Vector3i&, const Eigen::Vector3d&, const default_type, const default_type) const;
+            inline void add_to_set (SetFixel&,    const Eigen::Vector3i&, const Eigen::Vector3d&, const default_type, const default_type) const;
 
             // Convenience function to convert from streamline position index to a linear-interpolated
             //   factor value (TrackMapperTWI member field factors[] only contains one entry per pre-upsampled point)
@@ -275,6 +276,13 @@ namespace MR {
             assert (tod_plugin);
             (*tod_plugin) (d);
             out.insert (v, (*tod_plugin)(), l, f);
+          }
+          inline void TrackMapper::add_to_set (SetFixel&    out, const Eigen::Vector3i& v, const Eigen::Vector3d& d, const default_type l, const default_type f) const
+          {
+            assert (fixel_plugin);
+            const MR::Fixel::index_type fixel = (*fixel_plugin) (v, d);
+            if (fixel != fixel_plugin->nfixels())
+              out.insert (fixel, l, f);
           }
 
 

--- a/src/dwi/tractography/mapping/gaussian/voxel.h
+++ b/src/dwi/tractography/mapping/gaussian/voxel.h
@@ -41,7 +41,7 @@ namespace MR {
               void operator+= (const default_type f) const { sum_factors += f; }
               void operator=  (const default_type f) { sum_factors = f; }
               void operator=  (const VoxelAddon& that) { sum_factors = that.sum_factors; }
-              void normalize (const default_type l) const { sum_factors /= l; }
+              void normalize  (const default_type l) const { sum_factors /= l; }
             private:
               mutable default_type sum_factors;
           };
@@ -149,6 +149,30 @@ namespace MR {
 
 
 
+          class Fixel : public Mapping::Fixel, public VoxelAddon
+          {
+
+            using Base = Mapping::Fixel;
+            using index_type = Base::index_type;
+
+            public:
+            Fixel() = delete;
+            Fixel (const index_type F) : Base (F) , VoxelAddon () { }
+            Fixel (const index_type F, const default_type l) : Base (F, l), VoxelAddon () { }
+            Fixel (const index_type F, const default_type l, const default_type f) : Base (F, l), VoxelAddon (f) { }
+
+            Fixel& operator= (const Fixel& F) { Base::operator= (F); VoxelAddon::operator= (F); return *this; }
+            void operator+= (const default_type l) const { IntersectionLength::operator+= (l); }
+            bool operator== (const Fixel& F) const { return Base::operator== (F); }
+            bool operator<  (const Fixel& F) const { return Base::operator<  (F); }
+
+            void add (const default_type l, const default_type f) const { IntersectionLength::operator+= (l); VoxelAddon::operator+= (f); }
+            void normalize() const { VoxelAddon::normalize (get_length()); IntersectionLength::normalize(); }
+
+          };
+
+
+
 
 
 
@@ -237,6 +261,25 @@ namespace MR {
                   std::set<VoxelTOD>::insert (temp);
                 else
                   (*existing).add (t, l, f);
+              }
+          };
+
+
+
+          class SetFixel : public std::set<Fixel>, public Mapping::SetVoxelExtras
+          {
+            public:
+
+              using VoxType = Fixel;
+
+              inline void insert (const MR::Fixel::index_type& F, const default_type l, const default_type f)
+              {
+                const Fixel temp (F, l, f);
+                iterator existing = std::set<Fixel>::find (temp);
+                if (existing == std::set<Fixel>::end())
+                  std::set<Fixel>::insert (temp);
+                else
+                  (*existing).add (l, f);
               }
           };
 

--- a/src/dwi/tractography/mapping/voxel.h
+++ b/src/dwi/tractography/mapping/voxel.h
@@ -270,6 +270,7 @@ namespace MR {
             Fixel() = delete;
             Fixel (const index_type f) : length_type (1.0), index (f) { }
             Fixel (const index_type f, const default_type l) : length_type (l), index (f) { }
+            bool operator== (const Fixel& that) const { return index == that.index; }
             bool operator< (const Fixel& F) const { return (index < F.index); }
             Fixel& operator= (const Fixel& F) { index = F.index; set_length (F.get_length()); return *this; }
             operator index_type() const { return index; }

--- a/src/dwi/tractography/mapping/writer.cpp
+++ b/src/dwi/tractography/mapping/writer.cpp
@@ -24,7 +24,7 @@ namespace Mapping {
 
 
 
-const char* writer_dims[] = { "undefined", "greyscale", "DEC", "dixel", "TOD", NULL };
+const char* writer_dims[] = { "undefined", "greyscale", "DEC", "dixel", "TOD", "fixel", nullptr };
 
 
 

--- a/src/dwi/tractography/mapping/writer.h
+++ b/src/dwi/tractography/mapping/writer.h
@@ -39,14 +39,14 @@ namespace MR {
       namespace Mapping {
 
 
-
-        enum writer_dim { UNDEFINED, GREYSCALE, DEC, DIXEL, TOD };
+        // TODO Can we rename "greyscale" to "Voxel"?
+        enum writer_dim { UNDEFINED, GREYSCALE, DEC, DIXEL, TOD, FIXEL };
         extern const char* writer_dims[];
 
 
 
         class MapWriterBase
-        { 
+        {
 
           public:
             MapWriterBase (const Header& header, const std::string& name, const vox_stat_t s = V_SUM, const writer_dim t = GREYSCALE) :
@@ -72,11 +72,13 @@ namespace MR {
             virtual bool operator() (const SetVoxelDEC&) { return false; }
             virtual bool operator() (const SetDixel&)    { return false; }
             virtual bool operator() (const SetVoxelTOD&) { return false; }
+            virtual bool operator() (const SetFixel&) { return false; }
 
             virtual bool operator() (const Gaussian::SetVoxel&)    { return false; }
             virtual bool operator() (const Gaussian::SetVoxelDEC&) { return false; }
             virtual bool operator() (const Gaussian::SetDixel&)    { return false; }
             virtual bool operator() (const Gaussian::SetVoxelTOD&) { return false; }
+            virtual bool operator() (const Gaussian::SetFixel&)    { return false; }
 
 
           protected:
@@ -100,7 +102,7 @@ namespace MR {
 
         template <typename value_type>
           class MapWriter : public MapWriterBase
-        { 
+        {
 
           public:
           MapWriter (const Header& header, const std::string& name, const vox_stat_t voxel_statistic = V_SUM, const writer_dim type = GREYSCALE) :
@@ -119,7 +121,7 @@ namespace MR {
                 buffer.zero();
               } */
 
-            } else { // Greyscale and dixel
+            } else { // Greyscale, dixel and fixel
 
               if (voxel_statistic == V_MIN) {
                 for (auto l = loop (buffer); l; ++l )
@@ -152,13 +154,12 @@ namespace MR {
 
           void finalise () override {
 
-            auto loop = Loop (buffer, 0, 3);
             switch (voxel_statistic) {
 
               case V_SUM:
                 if (type == DEC) {
                   assert (counts);
-                  for (auto l = loop (buffer, *counts); l; ++l) {
+                  for (auto l = Loop(buffer, 0, 3) (buffer, *counts); l; ++l) {
                     const float total_weight = counts->value();
                     if (total_weight) {
                       auto value = get_dec();
@@ -172,22 +173,22 @@ namespace MR {
                 break;
 
               case V_MIN:
-                for (auto l = loop (buffer); l; ++l ) {
+                for (auto l = Loop (buffer, 0, 3) (buffer); l; ++l ) {
                   if (buffer.value() == std::numeric_limits<value_type>::max())
                     buffer.value() = value_type(0);
                 }
                 break;
 
               case V_MEAN:
-                if (type == GREYSCALE) {
+                if (type == GREYSCALE || type == FIXEL) {
                   assert (counts);
-                  for (auto l = loop (buffer, *counts); l; ++l) {
+                  for (auto l = Loop (buffer) (buffer, *counts); l; ++l) {
                     if (counts->value())
                       buffer.value() /= value_type(counts->value());
                   }
                 }
                 else if (type == DEC) {
-                  for (auto l = loop (buffer); l; ++l) {
+                  for (auto l = Loop (buffer, 0, 3) (buffer); l; ++l) {
                     auto value = get_dec();
                     if (value.squaredNorm())
                       set_dec (value.normalized());
@@ -195,7 +196,7 @@ namespace MR {
                 }
                 else if (type == TOD) {
                   assert (counts);
-                  for (auto l = loop (buffer, *counts); l; ++l) {
+                  for (auto l = Loop (buffer, 0, 3) (buffer, *counts); l; ++l) {
                     if (counts->value()) {
                       VoxelTOD::vector_type value;
                       get_tod (value);
@@ -203,7 +204,7 @@ namespace MR {
                       set_tod (value);
                     }
                   }
-                } else { // Dixel
+                } else if (type == DIXEL) {
                   assert (counts);
                   // TODO For dixels, should this be a voxel mean i.e. normalise each non-zero voxel to unit density,
                   //   rather than a per-dixel mean?
@@ -211,16 +212,13 @@ namespace MR {
                     if (counts->value())
                       buffer.value() /= default_type(counts->value());
                   }
+                } else {
+                  assert (false);
                 }
                 break;
 
               case V_MAX:
-                if (type == GREYSCALE) {
-                  for (auto l = loop (buffer); l; ++l) {
-                    if (buffer.value() == -std::numeric_limits<value_type>::max())
-                      buffer.value() = value_type(0);
-                  }
-                } else if (type == DIXEL) {
+                if (type == GREYSCALE || type == DIXEL || type == FIXEL) {
                   for (auto l = Loop (buffer) (buffer); l; ++l) {
                     if (buffer.value() == -std::numeric_limits<value_type>::max())
                       buffer.value() = value_type(0);
@@ -241,11 +239,13 @@ namespace MR {
           bool operator() (const SetVoxelDEC& in) override { receive_dec       (in); return true; }
           bool operator() (const SetDixel& in)    override { receive_dixel     (in); return true; }
           bool operator() (const SetVoxelTOD& in) override { receive_tod       (in); return true; }
+          bool operator() (const SetFixel& in)    override { receive_fixel     (in); return true; }
 
           bool operator() (const Gaussian::SetVoxel& in)    override { receive_greyscale (in); return true; }
           bool operator() (const Gaussian::SetVoxelDEC& in) override { receive_dec       (in); return true; }
           bool operator() (const Gaussian::SetDixel& in)    override { receive_dixel     (in); return true; }
           bool operator() (const Gaussian::SetVoxelTOD& in) override { receive_tod       (in); return true; }
+          bool operator() (const Gaussian::SetFixel& in)    override { receive_fixel     (in); return true; }
 
 
           private:
@@ -257,6 +257,7 @@ namespace MR {
           template <class Cont> void receive_dec       (const Cont&);
           template <class Cont> void receive_dixel     (const Cont&);
           template <class Cont> void receive_tod       (const Cont&);
+          template <class Cont> void receive_fixel     (const Cont&);
 
           // Partially specialized template function to shut up modern compilers
           //   regarding using multiplication in a boolean context
@@ -270,22 +271,23 @@ namespace MR {
           default_type get_factor (const VoxelDEC& element, const SetVoxelDEC& set) const { return set.factor; }
           default_type get_factor (const Dixel&    element, const SetDixel&    set) const { return set.factor; }
           default_type get_factor (const VoxelTOD& element, const SetVoxelTOD& set) const { return set.factor; }
+          default_type get_factor (const Fixel&    element, const SetFixel&    set) const { return set.factor; }
           default_type get_factor (const Gaussian::Voxel&    element, const Gaussian::SetVoxel&    set) const { return element.get_factor(); }
           default_type get_factor (const Gaussian::VoxelDEC& element, const Gaussian::SetVoxelDEC& set) const { return element.get_factor(); }
           default_type get_factor (const Gaussian::Dixel&    element, const Gaussian::SetDixel&    set) const { return element.get_factor(); }
           default_type get_factor (const Gaussian::VoxelTOD& element, const Gaussian::SetVoxelTOD& set) const { return element.get_factor(); }
+          default_type get_factor (const Gaussian::Fixel&    element, const Gaussian::SetFixel&    set) const { return element.get_factor(); }
 
 
           // Convenience functions for Directionally-Encoded Colour processing
           Eigen::Vector3d get_dec ();
-          void           set_dec (const Eigen::Vector3d&);
+          void            set_dec (const Eigen::Vector3d&);
 
           // Convenience functions for Track Orientation Distribution processing
           void get_tod (      VoxelTOD::vector_type&);
           void set_tod (const VoxelTOD::vector_type&);
 
         };
-
 
 
 
@@ -433,6 +435,33 @@ namespace MR {
                   break;
                 default:
                   throw Exception ("Unknown / unhandled voxel statistic in MapWriter::receive_tod()");
+              }
+            }
+          }
+
+
+
+        template <typename value_type>
+          template <class Cont>
+          void MapWriter<value_type>::receive_fixel (const Cont& in)
+          {
+            assert (MapWriterBase::type == FIXEL);
+            for (const auto& i : in) {
+              buffer.index(0) = MR::Fixel::index_type(i);
+              const default_type factor = get_factor (i, in);
+              const default_type weight = in.weight * i.get_length();
+              switch (voxel_statistic) {
+                case V_SUM:  add (weight, factor); break;
+                case V_MIN:  buffer.value() = std::min (default_type (buffer.value()), factor); break;
+                case V_MAX:  buffer.value() = std::max (default_type (buffer.value()), factor); break;
+                case V_MEAN:
+                             add (weight, factor);
+                             assert (counts);
+                             counts->index(0) = MR::Fixel::index_type(i);
+                             counts->value() += weight;
+                             break;
+                default:
+                             throw Exception ("Unknown / unhandled voxel statistic in MapWriter::receive_fixel()");
               }
             }
           }


### PR DESCRIPTION
Targets base of #2657. In a draft state for now; pushing out first compiling version to outsource testing to @ArshiyaSan.

As per task list there, once this is confirmed working, `tck2fixel` will be deprecated and can be removed.

Refactoring here does remind me that the handling of streamline contributions that vary along the length of the streamline needs to be overhauled at some point. But I will talk about that at more length elsewhere. That has to do with private code written ~ 10 years ago that probably needs to be done from scratch...

TODO before merge:

- [ ] As per code comment, make user interface when using both `-template` and `-fixel` more robust.
    Over and above `-template` potentially being index / datafile / directory, user could omit `-fixel` but if the input to `-template` is a fixel data file and the corresponding index image can be found it's probably safe to proceed with a message.
- [ ] Try to change image writer "dimensionality" of "greyscale" to "voxel" to be more consistent with code elsewhere
- [ ] Delete `tck2fixel` (and update any referring documentation)
- [ ] Consider adding some test data and tests