### PR TITLE
Fix online documentation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,11 @@
 # Required
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.7"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
@@ -20,6 +25,5 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-   version: 3.7
    install:
       - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,3 @@
 sphinx-notfound-page
+recommonmark
+

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
-sphinx-notfound-page
 recommonmark
-
+sphinx-notfound-page
+sphinx_rtd_theme 
+typing


### PR DESCRIPTION
The ReadTheDocs online documentation is currently not displaying correctly.

[Here it is](https://mrtrix.readthedocs.io/en/3.0.4/) at tag `3.0.4`, appearing as intended:
![Screenshot from 2023-10-04 13-27-14](https://github.com/MRtrix3/mrtrix3/assets/5637955/dbf4ed1c-17f0-4c62-a705-5b18d4c5b335)

[Here](https://mrtrix.readthedocs.io/en/latest/) is the current `latest`:
![Screenshot from 2023-10-04 13-25-37](https://github.com/MRtrix3/mrtrix3/assets/5637955/cda5a3fe-10a2-4e77-b59e-fc2341a95198)

Now I found [here](https://blog.readthedocs.com/use-build-os-config/) instructions for config modification that needs to be done by October 16; so I did that, but that [produces](https://mrtrix.readthedocs.io/en/readthedocs_build_os/) a different incorrect answer: 
![Screenshot from 2023-10-04 13-26-21](https://github.com/MRtrix3/mrtrix3/assets/5637955/fa6ef50b-4946-489d-ab9e-6916350cff5c)

So this PR does not resolve the issue, but probably the fix for such should be build atop it.

I don't have experience with ReadTheDocs itself, so hoping somebody might recognise the issue from some precedent.