### PR TITLE
New fixelcorrespondence

### DIFF
--- a/cmd/fixel2fixel.cpp
+++ b/cmd/fixel2fixel.cpp
@@ -1,0 +1,323 @@
+/* Copyright (c) 2008-2017 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * MRtrix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * For more details, see http://www.mrtrix.org/.
+ */
+
+
+#include <string>
+
+#include "command.h"
+#include "header.h"
+#include "image.h"
+#include "progressbar.h"
+#include "thread_queue.h"
+#include "types.h"
+#include "algo/copy.h"
+#include "fixel/helpers.h"
+
+#include "fixel/correspondence/correspondence.h"
+#include "fixel/correspondence/mapping.h"
+
+using namespace MR;
+using namespace App;
+using namespace MR::Fixel::Correspondence;
+
+constexpr float default_fillvalue = 0.0f;
+
+enum class metric_t { SUM, MEAN, COUNT, ANGLE };
+const char* metrics[] = { "sum", "mean", "count", "angle", nullptr };
+// TODO Other metrics:
+//   - Angle that also takes into account misalignment of multiple source fixels
+//     that are mapped to the same target fixel
+
+
+void usage ()
+{
+  AUTHOR = "Robert E. Smith (robert.smith@florey.edu.au)";
+
+  SYNOPSIS = "Project quantities from one fixel dataset to another";
+
+  DESCRIPTION
+  + "This command requires pre-calculation of fixel correspondence between two fixel datasets; "
+    "this would most typically be achieved using the fixelcorrespondence command."
+
+  + "The -weighted option does not act as a per-fixel value multipler as is done in the "
+    "calculation of the Fibre Density and Cross-section (FDC) measure. Rather, whenever "
+    "a quantitative value for a target fixel is to be determined from the aggregation of "
+    "multiple source fixels, the fixel data file provided via the -weights option will "
+    "be used to modulate the magnitude by which each source fixel contributes to that "
+    "aggregate. Most typically this would be a file containing fixel densities / volumes, "
+    "if e.g. the value for a low-density source fixel should not contribute as much as a "
+    "high-density source fixel in calculation of a weighted mean value for a target fixel.";
+
+  // TODO Should data_in be a directions file if angle is the metric of interest?
+
+  ARGUMENTS
+  + Argument ("data_in", "the source fixel data file").type_image_in()
+  + Argument ("correspondence", "the directory containing the fixel-fixel correspondence mapping").type_directory_in()
+  + Argument ("metric", "the metric to calculate when mapping multiple input fixels to an output fixel; "
+                        "options are: " + join(metrics, ", ")).type_choice (metrics)
+  + Argument ("directory_out", "the output fixel directory in which the output fixel data file will be placed").type_text()
+  + Argument ("data_out", "the name of the output fixel data file").type_text();
+
+  OPTIONS
+
+  + Option ("weighted", "specify fixel data file containing weights to use during aggregation of multiple source fixels")
+    + Argument ("weights_in").type_image_in()
+
+  + OptionGroup ("Options relating to filling data values for specific fixels")
+  + Option ("fill", "value for output fixels to which no input fixels are mapped "
+                    "(default: " + str(default_fillvalue) + ")")
+    + Argument ("value").type_float()
+  + Option ("nan_many2one", "insert NaN value in cases where multiple input fixels map to the same output fixel")
+  + Option ("nan_one2many", "insert NaN value in cases where one input fixel maps to multiple output fixels");
+
+}
+
+
+
+struct FillSettings
+{
+    float value;
+    bool nan_many2one, nan_one2many;
+};
+
+
+
+class Functor
+{
+
+  private:
+    // TODO In this scenario, the use of a Fixel class will be slightly different:
+    // - Initialise with the template fixel
+    // - Add subject fixels - need to keep a list
+    // - Extract the relevant metric
+    // Is a class needed here, or just deal with it in the functor?
+  public:
+    Functor (const std::string& input_path,
+             const Mapping& correspondence,
+             const metric_t metric,
+             const FillSettings& fill_settings,
+             Image<float>& explicit_weights,
+             const std::string& output_directory) :
+        correspondence (correspondence),
+        metric (metric),
+        fill (fill_settings),
+        explicit_weights (explicit_weights)
+    {
+      if (Path::is_dir (input_path))
+        throw Exception ("Input must be a fixel data file to be mapped, not a fixel directory");
+      Header input_header (Header::open (input_path));
+      if (!MR::Fixel::is_data_file (input_header))
+        throw Exception ("Input image is not a fixel data file");
+      if (explicit_weights.valid() && explicit_weights.size(0) != input_header.size(0))
+        throw Exception ("Number of fixels in input file (" + str(input_header.size(0)) + ") does not match number of fixels in fixel weights file (" + str(explicit_weights.size(0)) + ")");
+
+      const std::string fixel_directory = MR::Fixel::get_fixel_directory (input_path);
+      input_directions = MR::Fixel::find_directions_header (fixel_directory).get_image<float>();
+      input_data = input_header.get_image<float>();
+
+      target_directions = MR::Fixel::find_directions_header (output_directory).get_image<float>();
+      if (target_directions.size(0) != correspondence.size())
+        throw Exception ("Number of fixels in output directory (" + str(target_directions.size(0)) +
+                         ") does not match number of lines in fixel correspondence file (" + str(correspondence.size()) + ")");
+
+      Header H_output (target_directions);
+      H_output.size(1) = 1;
+      output_data = Image<float>::scratch (H_output, "scratch storage of remapped fixel data");
+
+      // Here we need the number of output fixels to which each input fixel maps,
+      //   for two reasons:
+      //   - If fill.nan_one2many is set, want to detect this as soon as possible,
+      //     insert the fill value and exit
+      //   - Wherever an input fixel contributes to more than one output fixel, its
+      //     volume is effectively "spread" over those fixels; hence it needs to
+      //     contribute with less weight
+      vector<uint8_t> objectives_per_source_fixel (input_header.size(0), 0);
+      for (size_t out_index = 0; out_index != correspondence.size(); ++out_index) {
+        for (auto i : correspondence[out_index]) {
+          assert (i < input_header.size(0));
+          ++objectives_per_source_fixel[i];
+        }
+      }
+      implicit_weights = Image<float>::scratch (input_data, "Implicit weights for source fixels based on multiple objective target fixels");
+      for (auto l = Loop(0) (implicit_weights); l; ++l)
+        implicit_weights.value() = objectives_per_source_fixel[implicit_weights.index(0)] ?
+                                   1.0f / float(objectives_per_source_fixel[implicit_weights.index(0)]) :
+                                   0.0f;
+    }
+
+
+    // Input argument is the fixel index of the output file
+    bool operator() (const size_t& out_index)
+    {
+      assert (out_index < correspondence.size());
+      output_data.index(0) = out_index;
+
+      const auto& in_indices = correspondence[out_index];
+      if (!in_indices.size()) {
+        output_data.value() = fill.value;
+        return true;
+      }
+      if (in_indices.size() > 1 && fill.nan_many2one) {
+        output_data.value() = std::numeric_limits<float>::quiet_NaN();
+        return true;
+      }
+
+      // Regardless of which metric we are calculating, still need to
+      //   accumulate all of the input fixel data for this output fixel
+
+      vector<dir_t> directions;
+      vector<float> values, weights;
+      for (auto i : in_indices) {
+        // If set up to fill with NaN whenever an input fixel contributes to more than one output fixel,
+        //   need to see if any of the input fixels for this output fixel also contribute to at least one
+        //   other output fixel
+        implicit_weights.index(0) = i;
+        if (fill.nan_one2many && implicit_weights.value() < 1.0f) {
+          output_data.value() = std::numeric_limits<float>::quiet_NaN();
+          return true;
+        }
+        input_directions.index(0) = i;
+        directions.emplace_back (dir_t (input_directions.row(1)));
+        input_data.index(0) = i;
+        values.push_back (input_data.value());
+
+        if (explicit_weights.valid()) {
+          explicit_weights.index(0) = i;
+          weights.push_back (implicit_weights.value() * explicit_weights.value());
+        } else {
+          weights.push_back (implicit_weights.value());
+        }
+      }
+
+      float result = 0.0f;
+      switch (metric) {
+        case metric_t::SUM:
+          {
+            for (size_t i = 0; i != in_indices.size(); ++i)
+              result += values[i] * weights[i];
+          }
+          break;
+        case metric_t::MEAN:
+          {
+            float sum_weights = 0.0f;
+            for (size_t i = 0; i != in_indices.size(); ++i) {
+              result += values[i] * weights[i];
+              sum_weights += weights[i];
+            }
+          result /= sum_weights;
+          }
+          break;
+        case metric_t::COUNT:
+          result = in_indices.size();
+          break;
+        case metric_t::ANGLE:
+          {
+            target_directions.index(0) = out_index;
+            const dir_t out_dir (target_directions.row(1));
+            dir_t mean_dir (0.0f, 0.0f, 0.0f);
+            for (size_t i = 0; i != in_indices.size(); ++i)
+              mean_dir += directions[i] * weights[i] * (out_dir.dot (directions[i]) < 0.0 ? -1.0f : +1.0f);
+            mean_dir.normalize();
+            result = std::acos (out_dir.dot (mean_dir));
+          }
+          break;
+      }
+
+      output_data.value() = result;
+      return true;
+    }
+
+
+
+    void save (const std::string& path)
+    {
+      Image<float> out = Image<float>::create (path, output_data);
+      copy (output_data, out);
+    }
+
+
+
+  private:
+    const Mapping& correspondence;
+    const metric_t metric;
+    const FillSettings& fill;
+
+    Image<float> input_data;
+    Image<float> implicit_weights;
+    Image<float> explicit_weights;
+    Image<float> input_directions;
+    Image<float> target_directions;
+    Image<float> output_data;
+
+};
+
+
+
+class Source
+{
+  public:
+    Source (const size_t i) :
+        size (i),
+        progress ("remapping fixel data", i),
+        counter (0) { }
+    bool operator() (size_t& index)
+    {
+      ++progress;
+      return ((index = counter++) < size);
+    }
+
+  private:
+    const size_t size;
+    ProgressBar progress;
+    size_t counter;
+};
+
+
+
+
+void run()
+{
+  FillSettings fill_settings;
+  fill_settings.value = get_option_value ("fill", default_fillvalue);
+  fill_settings.nan_many2one = get_options ("nan_many2one").size();
+  fill_settings.nan_one2many = get_options ("nan_one2many").size();
+
+  const std::string input_path (argument[0]);
+  const Mapping correspondence ((std::string (argument[1])));
+  metric_t metric;
+  switch (int(argument[2])) {
+    case 0: metric = metric_t::SUM; break;
+    case 1: metric = metric_t::MEAN; break;
+    case 2: metric = metric_t::COUNT; break;
+    case 3: metric = metric_t::ANGLE; break;
+  }
+
+  const std::string output_directory (argument[3]);
+
+  if (!Path::is_dir (output_directory))
+    throw Exception ("Output fixel directory \"" + output_directory + "\" not found");
+
+  Image<float> explicit_weights;
+  auto opt = get_options ("weighted");
+  if (opt.size()) {
+    explicit_weights = Image<float>::open (opt[0][0]);
+    if (!MR::Fixel::is_data_file (explicit_weights))
+      throw Exception ("Image provided via -weighted option must be a fixel data file");
+  }
+
+  Source source (correspondence.size());
+  Functor functor (input_path, correspondence, metric, fill_settings, explicit_weights, output_directory);
+  Thread::run_queue (source, Thread::batch (size_t()), Thread::multi (functor));
+  functor.save (Path::join(output_directory, argument[4]));
+}
+

