### PR TITLE
FOD FMLS: fix assertion failure in retrospective assignment

### DIFF
--- a/src/dwi/fmls.cpp
+++ b/src/dwi/fmls.cpp
@@ -209,9 +209,9 @@ namespace MR {
                 lobe = l;
               }
             }
-            assert (lobe < out.size());
-            out[lobe].add (dirs, i, amplitude, (*weights)[i]);
           }
+          assert (lobe < out.size());
+          out[lobe].add (dirs, i, amplitude, (*weights)[i]);
         }
 
         for (auto i = out.begin(); i != out.end();) { // Empty increment


### PR DESCRIPTION
Was getting segfaults from `fod2fixel` after [2704f7e](https://github.com/MRtrix3/mrtrix3/pull/2644/commits/2704f7eb06ed0b405ba465509520510e96b1469f)

A misplaced brace in the restrospective assignments loop seems to be the issue, unless I've really misunderstood the assignment process.