### PR TITLE
Fix typo in CMake presets file

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -6,7 +6,7 @@
             "displayName" : "Base configuration",
             "hidden" : true,
             "generator" : "Ninja",
-            "binaryDir": "${sourceParentDir}/build-mrtrix3-${presetName}",
+            "binaryDir": "${sourceParentDir}/build-mrtrix3-${presetName}"
         },
         {
             "name": "debug",


### PR DESCRIPTION
Removes an extra comma in `CMakePresets.json` that prevented CMake to parse the file.