### PR TITLE
Fix memory leak in mrdegibbs

### DIFF
--- a/core/math/fft.h
+++ b/core/math/fft.h
@@ -32,21 +32,21 @@ namespace Math {
 class FFT1D {
 public:
   FFT1D(size_t N, int direction) : _data(N), direction(direction) {
-    fftw_complex *p = reinterpret_cast<fftw_complex *>(&(_data[0]));
-    _plan = fftw_plan_dft_1d(N, p, p, direction, FFTW_MEASURE);
+    fftw_complex *p = reinterpret_cast<fftw_complex *>(_data.data());
+    _plan = fftw_plan_dft_1d(static_cast<int>(N), p, p, direction, FFTW_MEASURE);
   }
 
   FFT1D(const FFT1D &other) : _data(other._data.size()), direction(other.direction) {
-    fftw_complex *p = reinterpret_cast<fftw_complex *>(&(_data[0]));
-    _plan = fftw_plan_dft_1d(other._data.size(), p, p, direction, FFTW_MEASURE);
+    fftw_complex *p = reinterpret_cast<fftw_complex *>(_data.data());
+    _plan = fftw_plan_dft_1d(static_cast<int>(_data.size()), p, p, direction, FFTW_MEASURE);
   }
 
   FFT1D &operator=(const FFT1D &other) {
     fftw_destroy_plan(_plan);
     _data.resize(other._data.size());
     direction = other.direction;
-    fftw_complex *p = reinterpret_cast<fftw_complex *>(&(_data[0]));
-    _plan = fftw_plan_dft_1d(other._data.size(), p, p, direction, FFTW_MEASURE);
+    fftw_complex *p = reinterpret_cast<fftw_complex *>(_data.data());
+    _plan = fftw_plan_dft_1d(static_cast<int>(_data.size()), p, p, direction, FFTW_MEASURE);
     return *this;
   }
 

--- a/core/math/fft.h
+++ b/core/math/fft.h
@@ -41,6 +41,20 @@ public:
     _plan = fftw_plan_dft_1d(other._data.size(), p, p, direction, FFTW_MEASURE);
   }
 
+  FFT1D &operator=(const FFT1D &other) {
+    fftw_destroy_plan(_plan);
+    _data.resize(other._data.size());
+    direction = other.direction;
+    fftw_complex *p = reinterpret_cast<fftw_complex *>(&(_data[0]));
+    _plan = fftw_plan_dft_1d(other._data.size(), p, p, direction, FFTW_MEASURE);
+    return *this;
+  }
+
+  ~FFT1D() { fftw_destroy_plan(_plan); }
+
+  FFT1D(FFT1D &&other) = delete;
+  FFT1D &operator=(FFT1D &&other) = delete;
+
   const size_t size() const { return _data.size(); }
 
   const cdouble &operator[](size_t n) const { return _data[n]; }


### PR DESCRIPTION
The `FFT1D` class in `core/math/fft.h` never called `fftw_destroy_plan` as documented [here](https://www.fftw.org/fftw3_doc/Using-Plans.html). This resulted in a memory leak. This fix calls this function in the destructor of this class, and it also additionally provides a copy assignment operator (to follow the rule of five I have deleted the move constructor and assignment operator).