### PR TITLE
Make mrtrix::gui to not depend on mrtrix::headless

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,6 +66,7 @@ if(MRTRIX_BUILD_GUI)
     set_target_properties(mrtrix-gui PROPERTIES
         AUTOMOC ON
         AUTOUIC ON
+        LINK_DEPENDS_NO_SHARED ON
     )
 
     target_link_libraries(mrtrix-gui PUBLIC


### PR DESCRIPTION
Uses `LINK_DEPENDS_NO_SHARED` to ensure that the gui library does not have a file level dependency on the shared library files of the `mrtrix::headless` lib. This prevents `mrtrix::gui` to be relinked on every modification of `mrtrix::headless`, but only on those that trigger a change in header files.