--- a/docs/reference/commands/fixel2fixel.rst
+++ b/docs/reference/commands/fixel2fixel.rst
@@ -1,0 +1,90 @@
+.. _fixel2fixel:
+
+fixel2fixel
+===================
+
+Synopsis
+--------
+
+Project quantities from one fixel dataset to another
+
+Usage
+--------
+
+::
+
+    fixel2fixel [ options ]  data_in correspondence metric directory_out data_out
+
+-  *data_in*: the source fixel data file
+-  *correspondence*: the directory containing the fixel-fixel correspondence mapping
+-  *metric*: the metric to calculate when mapping multiple input fixels to an output fixel; options are: sum, mean, count, angle
+-  *directory_out*: the output fixel directory in which the output fixel data file will be placed
+-  *data_out*: the name of the output fixel data file
+
+Description
+-----------
+
+This command requires pre-calculation of fixel correspondence between two fixel datasets; this would most typically be achieved using the fixelcorrespondence command.
+
+The -weighted option does not act as a per-fixel value multipler as is done in the calculation of the Fibre Density and Cross-section (FDC) measure. Rather, whenever a quantitative value for a target fixel is to be determined from the aggregation of multiple source fixels, the fixel data file provided via the -weights option will be used to modulate the magnitude by which each source fixel contributes to that aggregate. Most typically this would be a file containing fixel densities / volumes, if e.g. the value for a low-density source fixel should not contribute as much as a high-density source fixel in calculation of a weighted mean value for a target fixel.
+
+Options
+-------
+
+-  **-weighted weights_in** specify fixel data file containing weights to use during aggregation of multiple source fixels
+
+Options relating to filling data values for specific fixels
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  **-fill value** value for output fixels to which no input fixels are mapped (default: 0)
+
+-  **-nan_many2one** insert NaN value in cases where multiple input fixels map to the same output fixel
+
+-  **-nan_one2many** insert NaN value in cases where one input fixel maps to multiple output fixels
+
+Standard options
+^^^^^^^^^^^^^^^^
+
+-  **-info** display information messages.
+
+-  **-quiet** do not display information messages or progress status; alternatively, this can be achieved by setting the MRTRIX_QUIET environment variable to a non-empty string.
+
+-  **-debug** display debugging messages.
+
+-  **-force** force overwrite of output files (caution: using the same file as input and output might cause unexpected behaviour).
+
+-  **-nthreads number** use this number of threads in multi-threaded applications (set to 0 to disable multi-threading).
+
+-  **-config key value** *(multiple uses permitted)* temporarily set the value of an MRtrix config file entry.
+
+-  **-help** display this information page and exit.
+
+-  **-version** display version information and exit.
+
+References
+^^^^^^^^^^
+
+Tournier, J.-D.; Smith, R. E.; Raffelt, D.; Tabbara, R.; Dhollander, T.; Pietsch, M.; Christiaens, D.; Jeurissen, B.; Yeh, C.-H. & Connelly, A. MRtrix3: A fast, flexible and open software framework for medical image processing and visualisation. NeuroImage, 2019, 202, 116137
+
+--------------
+
+
+
+**Author:** Robert E. Smith (robert.smith@florey.edu.au)
+
+**Copyright:** Copyright (c) 2008-2023 the MRtrix3 contributors.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Covered Software is provided under this License on an "as is"
+basis, without warranty of any kind, either expressed, implied, or
+statutory, including, without limitation, warranties that the
+Covered Software is free of defects, merchantable, fit for a
+particular purpose or non-infringing.
+See the Mozilla Public License v. 2.0 for more details.
+
+For more details, see http://www.mrtrix.org/.
+
+

--- a/docs/reference/commands/fixelcorrespondence.rst
+++ b/docs/reference/commands/fixelcorrespondence.rst
@@ -6,32 +6,61 @@ fixelcorrespondence
 Synopsis
 --------
 
-Obtain fixel-fixel correpondence between a subject fixel image and a template fixel mask
+Establish correpondence between two fixel datasets
 
 Usage
 --------
 
 ::
 
-    fixelcorrespondence [ options ]  subject_data template_directory output_directory output_data
+    fixelcorrespondence [ options ]  source_density target_density output
 
--  *subject_data*: the input subject fixel data file. This should be a file inside the fixel directory
--  *template_directory*: the input template fixel directory.
--  *output_directory*: the fixel directory where the output file will be written.
--  *output_data*: the name of the output fixel data file. This will be placed in the output fixel directory
+-  *source_density*: the input source fixel data file corresponding to the FD or FDC metric
+-  *target_density*: the input target fixel data file corresponding to the FD or FDC metric
+-  *output*: the name of the output directory encoding the fixel correspondence
 
 Description
 -----------
 
-It is assumed that the subject image has already been spatially normalised and is aligned with the template. The output fixel image will have the same fixels (and directions) of the template.
+It is assumed that the source image has already been spatially normalised and is defined on the same voxel grid as the target. One would typically also want to have performed a reorientation of fibre information to reflect this spatial normalisation prior to invoking this command, as this would be expected to improve fibre orientation correspondence across datasets.
 
-Fixel data are stored utilising the fixel directory format described in the main documentation, which can be found at the following link:  |br|
-https://mrtrix.readthedocs.io/en/3.0.4/fixel_based_analysis/fixel_directory_format.html
+The output of the command is a directory encoding how data from source fixels should be remapped in order to express those data in target fixel space. This information would typically then be utilised by command fixel2fixel to project some quantitative parameter from the source fixel dataset to the target fixels.
+
+Multiple algorithms are provided; a brief description of each of these is provided below.
+
+"all2all": This algorithm is defined for debugging / demonstrative purposes only. It assigns all source fixels to all target fixels, and is therefore not appropriate for practical use.
+
+"nearest": This algorithm duplicates the behaviour of the fixelcorrespondence command in MRtrix versions 3.0.x. and earlier. It determines, for every target fixel, the nearest source fixel, and then assigns that source fixel to the target fixel as long as the angle between them is less than some threshold.
+
+"ismrm2018": This is a combinatorial algorithm, for which the algorithm and cost function are described in the relevant reference (Smith et al., 2018).
+
+"in2023": This is a combinatorial algorithm, for which the combinatorial algorithm utilised is described in reference (Smith et al., 2018), but an alternative cost function is proposed (publication pending).
 
 Options
 -------
 
--  **-angle value** the max angle threshold for computing inter-subject fixel correspondence (Default: 45 degrees)
+-  **-algorithm choice** the algorithm to use when establishing fixel correspondence; options are: all2all,nearest,ismrm2018,in2023 (default: in2023)
+
+-  **-remapped path** export the remapped source fixels to a new fixel directory
+
+Options specific to algorithm "nearest"
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  **-angle value** maximum angle within which a corresponding fixel may be selected, in degrees (default: 45)
+
+Options specific to algorithm "in2023"
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  **-constants alpha beta** set values for the two constants that modulate the influence of different cost function terms
+
+Options applicable to all combinatorial-based algorithms
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  **-max_origins value** maximal number of origin source fixels for an individual target fixel (default: 3)
+
+-  **-max_objectives value** maximal number of objective target fixels for an individual source fixel (default: 3)
+
+-  **-cost path** export a 3D image containing the optimal value of the relevant cost function in each voxel
 
 Standard options
 ^^^^^^^^^^^^^^^^
@@ -55,13 +84,15 @@ Standard options
 References
 ^^^^^^^^^^
 
+* If using -algorithm ismrm2018 or -algorithm in2023: Smith, R.E.; Connelly, A. Mitigating the effects of imperfect fixel correspondence in Fixel-Based Analysis. In Proc ISMRM 2018: 456.
+
 Tournier, J.-D.; Smith, R. E.; Raffelt, D.; Tabbara, R.; Dhollander, T.; Pietsch, M.; Christiaens, D.; Jeurissen, B.; Yeh, C.-H. & Connelly, A. MRtrix3: A fast, flexible and open software framework for medical image processing and visualisation. NeuroImage, 2019, 202, 116137
 
 --------------
 
 
 
-**Author:** David Raffelt (david.raffelt@florey.edu.au)
+**Author:** Robert E. Smith (robert.smith@florey.edu.au)
 
 **Copyright:** Copyright (c) 2008-2023 the MRtrix3 contributors.
 

--- a/docs/reference/commands_list.rst
+++ b/docs/reference/commands_list.rst
@@ -44,6 +44,7 @@ List of MRtrix3 commands
     commands/dwigradcheck
     commands/dwinormalise
     commands/dwishellmath
+    commands/fixel2fixel
     commands/fixel2peaks
     commands/fixel2sh
     commands/fixel2tsf
@@ -176,6 +177,7 @@ List of MRtrix3 commands
     |python.png|, :ref:`dwigradcheck`, "Check the orientation of the diffusion gradient table"
     |python.png|, :ref:`dwinormalise`, "Perform various forms of intensity normalisation of DWIs"
     |python.png|, :ref:`dwishellmath`, "Apply an mrmath operation to each b-value shell in a DWI series"
+    |cpp.png|, :ref:`fixel2fixel`, "Project quantities from one fixel dataset to another"
     |cpp.png|, :ref:`fixel2peaks`, "Convert data in the fixel directory format into a 4D image of 3-vectors"
     |cpp.png|, :ref:`fixel2sh`, "Convert a fixel-based sparse-data image into an spherical harmonic image"
     |cpp.png|, :ref:`fixel2tsf`, "Map fixel values to a track scalar file based on an input tractogram"
