### PR TITLE
CI: Install Python / numpy via mingw64

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -148,8 +148,6 @@ jobs:
           release: false
           install: |
             git
-            python
-            python-pip
             ${{env.MINGW_PACKAGE_PREFIX}}-bc
             ${{env.MINGW_PACKAGE_PREFIX}}-diffutils
             ${{env.MINGW_PACKAGE_PREFIX}}-eigen3
@@ -157,13 +155,11 @@ jobs:
             ${{env.MINGW_PACKAGE_PREFIX}}-gcc
             ${{env.MINGW_PACKAGE_PREFIX}}-libtiff
             ${{env.MINGW_PACKAGE_PREFIX}}-pkg-config
+            ${{env.MINGW_PACKAGE_PREFIX}}-python
+            ${{env.MINGW_PACKAGE_PREFIX}}-python-numpy
             ${{env.MINGW_PACKAGE_PREFIX}}-qt5-base
             ${{env.MINGW_PACKAGE_PREFIX}}-qt5-svg
             ${{env.MINGW_PACKAGE_PREFIX}}-zlib
-
-      - name: Install numpy
-        run: |
-          pip install numpy
 
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3


### PR DESCRIPTION
Separating out testing changes to CI from #2437 into a separate PR so I can go back and forth on it if need be.

For whatever reason, the msys version of pip refuses to install numpy; so I'm trying the mingw64 version of python instead.