### PR TITLE
Docs: Fix missing boolean types in full usage

### DIFF
--- a/core/app.cpp
+++ b/core/app.cpp
@@ -212,6 +212,8 @@ namespace MR
     const char* argtype_description (ArgType type)
     {
       switch (type) {
+        case Boolean:
+          return ("boolean");
         case Integer:
           return ("integer");
         case Float:
@@ -502,6 +504,9 @@ namespace MR
       switch (type) {
         case Undefined:
           assert (0);
+          break;
+        case Boolean:
+          stream << "BOOL";
           break;
         case Integer:
           stream << "INT " << limits.i.min << " " << limits.i.max;


### PR DESCRIPTION
Noticed while working on #2678 an assertion failure for which the fix is applicable to `master`. Can see the difference for example for `mrconvert -bvalue_scaling` option, which currently does not report a type in `__print_full_usage__`.

Raises a secondary question. Just as the RST documentation is generated and stored within the repository and CI then re-generates and cross-checks against that content, there is an argument to be made for the full interface definitions generated by `__print_full_usage__` to be stored within the repository also (as has been argued for the Pydra interfaces in #2665).