@@ -183,7 +185,7 @@ List of MRtrix3 commands
     |cpp.png|, :ref:`fixelcfestats`, "Fixel-based analysis using connectivity-based fixel enhancement and non-parametric permutation testing"
     |cpp.png|, :ref:`fixelconnectivity`, "Generate a fixel-fixel connectivity matrix"
     |cpp.png|, :ref:`fixelconvert`, "Convert between the old format fixel image (.msf / .msh) and the new fixel directory format"
-    |cpp.png|, :ref:`fixelcorrespondence`, "Obtain fixel-fixel correpondence between a subject fixel image and a template fixel mask"
+    |cpp.png|, :ref:`fixelcorrespondence`, "Establish correpondence between two fixel datasets"
     |cpp.png|, :ref:`fixelcrop`, "Crop/remove fixels from sparse fixel image using a binary fixel mask"
     |cpp.png|, :ref:`fixelfilter`, "Perform filtering operations on fixel-based data"
     |cpp.png|, :ref:`fixelreorient`, "Reorient fixel directions"

--- a/src/fixel/correspondence/adjacency.h
+++ b/src/fixel/correspondence/adjacency.h
@@ -1,0 +1,86 @@
+/* Copyright (c) 2008-2017 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * MRtrix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * For more details, see http://www.mrtrix.org/.
+ */
+
+#include "dwi/directions/set.h"
+
+#include "fixel/correspondence/correspondence.h"
+#include "fixel/correspondence/fixel.h"
+
+
+namespace MR {
+  namespace Fixel {
+    namespace Correspondence {
+
+
+
+
+
+      // Class that assists in classifying impermissible mappings based on fixel adjacency
+      // If the number of fixels is fewer than 4 / 5, then any mapping will be permitted;
+      //   not only because all fixels are adjacent by definition, but also because the convex set
+      //   algorithm requires that at least 4 directions be present in order to initialise
+      class Adjacency
+      {
+
+        public:
+          Adjacency (const vector<Correspondence::Fixel>& fixels)
+          {
+            if (fixels.size() < min_dirs_to_enforce_adjacency)
+              return;
+            Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic> temp (fixels.size(), 3);
+            for (size_t i = 0; i != fixels.size(); ++i)
+              temp.row(i) = fixels[i].dir();
+            dirs.reset (new DWI::Directions::Set (temp));
+          }
+
+          // Are two directions adjacent to one another?
+          bool operator() (const size_t i, const size_t j) const
+          {
+            if (!dirs) return true;
+            assert (i < dirs->size());
+            assert (j < dirs->size());
+            return dirs->dirs_are_adjacent (i, j);
+          }
+
+          // Is a specific set of source fixels permissible?
+          // For all fixels, at least one of the other fixels in the set must be present in the adjacency set
+          bool operator() (const vector<uint32_t>& indices) const
+          {
+            if (!dirs || indices.size() < 2)
+              return true;
+            for (const auto i : indices) {
+              const auto& list (dirs->get_adj_dirs (i));
+              // For each direction that is adjacent to "i", search through "indices" in pursuit of a match;
+              //   if *none* of those adjacent directions are also part of set "indices" (i.e. iterator != end, indicating a hit),
+              //   then this fixel is disconnected from the rest of the fixel set in "indices", and so should be rejected as a candidate
+              if (std::none_of (list.begin(),
+                                list.end(),
+                                [&] (const DWI::Directions::index_type j)
+                                {
+                                  return std::find (indices.begin(), indices.end(), j) != indices.end();
+                                }))
+                return false;
+            }
+            return true;
+          }
+
+        private:
+          std::unique_ptr<DWI::Directions::Set> dirs;
+
+      };
+
+
+
+    }
+  }
+}

--- a/src/fixel/correspondence/algorithms/all2all.h
+++ b/src/fixel/correspondence/algorithms/all2all.h
@@ -1,0 +1,60 @@
+/* Copyright (c) 2008-2017 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * MRtrix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * For more details, see http://www.mrtrix.org/.
+ */
+
+#ifndef __fixel_correspondence_algorithms_all2all_h__
+#define __fixel_correspondence_algorithms_all2all_h__
+
+
+#include "types.h"
+
+#include "fixel/correspondence/algorithms/base.h"
+#include "fixel/correspondence/fixel.h"
+
+
+namespace MR {
+  namespace Fixel {
+    namespace Correspondence {
+      namespace Algorithms {
+
+
+
+#ifdef FIXELCORRESPONDENCE_INCLUDE_ALL2ALL
+        // For the sake of testing, construct a correspondence algorithm with predictable behaviour:
+        //   assign all source fixels to every target fixel
+        class All2All : public Base
+        {
+          public:
+            All2All() {}
+            virtual ~All2All() {}
+            vector< vector<uint32_t> > operator() (const voxel_t&,
+                                                   const vector<Correspondence::Fixel>& s,
+                                                   const vector<Correspondence::Fixel>& t) const final
+            {
+              vector< vector<uint32_t> > result;
+              vector<uint32_t> all_s;
+              for (uint32_t i = 0; i != s.size(); ++i)
+                all_s.push_back (i);
+              result.assign (t.size(), all_s);
+              return result;
+            }
+        };
+#endif
+
+
+
+      }
+    }
+  }
+}
+
+#endif

--- a/src/fixel/correspondence/algorithms/base.h
+++ b/src/fixel/correspondence/algorithms/base.h
@@ -1,0 +1,61 @@
+/* Copyright (c) 2008-2017 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * MRtrix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * For more details, see http://www.mrtrix.org/.
+ */
+
+#ifndef __fixel_correspondence_algorithms_base_h__
+#define __fixel_correspondence_algorithms_base_h__
+
+
+#include <string>
+
+#include "image.h"
+#include "types.h"
+
+#include "fixel/correspondence/correspondence.h"
+#include "fixel/correspondence/fixel.h"
+
+
+namespace MR {
+  namespace Fixel {
+    namespace Correspondence {
+      namespace Algorithms {
+
+
+
+        class Base
+        {
+          public:
+            Base() {}
+            ~Base() {}
+
+            void export_cost_image (const std::string& path)
+            {
+              if (!cost_image.valid()) return;
+              Image<float> output (Image<float>::create (path, cost_image));
+              copy (cost_image, output);
+            }
+
+            virtual vector< vector<uint32_t> > operator() (const voxel_t& v,
+                                                           const vector<Correspondence::Fixel>& s,
+                                                           const vector<Correspondence::Fixel>& t) const = 0;
+          protected:
+            Image<float> cost_image;
+        };
+
+
+
+      }
+    }
+  }
+}
+
+#endif

--- a/src/fixel/correspondence/algorithms/combinatorial.cpp
+++ b/src/fixel/correspondence/algorithms/combinatorial.cpp
@@ -1,0 +1,47 @@
+/* Copyright (c) 2008-2017 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * MRtrix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * For more details, see http://www.mrtrix.org/.
+ */
+
+#include "fixel/correspondence/algorithms/combinatorial.h"
+
+#include "fixel/correspondence/correspondence.h"
+
+
+namespace MR {
+  namespace Fixel {
+    namespace Correspondence {
+      namespace Algorithms {
+
+
+
+        using namespace App;
+
+
+        OptionGroup CombinatorialOptions = OptionGroup ("Options applicable to all combinatorial-based algorithms")
+
+        + Option ("max_origins", "maximal number of origin source fixels for an individual target fixel "
+                                 "(default: " + str(default_max_origins_per_target) + ")")
+          + Argument ("value").type_integer (1)
+
+        + Option ("max_objectives", "maximal number of objective target fixels for an individual source fixel "
+                                    "(default: " + str(default_max_objectives_per_source) + ")")
+          + Argument ("value").type_integer (1)
+
+        + Option ("cost", "export a 3D image containing the optimal value of the relevant cost function in each voxel")
+          + Argument ("path").type_image_out();
+
+
+
+      }
+    }
+  }
+}

