### PR TITLE
Docs: Explicitly specify English language to Sphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,7 +69,7 @@ release = u'3.0'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
Addressing CI error observed in #2713:
```
Run python3 -m sphinx -n -N -W -w sphinx.log docs/ tmp/
  python3 -m sphinx -n -N -W -w sphinx.log docs/ tmp/
  shell: /usr/bin/bash -e {0}
  env:
    QT_SELECT: qt5
Running Sphinx v7.[2](https://github.com/MRtrix3/mrtrix3/actions/runs/6147387227/job/16678768734?pr=2713#step:7:2).[5](https://github.com/MRtrix3/mrtrix3/actions/runs/6147387227/job/16678768734?pr=2713#step:7:5)

Warning, treated as error:
Invalid configuration value found: 'language = None'. Update your configuration to a valid language code. Falling back to 'en' (English).
Error: Process completed with exit code 2.
```