### PR TITLE
Add periodic checks with sanitizers

### DIFF
--- a/.github/workflows/nightly-sanitizers.yml
+++ b/.github/workflows/nightly-sanitizers.yml
@@ -1,0 +1,62 @@
+name: Nightly checks with sanitizers
+
+on:
+  workflow_dispatch:
+  # Run this every day at midnight
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  linux-clang-build:
+    runs-on: ubuntu-latest
+
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_CACHE_SIZE: "2G"
+
+    strategy:
+        fail-fast: false
+        matrix:
+            sanitizer: [address, thread, undefined]
+
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+        ref: dev
+
+    - name: install dependencies
+      run: |
+         sudo apt-get update
+         sudo apt-get install clang llvm qt6-base-dev libglvnd-dev libeigen3-dev zlib1g-dev libfftw3-dev ninja-build
+
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.3
+
+    - name: Get CMake
+      uses: lukka/get-cmake@latest
+      with:
+        cmakeVersion: '3.16.3'
+
+    - name: Print CMake version
+      run: cmake --version
+
+    - name: configure
+      run: >
+        cmake
+        -B build
+        -G Ninja
+        -D CMAKE_BUILD_TYPE=RelWithDebInfo
+        -D MRTRIX_BUILD_TESTS=ON
+        -D ECM_ENABLE_SANITIZERS=${{ matrix.sanitizer }}
+        -D CMAKE_C_COMPILER=clang
+        -D CMAKE_CXX_COMPILER=clang++
+
+    - name: build
+      run: cmake --build build
+
+    - name: binary tests
+      run: cd build && ctest -R bin --output-on-failure
+
+    - name: unit tests
+      run: cd build && ctest -R unit --output-on-failure

--- a/.github/workflows/weekly_sanitizers.yml
+++ b/.github/workflows/weekly_sanitizers.yml
@@ -1,4 +1,4 @@
-name: Nightly checks with sanitizers
+name: Sanitizers checks
 
 on:
   workflow_dispatch:

--- a/.github/workflows/weekly_sanitizers.yml
+++ b/.github/workflows/weekly_sanitizers.yml
@@ -2,9 +2,9 @@ name: Nightly checks with sanitizers
 
 on:
   workflow_dispatch:
-  # Run this every day at midnight
+  # Run this every Sunday at midnight
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 0 * * 0"
 
 jobs:
   linux-clang-build:


### PR DESCRIPTION
Sanitizers are very valuable tools to detect problems by instrumenting code for runtime bug detection. They have already proven useful for us as demonstrated in #2760, #2761 and #2755. 
This PR adds a new GitHub Actions workflow that runs our unit and binary tests compiled with sanitizers provided by [LLVM](https://github.com/google/sanitizers) each night. It'd be rather computationally expensive to run these checks on pull requests, but my tests show that they are fast enough to be run once a day (with caching enabled).

Note that this PR must be merged into `master` since scheduled GitHub Actions only run on the default or base branch. 