--- a/src/fixel/correspondence/algorithms/combinatorial.h
+++ b/src/fixel/correspondence/algorithms/combinatorial.h
@@ -1,0 +1,493 @@
+/* Copyright (c) 2008-2017 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * MRtrix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * For more details, see http://www.mrtrix.org/.
+ */
+
+#ifndef __fixel_correspondence_algorithms_combinatorial_h__
+#define __fixel_correspondence_algorithms_combinatorial_h__
+
+
+//#define FIXELCORRESPONDENCE_TEST_PERVOXEL
+
+
+#include "header.h"
+#include "image.h"
+#include "types.h"
+
+#include "fixel/correspondence/algorithms/base.h"
+#include "fixel/correspondence/adjacency.h"
+#include "fixel/correspondence/correspondence.h"
+#include "fixel/correspondence/dp2cost.h"
+
+
+namespace MR {
+
+  namespace App {
+    class OptionGroup;
+  }
+
+  namespace Fixel {
+    namespace Correspondence {
+      namespace Algorithms {
+
+
+
+        extern App::OptionGroup CombinatorialOptions;
+
+
+
+        // Base class to handle the combinatorial aspects of both
+        //   what was presented at ISMRM2018 and new proposed expression
+        template <class CostFunctor>
+        class Combinatorial : public Base
+        {
+
+          public:
+            Combinatorial (const size_t max_origins_per_target,
+                           const size_t max_objectives_per_source,
+                           const Header& H_cost) :
+                max_origins_per_target (max_origins_per_target),
+                max_objectives_per_source (max_objectives_per_source)
+#ifdef FIXELCORRESPONDENCE_TEST_COMBINATORICS
+                , mutex (new std::mutex)
+#endif
+            {
+              cost_image = Image<float>::scratch (H_cost, "scratch image containing minimal cost function per voxel");
+            }
+
+            virtual ~Combinatorial() {}
+
+            vector< vector<uint32_t> > operator() (const voxel_t& v,
+                                                   const vector<Correspondence::Fixel>& s,
+                                                   const vector<Correspondence::Fixel>& t) const final
+            {
+              if (std::max (s.size(), t.size()) > max_fixels_for_no_combinatorial_warning
+                  && !fixel_count_warning_issued.test_and_set (std::memory_order_relaxed)) {
+                WARN("Excessive fixel counts can currently lead to prohibitively long execution times; "
+                     "suggest limiting maximal fixel count per voxel to no greater than " + str(max_fixels_for_no_combinatorial_warning));
+              }
+
+              // For each remapped source fixel, these are the source fixels
+              //   from which they could possibly be derived
+              vector< vector<uint32_t> > remapping_origins;
+
+              // May need to forbid certain mappings due to source fixels not forming a
+              //   cohesive cluster (based on connectivity in the convex set)
+              const Correspondence::Adjacency adjacency_s (s);
+
+              // Worst-case scenario of the number of different combinations of source
+              //   fixels that could be mapped to any one remapped fixel
+              // 2 ^ (number_of_source_fixels)
+              const uint32_t max_src_fixel_combinations = uint32_t(1) << s.size();
+
+#if defined(FIXELCORRESPONDENCE_TEST_COMBINATORICS) || !defined(NDEBUG)
+              // Only combinations where no target fixel draws from
+              //   more than "max_origins_per_target" source fixels are considered;
+              //   here we want to ensure that the generated number of
+              //   combinations matches with theory
+              uint32_t permissible_src_fixel_combinations = max_src_fixel_combinations;
+              for (uint32_t r = s.size(); r > max_origins_per_target; --r)
+                permissible_src_fixel_combinations -= n_choose_k (s.size(), r);
+#endif
+
+#ifdef FIXELCORRESPONDENCE_TEST_COMBINATORICS
+              uint32_t adjacency_rejection_count = 0;
+#endif
+
+#ifdef FIXELCORRESPONDENCE_TEST_PERVOXEL
+              std::cerr << "\n\n\n\nBuilding " << permissible_src_fixel_combinations << " permissible of " << max_src_fixel_combinations << " maximum combinations for " << s.size() << " source fixels:\n";
+#endif
+              for (uint32_t code = 0; code != max_src_fixel_combinations; ++code) {
+                vector<uint32_t> fixels;
+#ifdef FIXELCORRESPONDENCE_TEST_PERVOXEL
+                std::cerr << "[ ";
+#endif
+                for (uint32_t f = 0; f != s.size(); ++f) {
+                  if ((uint32_t(1) << f) & code) {
+                    fixels.push_back (f);
+#ifdef FIXELCORRESPONDENCE_TEST_PERVOXEL
+                    std::cerr << f << " ";
+#endif
+                  }
+                }
+#ifdef FIXELCORRESPONDENCE_TEST_PERVOXEL
+                std::cerr << "]";
+#endif
+                // Don't allow more than "max_origins_per_target" source fixels to contribute toward a single target fixel
+                if (fixels.size() <= max_origins_per_target) {
+                  // Don't allow template fixels to select sets of source fixels that include disconnections
+                  if (adjacency_s (fixels)) {
+                    remapping_origins.push_back (std::move (fixels));
+#ifdef FIXELCORRESPONDENCE_TEST_PERVOXEL
+                    std::cerr << "\n";
+#endif
+#ifdef FIXELCORRESPONDENCE_TEST_COMBINATORICS
+                  } else {
+#ifdef FIXELCORRESPONDENCE_TEST_PERVOXEL
+                    std::cerr << " <- REJECTED (adjacency)\n";
+#endif
+                    ++adjacency_rejection_count;
+#endif
+                  }
+#ifdef FIXELCORRESPONDENCE_TEST_PERVOXEL
+                } else {
+                  std::cerr << " <- REJECTED (origins per target)\n";
+#endif
+                }
+              }
+
+#ifndef NDEBUG
+              // This equivalence only holds if sets of source fixels were not excluded due to
+              //   the adjacency requirement
+              if (s.size() < min_dirs_to_enforce_adjacency)
+                assert (remapping_origins.size() == permissible_src_fixel_combinations);
+#endif
+
+#ifdef FIXELCORRESPONDENCE_TEST_PERVOXEL
+              if (s.size() >= min_dirs_to_enforce_adjacency)
+                std::cerr << "Of a possible " << permissible_src_fixel_combinations << " source fixel combinations, " << adjacency_rejection_count << " were rejected due to adjacency requirements\n";
+#endif
+
+              // Require every possible combination where each remapped source fixel is drawing
+              //   from one of the entries in "remapping_origins"
+              // Each remapped source fixel has:
+              //   max_src_fixel_combinations = 2^(number_of_source_fixels)
+              //   possible origins to choose from
+              // Total number of possibilities is hence:
+              //   (2 ^ (number_of_source_fixels)) ^ number_of_target_fixels
+              // However this total is immediately decreased by the fact that we reject
+              //   remapping sources that draw from more than "max_origins_per_target" source fixels
+#ifdef FIXELCORRESPONDENCE_TEST_COMBINATORICS
+              const uint64_t worstcase_total_combinations = std::pow<uint64_t> (max_src_fixel_combinations, t.size());
+#endif
+#if defined(FIXELCORRESPONDENCE_TEST_COMBINATORICS) || !defined(NDEBUG)
+              const uint64_t total_combinations_after_origin_limit = std::pow<uint64_t> (remapping_origins.size(), t.size());
+#endif
+
+              /////////////////////////////////////////////////////////////
+              // Data that will be utilised for every unique combination //
+              /////////////////////////////////////////////////////////////
+
+              // Each template fixel indexes into "remapping_origins"
+              vector<uint32_t> mapping (t.size(), 0);
+
+              // Note: Signed type used to permit 8-bit Math::pow2() following subtraction of 1 from 0
+              //   within some CostFunctors
+              Eigen::Array<int8_t, Eigen::Dynamic, 1> objectives_per_source_fixel (s.size());
+              Eigen::Array<float, Eigen::Dynamic, 1> source_fixel_multipliers (s.size());
+              Eigen::Array<int8_t, Eigen::Dynamic, 1> origins_per_remapped_fixel (t.size());
+              bool skip;
+              uint32_t increment_index_for_skip;
+              float cost;
+              dir_t mean_direction;
+              float sum_densities;
+
+              // Required for enforcing the criterion where if a single source fixel maps to
+              //   multiple template fixels, those template fixels must not be disconnected
+              //   from one another in the space of convex hull adjacency
+              vector<vector<uint32_t>> inv_mapping (s.size());
+              const Correspondence::Adjacency adjacency_t (t);
+
+#if defined(FIXELCORRESPONDENCE_TEST_COMBINATORICS) || !defined(NDEBUG)
+              uint64_t cost_counter = 0;
+              uint64_t skip_trigger_counter = 0;
+              uint64_t skipped_entirely_counter = 0;
+#endif
+
+              vector< vector<uint32_t> > result;
+              float min_cost = std::numeric_limits<float>::infinity();
+
+              do {
+
+                objectives_per_source_fixel.setZero();
+                origins_per_remapped_fixel.setZero();
+
+#ifdef FIXELCORRESPONDENCE_TEST_PERVOXEL
+                std::cerr << "\nMapping being tested: ";
+                for (const auto& i : mapping) {
+                  std::cerr << " [ ";
+                  if (remapping_origins[i].size()) {
+                    for (auto j : remapping_origins[i])
+                      std::cerr << j << " ";
+                  } else {
+                    std::cerr << "{} ";
+                  }
+                  std::cerr << "] ";
+                }
+                std::cerr << "\n";
+#endif
+
+                // Incorporate skipping implausible mappings here:
+                //   No source fixel is permitted to contribute to more than "max_objectives_per_source" remapped fixels
+/*
+                skip = false;
+                increment_index_for_skip = mapping.size();
+                for (int32_t it = t.size() - 1; !skip && it >= 0; --it) {
+                  const uint32_t src_fixel_list_index = mapping[it];
+                  assert (src_fixel_list_index < remapping_origins.size());
+                  for (const auto& is : remapping_origins[src_fixel_list_index]) {
+                    if (++objectives_per_source_fixel[is] > max_objectives_per_source) {
+                      increment_index_for_skip = uint32_t(it);
+                      skip = true;
+                      break;
+                    }
+                  }
+                }
+*/
+                // TODO Tricky addition:
+                // Need to forbid configurations where there are multiple template fixels that are
+                //   drawing data from the same source fixel, but those template fixels are themselves
+                //   not adjacent to one another
+                // Or more specifically, of the set of template fixels that are drawing data from a
+                //   single subject fixel, none are permitted to be disconnected from the others
+                // Even trickier, when we detect such a disconnection, we want to identify the largest
+                //   index that leads to an invalid mapping, since this results in the greatest number
+                //   of candidate mappings being skipped without computational penalty.
+
+                // I think what's going to need to happen here is construction of the complete inverse mapping;
+                //   variable "objectives_per_source_fixel" above is a derivative quantity from such
+                for (auto& i : inv_mapping)
+                  i.clear();
+                for (uint32_t it = 0; it != t.size(); ++it) {
+                  for (const auto& is : remapping_origins[mapping[it]])
+                    inv_mapping[is].push_back (it);
+                }
+
+#ifdef FIXELCORRESPONDENCE_TEST_PERVOXEL
+                std::cerr << "Corresponding inverse mapping: ";
+                for (const auto& i : inv_mapping) {
+                  std::cerr << " [ ";
+                  if (i.size()) {
+                    for (auto j : i)
+                      std::cerr << j << " ";
+                  } else {
+                    std::cerr << "{} ";
+                  }
+                  std::cerr << "] ";
+                }
+                std::cerr << "\n";
+#endif
+
+                // Okay. Now we need to not only determine whether or not this is a legitimate mapping,
+                //   but also determine the largest possible template fixel index that turns it into an
+                //   illegitimate mapping
+                // I *think* that this means not relying on Adjacency::operator()...
+                // What is it that guarantees that no change to the lower mapping indices could result in an acceptable mapping?
+                // After all, while one particular configuration could lead to a disconnected fixel, the addition of
+                //   some other fixel into that set could lead to its reconnection... This could at least be triggered by
+                //   that template fixel contributing to the maximum permissible number of objectives per source fixel?
+
+                // Maybe we should start with baby steps...
+                // 1. Is the mapping permissible?
+                //
+                // W.r.t. "max_objectives_per_source": Of the set of fixels that lead to the violation,
+                //   want to select the smallest index; but across multiple failures, want to select the largest index
+
+                // Unlike code above, we now have multiple potential sources of combinatorial skipping;
+                //   across these sources, we want to choose the one that results in the greatest skip, but
+                //   within each individual criterion,
+                increment_index_for_skip = 0;
+                skip = false;
+                for (uint32_t is = 0; is != s.size(); ++is) {
+                  // TODO May be able to remove variable "objectives_per_source_fixel" now that the entire inverse mapping is constructed
+                  if (uint32_t((objectives_per_source_fixel[is] = inv_mapping[is].size())) > max_objectives_per_source) {
+                    skip = true;
+                    // Smallest template fixel index is guaranteed to be at the end of the list
+                    //   (we can only do the most conservative increment given the conflict)
+                    increment_index_for_skip = std::max (increment_index_for_skip, inv_mapping[is].front());
+                  }
+                  if (!adjacency_t (inv_mapping[is])) {
+                    skip = true;
+                    // Can only use the illegitimacy of this mapping w.r.t. adjacency of template fixels
+                    //   if the number of template fixels to which this subject fixel maps is equal to
+                    //   the maximum permissible number; otherwise, it'd be possible for some other mapping
+                    //   of the subject fixel to incorporate another template fixel that bridges the disconnection
+                    if (inv_mapping[is].size() == max_objectives_per_source)
+                      increment_index_for_skip = std::max (increment_index_for_skip, inv_mapping[is].front());
+                    break;
+                  }
+                }
+
+
+
+
+
+
+#ifdef FIXELCORRESPONDENCE_TEST_PERVOXEL
+                std::cerr << "Remapping objectives per source fixel: [ " << objectives_per_source_fixel.transpose() << " ]\n";
+#endif
+
+                if (skip) {
+
+#if defined(FIXELCORRESPONDENCE_TEST_COMBINATORICS) || !defined(NDEBUG)
+                  ++skip_trigger_counter;
+                  skipped_entirely_counter += std::pow<uint64_t> (remapping_origins.size(), increment_index_for_skip) - 1;
+#endif
+
+                  // At least one source fixel is contributing to more than "max_objectives_per_source"
+                  //   remapped fixels. When this occurs, we need to increment the
+                  //   mapping for this source fixel, and also reset mapping for all lower
+                  //   fixels (since we don't need to test all possible combinations;
+                  //   we know from the higher fixels that the mapping is invalid)
+                  for (uint32_t it = 0; it != increment_index_for_skip; ++it)
+                    mapping[it] = 0;
+
+                } else {
+
+#if defined(FIXELCORRESPONDENCE_TEST_COMBINATORICS) || !defined(NDEBUG)
+                  ++cost_counter;
+#endif
+
+                  // Fibre density of each source fixel is distributed equally
+                  //   among the remapped fixels to which it contributes;
+                  //   its contribution toward remapped fixel orientations is
+                  //   similarly decreased
+                  source_fixel_multipliers = 1.0 / objectives_per_source_fixel.cast<float>();
+
+#ifdef FIXELCORRESPONDENCE_TEST_PERVOXEL
+                  std::cerr << "Source fixel multipliers: [ " << source_fixel_multipliers.transpose() << " ]\n";
+#endif
+
+                  // Loops over remapped source fixels
+                  vector<Correspondence::Fixel> rs;
+                  for (uint32_t rs_index = 0; rs_index != t.size(); ++rs_index) {
+
+                    // This is the list of source fixels from which data shall be drawn
+                    //   in the construction of this remapped source fixel
+                    const vector<uint32_t>& origin_fixels (remapping_origins[mapping[rs_index]]);
+
+                    mean_direction.setZero();
+                    sum_densities = 0.0f;
+                    for (const auto& s_index : origin_fixels) {
+                      mean_direction += s[s_index].dir() * source_fixel_multipliers[s_index] * s[s_index].density() * (t[rs_index].dot(s[s_index]) < 0.0f ? -1.0f : 1.0f);
+                      sum_densities += source_fixel_multipliers[s_index] * s[s_index].density();
+                    }
+                    rs.emplace_back (Correspondence::Fixel (mean_direction.normalized(), sum_densities));
+
+                    origins_per_remapped_fixel[rs_index] = origin_fixels.size();
+
+                  }
+
+                  cost = static_cast<const CostFunctor* const>(this)->calculate (s, rs, t,
+                                                                                 objectives_per_source_fixel,
+                                                                                 origins_per_remapped_fixel);
+
+                  if (cost < min_cost) {
+                    min_cost = cost;
+                    result.clear();
+                    for (uint32_t t_index = 0; t_index != t.size(); ++t_index)
+                      result.push_back (remapping_origins[mapping[t_index]]);
+                  }
+
+                  increment_index_for_skip = 0;
+                }
+
+                // Increments the mapping index; unless this was the last source for this target fixel,
+                //   in which case set it back to 0 and increment the mapping for the next fixel
+                while (++mapping[increment_index_for_skip] == remapping_origins.size() && ++increment_index_for_skip < t.size())
+                  mapping[increment_index_for_skip-1] = 0;
+              } while (mapping.back() != remapping_origins.size());
+
+#ifndef NDEBUG
+              assert (cost_counter + skip_trigger_counter + skipped_entirely_counter == total_combinations_after_origin_limit);
+#endif
+
+              Image<float> local_cost_image (cost_image);
+              assign_pos_of (v).to (local_cost_image);
+              local_cost_image.value() = min_cost;
+
+#ifdef FIXELCORRESPONDENCE_TEST_COMBINATORICS
+              {
+                std::lock_guard<std::mutex> lock (*mutex);
+                if (cost_counter > max_computed_combinations) {
+                  max_computed_combinations = cost_counter;
+                  std::cerr << "\nMaximum computed combinations incremented to " << max_computed_combinations
+                            << " (" << s.size() << " x " << t.size() << "): "
+                            << "worst case was " << worstcase_total_combinations << "; "
+                            << total_combinations_after_origin_limit << " after restricting origins per target fixel"
+#ifdef FIXELCORRESPONDENCE_ENFORCE_ADJACENCY
+                            << " & source fixel adjacency"
+#endif
+                            << "; " << skip_trigger_counter << " skip triggers due to objectives per source fixel limit"
+#ifdef FIXELCORRESPONDENCE_ENFORCE_ADJACENCY
+                            << " & target fixel adjacency"
+#endif
+                            << ", with by-product of " << skipped_entirely_counter << " combinations never assessed\n";
+                }
+              }
+#endif
+
+              return result;
+            }
+
+          protected:
+            const uint32_t max_origins_per_target;
+            const uint32_t max_objectives_per_source;
+
+            static DP2Cost dp2cost;
+
+            // Derived class function to calculate cost function
+            // CRTP to template out: Can't be calling a virtual function
+            //   this regularly without severe slowdown...
+            FORCE_INLINE static float calculate (const vector<Correspondence::Fixel>& s,
+                                                 const vector<Correspondence::Fixel>& rs,
+                                                 const vector<Correspondence::Fixel>& t,
+                                                 const Eigen::Array<int8_t, Eigen::Dynamic, 1>& objectives_per_source_fixel,
+                                                 const Eigen::Array<int8_t, Eigen::Dynamic, 1>& origins_per_remapped_fixel)
+            {
+              return CostFunctor::calculate (s, rs, t, objectives_per_source_fixel, origins_per_remapped_fixel);
+            }
+
+            static std::atomic_flag fixel_count_warning_issued;
+#ifdef FIXELCORRESPONDENCE_TEST_COMBINATORICS
+            // Track across the entire image the situation that results in the
+            //   largest number of combinations for which calculation of the
+            //   cost function was required
+            // (if fixel counts in any individual voxel are too high,
+            //   computation time goes through the roof)
+            std::shared_ptr<std::mutex> mutex;
+            static uint64_t max_computed_combinations;
+#endif
+
+          uint64_t n_choose_k (const uint32_t n, uint32_t k) const
+          {
+            if (k > n) return 0;
+            if (k * 2 > n) k = n-k;
+            if (k == 0) return 1;
+            uint64_t result = n;
+            for (uint32_t i = 2; i <= k; ++i) {
+              result *= (n-i+1);
+              result /= i;
+            }
+            return result;
+          }
+
+        };
+
+        template <class CostFunctor>
+        DP2Cost Combinatorial<CostFunctor>::dp2cost;
+
+        template <class CostFunctor>
+        std::atomic_flag Combinatorial<CostFunctor>::fixel_count_warning_issued = ATOMIC_FLAG_INIT;
+
+#ifdef FIXELCORRESPONDENCE_TEST_COMBINATORICS
+        template <class CostFunctor>
+        uint64_t Combinatorial<CostFunctor>::max_computed_combinations = 0;
+#endif
+
+
+
+      }
+    }
+  }
+}
+
+#endif

