### PR TITLE
Explicitly set compiler for CI clang build

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -47,6 +47,8 @@ jobs:
         -D MRTRIX_BUILD_TESTS=ON
         -D MRTRIX_STL_DEBUGGING=ON
         -D MRTRIX_WARNINGS_AS_ERRORS=ON
+        -D CMAKE_C_COMPILER=clang
+        -D CMAKE_CXX_COMPILER=clang++
 
     - name: build
       run: cmake --build build


### PR DESCRIPTION
When we switched to CMake, it seems that I forgot to explicitly set Clang as the compiler for our `linux-clang-build`CI workflow, so it was using GCC since it's the default compiler on Linux. This PR fixes that.