### PR TITLE
mrview: fix crash due to change in order of includes

### DIFF
--- a/build
+++ b/build
@@ -857,8 +857,8 @@ class Entry:
     self.action = 'RCC'
     with codecs.open (modify_path (self.name, strip=cpp_suffix, add=h_suffix), mode='r', encoding='utf-8') as fd:
       for line in fd:
-        if line.startswith ('//RCC:'):
-          for entry in line[6:].strip().split():
+        if line.startswith ('// RCC:'):
+          for entry in line[7:].strip().split():
             self.deps = self.deps.union (glob.glob (os.path.normpath (os.path.join (mrtrix_dir[-1], 'icons', entry))))
     self.deps.add (config_file)
     qrc_file = os.path.normpath (os.path.join (mrtrix_dir[-1], 'icons', os.path.basename (os.path.dirname(self.name)) + '.qrc'))

--- a/cmd/mrview.cpp
+++ b/cmd/mrview.cpp
@@ -14,8 +14,11 @@
  * For more details, see http://www.mrtrix.org/.
  */
 
-#include "command.h"
+// clang-format off
 #include "gui/gui.h"
+#include "command.h"
+// clang-format on
+
 #include "gui/mrview/file_open.h"
 #include "gui/mrview/icons.h"
 #include "gui/mrview/mode/list.h"

--- a/cmd/shview.cpp
+++ b/cmd/shview.cpp
@@ -14,9 +14,12 @@
  * For more details, see http://www.mrtrix.org/.
  */
 
-#include "command.h"
-#include "file/path.h"
+// clang-format off
 #include "gui/gui.h"
+#include "command.h"
+// clang-format on
+
+#include "file/path.h"
 #include "gui/shview/file_open.h"
 #include "gui/shview/icons.h"
 #include "gui/shview/render_window.h"


### PR DESCRIPTION
mrview: fix crash due to change in order of includes
Also fix generation of icons QRC file.

Both changes required following move to clang-format