--- a/src/fixel/correspondence/algorithms/in2023.cpp
+++ b/src/fixel/correspondence/algorithms/in2023.cpp
@@ -1,0 +1,41 @@
+/* Copyright (c) 2008-2017 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * MRtrix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * For more details, see http://www.mrtrix.org/.
+ */
+
+#include "fixel/correspondence/algorithms/in2023.h"
+
+#include "app.h"
+
+namespace MR {
+  namespace Fixel {
+    namespace Correspondence {
+      namespace Algorithms {
+
+
+
+        using namespace App;
+
+        OptionGroup IN2023Options = OptionGroup ("Options specific to algorithm \"in2023\"")
+        + Option ("constants", "set values for the two constants that modulate the influence of different cost function terms")
+          + Argument ("alpha").type_float (0.0)
+          + Argument ("beta").type_float (0.0);
+
+
+
+        float IN2023::a = default_in2023_alpha;
+        float IN2023::b = default_in2023_beta;
+
+
+      }
+    }
+  }
+}

--- a/src/fixel/correspondence/algorithms/in2023.h
+++ b/src/fixel/correspondence/algorithms/in2023.h
@@ -1,0 +1,97 @@
+/* Copyright (c) 2008-2017 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * MRtrix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * For more details, see http://www.mrtrix.org/.
+ */
+
+#ifndef __fixel_correspondence_algorithms_in2023_h__
+#define __fixel_correspondence_algorithms_in2023_h__
+
+#include <stdint.h>
+
+#include "header.h"
+
+#include "fixel/correspondence/algorithms/combinatorial.h"
+
+
+namespace MR {
+
+  namespace App {
+    class OptionGroup;
+  }
+
+  namespace Fixel {
+    namespace Correspondence {
+      namespace Algorithms {
+
+
+
+        extern App::OptionGroup IN2023Options;
+
+
+
+        class IN2023 : public Combinatorial<IN2023>
+        {
+          public:
+
+            IN2023 (const size_t max_origins_per_target,
+                    const size_t max_objectives_per_source,
+                    const Header& H_cost) :
+                Combinatorial (max_origins_per_target, max_objectives_per_source, H_cost) {}
+
+            FORCE_INLINE static float calculate (const vector<Correspondence::Fixel>& s,
+                                                 const vector<Correspondence::Fixel>& rs,
+                                                 const vector<Correspondence::Fixel>& t,
+                                                 const Eigen::Array<int8_t, Eigen::Dynamic, 1>& objectives_per_source_fixel,
+                                                 const Eigen::Array<int8_t, Eigen::Dynamic, 1>& origins_per_remapped_fixel)
+            {
+              assert (rs.size() == t.size());
+              assert (s.size() == size_t(objectives_per_source_fixel.size()));
+              float result = 0.0f;
+              for (uint32_t t_index = 0; t_index != rs.size(); ++t_index) {
+
+                result += t[t_index].density() * (rs[t_index].density() ?
+                                                  dp2cost (t[t_index].absdot(rs[t_index])) :
+                                                  1.0f);
+
+                result += a * Math::pow2 (t[t_index].density() - rs[t_index].density());
+
+                result += b * Math::pow2 (origins_per_remapped_fixel[t_index] - int8_t(1));
+
+              }
+
+              for (uint32_t s_index = 0; s_index != s.size(); ++s_index) {
+
+                if (!objectives_per_source_fixel[s_index]) {
+                  result += s[s_index].density();
+                  result += a * Math::pow2 (s[s_index].density());
+                }
+
+                result += b * Math::pow2 (objectives_per_source_fixel[s_index] - int8_t(1));
+
+              }
+
+              return result;
+            }
+
+            static void set_constants (const float alpha, const float beta) { a = alpha; b = beta; }
+
+          protected:
+            static float a, b;
+        };
+
+
+
+      }
+    }
+  }
+}
+
+#endif

