### PR TITLE
Barzilai-Borwein gradient descent: Step size options

### DIFF
--- a/core/math/gradient_descent_bb.h
+++ b/core/math/gradient_descent_bb.h
@@ -43,14 +43,20 @@ public:
   }
 };
 
+
+// "LEGACY" corresponds to implementation prior to 3.1.x, which may be erroneous
+enum class bbgd_step_size_t {SHORT, LONG, GEOMMEAN, LEGACY};
+
+
 //! Computes the minimum of a function using a Barzilai Borwein gradient descent approach. ENH: implement stabilised
 //! version https://arxiv.org/abs/1907.06409
 template <class Function, class UpdateFunctor = LinearUpdateBB> class GradientDescentBB {
 public:
   using value_type = typename Function::value_type;
 
-  GradientDescentBB(Function &function, UpdateFunctor update_functor = LinearUpdateBB(), bool verbose = false)
+  GradientDescentBB(Function &function, bbgd_step_size_t step_type, UpdateFunctor update_functor = LinearUpdateBB(), bool verbose = false)
       : func(function),
+        step_type (step_type),
         update_func(update_functor),
         x1(func.size()),
         x2(func.size()),
@@ -209,6 +215,7 @@ public:
 
 protected:
   Function &func;
+  bbgd_step_size_t step_type;
   UpdateFunctor update_func;
   Eigen::Matrix<value_type, Eigen::Dynamic, 1> x1, x2, x3, g1, g2, g3, preconditioner_weights;
   value_type f, dt, normg;
@@ -232,14 +239,30 @@ protected:
     return cost;
   }
 
-  void compute_normg_and_step() {
-    if (preconditioner_weights.size()) {
-      g2.array() *= preconditioner_weights.array();
-    }
-    normg = g2.norm();
-    assert((g2 - g1).norm() > 0.0);
-    dt = (x2 - x1).norm() / (g2 - g1).norm();
+  void compute_normg_and_step () {
+  if (preconditioner_weights.size()) {
+    g2.array() *= preconditioner_weights.array();
   }
+  normg = g2.norm();
+  auto dx = x2-x1;
+  auto dg = g2-g1;
+  assert(dg.norm() > 0.0);
+  switch (step_type) {
+    case bbgd_step_size_t::SHORT:
+      dt = dx.dot(dg) / dg.squaredNorm();
+      break;
+    case bbgd_step_size_t::LONG:
+      dt = dx.squaredNorm() / dx.dot(dg);
+      break;
+    case bbgd_step_size_t::GEOMMEAN:
+      dt = std::sqrt(Math::pow2 (dx.dot(dg) / dg.squaredNorm()) + Math::pow2 (dx.squaredNorm() / dx.dot(dg)));
+      break;
+    case bbgd_step_size_t::LEGACY:
+      dt = dx.norm() / dg.norm();
+      break;
+  }
+}
+
 };
 //! @}
 } // namespace Math

--- a/src/registration/linear.h
+++ b/src/registration/linear.h
@@ -500,7 +500,7 @@ public:
       for (auto stage_iter = 1U; stage_iter <= stage.stage_iterations; ++stage_iter) {
         if (stage.gd_max_iter > 0 and stage.optimisers[stage_iter - 1] == OptimiserAlgoType::bbgd) {
           Math::GradientDescentBB<Metric::Evaluate<MetricType, ParamType>, typename TransformType::UpdateType> optim(
-              evaluate, *transform.get_gradient_descent_updator());
+              evaluate, bbgd_step_size_t::LEGACY, *transform.get_gradient_descent_updator());
           optim.be_verbose(analyse_descent);
           optim.precondition(optimiser_weights);
           optim.run(stage.gd_max_iter, grad_tolerance, analyse_descent ? std::cout.rdbuf() : log_stream);


### PR DESCRIPTION
Hoping to draw comment from @maxpietsch.

Been looking at [Barzilai-Borwein gradient descent](https://en.wikipedia.org/wiki/Barzilai-Borwein_method) as a possible numerical solver for a problem I'm currently facing. This is already in use for the purpose of affine image registration.

On looking at the code I immediately spotted a difference between the [current implementation](https://github.com/MRtrix3/mrtrix3/blame/3.0.4/core/math/gradient_descent_bb.h#L228) for determining step size:
`dt = (x2-x1).norm()/(g2-g1).norm();`
and the [Wikipedia page](https://en.wikipedia.org/wiki/Barzilai-Borwein_method):
![BBGD_step_size](https://github.com/MRtrix3/mrtrix3/assets/5637955/8d86d770-6678-42fb-91ce-8ae03c711051)

What I'm not sure about is whether this is an outright bug in implementation, or if there's something else going on. I'll try to at some point run rigid-body registration with the verbosity increased and see if the alternative expressions provide faster or more stable convergence. But external expertise would be welcome also.

