### PR TITLE
DICOM: fix multiframe encoding with explicit length sequences

### DIFF
--- a/core/file/dicom/element.cpp
+++ b/core/file/dicom/element.cpp
@@ -228,10 +228,15 @@ namespace MR {
 
 
 
-        if (parents.size())
-          if ((parents.back().end && data > parents.back().end) ||
-              (group == GROUP_SEQUENCE && element == ELEMENT_SEQUENCE_DELIMITATION_ITEM))
+        if (parents.size()) {
+          if (group == GROUP_SEQUENCE && element == ELEMENT_SEQUENCE_DELIMITATION_ITEM) {
             parents.pop_back();
+          }
+          else { // Undefined length encoding:
+            while (parents.size() && parents.back().end && data > parents.back().end)
+              parents.pop_back();
+          }
+        }
 
         if (is_new_sequence()) {
           if (size == LENGTH_UNDEFINED)


### PR DESCRIPTION
As discussed in #2690

Problem stems from failure to handle cases where nested sequences all end at the same point. Previous implementation only closed the current sequence, without considering whether its own parents also needed to close at that point. 

I'll be running my battery of tests shortly to confirm this doesn't introduce any issues with current datasets. 