--- a/src/fixel/correspondence/algorithms/ismrm2018.h
+++ b/src/fixel/correspondence/algorithms/ismrm2018.h
@@ -1,0 +1,77 @@
+/* Copyright (c) 2008-2017 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * MRtrix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * For more details, see http://www.mrtrix.org/.
+ */
+
+#ifndef __fixel_correspondence_algorithms_ismrm2018_h__
+#define __fixel_correspondence_algorithms_ismrm2018_h__
+
+
+#include "header.h"
+#include "types.h"
+#include "math/math.h"
+#include "fixel/correspondence/algorithms/combinatorial.h"
+
+
+namespace MR {
+  namespace Fixel {
+    namespace Correspondence {
+      namespace Algorithms {
+
+
+
+
+        class ISMRM2018 : public Combinatorial<ISMRM2018>
+        {
+          public:
+            ISMRM2018 (const size_t max_origins_per_target,
+                       const size_t max_objectives_per_source,
+                       const Header& H_cost) :
+                Combinatorial (max_origins_per_target, max_objectives_per_source, H_cost) {}
+
+            FORCE_INLINE static float calculate (const vector<Correspondence::Fixel>& s,
+                                                 const vector<Correspondence::Fixel>& rs,
+                                                 const vector<Correspondence::Fixel>& t,
+                                                 const Eigen::Array<int8_t, Eigen::Dynamic, 1>& objectives_per_source_fixel,
+                                                 const Eigen::Array<int8_t, Eigen::Dynamic, 1>& origins_per_remapped_fixel)
+            {
+              assert (rs.size() == t.size());
+              assert (s.size() == size_t(objectives_per_source_fixel.size()));
+              float result = 0.0f;
+              for (uint32_t index = 0; index != rs.size(); ++index) {
+                if (rs[index].density()) {
+                  // Differences in fixel orientation contribute in such a way that
+                  //   angles of greater than 45 degrees are penalised more severely
+                  //   than would be leaving those fixels unmatched
+                  result += Math::pow2 (t[index].density() - rs[index].density()) * dp2cost (t[index].absdot(rs[index]));
+                } else {
+                  result += Math::pow2 (t[index].density());
+                }
+              }
+
+              // Need to find source fixels that did not contribute to any remapped fixel
+              for (uint32_t index = 0; index != s.size(); ++index) {
+                if (!objectives_per_source_fixel[index])
+                  result += Math::pow2 (s[index].density());
+              }
+
+              return result;
+            }
+        };
+
+
+
+      }
+    }
+  }
+}
+
+#endif

--- a/src/fixel/correspondence/algorithms/nearest.cpp
+++ b/src/fixel/correspondence/algorithms/nearest.cpp
@@ -1,0 +1,38 @@
+/* Copyright (c) 2008-2017 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * MRtrix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * For more details, see http://www.mrtrix.org/.
+ */
+
+#include "fixel/correspondence/algorithms/nearest.h"
+
+#include "app.h"
+#include "fixel/correspondence/correspondence.h"
+
+namespace MR {
+  namespace Fixel {
+    namespace Correspondence {
+      namespace Algorithms {
+
+
+
+        using namespace App;
+
+        OptionGroup NearestOptions = OptionGroup ("Options specific to algorithm \"nearest\"")
+        + Option ("angle", "maximum angle within which a corresponding fixel may be selected, in degrees "
+                           "(default: " + str(default_nearest_maxangle) + ")")
+          + Argument ("value").type_float (0.0f, 90.0f);
+
+
+
+      }
+    }
+  }
+}

--- a/src/fixel/correspondence/algorithms/nearest.h
+++ b/src/fixel/correspondence/algorithms/nearest.h
@@ -1,0 +1,85 @@
+/* Copyright (c) 2008-2017 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * MRtrix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * For more details, see http://www.mrtrix.org/.
+ */
+
+#ifndef __fixel_correspondence_algorithms_nearest_h__
+#define __fixel_correspondence_algorithms_nearest_h__
+
+
+#include "types.h"
+
+#include "fixel/correspondence/algorithms/base.h"
+
+
+namespace MR {
+
+  namespace App {
+    class OptionGroup;
+  }
+
+  namespace Fixel {
+    namespace Correspondence {
+      namespace Algorithms {
+
+
+
+        extern App::OptionGroup NearestOptions;
+
+
+
+        // Duplicate the functionality of the old fixelcorrespondence command:
+        // For each target fixel, simply select the closest source fixel,
+        //   as long as it is within some angular limit
+        class Nearest : public Base
+        {
+          public:
+            Nearest (const float max_angle) :
+                dp_threshold (std::cos (max_angle*Math::pi/180.0)) {}
+            virtual ~Nearest() {}
+
+            vector< vector<uint32_t> > operator() (const voxel_t&,
+                                                   const vector<Correspondence::Fixel>& s,
+                                                   const vector<Correspondence::Fixel>& t) const final
+            {
+              vector< vector<uint32_t> > result;
+              for (uint32_t it = 0; it != t.size(); ++it) {
+                uint32_t closest_index = 0;
+                float max_dp = 0.0f;
+                for (uint32_t is = 0; is != s.size(); ++is) {
+                  const float dp = t[it].absdot (s[is]);
+                  if (dp > max_dp) {
+                    max_dp = dp;
+                    closest_index = is;
+                  }
+                }
+                if (max_dp > dp_threshold) {
+                  result.emplace_back (vector<uint32_t> (1, closest_index));
+                } else {
+                  result.emplace_back (vector<uint32_t>());
+                }
+              }
+              return result;
+            }
+
+          protected:
+            const float dp_threshold;
+        };
+
+
+
+
+      }
+    }
+  }
+}
+
+#endif

--- a/src/fixel/correspondence/correspondence.h
+++ b/src/fixel/correspondence/correspondence.h
@@ -1,0 +1,56 @@
+/* Copyright (c) 2008-2017 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * MRtrix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * For more details, see http://www.mrtrix.org/.
+ */
+
+#ifndef __fixel_correspondence_correspondence_h__
+#define __fixel_correspondence_correspondence_h__
+
+
+#include "fixel/fixel.h"
+
+
+#define FIXELCORRESPONDENCE_INCLUDE_ALL2ALL
+//#define FIXELCORRESPONDENCE_TEST_COMBINATORICS
+
+
+
+namespace MR {
+  namespace Fixel {
+    namespace Correspondence {
+
+
+
+      // TODO Make extensive use of index_type
+      using index_type = MR::Fixel::index_type;
+      using dir_t = Eigen::Matrix<float, 3, 1>;
+      using voxel_t = Eigen::Array<uint32_t, 3, 1>;
+
+
+      constexpr unsigned int min_dirs_to_enforce_adjacency = 4;
+      constexpr unsigned int max_fixels_for_no_combinatorial_warning = 6;
+      constexpr unsigned int dp2cost_lookup_resolution = 1000;
+
+      constexpr float default_in2023_alpha = 0.5f;
+      constexpr float default_in2023_beta = 0.1f;
+      constexpr float default_nearest_maxangle = 45.0f;
+
+      constexpr unsigned int default_max_origins_per_target = 3;
+      constexpr unsigned int default_max_objectives_per_source = 3;
+
+
+
+
+    }
+  }
+}
+
+#endif

--- a/src/fixel/correspondence/dp2cost.h
+++ b/src/fixel/correspondence/dp2cost.h
@@ -1,0 +1,66 @@
+/* Copyright (c) 2008-2017 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * MRtrix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * For more details, see http://www.mrtrix.org/.
+ */
+
+
+#include "types.h"
+
+#include "fixel/correspondence/correspondence.h"
+
+//#define FIXELCORRESPONDENCE_TEST_DP2COST
+
+
+namespace MR {
+  namespace Fixel {
+    namespace Correspondence {
+
+
+
+      // Fast lookup for angular penalisation term
+      class DP2Cost
+      {
+        public:
+          DP2Cost () :
+              data (dp2cost_lookup_resolution+2),
+              multiplier (dp2cost_lookup_resolution)
+          {
+            for (size_t bin = 0; bin <= dp2cost_lookup_resolution; ++bin) {
+              const default_type dp = default_type(bin) / default_type(dp2cost_lookup_resolution);
+              data[bin] = std::tan(std::acos(dp));
+            }
+            // Pad lookup table so that the functor does not need to branch
+            //   to prevent buffer overrun in the case where dp = 1.0
+            data[dp2cost_lookup_resolution+1] = 0.0f;
+          }
+
+          float operator() (const float dp) const
+          {
+            assert (dp >= 0.0f && dp <= 1.0f);
+            const float position = dp * multiplier;
+            const size_t lower = std::floor (position);
+            const float mu = position - float(lower);
+            const float result = ((1.0f-mu) * data[lower]) + (mu * data[lower+1]);
+#ifdef FIXELCORRESPONDENCE_TEST_DP2COST
+            std::cerr << "DP = " << dp << "; exact = " << std::tan (std::acos (dp)) << "; lookup = " << result << "\n";
+#endif
+            return result;
+          }
+        private:
+          Eigen::Array<float, Eigen::Dynamic, 1> data;
+          const float multiplier;
+      };
+
+
+
+    }
+  }
+}

--- a/src/fixel/correspondence/fixel.h
+++ b/src/fixel/correspondence/fixel.h
@@ -1,0 +1,57 @@
+/* Copyright (c) 2008-2017 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * MRtrix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * For more details, see http://www.mrtrix.org/.
+ */
+
+#ifndef __fixel_correspondence_fixel_h__
+#define __fixel_correspondence_fixel_h__
+
+
+#include "image.h"
+#include "image_helpers.h"
+
+#include "fixel/correspondence/correspondence.h"
+
+
+namespace MR {
+  namespace Fixel {
+    namespace Correspondence {
+
+
+
+      // Information to be stored for each fixel that will be useful during correspondence
+      class Fixel
+      {
+        public:
+          Fixel (const Helper::ConstRow<Image<float>>& direction, const float density) :
+              _dir ( dir_t{ direction[0], direction[1], direction[2] }.normalized() ),
+              _density (density) { }
+          Fixel (const dir_t& direction, const float density) :
+              _dir (direction),
+              _density (density) { }
+          const dir_t& dir() const { return _dir; }
+          float density() const { return _density; }
+          float dot (const Fixel& i) const { return dir().dot (i.dir()); }
+          float dot (const dir_t& d) const { return dir().dot (d); }
+          float absdot (const Fixel& i) const { return std::abs (dir().dot (i.dir())); }
+          float absdot (const dir_t& d) const { return std::abs (dir().dot (d)); }
+        protected:
+          const dir_t _dir;
+          const float _density;
+      };
+
+
+
+    }
+  }
+}
+
+#endif

--- a/src/fixel/correspondence/mapping.cpp
+++ b/src/fixel/correspondence/mapping.cpp
@@ -1,0 +1,150 @@
+/* Copyright (c) 2008-2017 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * MRtrix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * For more details, see http://www.mrtrix.org/.
+ */
+
+#include "fixel/correspondence/mapping.h"
+
+#include "header.h"
+#include "image.h"
+
+
+namespace MR {
+  namespace Fixel {
+    namespace Correspondence {
+
+
+
+
+
+      Mapping::Mapping (const uint32_t source_fixels, const uint32_t target_fixels) :
+          source_fixels (source_fixels),
+          target_fixels (target_fixels),
+          M (target_fixels, vector<uint32_t>()) { }
+
+
+      Mapping::Mapping (const std::string& directory)
+      {
+        load (directory);
+      }
+
+
+
+      void Mapping::load (const std::string& directory, const bool import_inverse)
+      {
+        const std::string dir_string = import_inverse ? "inverse" : "forward";
+        Image<uint32_t> index_image = Image<uint32_t>::open (Path::join (directory, "index_" + dir_string + ".mif"));
+        Image<uint32_t> fixels_image = Image<uint32_t>::open (Path::join (directory, "fixels_" + dir_string + ".mif"));
+        Header converse_index_header = Header::open (Path::join (directory, std::string("index_") + (import_inverse ? "forward" : "inverse") + ".mif"));
+
+        M.assign (index_image.size(0), vector<uint32_t>());
+        for (uint32_t t_index = 0; t_index != index_image.size(0); ++t_index) {
+          index_image.index(0) = t_index;
+          index_image.index(1) = 0;
+          const uint32_t count = index_image.value();
+          index_image.index(1) = 1;
+          const uint32_t offset = index_image.value();
+          M[t_index].reserve (count);
+          fixels_image.index(0) = offset;
+          for (uint32_t i = 0; i != count; ++i) {
+            M[t_index].push_back (fixels_image.value());
+            fixels_image.index(0)++;
+          }
+        }
+        source_fixels = converse_index_header.size(0);
+        target_fixels = index_image.size(0);
+      }
+
+
+
+      void Mapping::save (const std::string& directory) const
+      {
+        File::mkdir (directory);
+        save (directory, false);
+        save (directory, true);
+      }
+
+
+      vector< vector<uint32_t> > Mapping::inverse() const
+      {
+        vector< vector<uint32_t> > Minv (source_fixels, vector<uint32_t>());
+        for (uint32_t t_index = 0; t_index != target_fixels; ++t_index) {
+          for (auto s_index : M[t_index])
+            Minv[s_index].push_back (t_index);
+        }
+        return Minv;
+      }
+
+
+
+      void Mapping::save (const std::string& directory, const bool export_inverse) const
+      {
+        vector< vector<uint32_t> > Minv;
+        if (export_inverse)
+          Minv = inverse();
+        const vector< vector<uint32_t> >& data (export_inverse ? Minv : M);
+        const std::string dir_string = (export_inverse ? "inverse" : "forward");
+        const std::string index_path = Path::join (directory, "index_" + dir_string + ".mif");
+        const std::string fixels_path = Path::join (directory, "fixels_" + dir_string + ".mif");
+
+        uint32_t fixel_map_count = 0;
+        for (const auto& row : data)
+          fixel_map_count += row.size();
+
+        Header H_index;
+        H_index.ndim() = 3;
+        H_index.size(0) = data.size();
+        H_index.size(1) = 2;
+        H_index.size(2) = 1;
+        H_index.stride(0) = 2;
+        H_index.stride(1) = 1;
+        H_index.stride(2) = 3;
+        H_index.spacing(0) = H_index.spacing(1) = H_index.spacing(2) = 1.0;
+        H_index.transform() = transform_type::Identity();
+        H_index.datatype() = DataType::UInt32;
+        H_index.datatype().set_byte_order_native();
+        H_index.keyval()["fixels"] = "fixels_" + dir_string + ".mif";
+
+        Header H_fixels;
+        H_fixels.ndim() = 3;
+        H_fixels.size(0) = fixel_map_count;
+        H_fixels.size(1) = 1;
+        H_fixels.size(2) = 1;
+        H_fixels.stride(0) = 1;
+        H_fixels.stride(1) = 2;
+        H_fixels.stride(2) = 3;
+        H_fixels.spacing(0) = H_fixels.spacing(1) = H_fixels.spacing(2) = 1.0;
+        H_fixels.transform() = transform_type::Identity();
+        H_fixels.datatype() = DataType::UInt32;
+        H_fixels.datatype().set_byte_order_native();
+        H_fixels.keyval()["index"] = "index_" + dir_string + ".mif";
+
+        Image<uint32_t> index_image = Image<uint32_t>::create (index_path, H_index);
+        Image<uint32_t> fixels_image = Image<uint32_t>::create (fixels_path, H_fixels);
+
+        for (size_t t_index = 0; t_index != data.size(); ++t_index) {
+          index_image.index(0) = t_index;
+          index_image.index(1) = 0;
+          index_image.value() = data[t_index].size();
+          index_image.index(1) = 1;
+          index_image.value() = fixels_image.index(0);
+          for (auto s_index : data[t_index]) {
+            fixels_image.value() = s_index;
+            fixels_image.index(0) += 1;
+          }
+        }
+
+      }
+
+
+    }
+  }
+}

--- a/src/fixel/correspondence/mapping.h
+++ b/src/fixel/correspondence/mapping.h
@@ -1,0 +1,109 @@
+/* Copyright (c) 2008-2017 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * MRtrix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * For more details, see http://www.mrtrix.org/.
+ */
+
+#ifndef __fixel_correspondence_mapping_h__
+#define __fixel_correspondence_mapping_h__
+
+#include <string>
+
+#include "types.h"
+
+
+namespace MR {
+  namespace Fixel {
+    namespace Correspondence {
+
+
+
+
+      // TODO Do we want to store a fractional weight for each projection as part of the mapping,
+      //   both in the internal RAM representation and on the filesystem?
+      //
+      // TODO Change from a vector< vector<uint32_t> > (vector of fixel indices per fixel)
+      //   to something more faithful to what will be stored on disk (and have less overhead):
+      //   Forward:
+      //     Eigen::Array<index_type, Nt, 2, RowMajor>
+      //     Eigen::Array<index_type, C, 1>
+      //     Eigen::Array<float, C, 1>  (maybe)
+      //   Note that this is not something that can be trivially dynamically expanded...
+      //
+      // TODO Consider automatically computing for every source fixel the number of template fixels
+      //   to which it is attributed
+      //   (in the case of explicitly storing attribution weights,
+      //   this would need to be a count of non-zero attribution weights and a sum of such)
+      //   This would not need to be stored on disk,
+      //   but would be used for various calculations
+      //
+      // TODO Consider (both here and potentially for fixel dataset also) a pair of classes where
+      //   one uses a data representation that clearly comes straight from disk and is read-only,
+      //   and one is intended to be dynamically resizable,
+      //   but they operate using the same interface (perhaps using CRTP)
+      // In this way the interface for fixelcorrespondence and fixel2fixel could look identical,
+      //   even though the underlying data structures would be different
+      class Mapping
+      {
+        public:
+          Mapping (const uint32_t source_fixels, const uint32_t target_fixels);
+          Mapping (const std::string& directory);
+
+          void load (const std::string& directory, const bool import_inverse = false);
+
+          // Save to new format:
+          // - Create directory based on user input
+          // - index_forward.mif: Nt x 2 x 1, containing count and offset for each target fixel
+          // - fixels_forward.mif: C x 1 x 1, containing source fixel indices to pull into target fixels
+          // - index_inverse.mif: Ns x 2 x 1, containing count and offset for each source fixel in the inverse mapping
+          // - fixels_inverse.mif: C x 1 x 1, containing target fixel indices to pull into source fixels
+          void save (const std::string& directory) const;
+
+          const vector<uint32_t>& operator[] (const size_t index) const { return M[index]; }
+
+          class Value
+          {
+            public:
+              Value (vector<vector<uint32_t>>& M, const size_t index) :
+                  M (M),
+                  index (index)
+              {
+                assert (index < M.size());
+              }
+              const vector<uint32_t>& operator() () const { return M[index]; }
+              const vector<uint32_t>& operator= (const vector<uint32_t>& data) { M[index] = data; return M[index]; }
+              uint32_t operator[] (const size_t i) const { assert (i < M[index].size()); return M[index][i]; }
+            private:
+              vector<vector<uint32_t>>& M;
+              const size_t index;
+          };
+          Value operator[] (const size_t index) { return Value (M, index); }
+
+          size_t size() const { return M.size(); }
+
+          // TODO Modify to yield a complete instance of the Mapping class?
+          vector< vector<uint32_t> > inverse() const;
+
+        private:
+          uint32_t source_fixels, target_fixels;
+          vector< vector<uint32_t> > M;
+
+
+          void save (const std::string& directory, const bool export_inverse) const;
+
+      };
+
+
+
+    }
+  }
+}
+
+#endif

--- a/src/fixel/correspondence/matcher.cpp
+++ b/src/fixel/correspondence/matcher.cpp
@@ -1,0 +1,153 @@
+/* Copyright (c) 2008-2017 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * MRtrix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * For more details, see http://www.mrtrix.org/.
+ */
+
+
+#include "fixel/correspondence/matcher.h"
+
+#include "header.h"
+#include "fixel/helpers.h"
+#include "fixel/correspondence/algorithms/base.h"
+#include "fixel/correspondence/fixel.h"
+
+
+namespace MR {
+  namespace Fixel {
+    namespace Correspondence {
+
+
+
+      Matcher::Matcher (const std::string& source_file,
+                        const std::string& target_file,
+                        std::shared_ptr<Algorithms::Base>& algorithm) :
+          algorithm (algorithm)
+#ifdef FIXELCORRESPONDENCE_TEST_COMBINATORICS
+          , mutex (new std::mutex)
+#endif
+      {
+        if (Path::is_dir (source_file))
+          throw Exception ("Please input the source fixel data file to be used during fixel correspondence; not the fixel directory");
+        Header source_header (Header::open (source_file));
+        if (!MR::Fixel::is_data_file (source_header))
+          throw Exception ("Source input image is not a fixel data file");
+
+        const std::string source_directory = MR::Fixel::get_fixel_directory (source_file);
+        source_index = MR::Fixel::find_index_header (source_directory).get_image<uint32_t>();
+        source_directions = MR::Fixel::find_directions_header (source_directory).get_image<float>();
+        source_data = source_header.get_image<float>();
+        MR::Fixel::check_fixel_size (source_index, source_data);
+
+        if (Path::is_dir (target_file))
+          throw Exception ("Please input the target fixel data file to be used during fixel correspondence; not the fixel directory");
+        Header target_header (Header::open (target_file));
+        if (!MR::Fixel::is_data_file (target_header))
+          throw Exception ("Target input image is not a fixel data file");
+
+        const std::string target_directory = MR::Fixel::get_fixel_directory (target_file);
+        target_index = MR::Fixel::find_index_header (target_directory).get_image<uint32_t>();
+        target_directions = MR::Fixel::find_directions_header (target_directory).get_image<float>();
+        target_data = target_header.get_image<float>();
+        MR::Fixel::check_fixel_size (target_index, target_data);
+
+        // Source and target images need to match spatially,
+        //   but do not need to contain the same number of fixels
+        check_dimensions (source_index, target_index);
+        check_voxel_grids_match_in_scanner_space (source_index, target_index);
+
+        remapped_directions = Image<float>::scratch (target_directions, "scratch image for remapped fixel directions");
+        remapped_data = Image<float>::scratch (target_data, "scratch image for remapped fixel densities");
+
+        mapping.reset (new MR::Fixel::Correspondence::Mapping (MR::Fixel::get_number_of_fixels (source_index),
+                                                               MR::Fixel::get_number_of_fixels (target_index)));
+      }
+
+
+
+      void Matcher::operator() (Image<uint32_t>& voxel)
+      {
+        assign_pos_of (voxel, 0, 3).to (source_index, target_index);
+        source_index.index(3) = target_index.index(3) = 0;
+        const uint32_t nfixels_source = source_index.value();
+        const uint32_t nfixels_target = target_index.value();
+        source_index.index(3) = target_index.index(3) = 1;
+        const uint32_t offset_source = source_index.value();
+        const uint32_t offset_target = target_index.value();
+
+        // Perform an initial load of the fixel information; this can
+        //   then be palmed off to the appropriate algorithm
+        // By pre-loading into vectors, can have fixels in both spaces indexed from zero
+        //   during the correspondence determination
+        vector<Correspondence::Fixel> source_fixels, target_fixels;
+        for (uint32_t i = 0; i != nfixels_source; ++i) {
+          source_directions.index(0) = source_data.index(0) = offset_source + i;
+          source_fixels.push_back (Correspondence::Fixel (source_directions.row(1), source_data.value()));
+        }
+        for (uint32_t i = 0; i != nfixels_target; ++i) {
+          target_directions.index(0) = target_data.index(0) = offset_target + i;
+          target_fixels.push_back (Correspondence::Fixel (target_directions.row(1), target_data.value()));
+        }
+
+        vector< vector<uint32_t> > M;
+        if (target_fixels.size()) {
+          if (source_fixels.size())
+            M = (*algorithm) ({uint32_t(voxel.index(0)), uint32_t(voxel.index(1)), uint32_t(voxel.index(2))}, source_fixels, target_fixels);
+          else
+            M.assign (target_fixels.size(), vector<uint32_t>());
+        }
+
+        // TODO Generate the set of remapped subject fixels
+        Eigen::Array<uint8_t, Eigen::Dynamic, 1> objectives_per_source_fixel (Eigen::Array<uint8_t, Eigen::Dynamic, 1>::Zero (nfixels_source));
+        for (uint32_t it = 0; it != nfixels_target; ++it) {
+          for (auto is : M[it])
+            ++objectives_per_source_fixel[is];
+        }
+        const Eigen::Array<float, Eigen::Dynamic, 1> source_fixel_multipliers (1.0 / objectives_per_source_fixel.cast<float>());
+        for (uint32_t it = 0; it != nfixels_target; ++it) {
+          target_directions.index(0) = remapped_directions.index(0) = remapped_data.index(0) = offset_target + it;
+          dir_t direction (0.0f, 0.0f, 0.0f);
+          float density = 0.0f;
+          for (auto is : M[it]) {
+            direction += source_fixels[is].density() * source_fixels[is].dir() * (source_fixels[is].dot(target_fixels[it]) > 0.0f ? 1.0f : -1.0f);
+            density += source_fixels[is].density();
+          }
+          remapped_directions.row(1) = direction.normalized();
+          remapped_data.value() = density;
+        }
+
+        // When writing, need to now deal with the offset to the first fixel in the
+        //   voxel for each of the two images
+        assert (M.size() == nfixels_target);
+        for (uint32_t i = 0; i != nfixels_target; ++i) {
+          for (uint32_t j = 0; j != M[i].size(); ++j)
+            M[i][j] += offset_source;
+          (*mapping)[offset_target + i] = M[i];
+        }
+      }
+
+
+
+      void Matcher::export_remapped (const std::string& dirname)
+      {
+        MR::Fixel::check_fixel_directory (dirname, true, true);
+        Image<uint32_t> out_index (Image<uint32_t>::create (Path::join (dirname, "index.mif"), target_index));
+        copy (target_index, out_index);
+        Image<float> out_directions (Image<float>::create (Path::join (dirname, "directions.mif"), target_directions));
+        copy (remapped_directions, out_directions);
+        Image<float> out_data (Image<float>::create (Path::join (dirname, "fd.mif"), target_data));
+        copy (remapped_data, out_data);
+      }
+
+
+
+    }
+  }
+}

--- a/src/fixel/correspondence/matcher.h
+++ b/src/fixel/correspondence/matcher.h
@@ -1,0 +1,95 @@
+/* Copyright (c) 2008-2017 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * MRtrix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * For more details, see http://www.mrtrix.org/.
+ */
+
+#ifndef __fixel_correspondence_matcher_h__
+#define __fixel_correspondence_matcher_h__
+
+#include <mutex>
+#include <string>
+
+#include "image.h"
+
+#include "fixel/correspondence/correspondence.h"
+#include "fixel/correspondence/mapping.h"
+
+
+namespace MR {
+  namespace Fixel {
+    namespace Correspondence {
+
+
+
+      namespace Algorithms
+      {
+        class Base;
+      }
+
+
+
+
+      // Functor is safe to copy-construct for multi-threading:
+      //   correspondence data are stored in a std::shared_ptr<>
+      class Matcher
+      {
+
+        public:
+
+          Matcher (const std::string& source_file,
+                   const std::string& target_file,
+                   std::shared_ptr<Algorithms::Base>& algorithm);
+
+
+
+          // Input is just a dummy iterator that provides the location
+          void operator() (Image<uint32_t>& voxel);
+
+
+          // Use this to get a template image in order to loop over voxels
+          Image<uint32_t> get_template() const { return Image<uint32_t> (target_index); }
+
+          const MR::Fixel::Correspondence::Mapping& get_mapping() const { assert (mapping); return *mapping; }
+
+          size_t num_source_fixels() const { return source_data.size(0); }
+          size_t num_target_fixels() const { return target_data.size(0); }
+
+          void export_remapped (const std::string& dirname);
+
+
+        private:
+          std::shared_ptr<Algorithms::Base> algorithm;
+
+          Image<uint32_t> source_index, target_index;
+          Image<float> source_directions, target_directions, remapped_directions;
+          Image<float> source_data, target_data, remapped_data;
+
+          std::shared_ptr<MR::Fixel::Correspondence::Mapping> mapping;
+
+#ifdef FIXELCORRESPONDENCE_TEST_COMBINATORICS
+          std::shared_ptr<std::mutex> mutex;
+          static uint64_t max_computed_combinations;
+#endif
+
+      };
+
+#ifdef FIXELCORRESPONDENCE_TEST_COMBINATORICS
+      uint64_t Matcher::max_computed_combinations = 0;
+#endif
+
+
+
+
+    }
+  }
+}
+
+#endif


### PR DESCRIPTION
Recently went to a bunch of effort splitting code across header files only to discover that I'd actually done it a couple of years ago in https://github.com/MRtrix3/mrtrix3/commit/747dd95b4ffb285ee21d02c6fae84b3349005815. Retaining the more recent version.

- [x] Move function `n_choose_k()` to new file `core/math/binomial.h` as was done previously in  https://github.com/MRtrix3/mrtrix3/commit/64759f6177f0b6203c410446b5a34985c1f9bb63
- [ ] Try to do some heuristic tuning of more recent proposed correpsondence metric
    (currently processing a cohort that should serve well for this purpose)
- [ ] Update FBA documentation to use these modified / new commands
    Consider initially updating them to explicitly use the "nearest" algorithm, which duplicates prior behaviour; changing the advised algorithm can be discussed in #2685
- [x] Move templated combinatorial matching code from `.h` to `.cpp` and explicitly instantiate the two required versions
- [x] Change filesystem storage format (#2200).
    - [x] Switch from `.mif` to `.npy`
    - [x] Contemplate explicit export of attribution weights
        **Edit**: Think I am now in favour of this. @maxpietsch had initially proposed this as a way of handling a more continuous measure of attribution. However the change in 9018cdb62cfafd05678d3bb9b3fa5e3e442e9847 would not be required if these weights were explicit: the `nearest` would simply state that the nearest source fixel maps to the target fixel with weight 1.0 always, and this would be encoded in the input mapping data to `fixel2fixel`.
- [ ] Change internal representation
    - [ ] Currently for each fixel a `vector<index_type>` is used. While this could be used during the optimisation process itself if necessary / beneficial, better would be something more consistent with the on-disk storage: an index array with count & offset per fixel, which provides lookup into a table of fixel indices. An accessor class could deal with translation of such, providing iteration via `:` operator, etc..
    - [x] Automatically compute number of sources per target and number of targets per source
- [x] Make sure that compilation / execution works with / without the demonstration "`all2all`" class (or just remove it)
- [ ] Clean up old code comments to be descriptive rather than prescriptive
- [x] Add to `fixel2fixel` command ability to disable implicit scaling; this is necessary to exactly replicate behaviour of old `fixelcorrespondence` command, where the entirety of the FD of a subject fixel may project to multiple template fixels