### PR TITLE
Use std containers and std::make_unique/shared

### DIFF
--- a/check_syntax
+++ b/check_syntax
@@ -64,20 +64,6 @@ for f in $(find cmd core src -type f -name '*.h' -o -name '*.cpp' | $grep -v '_m
 # remove quoted strings:
   cat .check_syntax2.tmp | perl -pe 's/(")(\\"|.)*?"//g' > .check_syntax.tmp
 
-# detect any instances of std::vector:
-  res="$res"$(
-    cat .check_syntax.tmp | \
-# match for the parts we're interested in and output just the bits that match:
-    $grep -Po '(?<!::)std::vector\b'
-  )
-
-
-# detect any instances of std::make_shared:
-  res="$res"$(
-    cat .check_syntax.tmp | \
-# match for the parts we're interested in and output just the bits that match:
-    $grep -Po '(?<!::)std::make_shared\b'
-  )
 
 # detect any instances of "using namespace std;":
   res="$res"$(
@@ -126,8 +112,6 @@ else
   echo "" >> $LOG
   echo "Please check the following syntax requirements:
   - Add MEMALIGN() or NOMEMALIGN macro to any class declarations identified above;
-  - Replace all occurrences of std::vector<> with MR::vector<> (or just vector<>);
-  - Avoid use of std::make_shared();
   - Replace all instances of std::abs() with MR::abs() (or just abs());
   - Replace all instances of %zu in print() calls with PRI_SIZET." >> $LOG
   exit 1

--- a/cmd/afdconnectivity.cpp
+++ b/cmd/afdconnectivity.cpp
@@ -215,7 +215,7 @@ value_type AFDConnectivity::get(const std::string &path) {
     if (all_fixels) {
 
       // All fixels contribute to the result
-      for (vector<AFDConnFixel>::const_iterator i = fixels.begin(); i != fixels.end(); ++i) {
+      for (std::vector<AFDConnFixel>::const_iterator i = fixels.begin(); i != fixels.end(); ++i) {
         if (i->is_selected())
           sum_volumes += i->get_FOD();
       }

--- a/cmd/amp2response.cpp
+++ b/cmd/amp2response.cpp
@@ -101,8 +101,8 @@ Eigen::Matrix<default_type, 3, 3> gen_rotation_matrix(const Eigen::Vector3d &dir
   return R;
 }
 
-vector<size_t> all_volumes(const size_t num) {
-  vector<size_t> result(num);
+std::vector<size_t> all_volumes(const size_t num) {
+  std::vector<size_t> result(num);
   for (size_t i = 0; i != num; ++i)
     result[i] = i;
   return result;
@@ -112,7 +112,7 @@ class Accumulator {
 public:
   class Shared {
   public:
-    Shared(int lmax, const vector<size_t> &volumes, const Eigen::MatrixXd &dirs)
+    Shared(int lmax, const std::vector<size_t> &volumes, const Eigen::MatrixXd &dirs)
         : lmax(lmax),
           dirs(dirs),
           volumes(volumes),
@@ -122,7 +122,7 @@ public:
 
     const int lmax;
     const Eigen::MatrixXd &dirs;
-    const vector<size_t> &volumes;
+    const std::vector<size_t> &volumes;
     Eigen::MatrixXd M;
     Eigen::VectorXd b;
     size_t count;
@@ -196,8 +196,8 @@ void run() {
   auto header = Header::open(argument[0]);
 
   // May be dealing with multiple shells
-  vector<Eigen::MatrixXd> dirs_azel;
-  vector<vector<size_t>> volumes;
+  std::vector<Eigen::MatrixXd> dirs_azel;
+  std::vector<std::vector<size_t>> volumes;
   std::unique_ptr<DWI::Shells> shells;
 
   auto opt = get_options("directions");
@@ -207,7 +207,7 @@ void run() {
   } else {
     auto hit = header.keyval().find("directions");
     if (hit != header.keyval().end()) {
-      vector<default_type> dir_vector;
+      std::vector<default_type> dir_vector;
       for (auto line : split_lines(hit->second)) {
         auto v = parse_floats(line);
         dir_vector.insert(dir_vector.end(), v.begin(), v.end());
@@ -230,7 +230,7 @@ void run() {
     }
   }
 
-  vector<uint32_t> lmax;
+  std::vector<uint32_t> lmax;
   uint32_t max_lmax = 0;
   opt = get_options("lmax");
   if (get_options("isotropic").size()) {

--- a/cmd/amp2sh.cpp
+++ b/cmd/amp2sh.cpp
@@ -81,14 +81,14 @@ class Amp2SHCommon {
 public:
   template <class MatrixType>
   Amp2SHCommon(const MatrixType &sh2amp,
-               const vector<size_t> &bzeros,
-               const vector<size_t> &dwis,
+               const std::vector<size_t> &bzeros,
+               const std::vector<size_t> &dwis,
                bool normalise_to_bzero)
       : sh2amp(sh2amp), amp2sh(Math::pinv(sh2amp)), bzeros(bzeros), dwis(dwis), normalise(normalise_to_bzero) {}
 
   Eigen::MatrixXd sh2amp, amp2sh;
-  const vector<size_t> &bzeros;
-  const vector<size_t> &dwis;
+  const std::vector<size_t> &bzeros;
+  const std::vector<size_t> &dwis;
   bool normalise;
 };
 
@@ -175,7 +175,7 @@ void run() {
   auto amp = Image<value_type>::open(argument[0]).with_direct_io(3);
   Header header(amp);
 
-  vector<size_t> bzeros, dwis;
+  std::vector<size_t> bzeros, dwis;
   Eigen::MatrixXd dirs;
   auto opt = get_options("directions");
   if (opt.size()) {
@@ -185,7 +185,7 @@ void run() {
   } else {
     auto hit = header.keyval().find("directions");
     if (hit != header.keyval().end()) {
-      vector<default_type> dir_vector;
+      std::vector<default_type> dir_vector;
       for (auto line : split_lines(hit->second)) {
         auto v = parse_floats(line);
         dir_vector.insert(dir_vector.end(), v.begin(), v.end());

--- a/cmd/connectome2tck.cpp
+++ b/cmd/connectome2tck.cpp
@@ -158,9 +158,9 @@ void run() {
   Tractography::Properties properties;
   Tractography::Reader<float> reader(argument[0], properties);
 
-  vector<vector<node_t>> assignments_lists;
+  std::vector<std::vector<node_t>> assignments_lists;
   assignments_lists.reserve(to<size_t>(properties["count"]));
-  vector<NodePair> assignments_pairs;
+  std::vector<NodePair> assignments_pairs;
   bool nonpair_found = false;
   node_t max_node_index = 0;
   {
@@ -172,7 +172,7 @@ void run() {
       if (line.empty())
         continue;
       std::stringstream line_stream(line);
-      vector<node_t> nodes;
+      std::vector<node_t> nodes;
       while (1) {
         node_t n;
         line_stream >> n;
@@ -216,7 +216,7 @@ void run() {
   const bool keep_self = get_options("keep_self").size();
 
   // Get the list of nodes of interest
-  vector<node_t> nodes;
+  std::vector<node_t> nodes;
   opt = get_options("nodes");
   bool manual_node_list = false;
   if (opt.size()) {
@@ -256,8 +256,8 @@ void run() {
     // Load the node image, get the centres of mass
     // Generate exemplars - these can _only_ be done per edge, and requires a mutex per edge to multi-thread
     auto image = Image<node_t>::open(opt[0][0]);
-    vector<Eigen::Vector3f> COMs(max_node_index + 1, Eigen::Vector3f(0.0f, 0.0f, 0.0f));
-    vector<size_t> volumes(max_node_index + 1, 0);
+    std::vector<Eigen::Vector3f> COMs(max_node_index + 1, Eigen::Vector3f(0.0f, 0.0f, 0.0f));
+    std::vector<size_t> volumes(max_node_index + 1, 0);
     for (auto i = Loop()(image); i; ++i) {
       const node_t index = image.value();
       if (index) {
@@ -344,7 +344,7 @@ void run() {
       } else {
         // For each node in the list, write one file for an exemplar to every other node
         ProgressBar progress("writing exemplars to files", nodes.size() * COMs.size());
-        for (vector<node_t>::const_iterator n = nodes.begin(); n != nodes.end(); ++n) {
+        for (std::vector<node_t>::const_iterator n = nodes.begin(); n != nodes.end(); ++n) {
           for (size_t i = first_node; i != COMs.size(); ++i) {
             generator.write(*n,
                             i,
@@ -356,7 +356,7 @@ void run() {
       }
     } else if (file_format == 1) { // One file per node
       ProgressBar progress("writing exemplars to files", nodes.size());
-      for (vector<node_t>::const_iterator n = nodes.begin(); n != nodes.end(); ++n) {
+      for (std::vector<node_t>::const_iterator n = nodes.begin(); n != nodes.end(); ++n) {
         generator.write(
             *n, prefix + str(*n) + ".tck", weights_prefix.size() ? (weights_prefix + str(*n) + ".csv") : "");
         ++progress;
@@ -399,7 +399,7 @@ void run() {
       INFO("A total of " + str(writer.file_count()) + " output track files will be generated (one for each edge)");
       break;
     case 1: // One file per node
-      for (vector<node_t>::const_iterator i = nodes.begin(); i != nodes.end(); ++i)
+      for (std::vector<node_t>::const_iterator i = nodes.begin(); i != nodes.end(); ++i)
         writer.add(*i, prefix + str(*i) + ".tck", weights_prefix.size() ? (weights_prefix + str(*i) + ".csv") : "");
       INFO("A total of " + str(writer.file_count()) + " output track files will be generated (one for each node)");
       break;

--- a/cmd/connectomestats.cpp
+++ b/cmd/connectomestats.cpp
@@ -210,7 +210,7 @@ void run() {
 
   // Before validating the contrast matrix, we first need to see if there are any
   //   additional design matrix columns coming from edge-wise subject data
-  vector<CohortDataImport> extra_columns;
+  std::vector<CohortDataImport> extra_columns;
   bool nans_in_columns = false;
   auto opt = get_options("column");
   for (size_t i = 0; i != opt.size(); ++i) {
@@ -236,7 +236,7 @@ void run() {
     CONSOLE("Number of variance groups: " + str(num_vgs));
 
   // Load hypotheses
-  const vector<Hypothesis> hypotheses = Math::Stats::GLM::load_hypotheses(argument[3]);
+  const std::vector<Hypothesis> hypotheses = Math::Stats::GLM::load_hypotheses(argument[3]);
   const index_type num_hypotheses = hypotheses.size();
   if (hypotheses[0].cols() != num_factors)
     throw Exception(

--- a/cmd/dcmedit.cpp
+++ b/cmd/dcmedit.cpp
@@ -82,8 +82,8 @@ inline uint16_t read_hex(const std::string &m) {
 }
 
 void run() {
-  vector<Tag> tags;
-  vector<uint16_t> VRs;
+  std::vector<Tag> tags;
+  std::vector<uint16_t> VRs;
 
   auto opt = get_options("anonymise");
   if (opt.size()) {

--- a/cmd/dcminfo.cpp
+++ b/cmd/dcminfo.cpp
@@ -62,7 +62,7 @@ void run() {
   if (opt.size()) {
     std::istringstream hex;
 
-    vector<Tag> tags(opt.size());
+    std::vector<Tag> tags(opt.size());
     for (size_t n = 0; n < opt.size(); ++n) {
       tags[n].group = read_hex(opt[n][0]);
       tags[n].element = read_hex(opt[n][1]);

--- a/cmd/dirflip.cpp
+++ b/cmd/dirflip.cpp
@@ -61,7 +61,7 @@ public:
         best_signs(directions.rows(), 1),
         best_eddy(std::numeric_limits<value_type>::max()) {}
 
-  bool update(value_type eddy, const vector<int> &signs) {
+  bool update(value_type eddy, const std::vector<int> &signs) {
     std::lock_guard<std::mutex> lock(mutex);
     if (eddy < best_eddy) {
       best_eddy = eddy;
@@ -74,7 +74,7 @@ public:
     return num_permutations < target_num_permutations;
   }
 
-  value_type eddy(size_t i, size_t j, const vector<int> &signs) const {
+  value_type eddy(size_t i, size_t j, const std::vector<int> &signs) const {
     vector3_type a = {directions(i, 0), directions(i, 1), directions(i, 2)};
     vector3_type b = {directions(j, 0), directions(j, 1), directions(j, 2)};
     if (signs[i] < 0)
@@ -84,15 +84,15 @@ public:
     return 1.0 / (a - b).norm();
   }
 
-  vector<int> get_init_signs() const { return vector<int>(directions.rows(), 1); }
-  const vector<int> &get_best_signs() const { return best_signs; }
+  std::vector<int> get_init_signs() const { return std::vector<int>(directions.rows(), 1); }
+  const std::vector<int> &get_best_signs() const { return best_signs; }
 
 protected:
   const Eigen::MatrixXd &directions;
   const size_t target_num_permutations;
   size_t num_permutations;
   ProgressBar progress;
-  vector<int> best_signs;
+  std::vector<int> best_signs;
   value_type best_eddy;
   std::mutex mutex;
 };
@@ -121,7 +121,7 @@ public:
 
 protected:
   Shared &shared;
-  vector<int> signs;
+  std::vector<int> signs;
   Math::RNG rng;
   std::uniform_int_distribution<int> uniform;
 };
@@ -131,7 +131,7 @@ void run() {
 
   size_t num_permutations = get_option_value<size_t>("permutations", default_permutations);
 
-  vector<int> signs;
+  std::vector<int> signs;
   {
     Shared eddy_shared(directions, num_permutations);
     Thread::run(Thread::multi(Processor(eddy_shared)), "eval thread");

--- a/cmd/dirmerge.cpp
+++ b/cmd/dirmerge.cpp
@@ -50,7 +50,7 @@ void usage() {
 
 using value_type = double;
 using Direction = Eigen::Matrix<value_type, 3, 1>;
-using DirectionSet = vector<Direction>;
+using DirectionSet = std::vector<Direction>;
 
 struct OutDir {
   Direction d;
@@ -68,8 +68,8 @@ void run() {
   value_type unipolar_weight = App::get_option_value("unipolar_weight", 0.2);
   value_type bipolar_weight = 1.0 - unipolar_weight;
 
-  vector<vector<DirectionSet>> dirs;
-  vector<value_type> bvalue((argument.size() - 2) / (1 + num_subsets));
+  std::vector<std::vector<DirectionSet>> dirs;
+  std::vector<value_type> bvalue((argument.size() - 2) / (1 + num_subsets));
   INFO("expecting " + str(bvalue.size()) + " b-values");
   if (bvalue.size() * (1 + num_subsets) + 2 != argument.size())
     throw Exception("inconsistent number of arguments");
@@ -78,7 +78,7 @@ void run() {
   size_t current = 1, nb = 0;
   while (current < argument.size() - 1) {
     bvalue[nb] = to<value_type>(argument[current++]);
-    vector<DirectionSet> d;
+    std::vector<DirectionSet> d;
     for (size_t i = 0; i < num_subsets; ++i) {
       auto m = DWI::Directions::load_cartesian(argument[current++]);
       DirectionSet set;
@@ -87,7 +87,7 @@ void run() {
       d.push_back(set);
     }
     INFO("found b = " + str(bvalue[nb]) + ", " + str([&] {
-           vector<size_t> s;
+           std::vector<size_t> s;
            for (auto &n : d)
              s.push_back(n.size());
            return s;
@@ -112,7 +112,7 @@ void run() {
   std::mt19937 rng(rd());
   size_t first = std::uniform_int_distribution<size_t>(0, dirs[0][0].size() - 1)(rng);
 
-  vector<OutDir> merged;
+  std::vector<OutDir> merged;
 
   auto push = [&](size_t b, size_t p, size_t n) {
     merged.push_back({Direction(dirs[b][p][n][0], dirs[b][p][n][1], dirs[b][p][n][2]), b, p});
@@ -149,7 +149,7 @@ void run() {
     return best;
   };
 
-  vector<float> fraction;
+  std::vector<float> fraction;
   for (auto &d : dirs) {
     size_t n = 0;
     for (auto &m : d)
@@ -159,7 +159,7 @@ void run() {
 
   push(0, 0, first);
 
-  vector<size_t> counts(bvalue.size(), 0);
+  std::vector<size_t> counts(bvalue.size(), 0);
   ++counts[0];
 
   auto num_for_b = [&](size_t b) {

--- a/cmd/dirorder.cpp
+++ b/cmd/dirorder.cpp
@@ -47,9 +47,9 @@ void usage() {
 
 using value_type = double;
 
-vector<size_t> optimise(const Eigen::MatrixXd &directions, const size_t first_volume) {
-  vector<size_t> indices(1, first_volume);
-  vector<size_t> remaining;
+std::vector<size_t> optimise(const Eigen::MatrixXd &directions, const size_t first_volume) {
+  std::vector<size_t> indices(1, first_volume);
+  std::vector<size_t> remaining;
   for (size_t n = 0; n < size_t(directions.rows()); ++n)
     if (n != indices[0])
       remaining.push_back(n);
@@ -79,7 +79,7 @@ vector<size_t> optimise(const Eigen::MatrixXd &directions, const size_t first_vo
   return indices;
 }
 
-value_type calc_cost(const Eigen::MatrixXd &directions, const vector<size_t> &order) {
+value_type calc_cost(const Eigen::MatrixXd &directions, const std::vector<size_t> &order) {
   const size_t start = Math::SH::NforL(2);
   if (size_t(directions.rows()) <= start)
     return value_type(0);
@@ -112,10 +112,10 @@ void run() {
   }
 
   value_type min_cost = std::numeric_limits<value_type>::infinity();
-  vector<size_t> best_order;
+  std::vector<size_t> best_order;
   ProgressBar progress("Determining best reordering", directions.rows());
   for (size_t first_volume = 0; first_volume != last_candidate_first_volume; ++first_volume) {
-    const vector<size_t> order = optimise(directions, first_volume);
+    const std::vector<size_t> order = optimise(directions, first_volume);
     const value_type cost = calc_cost(directions, order);
     if (cost < min_cost) {
       min_cost = cost;

--- a/cmd/dirsplit.cpp
+++ b/cmd/dirsplit.cpp
@@ -60,7 +60,7 @@ public:
         s = 0;
     }
     INFO("split " + str(directions.rows()) + " directions into subsets with " + str([&] {
-           vector<size_t> c;
+           std::vector<size_t> c;
            for (auto &x : subset)
              c.push_back(x.size());
            return c;
@@ -68,7 +68,7 @@ public:
          " volumes");
   }
 
-  bool update(value_type energy, const vector<vector<size_t>> &set) {
+  bool update(value_type energy, const std::vector<std::vector<size_t>> &set) {
     std::lock_guard<std::mutex> lock(mutex);
     if (!progress)
       progress.reset(new ProgressBar("distributing directions", target_num_permutations));
@@ -88,13 +88,13 @@ public:
     return 1.0 / (a - b).norm() + 1.0 / (a + b).norm();
   }
 
-  const vector<vector<size_t>> &get_init_subset() const { return subset; }
-  const vector<vector<size_t>> &get_best_subset() const { return best_subset; }
+  const std::vector<std::vector<size_t>> &get_init_subset() const { return subset; }
+  const std::vector<std::vector<size_t>> &get_best_subset() const { return best_subset; }
 
 protected:
   const Eigen::MatrixXd &directions;
   std::mutex mutex;
-  vector<vector<size_t>> subset, best_subset;
+  std::vector<std::vector<size_t>> subset, best_subset;
   value_type best_energy;
   const size_t target_num_permutations;
   size_t num_permutations;
@@ -141,7 +141,7 @@ public:
 
 protected:
   Shared &shared;
-  vector<vector<size_t>> subset;
+  std::vector<std::vector<size_t>> subset;
   Math::RNG rng;
 };
 
@@ -154,7 +154,7 @@ void run() {
 
   const size_t num_permutations = get_option_value<size_t>("permutations", default_permutations);
 
-  vector<vector<size_t>> best;
+  std::vector<std::vector<size_t>> best;
   {
     Shared shared(directions, num_subsets, num_permutations);
     Thread::run(Thread::multi(EnergyCalculator(shared)), "energy eval thread");

--- a/cmd/dirstat.cpp
+++ b/cmd/dirstat.cpp
@@ -127,7 +127,7 @@ void run() {
     report(argument[0], directions);
 }
 
-vector<default_type> summarise_NN(const vector<double> &NN) {
+std::vector<default_type> summarise_NN(const std::vector<double> &NN) {
   double NN_min = std::numeric_limits<double>::max();
   double NN_mean = 0.0;
   double NN_max = 0.0;
@@ -142,7 +142,7 @@ vector<default_type> summarise_NN(const vector<double> &NN) {
   return {NN_mean, NN_min, NN_max};
 }
 
-vector<default_type> summarise_E(const vector<double> &E) {
+std::vector<default_type> summarise_E(const std::vector<double> &E) {
   double E_min = std::numeric_limits<double>::max();
   double E_total = 0.0;
   double E_max = 0.0;
@@ -157,7 +157,7 @@ vector<default_type> summarise_E(const vector<double> &E) {
 
 class Metrics {
 public:
-  vector<default_type> BN, UN, BE, UE, SH;
+  std::vector<default_type> BN, UN, BE, UE, SH;
   default_type ASYM;
   size_t ndirs;
 };
@@ -167,11 +167,11 @@ Metrics compute(Eigen::MatrixXd &directions) {
     throw Exception("unexpected matrix size for scheme \"" + str(argument[0]) + "\"");
   Math::Sphere::normalise_cartesian(directions);
 
-  vector<double> NN_bipolar(directions.rows(), -1.0);
-  vector<double> NN_unipolar(directions.rows(), -1.0);
+  std::vector<double> NN_bipolar(directions.rows(), -1.0);
+  std::vector<double> NN_unipolar(directions.rows(), -1.0);
 
-  vector<double> E_bipolar(directions.rows(), 0.0);
-  vector<double> E_unipolar(directions.rows(), 0.0);
+  std::vector<double> E_bipolar(directions.rows(), 0.0);
+  std::vector<double> E_unipolar(directions.rows(), 0.0);
 
   for (ssize_t i = 0; i < directions.rows() - 1; ++i) {
     for (ssize_t j = i + 1; j < directions.rows(); ++j) {

--- a/cmd/dwi2fod.cpp
+++ b/cmd/dwi2fod.cpp
@@ -163,7 +163,7 @@ class MSMT_Processor {
 public:
   MSMT_Processor(const DWI::SDeconv::MSMT_CSD::Shared &shared,
                  Image<bool> &mask_image,
-                 vector<Image<float>> odf_images,
+                 std::vector<Image<float>> odf_images,
                  Image<float> dwi_modelled = Image<float>())
       : sdeconv(shared),
         mask_image(mask_image),
@@ -204,7 +204,7 @@ public:
 private:
   DWI::SDeconv::MSMT_CSD sdeconv;
   Image<bool> mask_image;
-  vector<Image<float>> odf_images;
+  std::vector<Image<float>> odf_images;
   Image<float> modelled_image;
   Eigen::VectorXd dwi_data;
   Eigen::VectorXd output_data;
@@ -262,8 +262,8 @@ void run() {
     shared.parse_cmdline_options();
 
     const size_t num_tissues = (argument.size() - 2) / 2;
-    vector<std::string> response_paths;
-    vector<std::string> odf_paths;
+    std::vector<std::string> response_paths;
+    std::vector<std::string> odf_paths;
     for (size_t i = 0; i < num_tissues; ++i) {
       response_paths.push_back(argument[i * 2 + 2]);
       odf_paths.push_back(argument[i * 2 + 3]);
@@ -280,7 +280,7 @@ void run() {
 
     DWI::stash_DW_scheme(header_out, shared.grad);
 
-    vector<Image<float>> odfs;
+    std::vector<Image<float>> odfs;
     for (size_t i = 0; i < num_tissues; ++i) {
       header_out.size(3) = Math::SH::NforL(shared.lmax[i]);
       odfs.push_back(Image<float>(Image<float>::create(odf_paths[i], header_out)));

--- a/cmd/dwidenoise.cpp
+++ b/cmd/dwidenoise.cpp
@@ -134,7 +134,7 @@ public:
   using SValsType = Eigen::VectorXd;
 
   DenoisingFunctor(int ndwi,
-                   const vector<uint32_t> &extent,
+                   const std::vector<uint32_t> &extent,
                    Image<bool> &mask,
                    Image<real_type> &noise,
                    Image<uint16_t> &rank,
@@ -273,7 +273,7 @@ void process_image(Header &data,
                    Image<real_type> &noise,
                    Image<uint16_t> &rank,
                    const std::string &output_name,
-                   const vector<uint32_t> &extent,
+                   const std::vector<uint32_t> &extent,
                    bool exp1) {
   auto input = data.get_image<T>().with_direct_io(3);
   // create output
@@ -299,7 +299,7 @@ void run() {
   }
 
   opt = get_options("extent");
-  vector<uint32_t> extent;
+  std::vector<uint32_t> extent;
   if (opt.size()) {
     extent = parse_ints<uint32_t>(opt[0][0]);
     if (extent.size() == 1)

--- a/cmd/dwiextract.cpp
+++ b/cmd/dwiextract.cpp
@@ -65,7 +65,7 @@ void run() {
 
   // Want to support non-shell-like data if it's just a straight extraction
   //   of all dwis or all bzeros i.e. don't initialise the Shells class
-  vector<uint32_t> volumes;
+  std::vector<uint32_t> volumes;
   bool bzero = get_options("bzero").size();
   if (get_options("shells").size() || get_options("singleshell").size()) {
     DWI::Shells shells(grad);
@@ -101,7 +101,7 @@ void run() {
     const auto filter = parse_floats(opt[0][0]);
     if (!(filter.size() == 3 || filter.size() == 4))
       throw Exception("Phase encoding filter must be a comma-separated list of either 3 or 4 numbers");
-    vector<uint32_t> new_volumes;
+    std::vector<uint32_t> new_volumes;
     for (const auto i : volumes) {
       bool keep = true;
       for (size_t axis = 0; axis != 3; ++axis) {

--- a/cmd/fixel2sh.cpp
+++ b/cmd/fixel2sh.cpp
@@ -77,7 +77,7 @@ void run() {
   out_header.size(3) = n_sh_coeff;
 
   auto sh_image = Image<float>::create(argument[1], out_header);
-  vector<default_type> sh_values;
+  std::vector<default_type> sh_values;
   Eigen::Matrix<default_type, Eigen::Dynamic, 1> apsf_values;
 
   for (auto l1 = Loop("converting fixel image to spherical harmonic image", in_index_image)(in_index_image, sh_image);

--- a/cmd/fixelcfestats.cpp
+++ b/cmd/fixelcfestats.cpp
@@ -251,7 +251,7 @@ void run() {
 
   // Before validating the contrast matrix, we first need to see if there are any
   //   additional design matrix columns coming from fixel-wise subject data
-  vector<Math::Stats::CohortDataImport> extra_columns;
+  std::vector<Math::Stats::CohortDataImport> extra_columns;
   bool nans_in_columns = false;
   opt = get_options("column");
   for (size_t i = 0; i != opt.size(); ++i) {
@@ -292,7 +292,7 @@ void run() {
     CONSOLE("Number of variance groups: " + str(num_vgs));
 
   // Load hypotheses
-  const vector<Math::Stats::GLM::Hypothesis> hypotheses = Math::Stats::GLM::load_hypotheses(argument[3]);
+  const std::vector<Math::Stats::GLM::Hypothesis> hypotheses = Math::Stats::GLM::load_hypotheses(argument[3]);
   const Math::Stats::index_type num_hypotheses = hypotheses.size();
   if (hypotheses[0].cols() != num_factors)
     throw Exception(

--- a/cmd/fixelconvert.cpp
+++ b/cmd/fixelconvert.cpp
@@ -204,7 +204,7 @@ void convert_new2old() {
 
   Header H_index = Fixel::find_index_header(input_fixel_directory);
   Header H_dirs = Fixel::find_directions_header(input_fixel_directory);
-  vector<Header> H_data = Fixel::find_data_headers(input_fixel_directory, H_index, false);
+  std::vector<Header> H_data = Fixel::find_data_headers(input_fixel_directory, H_index, false);
   size_t size_index = H_data.size(), value_index = H_data.size();
 
   for (size_t i = 0; i != H_data.size(); ++i) {

--- a/cmd/fixelcrop.cpp
+++ b/cmd/fixelcrop.cpp
@@ -77,9 +77,9 @@ void run() {
       Image<index_type>::create(Path::join(out_fixel_directory, Path::basename(in_index_image.name())), out_header);
 
   // Open all data images and create output date images with size equal to expected number of fixels
-  vector<Header> in_headers = Fixel::find_data_headers(in_directory, in_index_header, true);
-  vector<Image<float>> in_data_images;
-  vector<Image<float>> out_data_images;
+  std::vector<Header> in_headers = Fixel::find_data_headers(in_directory, in_index_header, true);
+  std::vector<Image<float>> in_data_images;
+  std::vector<Image<float>> out_data_images;
   for (auto &in_data_header : in_headers) {
     in_data_images.push_back(in_data_header.get_image<float>().with_direct_io());
     check_dimensions(in_data_images.back(), mask_image, {0, 2});

--- a/cmd/fixelfilter.cpp
+++ b/cmd/fixelfilter.cpp
@@ -91,7 +91,7 @@ void run() {
   std::set<std::string> option_list{"threhsold_value", "threshold_connectivity", "fwhm", "minweight", "mask"};
 
   Image<float> single_file;
-  vector<Header> multiple_files;
+  std::vector<Header> multiple_files;
   std::unique_ptr<Fixel::Filter::Base> filter;
 
   {

--- a/cmd/fod2fixel.cpp
+++ b/cmd/fod2fixel.cpp
@@ -125,7 +125,7 @@ private:
         : dir(dir), integral(integral), max_peak_amp(max_peak_amp) {}
   };
 
-  class Primitive_FOD_lobes : public vector<Primitive_FOD_lobe> {
+  class Primitive_FOD_lobes : public std::vector<Primitive_FOD_lobe> {
   public:
     Primitive_FOD_lobes(const FOD_lobes &in, const index_type maxcount, bool dir_from_peak) : vox(in.vox) {
       const index_type N = maxcount ? std::min(index_type(in.size()), maxcount) : in.size();
@@ -142,7 +142,7 @@ private:
 
   Header H;
   std::string fixel_directory_path, index_path, dir_path, afd_path, peak_amp_path, disp_path;
-  vector<Primitive_FOD_lobes> lobes;
+  std::vector<Primitive_FOD_lobes> lobes;
   index_type fixel_count;
   index_type max_per_voxel;
   bool dir_from_peak;

--- a/cmd/fod2fixel.cpp
+++ b/cmd/fod2fixel.cpp
@@ -177,7 +177,7 @@ void Segmented_FOD_receiver::commit() {
   index_header.size(3) = 2;
   index_header.datatype() = DataType::from<index_type>();
   index_header.datatype().set_byte_order_native();
-  index_image = make_unique<IndexImage>(IndexImage::create(index_filepath, index_header));
+  index_image = std::make_unique<IndexImage>(IndexImage::create(index_filepath, index_header));
 
   auto fixel_data_header(H);
   fixel_data_header.ndim() = 3;
@@ -191,7 +191,7 @@ void Segmented_FOD_receiver::commit() {
   if (dir_path.size()) {
     auto dir_header(fixel_data_header);
     dir_header.size(1) = 3;
-    dir_image = make_unique<DataImage>(DataImage::create(Path::join(fixel_directory_path, dir_path), dir_header));
+    dir_image = std::make_unique<DataImage>(DataImage::create(Path::join(fixel_directory_path, dir_path), dir_header));
     dir_image->index(1) = 0;
     Fixel::check_fixel_size(*index_image, *dir_image);
   }
@@ -199,7 +199,7 @@ void Segmented_FOD_receiver::commit() {
   if (afd_path.size()) {
     auto afd_header(fixel_data_header);
     afd_header.size(1) = 1;
-    afd_image = make_unique<DataImage>(DataImage::create(Path::join(fixel_directory_path, afd_path), afd_header));
+    afd_image = std::make_unique<DataImage>(DataImage::create(Path::join(fixel_directory_path, afd_path), afd_header));
     afd_image->index(1) = 0;
     Fixel::check_fixel_size(*index_image, *afd_image);
   }
@@ -207,8 +207,8 @@ void Segmented_FOD_receiver::commit() {
   if (peak_amp_path.size()) {
     auto peak_amp_header(fixel_data_header);
     peak_amp_header.size(1) = 1;
-    peak_amp_image =
-        make_unique<DataImage>(DataImage::create(Path::join(fixel_directory_path, peak_amp_path), peak_amp_header));
+    peak_amp_image = std::make_unique<DataImage>(
+        DataImage::create(Path::join(fixel_directory_path, peak_amp_path), peak_amp_header));
     peak_amp_image->index(1) = 0;
     Fixel::check_fixel_size(*index_image, *peak_amp_image);
   }
@@ -216,7 +216,8 @@ void Segmented_FOD_receiver::commit() {
   if (disp_path.size()) {
     auto disp_header(fixel_data_header);
     disp_header.size(1) = 1;
-    disp_image = make_unique<DataImage>(DataImage::create(Path::join(fixel_directory_path, disp_path), disp_header));
+    disp_image =
+        std::make_unique<DataImage>(DataImage::create(Path::join(fixel_directory_path, disp_path), disp_header));
     disp_image->index(1) = 0;
     Fixel::check_fixel_size(*index_image, *disp_image);
   }

--- a/cmd/label2mesh.cpp
+++ b/cmd/label2mesh.cpp
@@ -60,7 +60,7 @@ void run() {
 
   using voxel_corner_t = Eigen::Array<int, 3, 1>;
 
-  vector<voxel_corner_t> lower_corners, upper_corners;
+  std::vector<voxel_corner_t> lower_corners, upper_corners;
   {
     for (auto i = Loop("Importing label image", labels)(labels); i; ++i) {
       const uint32_t index = labels.value();
@@ -83,7 +83,7 @@ void run() {
   meshes[0].set_name("none");
   const bool blocky = get_options("blocky").size();
 
-  vector<uint32_t> missing_nodes;
+  std::vector<uint32_t> missing_nodes;
   for (uint32_t i = 1; i != upper_corners.size(); ++i) {
     if (upper_corners[i][0] < 0)
       missing_nodes.push_back(i);
@@ -105,7 +105,7 @@ void run() {
 
     auto worker = [&](const size_t &in) {
       meshes[in].set_name(str(in));
-      vector<int> from, dimensions;
+      std::vector<int> from, dimensions;
       for (size_t axis = 0; axis != 3; ++axis) {
         from.push_back(lower_corners[in][axis]);
         dimensions.push_back(upper_corners[in][axis] - lower_corners[in][axis] + 1);

--- a/cmd/labelstats.cpp
+++ b/cmd/labelstats.cpp
@@ -96,7 +96,7 @@ void run() {
   Eigen::IOFormat fmt(Eigen::StreamPrecision, 0, ", ", "\n", "[ ", " ]", "", "");
   std::stringstream com_stringstream;
   com_stringstream << coms.format(fmt);
-  const vector<std::string> com_strings = split(com_stringstream.str(), "\n");
+  const std::vector<std::string> com_strings = split(com_stringstream.str(), "\n");
   assert(com_strings.size() == size_t(masses.size()));
 
   // Find width of first non-empty string, in order to centralise header label

--- a/cmd/maskdump.cpp
+++ b/cmd/maskdump.cpp
@@ -41,7 +41,7 @@ void run() {
   if (H.datatype() != DataType::Bit)
     WARN("Input is not a genuine boolean mask image");
   auto in = H.get_image<bool>();
-  vector<Eigen::ArrayXi> locations;
+  std::vector<Eigen::ArrayXi> locations;
   for (auto l = Loop(in)(in); l; ++l) {
     if (in.value()) {
       Eigen::ArrayXi this_voxel(in.ndim());

--- a/cmd/maskfilter.cpp
+++ b/cmd/maskfilter.cpp
@@ -125,7 +125,7 @@ void run() {
         input_image, std::string("applying connected-component filter to image ") + Path::basename(argument[0]));
     auto opt = get_options("axes");
     if (opt.size()) {
-      const vector<int> axes = opt[0][0];
+      const std::vector<int> axes = opt[0][0];
       filter.set_axes(axes);
     }
     bool largest_only = false;
@@ -188,7 +188,7 @@ void run() {
     Filter::Fill filter(input_image, std::string("filling interior of image ") + Path::basename(argument[0]));
     auto opt = get_options("axes");
     if (opt.size()) {
-      const vector<int> axes = opt[0][0];
+      const std::vector<int> axes = opt[0][0];
       filter.set_axes(axes);
     }
     opt = get_options("connectivity");

--- a/cmd/meshconvert.cpp
+++ b/cmd/meshconvert.cpp
@@ -63,7 +63,7 @@ void run() {
   auto opt = get_options("transform");
   if (opt.size()) {
     auto H = Header::open(opt[0][1]);
-    auto transform = make_unique<Surface::Filter::VertexTransform>(H);
+    auto transform = std::make_unique<Surface::Filter::VertexTransform>(H);
     switch (int(opt[0][0])) {
     case 0:
       transform->set_first2real();

--- a/cmd/mraverageheader.cpp
+++ b/cmd/mraverageheader.cpp
@@ -66,7 +66,7 @@ void run() {
 
   bool fill = get_options("fill").size();
 
-  vector<Header> headers_in;
+  std::vector<Header> headers_in;
   size_t dim(Header::open(argument[0]).ndim());
   if (dim < 3 or dim > 4)
     throw Exception("Please provide 3D or 4D images");
@@ -82,7 +82,7 @@ void run() {
     }
   }
 
-  vector<Eigen::Transform<default_type, 3, Eigen::Projective>> transform_header_with;
+  std::vector<Eigen::Transform<default_type, 3, Eigen::Projective>> transform_header_with;
   auto H = compute_minimum_average_header(headers_in, transform_header_with, resolution, padding);
   H.datatype() = DataType::Bit;
   if (fill) {

--- a/cmd/mrcalc.cpp
+++ b/cmd/mrcalc.cpp
@@ -406,7 +406,7 @@ void usage() {
 
 class Evaluator;
 
-class Chunk : public vector<complex_type> {
+class Chunk : public std::vector<complex_type> {
 public:
   complex_type value;
 };
@@ -417,7 +417,7 @@ public:
   copy_ptr<Image<complex_type>> image;
 };
 
-class ThreadLocalStorage : public vector<ThreadLocalStorageItem> {
+class ThreadLocalStorage : public std::vector<ThreadLocalStorageItem> {
 public:
   void load(Chunk &chunk, Image<complex_type> &image) {
     for (size_t n = 0; n < image.ndim(); ++n)
@@ -451,7 +451,7 @@ public:
   }
 
   const Iterator *iter;
-  vector<size_t> axes, size;
+  std::vector<size_t> axes, size;
 
 private:
   size_t current;
@@ -547,7 +547,7 @@ public:
   const std::string id;
   const char *format;
   bool ZtoR, RtoZ;
-  vector<StackEntry> operands;
+  std::vector<StackEntry> operands;
 
   Chunk &evaluate(ThreadLocalStorage &storage) const {
     Chunk &in1(operands[0].evaluate(storage));
@@ -717,7 +717,7 @@ public:
 };
 
 template <class Operation>
-void unary_operation(const std::string &operation_name, vector<StackEntry> &stack, Operation operation) {
+void unary_operation(const std::string &operation_name, std::vector<StackEntry> &stack, Operation operation) {
   if (stack.empty())
     throw Exception("no operand in stack for operation \"" + operation_name + "\"!");
   StackEntry &a(stack[stack.size() - 1]);
@@ -735,7 +735,7 @@ void unary_operation(const std::string &operation_name, vector<StackEntry> &stac
 }
 
 template <class Operation>
-void binary_operation(const std::string &operation_name, vector<StackEntry> &stack, Operation operation) {
+void binary_operation(const std::string &operation_name, std::vector<StackEntry> &stack, Operation operation) {
   if (stack.size() < 2)
     throw Exception("not enough operands in stack for operation \"" + operation_name + "\"");
   StackEntry &a(stack[stack.size() - 2]);
@@ -754,7 +754,7 @@ void binary_operation(const std::string &operation_name, vector<StackEntry> &sta
 }
 
 template <class Operation>
-void ternary_operation(const std::string &operation_name, vector<StackEntry> &stack, Operation operation) {
+void ternary_operation(const std::string &operation_name, std::vector<StackEntry> &stack, Operation operation) {
   if (stack.size() < 3)
     throw Exception("not enough operands in stack for operation \"" + operation_name + "\"");
   StackEntry &a(stack[stack.size() - 3]);
@@ -815,7 +815,9 @@ void get_header(const StackEntry &entry, Header &header) {
 
 class ThreadFunctor {
 public:
-  ThreadFunctor(const vector<size_t> &inner_axes, const StackEntry &top_of_stack, Image<complex_type> &output_image)
+  ThreadFunctor(const std::vector<size_t> &inner_axes,
+                const StackEntry &top_of_stack,
+                Image<complex_type> &output_image)
       : top_entry(top_of_stack), image(output_image), loop(Loop(inner_axes)) {
     storage.axes = loop.axes;
     storage.size.push_back(image.size(storage.axes[0]));
@@ -855,12 +857,12 @@ public:
 
   const StackEntry &top_entry;
   Image<complex_type> image;
-  decltype(Loop(vector<size_t>())) loop;
+  decltype(Loop(std::vector<size_t>())) loop;
   ThreadLocalStorage storage;
   size_t chunk_size;
 };
 
-void run_operations(const vector<StackEntry> &stack) {
+void run_operations(const std::vector<StackEntry> &stack) {
   Header header;
   get_header(stack[0], header);
 
@@ -966,7 +968,7 @@ public:
  **********************************************************************/
 
 void run() {
-  vector<StackEntry> stack;
+  std::vector<StackEntry> stack;
 
   for (int n = 1; n < App::argc; ++n) {
 

--- a/cmd/mrcat.cpp
+++ b/cmd/mrcat.cpp
@@ -55,7 +55,7 @@ void usage() {
       + DataType::options();
 }
 
-template <typename value_type> void write(vector<Header> &in, const size_t axis, Header &header_out) {
+template <typename value_type> void write(std::vector<Header> &in, const size_t axis, Header &header_out) {
   auto image_out = Image<value_type>::create(header_out.name(), header_out);
   size_t axis_offset = 0;
 
@@ -81,7 +81,7 @@ template <typename value_type> void write(vector<Header> &in, const size_t axis,
 
 void run() {
   size_t num_images = argument.size() - 1;
-  vector<Header> headers;
+  std::vector<Header> headers;
   ssize_t max_axis_nonunity = 0;
   for (size_t i = 0; i != num_images; ++i) {
     Header H = Header::open(argument[i]);

--- a/cmd/mrclusterstats.cpp
+++ b/cmd/mrclusterstats.cpp
@@ -175,7 +175,7 @@ void run() {
   auto mask_header = Header::open(argument[3]);
   check_effective_dimensionality(mask_header, 3);
   auto mask_image = mask_header.get_image<bool>();
-  std::shared_ptr<Voxel2Vector> v2v = make_shared<Voxel2Vector>(mask_image, mask_header);
+  std::shared_ptr<Voxel2Vector> v2v = std::make_shared<Voxel2Vector>(mask_image, mask_header);
   SubjectVoxelImport::set_mapping(v2v);
   Filter::Connector connector;
   connector.adjacency.set_26_adjacency(do_26_connectivity);

--- a/cmd/mrclusterstats.cpp
+++ b/cmd/mrclusterstats.cpp
@@ -199,7 +199,7 @@ void run() {
   // Before validating the contrast matrix, we first need to see if there are any
   //   additional design matrix columns coming from voxel-wise subject data
   // TODO Functionalise this
-  vector<CohortDataImport> extra_columns;
+  std::vector<CohortDataImport> extra_columns;
   bool nans_in_columns = false;
   auto opt = get_options("column");
   for (size_t i = 0; i != opt.size(); ++i) {
@@ -225,7 +225,7 @@ void run() {
     CONSOLE("Number of variance groups: " + str(num_vgs));
 
   // Load hypotheses
-  const vector<Hypothesis> hypotheses = Math::Stats::GLM::load_hypotheses(argument[2]);
+  const std::vector<Hypothesis> hypotheses = Math::Stats::GLM::load_hypotheses(argument[2]);
   const index_type num_hypotheses = hypotheses.size();
   if (hypotheses[0].cols() != num_factors)
     throw Exception(

--- a/cmd/mrcolour.cpp
+++ b/cmd/mrcolour.cpp
@@ -29,8 +29,8 @@
 using namespace MR;
 using namespace App;
 
-vector<std::string> colourmap_choices_std;
-vector<const char *> colourmap_choices_cstr;
+std::vector<std::string> colourmap_choices_std;
+std::vector<const char *> colourmap_choices_cstr;
 
 void usage() {
 

--- a/cmd/mrconvert.cpp
+++ b/cmd/mrconvert.cpp
@@ -211,7 +211,7 @@ void usage() {
       + PhaseEncoding::ImportOptions + PhaseEncoding::ExportOptions;
 }
 
-void permute_DW_scheme(Header &H, const vector<int> &axes) {
+void permute_DW_scheme(Header &H, const std::vector<int> &axes) {
   auto in = DWI::parse_DW_scheme(H);
   if (!in.rows())
     return;
@@ -231,7 +231,7 @@ void permute_DW_scheme(Header &H, const vector<int> &axes) {
   DWI::set_DW_scheme(H, out);
 }
 
-void permute_PE_scheme(Header &H, const vector<int> &axes) {
+void permute_PE_scheme(Header &H, const std::vector<int> &axes) {
   auto in = PhaseEncoding::parse_scheme(H);
   if (!in.rows())
     return;
@@ -249,7 +249,7 @@ void permute_PE_scheme(Header &H, const vector<int> &axes) {
   PhaseEncoding::set_scheme(H, out);
 }
 
-void permute_slice_direction(Header &H, const vector<int> &axes) {
+void permute_slice_direction(Header &H, const std::vector<int> &axes) {
   auto it = H.keyval().find("SliceEncodingDirection");
   if (it == H.keyval().end())
     return;
@@ -258,7 +258,7 @@ void permute_slice_direction(Header &H, const vector<int> &axes) {
   it->second = Axes::dir2id(new_dir);
 }
 
-template <class ImageType> inline vector<int> set_header(Header &header, const ImageType &input) {
+template <class ImageType> inline std::vector<int> set_header(Header &header, const ImageType &input) {
   header.ndim() = input.ndim();
   for (size_t n = 0; n < header.ndim(); ++n) {
     header.size(n) = input.size(n);
@@ -268,7 +268,7 @@ template <class ImageType> inline vector<int> set_header(Header &header, const I
   header.transform() = input.transform();
 
   auto opt = get_options("axes");
-  vector<int32_t> axes;
+  std::vector<int32_t> axes;
   if (opt.size()) {
     axes = parse_ints<int32_t>(opt[0][0]);
     header.ndim() = axes.size();
@@ -292,7 +292,7 @@ template <class ImageType> inline vector<int> set_header(Header &header, const I
 
   opt = get_options("vox");
   if (opt.size()) {
-    vector<default_type> vox = parse_floats(opt[0][0]);
+    std::vector<default_type> vox = parse_floats(opt[0][0]);
     if (vox.size() > header.ndim())
       throw Exception("too many axes supplied to -vox option");
     if (vox.size() == 1)
@@ -321,7 +321,7 @@ void copy_permute(const InputType &in, Header &header_out, const std::string &ou
 template <typename T>
 void extract(Header &header_in,
              Header &header_out,
-             const vector<vector<uint32_t>> &pos,
+             const std::vector<std::vector<uint32_t>> &pos,
              const std::string &output_filename) {
   auto in = header_in.get_image<T>();
   if (pos.empty()) {
@@ -402,9 +402,9 @@ void run() {
   }
 
   opt = get_options("coord");
-  vector<vector<uint32_t>> pos;
+  std::vector<std::vector<uint32_t>> pos;
   if (opt.size()) {
-    pos.assign(header_in.ndim(), vector<uint32_t>());
+    pos.assign(header_in.ndim(), std::vector<uint32_t>());
     for (size_t n = 0; n < opt.size(); n++) {
       size_t axis = opt[n][0];
       if (axis >= header_in.ndim())
@@ -466,7 +466,7 @@ void run() {
   opt = get_options("scaling");
   if (opt.size()) {
     if (header_out.datatype().is_integer()) {
-      vector<default_type> scaling = opt[0][0];
+      std::vector<default_type> scaling = opt[0][0];
       if (scaling.size() != 2)
         throw Exception("-scaling option expects comma-separated 2-vector of floating-point values");
       header_out.intensity_offset() = scaling[0];

--- a/cmd/mrdegibbs.cpp
+++ b/cmd/mrdegibbs.cpp
@@ -102,12 +102,12 @@ void run() {
 
   int mode = get_option_value("mode", 0);
 
-  vector<size_t> slice_axes = {0, 1};
+  std::vector<size_t> slice_axes = {0, 1};
   auto opt = get_options("axes");
   const bool axes_set_manually = opt.size();
   if (opt.size()) {
-    vector<uint32_t> axes = parse_ints<uint32_t>(opt[0][0]);
-    if (axes == vector<uint32_t>({0, 1, 2})) {
+    std::vector<uint32_t> axes = parse_ints<uint32_t>(opt[0][0]);
+    if (axes == std::vector<uint32_t>({0, 1, 2})) {
       mode = 1;
     } else {
       if (axes.size() != 2)
@@ -128,7 +128,7 @@ void run() {
     } else {
       try {
         const Eigen::Vector3d slice_encoding_axis_onehot = Axes::id2dir(slice_encoding_it->second);
-        vector<size_t> auto_slice_axes = {0, 0};
+        std::vector<size_t> auto_slice_axes = {0, 0};
         if (slice_encoding_axis_onehot[0])
           auto_slice_axes = {1, 2};
         else if (slice_encoding_axis_onehot[1])
@@ -170,7 +170,7 @@ void run() {
   }
 
   // build vector of outer axes:
-  vector<size_t> outer_axes(header.ndim());
+  std::vector<size_t> outer_axes(header.ndim());
   std::iota(outer_axes.begin(), outer_axes.end(), 0);
   for (const auto axis : slice_axes) {
     auto it = std::find(outer_axes.begin(), outer_axes.end(), axis);

--- a/cmd/mredit.cpp
+++ b/cmd/mredit.cpp
@@ -136,7 +136,7 @@ void run() {
     else
       centre_scannerspace = transform.voxel2scanner * centre_voxelspace;
     std::set<Vox> processed;
-    vector<Vox> to_expand;
+    std::vector<Vox> to_expand;
     const Vox seed_voxel(centre_voxelspace);
     processed.insert(seed_voxel);
     to_expand.push_back(seed_voxel);

--- a/cmd/mrfilter.cpp
+++ b/cmd/mrfilter.cpp
@@ -154,7 +154,7 @@ void run() {
     //   convert between cfloat and cdouble...
     auto input = Image<cdouble>::open(argument[0]);
 
-    vector<size_t> axes = {0, 1, 2};
+    std::vector<size_t> axes = {0, 1, 2};
     auto opt = get_options("axes");
     if (opt.size()) {
       axes = parse_ints<size_t>(opt[0][0]);
@@ -204,7 +204,7 @@ void run() {
     auto input = Image<float>::open(argument[0]);
     Filter::Gradient filter(input, get_options("magnitude").size());
 
-    vector<default_type> stdev;
+    std::vector<default_type> stdev;
     auto opt = get_options("stdev");
     if (opt.size()) {
       stdev = parse_floats(opt[0][0]);
@@ -258,7 +258,7 @@ void run() {
     if (opt.size()) {
       if (stdev_supplied)
         throw Exception("the stdev and FWHM options are mutually exclusive.");
-      vector<default_type> stdevs = parse_floats((opt[0][0]));
+      std::vector<default_type> stdevs = parse_floats((opt[0][0]));
       for (size_t d = 0; d < stdevs.size(); ++d)
         stdevs[d] = stdevs[d] / 2.3548; // convert FWHM to stdev
       filter.set_stdev(stdevs);

--- a/cmd/mrgrid.cpp
+++ b/cmd/mrgrid.cpp
@@ -198,7 +198,7 @@ void run() {
     }
 
     // over-sampling
-    vector<uint32_t> oversample = Adapter::AutoOverSample;
+    std::vector<uint32_t> oversample = Adapter::AutoOverSample;
     opt = get_options("oversample");
     if (opt.size()) {
       oversample = parse_ints<uint32_t>(opt[0][0]);
@@ -223,7 +223,7 @@ void run() {
     regrid_filter.set_interp_type(interp);
     regrid_filter.set_oversample(oversample);
 
-    vector<default_type> scale;
+    std::vector<default_type> scale;
     opt = get_options("scale");
     if (opt.size()) {
       scale = parse_floats(opt[0][0]);
@@ -233,7 +233,7 @@ void run() {
       ++resize_option_count;
     }
 
-    vector<uint32_t> image_size;
+    std::vector<uint32_t> image_size;
     opt = get_options("size");
     if (opt.size()) {
       image_size = parse_ints<uint32_t>(opt[0][0]);
@@ -241,7 +241,7 @@ void run() {
       ++resize_option_count;
     }
 
-    vector<default_type> voxel_size;
+    std::vector<default_type> voxel_size;
     opt = get_options("voxel");
     if (opt.size()) {
       voxel_size = parse_floats(opt[0][0]);
@@ -278,7 +278,7 @@ void run() {
 
     const size_t nd = get_options("nd").size() ? input_header.ndim() : 3;
 
-    vector<vector<ssize_t>> bounds(input_header.ndim(), vector<ssize_t>(2));
+    std::vector<std::vector<ssize_t>> bounds(input_header.ndim(), std::vector<ssize_t>(2));
     for (size_t axis = 0; axis < input_header.ndim(); axis++) {
       bounds[axis][0] = 0;
       bounds[axis][1] = input_header.size(axis) - 1;
@@ -301,9 +301,10 @@ void run() {
       }
 
       struct BoundsCheck {
-        vector<vector<ssize_t>> &overall_bounds;
-        vector<vector<ssize_t>> bounds;
-        BoundsCheck(vector<vector<ssize_t>> &overall_bounds) : overall_bounds(overall_bounds), bounds(overall_bounds) {}
+        std::vector<std::vector<ssize_t>> &overall_bounds;
+        std::vector<std::vector<ssize_t>> bounds;
+        BoundsCheck(std::vector<std::vector<ssize_t>> &overall_bounds)
+            : overall_bounds(overall_bounds), bounds(overall_bounds) {}
         ~BoundsCheck() {
           for (size_t axis = 0; axis != 3; ++axis) {
             overall_bounds[axis][0] = std::min(bounds[axis][0], overall_bounds[axis][0]);
@@ -395,7 +396,7 @@ void run() {
       std::string::size_type start = 0, end;
       end = spec.find_first_of(":", start);
       if (end == std::string::npos) { // spec = delta_lower,delta_upper
-        vector<int> delta;            // 0: not changed, > 0: pad, < 0: crop
+        std::vector<int> delta;       // 0: not changed, > 0: pad, < 0: crop
         try {
           delta = parse_ints<int>(opt[i][1]);
         } catch (Exception &E) {
@@ -433,8 +434,8 @@ void run() {
     if (crop_pad_option_count == 0)
       throw Exception("no crop or pad option supplied");
 
-    vector<ssize_t> from(input_header.ndim());
-    vector<ssize_t> size(input_header.ndim());
+    std::vector<ssize_t> from(input_header.ndim());
+    std::vector<ssize_t> size(input_header.ndim());
     for (size_t axis = 0; axis < input_header.ndim(); axis++) {
       from[axis] = bounds[axis][0];
       size[axis] = bounds[axis][1] - from[axis] + 1;

--- a/cmd/mrhistmatch.cpp
+++ b/cmd/mrhistmatch.cpp
@@ -66,12 +66,12 @@ void match_linear(Image<float> &input,
                   Image<bool> &mask_input,
                   Image<bool> &mask_target,
                   const bool estimate_intercept) {
-  vector<float> input_data, target_data;
+  std::vector<float> input_data, target_data;
   {
     ProgressBar progress("Loading & sorting image data", 4);
 
     auto fill = [](Image<float> &image, Image<bool> &mask) {
-      vector<float> data;
+      std::vector<float> data;
       if (mask.valid()) {
         Adapter::Replicate<Image<bool>> mask_replicate(mask, image);
         for (auto l = Loop(image)(image, mask_replicate); l; ++l) {

--- a/cmd/mrinfo.cpp
+++ b/cmd/mrinfo.cpp
@@ -124,7 +124,7 @@ void print_spacing(const Header &header) {
 
 void print_strides(const Header &header) {
   std::string buffer;
-  vector<ssize_t> strides(Stride::get(header));
+  std::vector<ssize_t> strides(Stride::get(header));
   Stride::symbolise(strides);
   for (size_t i = 0; i < header.ndim(); ++i) {
     if (i)
@@ -189,15 +189,15 @@ void print_properties(const Header &header, const std::string &key, const size_t
 void header2json(const Header &header, nlohmann::json &json) {
   // Capture _all_ header fields, not just the optional key-value pairs
   json["name"] = header.name();
-  vector<size_t> size(header.ndim());
-  vector<default_type> spacing(header.ndim());
+  std::vector<size_t> size(header.ndim());
+  std::vector<default_type> spacing(header.ndim());
   for (size_t axis = 0; axis != header.ndim(); ++axis) {
     size[axis] = header.size(axis);
     spacing[axis] = header.spacing(axis);
   }
   json["size"] = size;
   json["spacing"] = spacing;
-  vector<ssize_t> strides(Stride::get(header));
+  std::vector<ssize_t> strides(Stride::get(header));
   Stride::symbolise(strides);
   json["strides"] = strides;
   json["format"] = header.format();

--- a/cmd/mrmath.cpp
+++ b/cmd/mrmath.cpp
@@ -119,7 +119,7 @@ public:
       values.push_back(val);
   }
   value_type result() { return Math::median(values); }
-  vector<value_type> values;
+  std::vector<value_type> values;
 };
 
 class Sum {
@@ -400,7 +400,7 @@ void run() {
       throw Exception("mrmath requires either multiple input images, or the -axis option to be provided");
 
     // Pre-load all image headers
-    vector<Header> headers_in(num_inputs);
+    std::vector<Header> headers_in(num_inputs);
 
     // Header of first input image is the template to which all other input images are compared
     headers_in[0] = Header::open(argument[0]);

--- a/cmd/mrregister.cpp
+++ b/cmd/mrregister.cpp
@@ -149,7 +149,7 @@ using value_type = double;
 
 void run() {
 
-  vector<Header> input1, input2;
+  std::vector<Header> input1, input2;
   const size_t n_images = argument.size() / 2;
   { // parse arguments and load input headers
     if (n_images * 2 != argument.size()) {
@@ -244,7 +244,7 @@ void run() {
   }
 
   // multi-contrast settings
-  vector<Registration::MultiContrastSetting> mc_params(n_images);
+  std::vector<Registration::MultiContrastSetting> mc_params(n_images);
   for (auto &mc : mc_params) {
     mc.do_reorientation = do_reorientation;
   }
@@ -308,7 +308,7 @@ void run() {
   INFO("maximum input lmax: " + str(max_mc_image_lmax));
 
   opt = get_options("transformed");
-  vector<std::string> im1_transformed_paths;
+  std::vector<std::string> im1_transformed_paths;
   if (opt.size()) {
     if (opt.size() > n_images)
       throw Exception("number of -transformed images exceeds number of contrasts");
@@ -321,8 +321,8 @@ void run() {
     }
   }
 
-  vector<std::string> input1_midway_transformed_paths;
-  vector<std::string> input2_midway_transformed_paths;
+  std::vector<std::string> input1_midway_transformed_paths;
+  std::vector<std::string> input2_midway_transformed_paths;
   opt = get_options("transformed_midway");
   if (opt.size()) {
     if (opt.size() > n_images)
@@ -481,7 +481,7 @@ void run() {
   }
 
   opt = get_options("rigid_lmax");
-  vector<uint32_t> rigid_lmax;
+  std::vector<uint32_t> rigid_lmax;
   if (opt.size()) {
     if (!do_rigid)
       throw Exception("the -rigid_lmax option has been set when no rigid registration is requested");
@@ -632,7 +632,7 @@ void run() {
   }
 
   opt = get_options("affine_lmax");
-  vector<uint32_t> affine_lmax;
+  std::vector<uint32_t> affine_lmax;
   if (opt.size()) {
     if (!do_affine)
       throw Exception("the -affine_lmax option has been set when no affine registration is requested");
@@ -746,7 +746,7 @@ void run() {
     if (!do_nonlinear)
       throw Exception(
           "the non-linear multi-resolution scale factors were input when no non-linear registration is requested");
-    vector<default_type> scale_factors = parse_floats(opt[0][0]);
+    std::vector<default_type> scale_factors = parse_floats(opt[0][0]);
     if (nonlinear_init) {
       WARN("-nl_scale option ignored since only the full resolution will be performed when initialising with "
            "non-linear warp");
@@ -760,7 +760,7 @@ void run() {
     if (!do_nonlinear)
       throw Exception(
           "the number of non-linear iterations have been input when no non-linear registration is requested");
-    vector<uint32_t> iterations_per_level = parse_ints<uint32_t>(opt[0][0]);
+    std::vector<uint32_t> iterations_per_level = parse_ints<uint32_t>(opt[0][0]);
     if (nonlinear_init && iterations_per_level.size() > 1)
       throw Exception("when initialising the non-linear registration the max number of iterations can only be defined "
                       "for a single level");
@@ -792,7 +792,7 @@ void run() {
   }
 
   opt = get_options("nl_lmax");
-  vector<uint32_t> nl_lmax;
+  std::vector<uint32_t> nl_lmax;
   if (opt.size()) {
     if (!do_nonlinear)
       throw Exception("the -nl_lmax option has been set when no non-linear registration is requested");
@@ -810,7 +810,7 @@ void run() {
 
   opt = get_options("mc_weights");
   if (opt.size()) {
-    vector<default_type> mc_weights = parse_floats(opt[0][0]);
+    std::vector<default_type> mc_weights = parse_floats(opt[0][0]);
     if (mc_weights.size() == 1)
       mc_weights.resize(n_images, mc_weights[0]);
     else if (mc_weights.size() != n_images)
@@ -914,7 +914,7 @@ void run() {
     } else { // 3D
       if (rigid_metric == Registration::NCC) {
         Registration::Metric::LocalCrossCorrelation metric;
-        vector<size_t> extent(3, 3);
+        std::vector<size_t> extent(3, 3);
         rigid_registration.set_extent(extent);
         rigid_registration.run_masked(metric, rigid, images1, images2, im1_mask, im2_mask);
       } else if (rigid_metric == Registration::Diff) {
@@ -989,7 +989,7 @@ void run() {
     } else { // 3D
       if (affine_metric == Registration::NCC) {
         Registration::Metric::LocalCrossCorrelation metric;
-        vector<size_t> extent(3, 3);
+        std::vector<size_t> extent(3, 3);
         affine_registration.set_extent(extent);
         affine_registration.run_masked(metric, affine, images1, images2, im1_mask, im2_mask);
       } else if (affine_metric == Registration::Diff) {

--- a/cmd/mrstats.cpp
+++ b/cmd/mrstats.cpp
@@ -106,7 +106,7 @@ void run() {
     check_dimensions(mask, header, 0, 3);
   }
 
-  vector<std::string> fields;
+  std::vector<std::string> fields;
   opt = get_options("output");
   for (size_t n = 0; n < opt.size(); ++n)
     fields.push_back(opt[n][0]);

--- a/cmd/mrthreshold.cpp
+++ b/cmd/mrthreshold.cpp
@@ -141,8 +141,9 @@ Image<bool> get_mask(const Image<value_type> &in) {
   return mask;
 }
 
-vector<value_type> get_data(Image<value_type> &in, Image<bool> &mask, const size_t max_axis, const bool ignore_zero) {
-  vector<value_type> data;
+std::vector<value_type>
+get_data(Image<value_type> &in, Image<bool> &mask, const size_t max_axis, const bool ignore_zero) {
+  std::vector<value_type> data;
   data.reserve(voxel_count(in, 0, max_axis));
   if (mask.valid()) {
     Adapter::Replicate<Image<bool>> mask_replicate(mask, in);
@@ -232,7 +233,7 @@ default_type calculate(Image<value_type> &in,
     if (max_axis < in.ndim()) {
 
       // Need to extract just the current 3D volume
-      vector<size_t> in_from(in.ndim()), in_size(in.ndim());
+      std::vector<size_t> in_from(in.ndim()), in_size(in.ndim());
       size_t axis;
       for (axis = 0; axis != 3; ++axis) {
         in_from[axis] = 0;
@@ -244,7 +245,7 @@ default_type calculate(Image<value_type> &in,
       }
       Adapter::Subset<Image<value_type>> in_subset(in, in_from, in_size);
       if (mask.valid()) {
-        vector<size_t> mask_from(mask.ndim()), mask_size(mask.ndim());
+        std::vector<size_t> mask_from(mask.ndim()), mask_size(mask.ndim());
         for (axis = 0; axis != 3; ++axis) {
           mask_from[axis] = 0;
           mask_size[axis] = mask.size(axis);

--- a/cmd/mrtransform.cpp
+++ b/cmd/mrtransform.cpp
@@ -225,7 +225,7 @@ void apply_warp(Image<float> &input,
                 Image<default_type> &warp,
                 const int interp,
                 const float out_of_bounds_value,
-                const vector<uint32_t> &oversample,
+                const std::vector<uint32_t> &oversample,
                 const bool jacobian_modulate = false) {
   switch (interp) {
   case 0:
@@ -373,7 +373,7 @@ void run() {
 
   // Flip
   opt = get_options("flip");
-  vector<int32_t> axes;
+  std::vector<int32_t> axes;
   if (opt.size()) {
     axes = parse_ints<int32_t>(opt[0][0]);
     transform_type flip;
@@ -550,7 +550,7 @@ void run() {
   }
 
   // over-sampling
-  vector<uint32_t> oversample = Adapter::AutoOverSample;
+  std::vector<uint32_t> oversample = Adapter::AutoOverSample;
   opt = get_options("oversample");
   if (opt.size()) {
     if (!template_header.valid() && !warp)

--- a/cmd/mrview.cpp
+++ b/cmd/mrview.cpp
@@ -84,7 +84,7 @@ void run() {
       QFileOpenEvent *openEvent = static_cast<QFileOpenEvent *>(event);
       std::vector<std::unique_ptr<MR::Header>> list;
       try {
-        list.push_back(make_unique<MR::Header>(MR::Header::open(openEvent->file().toUtf8().data())));
+        list.push_back(std::make_unique<MR::Header>(MR::Header::open(openEvent->file().toUtf8().data())));
       } catch (Exception &E) {
         E.display();
       }

--- a/cmd/mrview.cpp
+++ b/cmd/mrview.cpp
@@ -82,7 +82,7 @@ void run() {
   GUI::App::setEventHandler([](QEvent *event) {
     if (event->type() == QEvent::FileOpen) {
       QFileOpenEvent *openEvent = static_cast<QFileOpenEvent *>(event);
-      vector<std::unique_ptr<MR::Header>> list;
+      std::vector<std::unique_ptr<MR::Header>> list;
       try {
         list.push_back(make_unique<MR::Header>(MR::Header::open(openEvent->file().toUtf8().data())));
       } catch (Exception &E) {

--- a/cmd/mtnormalise.cpp
+++ b/cmd/mtnormalise.cpp
@@ -473,7 +473,7 @@ void run() {
   size_t max_balance_iter = DEFAULT_BALANCE_MAXITER_VALUE;
   auto opt = get_options("niter");
   if (opt.size()) {
-    vector<size_t> num = parse_ints<size_t>(opt[0][0]);
+    std::vector<size_t> num = parse_ints<size_t>(opt[0][0]);
     if (num.size() < 1 && num.size() > 2)
       throw Exception("unexpected number of entries provided to option \"-niter\"");
     for (auto n : num)

--- a/cmd/peaks2fixel.cpp
+++ b/cmd/peaks2fixel.cpp
@@ -43,9 +43,9 @@ void usage() {
   +Option("dataname", "the name of the output fixel data file encoding peak amplitudes") + Argument("path").type_text();
 }
 
-vector<Eigen::Vector3d> get(Image<float> &data) {
+std::vector<Eigen::Vector3d> get(Image<float> &data) {
   data.index(3) = 0;
-  vector<Eigen::Vector3d> result;
+  std::vector<Eigen::Vector3d> result;
   while (data.index(3) < data.size(3)) {
     Eigen::Vector3d direction;
     for (size_t axis = 0; axis != 3; ++axis) {

--- a/cmd/sh2amp.cpp
+++ b/cmd/sh2amp.cpp
@@ -100,7 +100,7 @@ private:
 
 class SH2AmpMultiShell {
 public:
-  SH2AmpMultiShell(const vector<Eigen::MatrixXd> &dirs, const DWI::Shells &shells, bool nonneg)
+  SH2AmpMultiShell(const std::vector<Eigen::MatrixXd> &dirs, const DWI::Shells &shells, bool nonneg)
       : transforms(dirs), shells(shells), nonnegative(nonneg) {}
 
   void operator()(Image<value_type> &in, Image<value_type> &out) {
@@ -122,7 +122,7 @@ public:
   }
 
 private:
-  const vector<Eigen::MatrixXd> &transforms;
+  const std::vector<Eigen::MatrixXd> &transforms;
   const DWI::Shells &shells;
   const bool nonnegative;
   Eigen::VectorXd sh, amp;
@@ -194,7 +194,7 @@ void run() {
     } else if (!(sh_data.ndim() == 4 || (sh_data.ndim() > 4 && (sh_data.size(4) != 1))))
       throw Exception("number of shells differs between gradient scheme and input data");
 
-    vector<Eigen::MatrixXd> transforms;
+    std::vector<Eigen::MatrixXd> transforms;
 
     for (size_t n = 0; n < shells.count(); ++n) {
       Eigen::MatrixXd dirs(shells[n].count(), 2);

--- a/cmd/sh2peaks.cpp
+++ b/cmd/sh2peaks.cpp
@@ -145,7 +145,7 @@ public:
             Eigen::Matrix<value_type, Eigen::Dynamic, 2> &directions,
             int lmax,
             int npeaks,
-            vector<Direction> true_peaks,
+            std::vector<Direction> true_peaks,
             value_type threshold,
             Image<value_type> ipeaks_data,
             bool use_precomputer)
@@ -171,7 +171,7 @@ public:
       return true;
     }
 
-    vector<Direction> all_peaks;
+    std::vector<Direction> all_peaks;
 
     for (size_t i = 0; i < size_t(dirs.rows()); i++) {
       Direction p(dirs(i, 0), dirs(i, 1));
@@ -245,9 +245,9 @@ private:
   Image<value_type> dirs_vox;
   Eigen::Matrix<value_type, Eigen::Dynamic, 2> dirs;
   int lmax, npeaks;
-  vector<Direction> true_peaks;
+  std::vector<Direction> true_peaks;
   value_type threshold;
-  vector<Direction> peaks_out;
+  std::vector<Direction> peaks_out;
   Image<value_type> ipeaks_vox;
   Math::SH::PrecomputedAL<value_type> *precomputer;
 
@@ -299,7 +299,7 @@ void run() {
   int npeaks = get_option_value("num", DEFAULT_NPEAKS);
 
   opt = get_options("direction");
-  vector<Direction> true_peaks;
+  std::vector<Direction> true_peaks;
   for (size_t n = 0; n < opt.size(); ++n) {
     Direction p(Math::pi * to<float>(opt[n][0]) / 180.0, Math::pi * float(opt[n][1]) / 180.0);
     true_peaks.push_back(p);

--- a/cmd/shbasis.cpp
+++ b/cmd/shbasis.cpp
@@ -69,7 +69,7 @@ void usage() {
 
 // Perform a linear regression on the power ratio in each order
 // Omit l=2 - tends to be abnormally small due to non-isotropic brain-wide fibre distribution
-std::pair<float, float> get_regression(const vector<float> &ratios) {
+std::pair<float, float> get_regression(const std::vector<float> &ratios) {
   const size_t n = ratios.size() - 1;
   Eigen::VectorXf Y(n), b(2);
   Eigen::MatrixXf A(n, 2);
@@ -120,7 +120,7 @@ template <typename value_type> void check_and_update(Header &H, const conv_t con
   if (App::log_level > 0 && App::log_level < 2)
     progress.reset(new ProgressBar("Evaluating SH basis of image \"" + H.name() + "\"", N - 1));
 
-  vector<float> ratios;
+  std::vector<float> ratios;
 
   for (size_t l = 2; l <= lmax; l += 2) {
 
@@ -317,7 +317,7 @@ void run() {
     }
   }
 
-  for (vector<ParsedArgument>::const_iterator i = argument.begin(); i != argument.end(); ++i) {
+  for (std::vector<ParsedArgument>::const_iterator i = argument.begin(); i != argument.end(); ++i) {
 
     const std::string path = *i;
     Header H = Header::open(path);

--- a/cmd/shconv.cpp
+++ b/cmd/shconv.cpp
@@ -58,7 +58,7 @@ using value_type = float;
 
 class SConvFunctor {
 public:
-  SConvFunctor(const vector<Eigen::MatrixXd> &responses, vector<Image<value_type>> &inputs)
+  SConvFunctor(const std::vector<Eigen::MatrixXd> &responses, std::vector<Image<value_type>> &inputs)
       : responses(responses), inputs(inputs) {}
 
   void operator()(Image<value_type> &output) {
@@ -78,8 +78,8 @@ public:
   }
 
 protected:
-  const vector<Eigen::MatrixXd> &responses;
-  vector<Image<value_type>> inputs;
+  const std::vector<Eigen::MatrixXd> &responses;
+  std::vector<Image<value_type>> inputs;
   Eigen::VectorXd in, out;
 };
 
@@ -87,8 +87,8 @@ void run() {
   if (!(argument.size() & size_t(1U)))
     throw Exception("unexpected number of arguments");
 
-  vector<Image<value_type>> inputs((argument.size() - 1) / 2);
-  vector<Eigen::MatrixXd> responses(inputs.size());
+  std::vector<Image<value_type>> inputs((argument.size() - 1) / 2);
+  std::vector<Eigen::MatrixXd> responses(inputs.size());
 
   size_t lmax = 0;
   for (size_t n = 0; n < inputs.size(); ++n) {

--- a/cmd/tck2connectome.cpp
+++ b/cmd/tck2connectome.cpp
@@ -182,7 +182,7 @@ void run() {
 
   // First, find out how many segmented nodes there are, so the matrix can be pre-allocated
   // Also check for node volume for all nodes
-  vector<uint32_t> node_volumes(1, 0);
+  std::vector<uint32_t> node_volumes(1, 0);
   node_t max_node_index = 0;
   for (auto i = Loop(node_image, 0, 3)(node_image); i; ++i) {
     if (node_image.value() > max_node_index) {

--- a/cmd/tck2fixel.cpp
+++ b/cmd/tck2fixel.cpp
@@ -40,8 +40,8 @@ public:
   using SetVoxelDir = DWI::Tractography::Mapping::SetVoxelDir;
 
   TrackProcessor(Image<index_type> &fixel_indexer,
-                 const vector<Eigen::Vector3d> &fixel_directions,
-                 vector<uint16_t> &fixel_TDI,
+                 const std::vector<Eigen::Vector3d> &fixel_directions,
+                 std::vector<uint16_t> &fixel_TDI,
                  const float angular_threshold)
       : fixel_indexer(fixel_indexer),
         fixel_directions(fixel_directions),
@@ -50,7 +50,7 @@ public:
 
   bool operator()(const SetVoxelDir &in) {
     // For each voxel tract tangent, assign to a fixel
-    vector<int32_t> tract_fixel_indices;
+    std::vector<int32_t> tract_fixel_indices;
     for (SetVoxelDir::const_iterator i = in.begin(); i != in.end(); ++i) {
       assign_pos_of(*i).to(fixel_indexer);
       fixel_indexer.index(3) = 0;
@@ -80,8 +80,8 @@ public:
 
 private:
   Image<index_type> fixel_indexer;
-  const vector<Eigen::Vector3d> &fixel_directions;
-  vector<uint16_t> &fixel_TDI;
+  const std::vector<Eigen::Vector3d> &fixel_directions;
+  std::vector<uint16_t> &fixel_TDI;
   const float angular_threshold_dp;
 };
 
@@ -128,8 +128,8 @@ void run() {
 
   const float angular_threshold = get_option_value("angle", DEFAULT_ANGLE_THRESHOLD);
 
-  vector<Eigen::Vector3d> positions(num_fixels);
-  vector<Eigen::Vector3d> directions(num_fixels);
+  std::vector<Eigen::Vector3d> positions(num_fixels);
+  std::vector<Eigen::Vector3d> directions(num_fixels);
 
   const std::string output_fixel_folder = argument[2];
   Fixel::copy_index_and_directions_file(input_fixel_folder, output_fixel_folder);
@@ -151,7 +151,7 @@ void run() {
     }
   }
 
-  vector<uint16_t> fixel_TDI(num_fixels, 0.0);
+  std::vector<uint16_t> fixel_TDI(num_fixels, 0.0);
   const std::string track_filename = argument[0];
   DWI::Tractography::Properties properties;
   DWI::Tractography::Reader<float> track_file(track_filename, properties);

--- a/cmd/tckconvert.cpp
+++ b/cmd/tckconvert.cpp
@@ -186,12 +186,12 @@ private:
   File::OFStream VTKout;
   const bool write_ascii;
   size_t offset_num_points;
-  vector<std::pair<size_t, size_t>> track_list;
+  std::vector<std::pair<size_t, size_t>> track_list;
   size_t current_index = 0;
 };
 
-template <class T> void loadLines(vector<int64_t> &lines, std::ifstream &input, int number_of_line_indices) {
-  vector<T> buffer(number_of_line_indices);
+template <class T> void loadLines(std::vector<int64_t> &lines, std::ifstream &input, int number_of_line_indices) {
+  std::vector<T> buffer(number_of_line_indices);
   input.read((char *)&buffer[0], number_of_line_indices * sizeof(T));
   lines.resize(number_of_line_indices);
   // swap from big endian
@@ -254,8 +254,8 @@ public:
   }
 
 private:
-  vector<float> points;
-  vector<int64_t> lines;
+  std::vector<float> points;
+  std::vector<int64_t> lines;
   int lineIdx;
   int number_of_lines;
   int number_of_line_indices;
@@ -308,7 +308,7 @@ public:
 
 private:
   File::NameParser parser;
-  vector<uint32_t> count;
+  std::vector<uint32_t> count;
 };
 
 class PLYWriter : public WriterInterface<float> {

--- a/cmd/tckdfc.cpp
+++ b/cmd/tckdfc.cpp
@@ -212,7 +212,7 @@ private:
 
 void run() {
   bool is_static = get_options("static").size();
-  vector<float> window;
+  std::vector<float> window;
 
   auto opt = get_options("dynamic");
   if (opt.size()) {
@@ -281,7 +281,7 @@ void run() {
 
   Image<float> fmri_image(Image<float>::open(argument[1]).with_direct_io(3));
 
-  vector<default_type> voxel_size;
+  std::vector<default_type> voxel_size;
   opt = get_options("vox");
   if (opt.size())
     voxel_size = parse_floats(opt[0][0]);

--- a/cmd/tckedit.cpp
+++ b/cmd/tckedit.cpp
@@ -126,7 +126,7 @@ void run() {
   // Get the consensus streamline properties from among the multiple input files
   Tractography::Properties properties;
   size_t count = 0;
-  vector<std::string> input_file_list;
+  std::vector<std::string> input_file_list;
 
   for (size_t file_index = 0; file_index != num_inputs; ++file_index) {
 

--- a/cmd/tckinfo.cpp
+++ b/cmd/tckinfo.cpp
@@ -57,7 +57,7 @@ void run() {
 
     if (properties.comments.size()) {
       std::cout << "    Comments:             ";
-      for (vector<std::string>::iterator i = properties.comments.begin(); i != properties.comments.end(); ++i)
+      for (std::vector<std::string>::iterator i = properties.comments.begin(); i != properties.comments.end(); ++i)
         std::cout << (i == properties.comments.begin() ? "" : "                       ") << *i << "\n";
     }
 

--- a/cmd/tckmap.cpp
+++ b/cmd/tckmap.cpp
@@ -255,7 +255,7 @@ void run() {
 
   const size_t num_tracks = properties["count"].empty() ? 0 : to<size_t>(properties["count"]);
 
-  vector<default_type> voxel_size = get_option_value("vox", vector<default_type>());
+  std::vector<default_type> voxel_size = get_option_value("vox", std::vector<default_type>());
 
   if (voxel_size.size() == 1) {
     auto v = voxel_size.front();

--- a/cmd/tcksample.cpp
+++ b/cmd/tcksample.cpp
@@ -148,7 +148,7 @@ public:
     } else {
       if (statistic == MEDIAN) {
         // Don't bother with a weighted median here
-        vector<value_type> data;
+        std::vector<value_type> data;
         data.assign(values.data(), values.data() + values.size());
         out.second = Math::median(data);
       } else if (statistic == MIN) {
@@ -234,7 +234,7 @@ public:
         bool operator<(const WeightSort &that) const { return value < that.value; }
         value_type value, length;
       };
-      vector<WeightSort> data;
+      std::vector<WeightSort> data;
       for (const auto &v : voxels) {
         assign_pos_of(v).to(image);
         data.push_back(WeightSort(v, (image.value() * get_tdi_multiplier(v))));

--- a/cmd/tcksift.cpp
+++ b/cmd/tcksift.cpp
@@ -114,7 +114,7 @@ void run() {
       sifter.set_csv_path(opt[0][0]);
     opt = get_options("output_at_counts");
     if (opt.size()) {
-      vector<uint32_t> counts = parse_ints<uint32_t>(opt[0][0]);
+      std::vector<uint32_t> counts = parse_ints<uint32_t>(opt[0][0]);
       sifter.set_regular_outputs(counts, debug_path);
     }
 

--- a/cmd/tckstats.cpp
+++ b/cmd/tckstats.cpp
@@ -96,8 +96,8 @@ void run() {
   float max_length = -std::numeric_limits<float>::infinity();
   size_t empty_streamlines = 0, zero_length_streamlines = 0;
   default_type sum_lengths = 0.0, sum_weights = 0.0;
-  vector<default_type> histogram;
-  vector<LW> all_lengths;
+  std::vector<default_type> histogram;
+  std::vector<LW> all_lengths;
   all_lengths.reserve(header_count);
 
   {
@@ -113,7 +113,7 @@ void run() {
            "widths");
     }
 
-    vector<float> dump;
+    std::vector<float> dump;
     dump.reserve(header_count);
 
     ProgressBar progress("Reading track file", header_count);
@@ -184,11 +184,11 @@ void run() {
   }
 
   default_type ssd = 0.0;
-  for (vector<LW>::const_iterator i = all_lengths.begin(); i != all_lengths.end(); ++i)
+  for (std::vector<LW>::const_iterator i = all_lengths.begin(); i != all_lengths.end(); ++i)
     ssd += i->get_weight() * Math::pow2(i->get_length() - mean_length);
   const float stdev = sum_weights ? (std::sqrt(ssd / (((count - 1) / default_type(count)) * sum_weights))) : NaN;
 
-  vector<std::string> fields;
+  std::vector<std::string> fields;
   auto opt = get_options("output");
   for (size_t n = 0; n < opt.size(); ++n)
     fields.push_back(opt[n][0]);

--- a/cmd/tensor2metric.cpp
+++ b/cmd/tensor2metric.cpp
@@ -143,7 +143,7 @@ public:
             Image<value_type> &mk_img,
             Image<value_type> &ak_img,
             Image<value_type> &rk_img,
-            vector<uint32_t> &vals,
+            std::vector<uint32_t> &vals,
             int modulate,
             Eigen::MatrixXd mk_dirs,
             int rk_ndirs)
@@ -352,7 +352,7 @@ private:
   Image<value_type> mk_img;
   Image<value_type> ak_img;
   Image<value_type> rk_img;
-  vector<uint32_t> vals;
+  std::vector<uint32_t> vals;
   const int modulate;
   Eigen::MatrixXd mk_dirs;
   Eigen::MatrixXd mk_bmat, rk_bmat;
@@ -443,7 +443,7 @@ void run() {
     metric_count++;
   }
 
-  vector<uint32_t> vals = {1};
+  std::vector<uint32_t> vals = {1};
   opt = get_options("num");
   if (opt.size()) {
     vals = parse_ints<uint32_t>(opt[0][0]);

--- a/cmd/transformcalc.cpp
+++ b/cmd/transformcalc.cpp
@@ -213,7 +213,7 @@ void run() {
     transform_type transform_out;
     Eigen::Transform<default_type, 3, Eigen::Projective> Tin;
     Eigen::MatrixXd Min;
-    vector<Eigen::MatrixXd> matrices;
+    std::vector<Eigen::MatrixXd> matrices;
     for (size_t i = 0; i < num_inputs; i++) {
       DEBUG(str(argument[i]));
       Tin = File::Matrix::load_transform(argument[i]);

--- a/cmd/transformcompose.cpp
+++ b/cmd/transformcompose.cpp
@@ -91,7 +91,7 @@ void usage() {
 using value_type = float;
 
 void run() {
-  vector<std::unique_ptr<TransformBase>> transform_list;
+  std::vector<std::unique_ptr<TransformBase>> transform_list;
   std::unique_ptr<Header> template_header;
 
   for (size_t i = 0; i < argument.size() - 1; ++i) {

--- a/cmd/transformconvert.cpp
+++ b/cmd/transformconvert.cpp
@@ -56,7 +56,7 @@ void usage() {
 }
 
 transform_type get_flirt_transform(const Header &header) {
-  vector<size_t> axes;
+  std::vector<size_t> axes;
   transform_type nifti_transform = File::NIfTI::adjust_transform(header, axes);
   if (nifti_transform.matrix().topLeftCorner<3, 3>().determinant() < 0.0)
     return nifti_transform;
@@ -76,7 +76,7 @@ transform_type get_flirt_transform(const Header &header) {
 // template <class ValueType = default_type>
 //   transform_type parse_surfer_transform (const std::string& filename) {
 //     std::ifstream stream (filename, std::ios_base::in | std::ios_base::binary);
-//     vector<vector<ValueType>> V;
+//     std::vector<std::vector<ValueType>> V;
 //     std::string sbuf;
 //     std::string file_version;
 //     while (getline (stream, sbuf)) {
@@ -97,7 +97,7 @@ transform_type get_flirt_transform(const Header &header) {
 
 //     for (auto i = 0; i<4 && getline (stream, sbuf); ++i){
 //       // sbuf = strip (sbuf.substr (0, sbuf.find_first_of ('type')));
-//       V.push_back (vector<ValueType>());
+//       V.push_back (std::vector<ValueType>());
 //       const auto elements = MR::split (sbuf, " ,;\t", true);
 //       for (const auto& entry : elements)
 //         V.back().push_back (to<ValueType> (entry));
@@ -126,10 +126,10 @@ void parse_itk_trafo(const std::string &itk_file,
                      TransformationType &transformation,
                      Eigen::Vector3d &centre_of_rotation) {
   const std::string first_line = "#Insight Transform File V1.0";
-  vector<std::string> supported_transformations = {"MatrixOffsetTransformBase_double_3_3",
-                                                   "MatrixOffsetTransformBase_float_3_3",
-                                                   "AffineTransform_double_3_3",
-                                                   "AffineTransform_float_3_3"};
+  std::vector<std::string> supported_transformations = {"MatrixOffsetTransformBase_double_3_3",
+                                                        "MatrixOffsetTransformBase_float_3_3",
+                                                        "AffineTransform_double_3_3",
+                                                        "AffineTransform_float_3_3"};
   // TODO, support derived classes that are compatible
   // FixedCenterOfRotationAffineTransform_float_3_3?
   // QuaternionRigidTransform_double_3_3?
@@ -146,7 +146,7 @@ void parse_itk_trafo(const std::string &itk_file,
     } else if (file.key() == "Parameters") {
       line = file.value();
       std::replace(line.begin(), line.end(), ' ', ',');
-      vector<default_type> parameters(parse_floats(line));
+      std::vector<default_type> parameters(parse_floats(line));
       if (parameters.size() != 12)
         throw Exception("Expected itk file with 12 parameters but has " + str(parameters.size()) + " parameters.");
       transformation.linear().row(0) << parameters[0], parameters[1], parameters[2];
@@ -157,7 +157,7 @@ void parse_itk_trafo(const std::string &itk_file,
     } else if (file.key() == "FixedParameters") {
       line = file.value();
       std::replace(line.begin(), line.end(), ' ', ',');
-      vector<default_type> fixed_parameters(parse_floats(line));
+      std::vector<default_type> fixed_parameters(parse_floats(line));
       centre_of_rotation << fixed_parameters[0], fixed_parameters[1], fixed_parameters[2];
       invalid--;
     }

--- a/cmd/tsfinfo.cpp
+++ b/cmd/tsfinfo.cpp
@@ -62,7 +62,7 @@ void run() {
 
     if (properties.comments.size()) {
       std::cout << "    Comments:             ";
-      for (vector<std::string>::iterator i = properties.comments.begin(); i != properties.comments.end(); ++i)
+      for (std::vector<std::string>::iterator i = properties.comments.begin(); i != properties.comments.end(); ++i)
         std::cout << (i == properties.comments.begin() ? "" : "                       ") << *i << "\n";
     }
 
@@ -94,7 +94,7 @@ void run() {
         filename.replace(filename.size() - 4 - num.size(), num.size(), num);
 
         File::OFStream out(filename);
-        for (vector<float>::iterator i = tck.begin(); i != tck.end(); ++i)
+        for (std::vector<float>::iterator i = tck.begin(); i != tck.end(); ++i)
           out << (*i) << "\n";
         out.close();
 

--- a/cmd/tsfsmooth.cpp
+++ b/cmd/tsfsmooth.cpp
@@ -51,7 +51,7 @@ void run() {
 
   float stdev = get_option_value("stdev", DEFAULT_SMOOTHING);
 
-  vector<float> kernel(2 * ceil(2.5 * stdev) + 1, 0);
+  std::vector<float> kernel(2 * ceil(2.5 * stdev) + 1, 0);
   float norm_factor = 0.0;
   float radius = (kernel.size() - 1.0) / 2.0;
   for (size_t c = 0; c < kernel.size(); ++c) {

--- a/cmd/vectorstats.cpp
+++ b/cmd/vectorstats.cpp
@@ -142,7 +142,7 @@ void run() {
 
   // Before validating the contrast matrix, we first need to see if there are any
   //   additional design matrix columns coming from element-wise subject data
-  vector<CohortDataImport> extra_columns;
+  std::vector<CohortDataImport> extra_columns;
   bool nans_in_columns = false;
   auto opt = get_options("column");
   for (size_t i = 0; i != opt.size(); ++i) {
@@ -168,7 +168,7 @@ void run() {
     CONSOLE("Number of variance groups: " + str(num_vgs));
 
   // Load hypotheses
-  const vector<Hypothesis> hypotheses = Math::Stats::GLM::load_hypotheses(argument[2]);
+  const std::vector<Hypothesis> hypotheses = Math::Stats::GLM::load_hypotheses(argument[2]);
   const index_type num_hypotheses = hypotheses.size();
   if (hypotheses[0].cols() != num_factors)
     throw Exception(

--- a/core/adapter/extract.h
+++ b/core/adapter/extract.h
@@ -31,7 +31,7 @@ public:
   using base_type::parent;
   using base_type::spacing;
 
-  Extract1D(const ImageType &original, const size_t axis, const vector<uint32_t> &indices)
+  Extract1D(const ImageType &original, const size_t axis, const std::vector<uint32_t> &indices)
       : base_type(original), extract_axis(axis), indices(indices), nsize(indices.size()), trans(original.transform()) {
     reset();
 
@@ -77,7 +77,7 @@ public:
 
 private:
   const size_t extract_axis;
-  vector<uint32_t> indices;
+  std::vector<uint32_t> indices;
   const ssize_t nsize;
   transform_type trans;
   ssize_t current_pos;
@@ -92,7 +92,7 @@ public:
   using base_type::parent;
   using base_type::spacing;
 
-  Extract(const ImageType &original, const vector<vector<uint32_t>> &indices)
+  Extract(const ImageType &original, const std::vector<std::vector<uint32_t>> &indices)
       : base_type(original), current_pos(ndim()), indices(indices), trans(original.transform()) {
     reset();
     trans.translation() =
@@ -125,9 +125,9 @@ public:
   }
 
 private:
-  vector<ssize_t> current_pos;
-  vector<vector<uint32_t>> indices;
-  vector<ssize_t> sizes;
+  std::vector<ssize_t> current_pos;
+  std::vector<std::vector<uint32_t>> indices;
+  std::vector<ssize_t> sizes;
   transform_type trans;
 };
 

--- a/core/adapter/gaussian1D.h
+++ b/core/adapter/gaussian1D.h
@@ -95,7 +95,7 @@ protected:
   default_type stdev;
   ssize_t radius;
   size_t axis;
-  vector<default_type> kernel;
+  std::vector<default_type> kernel;
   const bool zero_boundary;
 };
 } // namespace Adapter

--- a/core/adapter/gradient1D.h
+++ b/core/adapter/gradient1D.h
@@ -79,8 +79,8 @@ protected:
   size_t axis;
   value_type result;
   const bool wrt_spacing;
-  vector<value_type> derivative_weights;
-  vector<value_type> half_derivative_weights;
+  std::vector<value_type> derivative_weights;
+  std::vector<value_type> half_derivative_weights;
 };
 } // namespace Adapter
 } // namespace MR

--- a/core/adapter/median.h
+++ b/core/adapter/median.h
@@ -33,18 +33,18 @@ public:
   using base_type::name;
   using base_type::size;
 
-  Median(const ImageType &parent) : base_type(parent) { set_extent(vector<int>(1, 3)); }
+  Median(const ImageType &parent) : base_type(parent) { set_extent(std::vector<int>(1, 3)); }
 
-  Median(const ImageType &parent, const vector<uint32_t> &extent) : base_type(parent) { set_extent(extent); }
+  Median(const ImageType &parent, const std::vector<uint32_t> &extent) : base_type(parent) { set_extent(extent); }
 
-  void set_extent(const vector<uint32_t> &ext) {
+  void set_extent(const std::vector<uint32_t> &ext) {
     for (size_t i = 0; i < ext.size(); ++i)
       if (!(ext[i] & uint32_t(1)))
         throw Exception("expected odd number for extent");
     if (ext.size() != 1 && ext.size() != 3)
       throw Exception("unexpected number of elements specified in extent");
     if (ext.size() == 1)
-      extent = vector<uint32_t>(3, ext[0]);
+      extent = std::vector<uint32_t>(3, ext[0]);
     else
       extent = ext;
 
@@ -78,8 +78,8 @@ public:
   }
 
 protected:
-  vector<uint32_t> extent;
-  vector<value_type> values;
+  std::vector<uint32_t> extent;
+  std::vector<value_type> values;
 };
 
 } // namespace Adapter

--- a/core/adapter/neighbourhood3D.h
+++ b/core/adapter/neighbourhood3D.h
@@ -67,7 +67,7 @@ public:
 
 protected:
   using base_type::parent;
-  vector<ssize_t> from_, size_;
+  std::vector<ssize_t> from_, size_;
   Iterator iter_;
   transform_type transform_;
 };

--- a/core/adapter/normalise3D.h
+++ b/core/adapter/normalise3D.h
@@ -32,18 +32,18 @@ public:
   using base_type::name;
   using base_type::size;
 
-  Normalise3D(const ImageType &parent) : base_type(parent) { set_extent(vector<int>(1, 3)); }
+  Normalise3D(const ImageType &parent) : base_type(parent) { set_extent(std::vector<int>(1, 3)); }
 
-  Normalise3D(const ImageType &parent, const vector<uint32_t> &extent) : base_type(parent) { set_extent(extent); }
+  Normalise3D(const ImageType &parent, const std::vector<uint32_t> &extent) : base_type(parent) { set_extent(extent); }
 
-  void set_extent(const vector<uint32_t> &ext) {
+  void set_extent(const std::vector<uint32_t> &ext) {
     for (size_t i = 0; i < ext.size(); ++i)
       if (!(ext[i] & uint32_t(1)))
         throw Exception("expected odd number for extent");
     if (ext.size() != 1 && ext.size() != 3)
       throw Exception("unexpected number of elements specified in extent");
     if (ext.size() == 1)
-      extent = vector<uint32_t>(3, ext[0]);
+      extent = std::vector<uint32_t>(3, ext[0]);
     else
       extent = ext;
 
@@ -83,7 +83,7 @@ public:
   }
 
 protected:
-  vector<uint32_t> extent;
+  std::vector<uint32_t> extent;
   value_type mean;
   value_type pos_value;
   size_t nelements;

--- a/core/adapter/permute_axes.h
+++ b/core/adapter/permute_axes.h
@@ -30,7 +30,7 @@ public:
   using base_type::parent;
   using base_type::size;
 
-  PermuteAxes(const ImageType &original, const vector<int> &axes) : base_type(original), axes_(axes) {
+  PermuteAxes(const ImageType &original, const std::vector<int> &axes) : base_type(original), axes_(axes) {
     for (int i = 0; i < static_cast<int>(parent().ndim()); ++i) {
       for (size_t a = 0; a < axes_.size(); ++a) {
         if (axes_[a] >= int(parent().ndim()))
@@ -75,8 +75,8 @@ public:
   }
 
 private:
-  vector<int> axes_;
-  vector<size_t> non_existent_axes;
+  std::vector<int> axes_;
+  std::vector<size_t> non_existent_axes;
 };
 
 } // namespace Adapter

--- a/core/adapter/regrid.h
+++ b/core/adapter/regrid.h
@@ -37,14 +37,14 @@ public:
         from_(container_cast<decltype(from_)>(from)),
         size_(container_cast<decltype(size_)>(size)),
         index_invalid_lower_upper([&] {
-          vector<vector<ssize_t>> v;
+          std::vector<std::vector<ssize_t>> v;
           for (size_t d = 0; d < from_.size(); ++d) {
-            v.push_back(vector<ssize_t>{from_[d] < 0 ? -(ssize_t)from_[d] - 1 : -1, original.size(d) - from_[d]});
+            v.push_back(std::vector<ssize_t>{from_[d] < 0 ? -(ssize_t)from_[d] - 1 : -1, original.size(d) - from_[d]});
           }
           return v;
         }()),
         index_requires_bound_check([&] {
-          vector<bool> v;
+          std::vector<bool> v;
           for (size_t d = 0; d < from_.size(); ++d) {
             v.push_back(from_[d] < 0 || size_[d] > original.size(d) - from_[d]);
           }
@@ -101,12 +101,12 @@ public:
 
 protected:
   using base_type::parent;
-  const vector<ssize_t> from_, size_;
-  const vector<vector<ssize_t>> index_invalid_lower_upper;
-  const vector<bool> index_requires_bound_check;
+  const std::vector<ssize_t> from_, size_;
+  const std::vector<std::vector<ssize_t>> index_invalid_lower_upper;
+  const std::vector<bool> index_requires_bound_check;
   const value_type fill_;
   transform_type transform_;
-  vector<ssize_t> index_;
+  std::vector<ssize_t> index_;
 };
 
 } // namespace Adapter

--- a/core/adapter/replicate.h
+++ b/core/adapter/replicate.h
@@ -59,7 +59,7 @@ public:
 protected:
   using base_type::parent;
   Header header_;
-  vector<ssize_t> pos_;
+  std::vector<ssize_t> pos_;
 };
 
 } // namespace Adapter

--- a/core/adapter/reslice.cpp
+++ b/core/adapter/reslice.cpp
@@ -19,6 +19,6 @@
 namespace MR {
 namespace Adapter {
 const transform_type NoTransform = transform_type::Identity();
-const vector<uint32_t> AutoOverSample;
+const std::vector<uint32_t> AutoOverSample;
 } // namespace Adapter
 } // namespace MR

--- a/core/adapter/reslice.h
+++ b/core/adapter/reslice.h
@@ -52,7 +52,7 @@ typename std::enable_if<std::is_floating_point<value_type>::value, value_type>::
 } // namespace
 
 extern const transform_type NoTransform;
-extern const vector<uint32_t> AutoOverSample;
+extern const std::vector<uint32_t> AutoOverSample;
 
 //! \addtogroup interp
 // @{
@@ -105,7 +105,7 @@ public:
   Reslice(const ImageType &original,
           const HeaderType &reference,
           const transform_type &transform = NoTransform,
-          const vector<uint32_t> &oversample = AutoOverSample,
+          const std::vector<uint32_t> &oversample = AutoOverSample,
           const value_type value_when_out_of_bounds = Interp::Base<ImageType>::default_out_of_bounds_value())
       : interp(original, value_when_out_of_bounds),
         x{0, 0, 0},

--- a/core/adapter/subset.h
+++ b/core/adapter/subset.h
@@ -64,7 +64,7 @@ public:
 
 protected:
   using base_type::parent;
-  const vector<ssize_t> from_, size_;
+  const std::vector<ssize_t> from_, size_;
   transform_type transform_;
 };
 

--- a/core/algo/histogram.cpp
+++ b/core/algo/histogram.cpp
@@ -42,7 +42,7 @@ void Calibrator::from_file(const std::string &path) {
     M = File::Matrix::load_matrix(path);
     if (M.cols() == 1)
       throw Exception("Histogram template must have at least 2 columns");
-    vector<default_type>().swap(data);
+    std::vector<default_type>().swap(data);
     auto V = M.row(0);
     num_bins = V.size();
     bin_width = (V[num_bins - 1] - V[0]) / default_type(num_bins - 1);
@@ -68,7 +68,7 @@ void Calibrator::finalize(const size_t num_volumes, const bool is_integer) {
       // Need to adjust the bin width accordingly... kinda ugly hack
       // Will need to revisit if mrstats gets capability to compute statistics across all volumes rather than splitting
       bin_width = 2.0 * get_iqr() * std::pow(static_cast<default_type>(data.size() / num_volumes), -1.0 / 3.0);
-      vector<default_type>().swap(data); // No longer required; free the memory used
+      std::vector<default_type>().swap(data); // No longer required; free the memory used
       // If the input data are integers, the bin width should also be an integer, to avoid getting
       //   regular spike artifacts in the histogram
       if (is_integer) {

--- a/core/algo/histogram.h
+++ b/core/algo/histogram.h
@@ -75,7 +75,7 @@ private:
   default_type min, max, bin_width;
   size_t num_bins;
   const bool ignore_zero;
-  vector<default_type> data;
+  std::vector<default_type> data;
 
   default_type get_iqr();
 };

--- a/core/algo/iterator.h
+++ b/core/algo/iterator.h
@@ -48,7 +48,7 @@ public:
   }
 
 private:
-  vector<ssize_t> d, p;
+  std::vector<ssize_t> d, p;
 
   void value() const { assert(0); }
 };

--- a/core/algo/loop.h
+++ b/core/algo/loop.h
@@ -132,7 +132,7 @@ struct inc_pos {
  * following example:
  * \code
  * float value = 0.0;
- * vector<size_t> order = { 1, 0, 2 };
+ * std::vector<size_t> order = { 1, 0, 2 };
  *
  * LoopInOrder loop (vox, order);
  * for (auto i = loop.run (vox); i; ++i)
@@ -306,15 +306,15 @@ struct LoopAlongAxesProgress {
 };
 
 struct LoopAlongDynamicAxes {
-  const vector<size_t> axes;
+  const std::vector<size_t> axes;
 
   template <class... ImageType> struct Run {
-    const vector<size_t> axes;
+    const std::vector<size_t> axes;
     const std::tuple<ImageType &...> vox;
     const size_t from;
     const ssize_t size0;
     bool ok;
-    FORCE_INLINE Run(const vector<size_t> &axes, const std::tuple<ImageType &...> &vox)
+    FORCE_INLINE Run(const std::vector<size_t> &axes, const std::tuple<ImageType &...> &vox)
         : axes(axes), vox(vox), from(axes[0]), size0(std::get<0>(vox).size(from)), ok(true) {
       for (auto axis : axes)
         MR::apply(set_pos(axis, 0), vox);
@@ -345,12 +345,12 @@ struct LoopAlongDynamicAxes {
 
 struct LoopAlongDynamicAxesProgress : public LoopAlongDynamicAxes {
   const std::string text;
-  LoopAlongDynamicAxesProgress(const std::string &text, const vector<size_t> &axes)
+  LoopAlongDynamicAxesProgress(const std::string &text, const std::vector<size_t> &axes)
       : LoopAlongDynamicAxes({axes}), text(text) {}
 
   template <class... ImageType> struct Run : public LoopAlongDynamicAxes::Run<ImageType...> {
     MR::ProgressBar progress;
-    FORCE_INLINE Run(const std::string &text, const vector<size_t> &axes, const std::tuple<ImageType &...> &vox)
+    FORCE_INLINE Run(const std::string &text, const std::vector<size_t> &axes, const std::tuple<ImageType &...> &vox)
         : LoopAlongDynamicAxes::Run<ImageType...>(axes, vox), progress(text, MR::voxel_count(std::get<0>(vox), axes)) {}
     FORCE_INLINE void operator++() {
       LoopAlongDynamicAxes::Run<ImageType...>::operator++();
@@ -380,9 +380,9 @@ FORCE_INLINE LoopAlongAxisRangeProgress Loop(const std::string &progress_message
   return {progress_message, axis_from, axis_to};
 }
 
-FORCE_INLINE LoopAlongDynamicAxes Loop(const vector<size_t> &axes) { return {axes}; }
+FORCE_INLINE LoopAlongDynamicAxes Loop(const std::vector<size_t> &axes) { return {axes}; }
 
-FORCE_INLINE LoopAlongDynamicAxesProgress Loop(const std::string &progress_message, const vector<size_t> &axes) {
+FORCE_INLINE LoopAlongDynamicAxesProgress Loop(const std::string &progress_message, const std::vector<size_t> &axes) {
   return {progress_message, axes};
 }
 

--- a/core/algo/neighbourhooditerator.h
+++ b/core/algo/neighbourhooditerator.h
@@ -39,7 +39,7 @@ class NeighbourhoodIterator {
 public:
   NeighbourhoodIterator() = delete;
   template <class IteratorType>
-  NeighbourhoodIterator(const IteratorType &iter, const vector<size_t> &extent)
+  NeighbourhoodIterator(const IteratorType &iter, const std::vector<size_t> &extent)
       : dim(iter.ndim()),
         offset(iter.ndim()),
         // pos (iter.ndim()),
@@ -105,7 +105,7 @@ public:
   }
 
 private:
-  vector<ssize_t> dim, offset, pos_orig, ext;
+  std::vector<ssize_t> dim, offset, pos_orig, ext;
   Eigen::Matrix<ssize_t, 1, Eigen::Dynamic> pos;
   bool has_next_;
 

--- a/core/algo/random_loop.h
+++ b/core/algo/random_loop.h
@@ -70,9 +70,9 @@ private:
   ImageType &image;
   RandomEngine &engine;
   size_t ax;
-  vector<size_t> idx;
-  vector<size_t>::iterator it;
-  vector<size_t>::iterator stop;
+  std::vector<size_t> idx;
+  std::vector<size_t>::iterator it;
+  std::vector<size_t>::iterator stop;
   size_t max_cnt;
   bool status;
   size_t cnt;

--- a/core/algo/random_threaded_loop.h
+++ b/core/algo/random_threaded_loop.h
@@ -32,19 +32,19 @@ namespace MR {
 namespace {
 
 template <int N, class Functor, class... ImageType> struct RandomThreadedLoopRunInner {
-  const vector<size_t> &outer_axes;
+  const std::vector<size_t> &outer_axes;
   decltype(Loop(outer_axes)) loop;
   typename std::remove_reference<Functor>::type func;
   double density;
   Math::RNG::Uniform<double> rng;
-  const vector<size_t> dims;
+  const std::vector<size_t> dims;
   std::tuple<ImageType...> vox;
 
-  RandomThreadedLoopRunInner(const vector<size_t> &outer_axes,
-                             const vector<size_t> &inner_axes,
+  RandomThreadedLoopRunInner(const std::vector<size_t> &outer_axes,
+                             const std::vector<size_t> &inner_axes,
                              const Functor &functor,
                              const double voxel_density,
-                             const vector<size_t> dimensions,
+                             const std::vector<size_t> dimensions,
                              ImageType &...voxels)
       : outer_axes(outer_axes),
         loop(Loop(inner_axes)),
@@ -67,8 +67,8 @@ template <int N, class Functor, class... ImageType> struct RandomThreadedLoopRun
 };
 
 template <class Functor, class... ImageType> struct RandomThreadedLoopRunInner<0, Functor, ImageType...> {
-  const vector<size_t> &outer_axes;
-  const vector<size_t> inner;
+  const std::vector<size_t> &outer_axes;
+  const std::vector<size_t> inner;
   decltype(Loop(outer_axes)) loop;
   // Random_loop<Iterator, std::default_random_engine>  random_loop;
   typename std::remove_reference<Functor>::type func;
@@ -77,21 +77,21 @@ template <class Functor, class... ImageType> struct RandomThreadedLoopRunInner<0
   size_t cnt;
   // Math::RNG::Uniform<double> rng;
   std::default_random_engine random_engine;
-  vector<size_t> idx;
-  vector<size_t>::iterator it;
-  vector<size_t>::iterator stop;
-  const vector<size_t> dims;
+  std::vector<size_t> idx;
+  std::vector<size_t>::iterator it;
+  std::vector<size_t>::iterator stop;
+  const std::vector<size_t> dims;
   // ImageType& image;
   // RandomEngine& engine;
   // size_t max_cnt;
   // bool status;
   // size_t cnt;
 
-  RandomThreadedLoopRunInner(const vector<size_t> &outer_axes,
-                             const vector<size_t> &inner_axes,
+  RandomThreadedLoopRunInner(const std::vector<size_t> &outer_axes,
+                             const std::vector<size_t> &inner_axes,
                              const Functor &functor,
                              const double voxel_density,
-                             const vector<size_t> &dimensions,
+                             const std::vector<size_t> &dimensions,
                              ImageType &...voxels)
       : outer_axes(outer_axes),
         inner(inner_axes),
@@ -105,7 +105,7 @@ template <class Functor, class... ImageType> struct RandomThreadedLoopRunInner<0
     Math::RNG rng;
     typename std::default_random_engine::result_type seed = rng.get_seed();
     random_engine = std::default_random_engine{static_cast<std::default_random_engine::result_type>(seed)};
-    idx = vector<size_t>(dims[inner_axes[0]]);
+    idx = std::vector<size_t>(dims[inner_axes[0]]);
     std::iota(std::begin(idx), std::end(idx), 0);
   }
 
@@ -138,11 +138,11 @@ template <class Functor, class... ImageType> struct RandomThreadedLoopRunInner<0
 template <class OuterLoopType> struct RandomThreadedLoopRunOuter {
   Iterator iterator;
   OuterLoopType outer_loop;
-  vector<size_t> inner_axes;
+  std::vector<size_t> inner_axes;
 
   //! invoke \a functor (const Iterator& pos) per voxel <em> in the outer axes only</em>
   template <class Functor>
-  void run_outer(Functor &&functor, const double voxel_density, const vector<size_t> &dimensions) {
+  void run_outer(Functor &&functor, const double voxel_density, const std::vector<size_t> &dimensions) {
     if (Thread::threads_to_execute() == 0) {
       for (auto i = outer_loop(iterator); i; ++i) {
         // std::cerr << "outer: " << str(iterator) << " " << voxel_density << " " << dimensions << std::endl;
@@ -181,7 +181,7 @@ template <class OuterLoopType> struct RandomThreadedLoopRunOuter {
 
   //! invoke \a functor (const Iterator& pos) per voxel <em> in the outer axes only</em>
   template <class Functor, class... ImageType>
-  void run(Functor &&functor, const double voxel_density, vector<size_t> dimensions, ImageType &&...vox) {
+  void run(Functor &&functor, const double voxel_density, std::vector<size_t> dimensions, ImageType &&...vox) {
     RandomThreadedLoopRunInner<sizeof...(ImageType),
                                typename std::remove_reference<Functor>::type,
                                typename std::remove_reference<ImageType>::type...>
@@ -193,19 +193,19 @@ template <class OuterLoopType> struct RandomThreadedLoopRunOuter {
 } // namespace
 
 template <class HeaderType>
-inline RandomThreadedLoopRunOuter<decltype(Loop(vector<size_t>()))>
-RandomThreadedLoop(const HeaderType &source, const vector<size_t> &outer_axes, const vector<size_t> &inner_axes) {
+inline RandomThreadedLoopRunOuter<decltype(Loop(std::vector<size_t>()))> RandomThreadedLoop(
+    const HeaderType &source, const std::vector<size_t> &outer_axes, const std::vector<size_t> &inner_axes) {
   return {source, Loop(outer_axes), inner_axes};
 }
 
 template <class HeaderType>
-inline RandomThreadedLoopRunOuter<decltype(Loop(vector<size_t>()))>
-RandomThreadedLoop(const HeaderType &source, const vector<size_t> &axes, size_t num_inner_axes = 1) {
+inline RandomThreadedLoopRunOuter<decltype(Loop(std::vector<size_t>()))>
+RandomThreadedLoop(const HeaderType &source, const std::vector<size_t> &axes, size_t num_inner_axes = 1) {
   return {source, Loop(get_outer_axes(axes, num_inner_axes)), get_inner_axes(axes, num_inner_axes)};
 }
 
 template <class HeaderType>
-inline RandomThreadedLoopRunOuter<decltype(Loop(vector<size_t>()))>
+inline RandomThreadedLoopRunOuter<decltype(Loop(std::vector<size_t>()))>
 RandomThreadedLoop(const HeaderType &source,
                    size_t from_axis = 0,
                    size_t to_axis = std::numeric_limits<size_t>::max(),
@@ -216,25 +216,25 @@ RandomThreadedLoop(const HeaderType &source,
 }
 
 template <class HeaderType>
-inline RandomThreadedLoopRunOuter<decltype(Loop("", vector<size_t>()))>
+inline RandomThreadedLoopRunOuter<decltype(Loop("", std::vector<size_t>()))>
 RandomThreadedLoop(const std::string &progress_message,
                    const HeaderType &source,
-                   const vector<size_t> &outer_axes,
-                   const vector<size_t> &inner_axes) {
+                   const std::vector<size_t> &outer_axes,
+                   const std::vector<size_t> &inner_axes) {
   return {source, Loop(progress_message, outer_axes), inner_axes};
 }
 
 template <class HeaderType>
-inline RandomThreadedLoopRunOuter<decltype(Loop("", vector<size_t>()))>
+inline RandomThreadedLoopRunOuter<decltype(Loop("", std::vector<size_t>()))>
 RandomThreadedLoop(const std::string &progress_message,
                    const HeaderType &source,
-                   const vector<size_t> &axes,
+                   const std::vector<size_t> &axes,
                    size_t num_inner_axes = 1) {
   return {source, Loop(progress_message, get_outer_axes(axes, num_inner_axes)), get_inner_axes(axes, num_inner_axes)};
 }
 
 template <class HeaderType>
-inline RandomThreadedLoopRunOuter<decltype(Loop("", vector<size_t>()))>
+inline RandomThreadedLoopRunOuter<decltype(Loop("", std::vector<size_t>()))>
 RandomThreadedLoop(const std::string &progress_message,
                    const HeaderType &source,
                    size_t from_axis = 0,

--- a/core/algo/stochastic_threaded_loop.h
+++ b/core/algo/stochastic_threaded_loop.h
@@ -30,15 +30,15 @@ namespace MR {
 namespace {
 
 template <int N, class Functor, class... ImageType> struct StochasticThreadedLoopRunInner {
-  const vector<size_t> &outer_axes;
+  const std::vector<size_t> &outer_axes;
   decltype(Loop(outer_axes)) loop;
   typename std::remove_reference<Functor>::type func;
   double density;
   Math::RNG::Uniform<double> rng;
   std::tuple<ImageType...> vox;
 
-  StochasticThreadedLoopRunInner(const vector<size_t> &outer_axes,
-                                 const vector<size_t> &inner_axes,
+  StochasticThreadedLoopRunInner(const std::vector<size_t> &outer_axes,
+                                 const std::vector<size_t> &inner_axes,
                                  const Functor &functor,
                                  const double voxel_density,
                                  ImageType &...voxels)
@@ -63,14 +63,14 @@ template <int N, class Functor, class... ImageType> struct StochasticThreadedLoo
 };
 
 template <class Functor, class... ImageType> struct StochasticThreadedLoopRunInner<0, Functor, ImageType...> {
-  const vector<size_t> &outer_axes;
+  const std::vector<size_t> &outer_axes;
   decltype(Loop(outer_axes)) loop;
   typename std::remove_reference<Functor>::type func;
   double density;
   Math::RNG::Uniform<double> rng;
 
-  StochasticThreadedLoopRunInner(const vector<size_t> &outer_axes,
-                                 const vector<size_t> &inner_axes,
+  StochasticThreadedLoopRunInner(const std::vector<size_t> &outer_axes,
+                                 const std::vector<size_t> &inner_axes,
                                  const Functor &functor,
                                  const double voxel_density,
                                  ImageType &...voxels)
@@ -95,7 +95,7 @@ template <class Functor, class... ImageType> struct StochasticThreadedLoopRunInn
 template <class OuterLoopType> struct StochasticThreadedLoopRunOuter {
   Iterator iterator;
   OuterLoopType outer_loop;
-  vector<size_t> inner_axes;
+  std::vector<size_t> inner_axes;
 
   //! invoke \a functor (const Iterator& pos) per voxel <em> in the outer axes only</em>
   template <class Functor> void run_outer(Functor &&functor, const double voxel_density) {
@@ -149,19 +149,19 @@ template <class OuterLoopType> struct StochasticThreadedLoopRunOuter {
 } // namespace
 
 template <class HeaderType>
-inline StochasticThreadedLoopRunOuter<decltype(Loop(vector<size_t>()))>
-StochasticThreadedLoop(const HeaderType &source, const vector<size_t> &outer_axes, const vector<size_t> &inner_axes) {
+inline StochasticThreadedLoopRunOuter<decltype(Loop(std::vector<size_t>()))> StochasticThreadedLoop(
+    const HeaderType &source, const std::vector<size_t> &outer_axes, const std::vector<size_t> &inner_axes) {
   return {source, Loop(outer_axes), inner_axes};
 }
 
 template <class HeaderType>
-inline StochasticThreadedLoopRunOuter<decltype(Loop(vector<size_t>()))>
-StochasticThreadedLoop(const HeaderType &source, const vector<size_t> &axes, size_t num_inner_axes = 1) {
+inline StochasticThreadedLoopRunOuter<decltype(Loop(std::vector<size_t>()))>
+StochasticThreadedLoop(const HeaderType &source, const std::vector<size_t> &axes, size_t num_inner_axes = 1) {
   return {source, Loop(get_outer_axes(axes, num_inner_axes)), get_inner_axes(axes, num_inner_axes)};
 }
 
 template <class HeaderType>
-inline StochasticThreadedLoopRunOuter<decltype(Loop(vector<size_t>()))>
+inline StochasticThreadedLoopRunOuter<decltype(Loop(std::vector<size_t>()))>
 StochasticThreadedLoop(const HeaderType &source,
                        size_t from_axis = 0,
                        size_t to_axis = std::numeric_limits<size_t>::max(),
@@ -172,25 +172,25 @@ StochasticThreadedLoop(const HeaderType &source,
 }
 
 template <class HeaderType>
-inline StochasticThreadedLoopRunOuter<decltype(Loop("", vector<size_t>()))>
+inline StochasticThreadedLoopRunOuter<decltype(Loop("", std::vector<size_t>()))>
 StochasticThreadedLoop(const std::string &progress_message,
                        const HeaderType &source,
-                       const vector<size_t> &outer_axes,
-                       const vector<size_t> &inner_axes) {
+                       const std::vector<size_t> &outer_axes,
+                       const std::vector<size_t> &inner_axes) {
   return {source, Loop(progress_message, outer_axes), inner_axes};
 }
 
 template <class HeaderType>
-inline StochasticThreadedLoopRunOuter<decltype(Loop("", vector<size_t>()))>
+inline StochasticThreadedLoopRunOuter<decltype(Loop("", std::vector<size_t>()))>
 StochasticThreadedLoop(const std::string &progress_message,
                        const HeaderType &source,
-                       const vector<size_t> &axes,
+                       const std::vector<size_t> &axes,
                        size_t num_inner_axes = 1) {
   return {source, Loop(progress_message, get_outer_axes(axes, num_inner_axes)), get_inner_axes(axes, num_inner_axes)};
 }
 
 template <class HeaderType>
-inline StochasticThreadedLoopRunOuter<decltype(Loop("", vector<size_t>()))>
+inline StochasticThreadedLoopRunOuter<decltype(Loop("", std::vector<size_t>()))>
 StochasticThreadedLoop(const std::string &progress_message,
                        const HeaderType &source,
                        size_t from_axis = 0,

--- a/core/algo/threaded_copy.h
+++ b/core/algo/threaded_copy.h
@@ -38,7 +38,7 @@ struct __copy_func {
 template <class InputImageType, class OutputImageType>
 inline void threaded_copy(InputImageType &source,
                           OutputImageType &destination,
-                          const vector<size_t> &axes,
+                          const std::vector<size_t> &axes,
                           size_t num_axes_in_thread = 1) {
   ThreadedLoop(source, axes, num_axes_in_thread).run(__copy_func(), source, destination);
 }
@@ -56,7 +56,7 @@ template <class InputImageType, class OutputImageType>
 inline void threaded_copy_with_progress_message(const std::string &message,
                                                 InputImageType &source,
                                                 OutputImageType &destination,
-                                                const vector<size_t> &axes,
+                                                const std::vector<size_t> &axes,
                                                 size_t num_axes_in_thread = 1) {
   ThreadedLoop(message, source, axes, num_axes_in_thread).run(__copy_func(), source, destination);
 }
@@ -74,7 +74,7 @@ inline void threaded_copy_with_progress_message(const std::string &message,
 template <class InputImageType, class OutputImageType>
 inline void threaded_copy_with_progress(InputImageType &source,
                                         OutputImageType &destination,
-                                        const vector<size_t> &axes,
+                                        const std::vector<size_t> &axes,
                                         size_t num_axes_in_thread = 1) {
   threaded_copy_with_progress_message("copying from \"" + shorten(source.name()) + "\" to \"" +
                                           shorten(destination.name()) + "\"",

--- a/core/algo/threaded_loop.h
+++ b/core/algo/threaded_loop.h
@@ -239,34 +239,34 @@ namespace MR {
 
 namespace {
 
-inline vector<size_t> get_inner_axes(const vector<size_t> &axes, size_t num_inner_axes) {
+inline std::vector<size_t> get_inner_axes(const std::vector<size_t> &axes, size_t num_inner_axes) {
   return {axes.begin(), axes.begin() + num_inner_axes};
 }
 
-inline vector<size_t> get_outer_axes(const vector<size_t> &axes, size_t num_inner_axes) {
+inline std::vector<size_t> get_outer_axes(const std::vector<size_t> &axes, size_t num_inner_axes) {
   return {axes.begin() + num_inner_axes, axes.end()};
 }
 
 template <class HeaderType>
-inline vector<size_t>
+inline std::vector<size_t>
 get_inner_axes(const HeaderType &source, size_t num_inner_axes, size_t from_axis, size_t to_axis) {
   return get_inner_axes(Stride::order(source, from_axis, to_axis), num_inner_axes);
 }
 
 template <class HeaderType>
-inline vector<size_t>
+inline std::vector<size_t>
 get_outer_axes(const HeaderType &source, size_t num_inner_axes, size_t from_axis, size_t to_axis) {
   return get_outer_axes(Stride::order(source, from_axis, to_axis), num_inner_axes);
 }
 
 template <int N, class Functor, class... ImageType> struct ThreadedLoopRunInner {
-  const vector<size_t> &outer_axes;
+  const std::vector<size_t> &outer_axes;
   decltype(Loop(outer_axes)) loop;
   typename std::remove_reference<Functor>::type func;
   std::tuple<ImageType...> vox;
 
-  ThreadedLoopRunInner(const vector<size_t> &outer_axes,
-                       const vector<size_t> &inner_axes,
+  ThreadedLoopRunInner(const std::vector<size_t> &outer_axes,
+                       const std::vector<size_t> &inner_axes,
                        const Functor &functor,
                        ImageType &...voxels)
       : outer_axes(outer_axes), loop(Loop(inner_axes)), func(functor), vox(voxels...) {}
@@ -279,12 +279,12 @@ template <int N, class Functor, class... ImageType> struct ThreadedLoopRunInner 
 };
 
 template <class Functor, class... ImageType> struct ThreadedLoopRunInner<0, Functor, ImageType...> {
-  const vector<size_t> &outer_axes;
+  const std::vector<size_t> &outer_axes;
   decltype(Loop(outer_axes)) loop;
   typename std::remove_reference<Functor>::type func;
 
-  ThreadedLoopRunInner(const vector<size_t> &outer_axes,
-                       const vector<size_t> &inner_axes,
+  ThreadedLoopRunInner(const std::vector<size_t> &outer_axes,
+                       const std::vector<size_t> &inner_axes,
                        const Functor &functor,
                        ImageType &.../*voxels*/)
       : outer_axes(outer_axes), loop(Loop(inner_axes)), func(functor) {}
@@ -305,7 +305,7 @@ inline auto __manage_progress(const LoopType *loop, const ThreadType *threads)
 template <class OuterLoopType> struct ThreadedLoopRunOuter {
   Iterator iterator;
   OuterLoopType outer_loop;
-  vector<size_t> inner_axes;
+  std::vector<size_t> inner_axes;
 
   //! invoke \a functor (const Iterator& pos) per voxel <em> in the outer axes only</em>
   template <class Functor> void run_outer(Functor &&functor) {
@@ -364,23 +364,23 @@ template <class OuterLoopType> struct ThreadedLoopRunOuter {
 //! Multi-threaded loop object
 //* \sa image_thread_looping for details */
 template <class HeaderType>
-inline ThreadedLoopRunOuter<decltype(Loop(vector<size_t>()))>
-ThreadedLoop(const HeaderType &source, const vector<size_t> &outer_axes, const vector<size_t> &inner_axes) {
+inline ThreadedLoopRunOuter<decltype(Loop(std::vector<size_t>()))>
+ThreadedLoop(const HeaderType &source, const std::vector<size_t> &outer_axes, const std::vector<size_t> &inner_axes) {
   return {source, Loop(outer_axes), inner_axes};
 }
 
 //! Multi-threaded loop object
 //* \sa image_thread_looping for details */
 template <class HeaderType>
-inline ThreadedLoopRunOuter<decltype(Loop(vector<size_t>()))>
-ThreadedLoop(const HeaderType &source, const vector<size_t> &axes, size_t num_inner_axes = 1) {
+inline ThreadedLoopRunOuter<decltype(Loop(std::vector<size_t>()))>
+ThreadedLoop(const HeaderType &source, const std::vector<size_t> &axes, size_t num_inner_axes = 1) {
   return {source, Loop(get_outer_axes(axes, num_inner_axes)), get_inner_axes(axes, num_inner_axes)};
 }
 
 //! Multi-threaded loop object
 //* \sa image_thread_looping for details */
 template <class HeaderType>
-inline ThreadedLoopRunOuter<decltype(Loop(vector<size_t>()))>
+inline ThreadedLoopRunOuter<decltype(Loop(std::vector<size_t>()))>
 ThreadedLoop(const HeaderType &source,
              size_t from_axis = 0,
              size_t to_axis = std::numeric_limits<size_t>::max(),
@@ -393,27 +393,28 @@ ThreadedLoop(const HeaderType &source,
 //! Multi-threaded loop object
 //* \sa image_thread_looping for details */
 template <class HeaderType>
-inline ThreadedLoopRunOuter<decltype(Loop("", vector<size_t>()))> ThreadedLoop(const std::string &progress_message,
-                                                                               const HeaderType &source,
-                                                                               const vector<size_t> &outer_axes,
-                                                                               const vector<size_t> &inner_axes) {
+inline ThreadedLoopRunOuter<decltype(Loop("", std::vector<size_t>()))>
+ThreadedLoop(const std::string &progress_message,
+             const HeaderType &source,
+             const std::vector<size_t> &outer_axes,
+             const std::vector<size_t> &inner_axes) {
   return {source, Loop(progress_message, outer_axes), inner_axes};
 }
 
 //! Multi-threaded loop object
 //* \sa image_thread_looping for details */
 template <class HeaderType>
-inline ThreadedLoopRunOuter<decltype(Loop("", vector<size_t>()))> ThreadedLoop(const std::string &progress_message,
-                                                                               const HeaderType &source,
-                                                                               const vector<size_t> &axes,
-                                                                               size_t num_inner_axes = 1) {
+inline ThreadedLoopRunOuter<decltype(Loop("", std::vector<size_t>()))> ThreadedLoop(const std::string &progress_message,
+                                                                                    const HeaderType &source,
+                                                                                    const std::vector<size_t> &axes,
+                                                                                    size_t num_inner_axes = 1) {
   return {source, Loop(progress_message, get_outer_axes(axes, num_inner_axes)), get_inner_axes(axes, num_inner_axes)};
 }
 
 //! Multi-threaded loop object
 //* \sa image_thread_looping for details */
 template <class HeaderType>
-inline ThreadedLoopRunOuter<decltype(Loop("", vector<size_t>()))>
+inline ThreadedLoopRunOuter<decltype(Loop("", std::vector<size_t>()))>
 ThreadedLoop(const std::string &progress_message,
              const HeaderType &source,
              size_t from_axis = 0,

--- a/core/app.cpp
+++ b/core/app.cpp
@@ -90,8 +90,8 @@ const char *SYNOPSIS = nullptr;
 
 std::string NAME;
 std::string command_history_string;
-vector<ParsedArgument> argument;
-vector<ParsedOption> option;
+std::vector<ParsedArgument> argument;
+std::vector<ParsedOption> option;
 
 // ENVVAR name: MRTRIX_QUIET
 // ENVVAR Do not display information messages or progress status. This has
@@ -121,7 +121,7 @@ void (*check_overwrite_files_func)(const std::string &name) = nullptr;
 
 namespace {
 
-inline void get_matches(vector<const Option *> &candidates, const OptionGroup &group, const std::string &stub) {
+inline void get_matches(std::vector<const Option *> &candidates, const OptionGroup &group, const std::string &stub) {
   for (size_t i = 0; i < group.size(); ++i) {
     if (stub.compare(0, stub.size(), std::string(group[i].id), 0, stub.size()) == 0)
       candidates.push_back(&group[i]);
@@ -139,11 +139,11 @@ std::string paragraph(const std::string &header, const std::string &text, int he
   if (size(line) < indent)
     resize(line, indent, ' ');
 
-  vector<std::string> paragraphs = split(text, "\n");
+  std::vector<std::string> paragraphs = split(text, "\n");
 
   for (size_t n = 0; n < paragraphs.size(); ++n) {
     size_t i = 0;
-    vector<std::string> words = split(paragraphs[n]);
+    std::vector<std::string> words = split(paragraphs[n]);
     while (i < words.size()) {
       do {
         line += " " + words[i++];
@@ -370,7 +370,7 @@ std::string OptionGroup::contents(int format) const {
 std::string OptionGroup::footer(int format) { return format ? "" : "\n"; }
 
 std::string OptionList::syntax(int format) const {
-  vector<std::string> group_names;
+  std::vector<std::string> group_names;
   for (size_t i = 0; i < size(); ++i) {
     if (std::find(group_names.begin(), group_names.end(), (*this)[i].name) == group_names.end())
       group_names.push_back((*this)[i].name);
@@ -606,7 +606,7 @@ std::string markdown_usage() {
     }
   }
 
-  vector<std::string> group_names;
+  std::vector<std::string> group_names;
   for (size_t i = 0; i < OPTIONS.size(); ++i) {
     if (std::find(group_names.begin(), group_names.end(), OPTIONS[i].name) == group_names.end())
       group_names.push_back(OPTIONS[i].name);
@@ -734,7 +734,7 @@ std::string restructured_text_usage() {
     }
   }
 
-  vector<std::string> group_names;
+  std::vector<std::string> group_names;
   for (size_t i = 0; i < OPTIONS.size(); ++i) {
     if (std::find(group_names.begin(), group_names.end(), OPTIONS[i].name) == group_names.end())
       group_names.push_back(OPTIONS[i].name);
@@ -795,7 +795,7 @@ const Option *match_option(const char *arg) {
   if (consume_dash(arg) && *arg && !isdigit(*arg) && *arg != '.') {
     while (consume_dash(arg))
       ;
-    vector<const Option *> candidates;
+    std::vector<const Option *> candidates;
     std::string root(arg);
 
     for (size_t i = 0; i < OPTIONS.size(); ++i)
@@ -944,7 +944,7 @@ void parse() {
       s += " " + std::string(a);
     e.push_back(s);
     if (argument.size() > num_args_required) {
-      vector<std::string> potential_options;
+      std::vector<std::string> potential_options;
       for (const auto &a : argument) {
         for (const auto &og : OPTIONS) {
           for (const auto &o : og) {
@@ -1139,8 +1139,8 @@ void init(int cmdline_argc, const char *const *cmdline_argv) {
   srand(time(nullptr));
 }
 
-const vector<ParsedOption> get_options(const std::string &name) {
-  vector<ParsedOption> matches;
+const std::vector<ParsedOption> get_options(const std::string &name) {
+  std::vector<ParsedOption> matches;
   for (size_t i = 0; i < option.size(); ++i) {
     assert(option[i].opt);
     if (option[i].opt->is(name))

--- a/core/app.h
+++ b/core/app.h
@@ -65,7 +65,7 @@ std::string usage_syntax(int format);
 // @{
 
 //! vector of strings to hold more comprehensive command description
-class Description : public vector<const char *> {
+class Description : public std::vector<const char *> {
 public:
   Description &operator+(const char *text) {
     push_back(text);
@@ -93,7 +93,7 @@ public:
 };
 
 //! a class to hold the list of Example's
-class ExampleList : public vector<Example> {
+class ExampleList : public std::vector<Example> {
 public:
   ExampleList &operator+(const Example &example) {
     push_back(example);
@@ -104,7 +104,7 @@ public:
 };
 
 //! a class to hold the list of Argument's
-class ArgumentList : public vector<Argument> {
+class ArgumentList : public std::vector<Argument> {
 public:
   ArgumentList &operator+(const Argument &argument) {
     push_back(argument);
@@ -115,7 +115,7 @@ public:
 };
 
 //! a class to hold the list of option groups
-class OptionList : public vector<OptionGroup> {
+class OptionList : public std::vector<OptionGroup> {
 public:
   OptionList &operator+(const OptionGroup &option_group) {
     push_back(option_group);
@@ -135,7 +135,7 @@ public:
   OptionGroup &back() {
     if (empty())
       push_back(OptionGroup());
-    return vector<OptionGroup>::back();
+    return std::vector<OptionGroup>::back();
   }
 
   std::string syntax(int format) const;
@@ -184,34 +184,34 @@ public:
   uint64_t as_uint() const { return uint64_t(as_int()); }
   default_type as_float() const;
 
-  vector<int32_t> as_sequence_int() const {
+  std::vector<int32_t> as_sequence_int() const {
     assert(arg->type == IntSeq);
     try {
       return parse_ints<int32_t>(p);
     } catch (Exception &e) {
       error(e);
     }
-    return vector<int32_t>();
+    return std::vector<int32_t>();
   }
 
-  vector<uint32_t> as_sequence_uint() const {
+  std::vector<uint32_t> as_sequence_uint() const {
     assert(arg->type == IntSeq);
     try {
       return parse_ints<uint32_t>(p);
     } catch (Exception &e) {
       error(e);
     }
-    return vector<uint32_t>();
+    return std::vector<uint32_t>();
   }
 
-  vector<default_type> as_sequence_float() const {
+  std::vector<default_type> as_sequence_float() const {
     assert(arg->type == FloatSeq);
     try {
       return parse_floats(p);
     } catch (Exception &e) {
       error(e);
     }
-    return vector<default_type>();
+    return std::vector<default_type>();
   }
 
   operator bool() const { return as_bool(); }
@@ -223,9 +223,9 @@ public:
   operator long long unsigned int() const { return as_uint(); }
   operator float() const { return as_float(); }
   operator double() const { return as_float(); }
-  operator vector<int32_t>() const { return as_sequence_int(); }
-  operator vector<uint32_t>() const { return as_sequence_uint(); }
-  operator vector<default_type>() const { return as_sequence_float(); }
+  operator std::vector<int32_t>() const { return as_sequence_int(); }
+  operator std::vector<uint32_t>() const { return as_sequence_uint(); }
+  operator std::vector<default_type>() const { return as_sequence_float(); }
 
   const char *c_str() const { return p; }
 
@@ -298,9 +298,9 @@ public:
 };
 
 //! the list of arguments parsed from the command-line
-extern vector<ParsedArgument> argument;
+extern std::vector<ParsedArgument> argument;
 //! the list of options parsed from the command-line
-extern vector<ParsedOption> option;
+extern std::vector<ParsedOption> option;
 
 //! additional description of the command over and above the synopsis
 /*! This is designed to be used within each command's usage() function. Add
@@ -409,11 +409,11 @@ extern OptionGroup __standard_options;
  *    std::string arg1 = opt[0][0];
  *    int arg2 = opt[0][1];
  *    float arg3 = opt[0][2];
- *    vector<int> arg4 = opt[0][3];
+ *    std::vector<int> arg4 = opt[0][3];
  *    auto values = opt[0][4].as_sequence_float();
  * }
  * \endcode */
-const vector<ParsedOption> get_options(const std::string &name);
+const std::vector<ParsedOption> get_options(const std::string &name);
 
 //! Returns the option value if set, and the default otherwise.
 /*! Only be used for command-line options that do not specify

--- a/core/cmdline_option.h
+++ b/core/cmdline_option.h
@@ -326,7 +326,7 @@ public:
  * Options can also be specified as required (see required() function), or
  * as multiple (see allow_multiple() function).
  */
-class Option : public vector<Argument> {
+class Option : public std::vector<Argument> {
 public:
   Option() : id(nullptr), flags(Optional) {}
 
@@ -391,7 +391,7 @@ public:
  * }
  * \endcode
  */
-class OptionGroup : public vector<Option> {
+class OptionGroup : public std::vector<Option> {
 public:
   OptionGroup(const char *group_name = "OPTIONS") : name(group_name) {}
   const char *name;
@@ -410,7 +410,7 @@ public:
   Option &back() {
     if (empty())
       push_back(Option());
-    return vector<Option>::back();
+    return std::vector<Option>::back();
   }
 
   std::string header(int format) const;

--- a/core/dwi/gradient.cpp
+++ b/core/dwi/gradient.cpp
@@ -134,7 +134,7 @@ Eigen::MatrixXd load_bvecs_bvals(const Header &header, const std::string &bvecs_
   // bvecs format actually assumes a LHS coordinate system even if image is
   // stored using RHS - x axis is flipped to make linear 3x3 part of
   // transform have negative determinant:
-  vector<size_t> order;
+  std::vector<size_t> order;
   auto adjusted_transform = File::NIfTI::adjust_transform(header, order);
   if (adjusted_transform.linear().determinant() > 0.0)
     bvecs.row(0) = -bvecs.row(0);
@@ -166,7 +166,7 @@ void save_bvecs_bvals(const Header &header, const std::string &bvecs_path, const
 
   // deal with FSL requiring gradient directions to coincide with data strides
   // also transpose matrices in preparation for file output
-  vector<size_t> order;
+  std::vector<size_t> order;
   auto adjusted_transform = File::NIfTI::adjust_transform(header, order);
   Eigen::MatrixXd bvecs(3, grad.rows());
   Eigen::MatrixXd bvals(1, grad.rows());

--- a/core/dwi/shells.cpp
+++ b/core/dwi/shells.cpp
@@ -39,17 +39,17 @@ FORCE_INLINE default_type bvalue_epsilon() {
   return value;
 }
 
-Shell::Shell(const Eigen::MatrixXd &grad, const vector<size_t> &indices)
+Shell::Shell(const Eigen::MatrixXd &grad, const std::vector<size_t> &indices)
     : volumes(indices), mean(0.0), stdev(0.0), min(std::numeric_limits<default_type>::max()), max(0.0) {
   assert(volumes.size());
-  for (vector<size_t>::const_iterator i = volumes.begin(); i != volumes.end(); i++) {
+  for (std::vector<size_t>::const_iterator i = volumes.begin(); i != volumes.end(); i++) {
     const default_type b = grad(*i, 3);
     mean += b;
     min = std::min(min, b);
     max = std::max(min, b);
   }
   mean /= default_type(volumes.size());
-  for (vector<size_t>::const_iterator i = volumes.begin(); i != volumes.end(); i++)
+  for (std::vector<size_t>::const_iterator i = volumes.begin(); i != volumes.end(); i++)
     stdev += Math::pow2(grad(*i, 3) - mean);
   stdev = std::sqrt(stdev / (volumes.size() - 1));
 }
@@ -92,11 +92,11 @@ Shells::select_shells(const bool force_singleshell, const bool force_with_bzero,
   auto opt = App::get_options("shells");
   if (opt.size()) {
 
-    vector<default_type> desired_bvalues = opt[0][0];
+    std::vector<default_type> desired_bvalues = opt[0][0];
     bool bzero_selected = false;
     size_t nonbzero_selected_count = 0;
 
-    for (vector<default_type>::const_iterator b = desired_bvalues.begin(); b != desired_bvalues.end(); ++b) {
+    for (std::vector<default_type>::const_iterator b = desired_bvalues.begin(); b != desired_bvalues.end(); ++b) {
 
       if (*b < 0)
         throw Exception("Cannot select shells corresponding to negative b-values");
@@ -173,7 +173,7 @@ Shells::select_shells(const bool force_singleshell, const bool force_with_bzero,
             // First, check to see if all non-zero shells have (effectively) non-zero standard deviation
             // (If one non-zero shell has negligible standard deviation, assume a Poisson distribution for all shells)
             bool zero_stdev = false;
-            for (vector<Shell>::const_iterator s = shells.begin(); s != shells.end(); ++s) {
+            for (std::vector<Shell>::const_iterator s = shells.begin(); s != shells.end(); ++s) {
               if (!s->is_bzero() && s->get_stdev() < 1.0) {
                 zero_stdev = true;
                 break;
@@ -265,7 +265,7 @@ Shells::select_shells(const bool force_singleshell, const bool force_with_bzero,
   }
 
   // Erase the unwanted shells
-  vector<Shell> new_shells;
+  std::vector<Shell> new_shells;
   for (size_t s = 0; s != count(); ++s) {
     if (to_retain[s])
       new_shells.push_back(shells[s]);
@@ -276,7 +276,7 @@ Shells::select_shells(const bool force_singleshell, const bool force_with_bzero,
 }
 
 Shells &Shells::reject_small_shells(const size_t min_volumes) {
-  for (vector<Shell>::iterator s = shells.begin(); s != shells.end();) {
+  for (std::vector<Shell>::iterator s = shells.begin(); s != shells.end();) {
     if (!s->is_bzero() && s->count() < min_volumes)
       s = shells.erase(s);
     else
@@ -287,7 +287,7 @@ Shells &Shells::reject_small_shells(const size_t min_volumes) {
 
 Shells::Shells(const Eigen::MatrixXd &grad) {
   BValueList bvals = grad.col(3);
-  vector<size_t> clusters(bvals.size(), 0);
+  std::vector<size_t> clusters(bvals.size(), 0);
   const size_t num_shells = clusterBvalues(bvals, clusters);
 
   if ((num_shells < 1) || (num_shells > std::sqrt(default_type(grad.rows()))))
@@ -296,7 +296,7 @@ Shells::Shells(const Eigen::MatrixXd &grad) {
 
   for (size_t shellIdx = 0; shellIdx <= num_shells; shellIdx++) {
 
-    vector<size_t> volumes;
+    std::vector<size_t> volumes;
     for (size_t volumeIdx = 0; volumeIdx != clusters.size(); ++volumeIdx) {
       if (clusters[volumeIdx] == shellIdx)
         volumes.push_back(volumeIdx);
@@ -333,7 +333,7 @@ Shells::Shells(const Eigen::MatrixXd &grad) {
         "}");
 }
 
-size_t Shells::clusterBvalues(const BValueList &bvals, vector<size_t> &clusters) const {
+size_t Shells::clusterBvalues(const BValueList &bvals, std::vector<size_t> &clusters) const {
   BitSet visited(bvals.size(), false);
   size_t clusterIdx = 0;
 
@@ -350,7 +350,7 @@ size_t Shells::clusterBvalues(const BValueList &bvals, vector<size_t> &clusters)
 
       visited[ii] = true;
       const default_type b = bvals[ii];
-      vector<size_t> neighborIdx;
+      std::vector<size_t> neighborIdx;
       regionQuery(bvals, b, neighborIdx);
 
       if (b > bzero_threshold() && neighborIdx.size() < DWI_SHELLS_MIN_LINKAGE) {
@@ -363,7 +363,7 @@ size_t Shells::clusterBvalues(const BValueList &bvals, vector<size_t> &clusters)
         for (size_t i = 0; i < neighborIdx.size(); i++) {
           if (!visited[neighborIdx[i]]) {
             visited[neighborIdx[i]] = true;
-            vector<size_t> neighborIdx2;
+            std::vector<size_t> neighborIdx2;
             regionQuery(bvals, bvals[neighborIdx[i]], neighborIdx2);
             if (neighborIdx2.size() >= DWI_SHELLS_MIN_LINKAGE)
               for (size_t j = 0; j != neighborIdx2.size(); j++)
@@ -379,7 +379,7 @@ size_t Shells::clusterBvalues(const BValueList &bvals, vector<size_t> &clusters)
   return clusterIdx;
 }
 
-void Shells::regionQuery(const BValueList &bvals, const default_type b, vector<size_t> &idx) const {
+void Shells::regionQuery(const BValueList &bvals, const default_type b, std::vector<size_t> &idx) const {
   for (ssize_t i = 0; i < bvals.size(); i++) {
     if (bvals[i] > bzero_threshold() && abs(b - bvals[i]) < bvalue_epsilon())
       idx.push_back(i);

--- a/core/dwi/shells.h
+++ b/core/dwi/shells.h
@@ -67,9 +67,9 @@ class Shell {
 
 public:
   Shell() : mean(0.0), stdev(0.0), min(0.0), max(0.0) {}
-  Shell(const Eigen::MatrixXd &grad, const vector<size_t> &indices);
+  Shell(const Eigen::MatrixXd &grad, const std::vector<size_t> &indices);
 
-  const vector<size_t> &get_volumes() const { return volumes; }
+  const std::vector<size_t> &get_volumes() const { return volumes; }
   size_t count() const { return volumes.size(); }
 
   default_type get_mean() const { return mean; }
@@ -88,7 +88,7 @@ public:
   }
 
 protected:
-  vector<size_t> volumes;
+  std::vector<size_t> volumes;
   default_type mean, stdev, min, max;
 };
 
@@ -107,15 +107,15 @@ public:
     return count;
   }
 
-  vector<size_t> get_counts() const {
-    vector<size_t> c(count());
+  std::vector<size_t> get_counts() const {
+    std::vector<size_t> c(count());
     for (size_t n = 0; n < count(); ++n)
       c[n] = shells[n].count();
     return c;
   }
 
-  vector<size_t> get_bvalues() const {
-    vector<size_t> b(count());
+  std::vector<size_t> get_bvalues() const {
+    std::vector<size_t> b(count());
     for (size_t n = 0; n < count(); ++n)
       b[n] = shells[n].get_mean();
     return b;
@@ -140,14 +140,14 @@ public:
   }
 
 protected:
-  vector<Shell> shells;
+  std::vector<Shell> shells;
 
 private:
   using BValueList = decltype(std::declval<const Eigen::MatrixXd>().col(0));
 
   // Functions for current b-value clustering implementation
-  size_t clusterBvalues(const BValueList &, vector<size_t> &) const;
-  void regionQuery(const BValueList &, const default_type, vector<size_t> &) const;
+  size_t clusterBvalues(const BValueList &, std::vector<size_t> &) const;
+  void regionQuery(const BValueList &, const default_type, std::vector<size_t> &) const;
 };
 
 } // namespace DWI

--- a/core/exception.h
+++ b/core/exception.h
@@ -100,7 +100,7 @@ public:
 
   static void (*display_func)(const Exception &E, int log_level);
 
-  vector<std::string> description;
+  std::vector<std::string> description;
 };
 
 class InvalidImageException : public Exception {

--- a/core/file/config.cpp
+++ b/core/file/config.cpp
@@ -120,7 +120,7 @@ void Config::get_RGB(const std::string &key, float *ret, float default_R, float 
   std::string value = get(key);
   if (value.size()) {
     try {
-      vector<default_type> V(parse_floats(value));
+      std::vector<default_type> V(parse_floats(value));
       if (V.size() < 3)
         throw Exception("malformed RGB entry \"" + value + "\" for key \"" + key +
                         "\" in configuration file - ignored");

--- a/core/file/dicom/csa_entry.h
+++ b/core/file/dicom/csa_entry.h
@@ -123,8 +123,8 @@ public:
       v[m] = NaN;
   }
 
-  vector<std::string> get_string() const {
-    vector<std::string> result;
+  std::vector<std::string> get_string() const {
+    std::vector<std::string> result;
     const uint8_t *p = start + 84;
     for (uint32_t m = 0; m < nitems; m++) {
       const uint32_t length = Raw::fetch_LE<uint32_t>(p);

--- a/core/file/dicom/element.cpp
+++ b/core/file/dicom/element.cpp
@@ -268,8 +268,8 @@ Element::Type Element::type() const {
   return OTHER;
 }
 
-vector<int32_t> Element::get_int() const {
-  vector<int32_t> V;
+std::vector<int32_t> Element::get_int() const {
+  std::vector<int32_t> V;
   if (VR == VR_SL)
     for (const uint8_t *p = data; p < data + size; p += sizeof(int32_t))
       V.push_back(Raw::fetch_<int32_t>(p, is_BE));
@@ -287,8 +287,8 @@ vector<int32_t> Element::get_int() const {
   return V;
 }
 
-vector<uint32_t> Element::get_uint() const {
-  vector<uint32_t> V;
+std::vector<uint32_t> Element::get_uint() const {
+  std::vector<uint32_t> V;
   if (VR == VR_UL)
     for (const uint8_t *p = data; p < data + size; p += sizeof(uint32_t))
       V.push_back(Raw::fetch_<uint32_t>(p, is_BE));
@@ -305,8 +305,8 @@ vector<uint32_t> Element::get_uint() const {
   return V;
 }
 
-vector<default_type> Element::get_float() const {
-  vector<default_type> V;
+std::vector<default_type> Element::get_float() const {
+  std::vector<default_type> V;
   if (VR == VR_FD)
     for (const uint8_t *p = data; p < data + size; p += sizeof(float64))
       V.push_back(Raw::fetch_<float64>(p, is_BE));
@@ -341,7 +341,7 @@ std::pair<Date, Time> Element::get_datetime() const {
           Time(std::string(reinterpret_cast<const char *>(data + 8), std::min(size - 8, 13U)))};
 }
 
-vector<std::string> Element::get_string() const {
+std::vector<std::string> Element::get_string() const {
   if (VR == VR_AT)
     return {printf("%04X %04X", Raw::fetch_<uint16_t>(data, is_BE), Raw::fetch_<uint16_t>(data + 2, is_BE))};
 
@@ -397,7 +397,7 @@ std::string Element::as_string() const {
 }
 
 namespace {
-template <class T> inline void print_vec(const vector<T> &V) {
+template <class T> inline void print_vec(const std::vector<T> &V) {
   for (const auto &entry : V)
     fprintf(stdout, "%s ", str(entry).c_str());
 }

--- a/core/file/dicom/element.h
+++ b/core/file/dicom/element.h
@@ -94,7 +94,7 @@ public:
   uint16_t group, element, VR;
   uint32_t size;
   uint8_t *data;
-  vector<Sequence> parents;
+  std::vector<Sequence> parents;
   bool transfer_syntax_supported;
 
   void set(const std::string &filename, bool force_read = false, bool read_write = false);
@@ -137,13 +137,13 @@ public:
   bool is_in_series_ref_sequence() const;
 
   Type type() const;
-  vector<int32_t> get_int() const;
-  vector<uint32_t> get_uint() const;
-  vector<default_type> get_float() const;
+  std::vector<int32_t> get_int() const;
+  std::vector<uint32_t> get_uint() const;
+  std::vector<default_type> get_float() const;
   Date get_date() const;
   Time get_time() const;
   std::pair<Date, Time> get_datetime() const;
-  vector<std::string> get_string() const;
+  std::vector<std::string> get_string() const;
 
   int32_t get_int(size_t idx, int32_t default_value = 0) const {
     auto v(get_int());
@@ -187,7 +187,7 @@ protected:
   uint8_t *start;
   bool is_explicit, is_BE, is_transfer_syntax_BE;
 
-  vector<uint8_t *> end_seq;
+  std::vector<uint8_t *> end_seq;
 
   uint16_t get_VR_from_tag_name(const std::string &name) {
     union {

--- a/core/file/dicom/image.cpp
+++ b/core/file/dicom/image.cpp
@@ -325,7 +325,7 @@ void phoenix_scalar(const KeyValues &keyval, const std::string &key, const Funct
     return;
   field = functor(it->second);
 }
-template <typename T> void phoenix_vector(const KeyValues &keyval, const std::string &key, vector<T> &data) {
+template <typename T> void phoenix_vector(const KeyValues &keyval, const std::string &key, std::vector<T> &data) {
   data.clear();
   for (size_t index = 0;; ++index) {
     const auto it = keyval.find(key + "[" + str(index) + "]");
@@ -364,7 +364,7 @@ void Image::decode_csa(const uint8_t *start, const uint8_t *end) {
       mosaic_slices_timing.resize(entry.num_items());
       entry.get_float(mosaic_slices_timing);
     } else if (strcmp("MrPhoenixProtocol", entry.key()) == 0) {
-      const vector<std::string> phoenix = entry.get_string();
+      const std::vector<std::string> phoenix = entry.get_string();
       const auto keyval = read_csa_ascii(phoenix);
       phoenix_scalar(
           keyval,
@@ -411,7 +411,7 @@ void Image::decode_csa(const uint8_t *start, const uint8_t *end) {
       bvalue = G[0] = G[1] = G[2] = 0.0;
 }
 
-KeyValues Image::read_csa_ascii(const vector<std::string> &data) {
+KeyValues Image::read_csa_ascii(const std::vector<std::string> &data) {
 
   auto split_keyval = [](const std::string &s) -> std::pair<std::string, std::string> {
     const size_t delimiter = s.find_first_of("=");
@@ -481,7 +481,7 @@ std::ostream &operator<<(std::ostream &stream, const Image &item) {
 
 namespace {
 
-inline void update_count(size_t num, vector<size_t> &dim, vector<size_t> &index) {
+inline void update_count(size_t num, std::vector<size_t> &dim, std::vector<size_t> &index) {
   for (size_t n = 0; n < num; ++n) {
     if (dim[n] && index[n] != dim[n])
       throw Exception("dimensions mismatch in DICOM series");
@@ -493,9 +493,9 @@ inline void update_count(size_t num, vector<size_t> &dim, vector<size_t> &index)
 
 } // namespace
 
-vector<size_t> Frame::count(const vector<Frame *> &frames) {
-  vector<size_t> dim(3, 0);
-  vector<size_t> index(3, 1);
+std::vector<size_t> Frame::count(const std::vector<Frame *> &frames) {
+  std::vector<size_t> dim(3, 0);
+  std::vector<size_t> index(3, 1);
   const Frame *previous = frames[0];
 
   for (auto frame_it = frames.cbegin() + 1; frame_it != frames.cend(); ++frame_it) {
@@ -522,7 +522,7 @@ vector<size_t> Frame::count(const vector<Frame *> &frames) {
   return dim;
 }
 
-default_type Frame::get_slice_separation(const vector<Frame *> &frames, size_t nslices) {
+default_type Frame::get_slice_separation(const std::vector<Frame *> &frames, size_t nslices) {
   default_type max_gap = 0.0;
   default_type min_separation = std::numeric_limits<default_type>::infinity();
   default_type max_separation = 0.0;
@@ -549,7 +549,7 @@ default_type Frame::get_slice_separation(const vector<Frame *> &frames, size_t n
 }
 
 std::string
-Frame::get_DW_scheme(const vector<Frame *> &frames, const size_t nslices, const transform_type &image_transform) {
+Frame::get_DW_scheme(const std::vector<Frame *> &frames, const size_t nslices, const transform_type &image_transform) {
   if (!std::isfinite(frames[0]->bvalue)) {
     DEBUG("no DW encoding information found in DICOM frames");
     return {};
@@ -592,7 +592,7 @@ Frame::get_DW_scheme(const vector<Frame *> &frames, const size_t nslices, const 
   return dw_scheme;
 }
 
-Eigen::MatrixXd Frame::get_PE_scheme(const vector<Frame *> &frames, const size_t nslices) {
+Eigen::MatrixXd Frame::get_PE_scheme(const std::vector<Frame *> &frames, const size_t nslices) {
   const size_t num_volumes = frames.size() / nslices;
   Eigen::MatrixXd pe_scheme = Eigen::MatrixXd::Zero(num_volumes, 4);
 

--- a/core/file/dicom/image.h
+++ b/core/file/dicom/image.h
@@ -71,8 +71,8 @@ public:
       flip_angle, partial_fourier, time_after_start;
   size_t echo_train_length;
   size_t bipolar_flag, readoutmode_flag;
-  vector<uint32_t> index;
-  vector<default_type> flip_angles;
+  std::vector<uint32_t> index;
+  std::vector<default_type> flip_angles;
 
   bool operator<(const Frame &frame) const {
     if (!ignore_series_num && series_num != frame.series_num)
@@ -125,11 +125,11 @@ public:
     return (philips_orientation == 'I' && bvalue > 0.0);
   }
 
-  static vector<size_t> count(const vector<Frame *> &frames);
-  static default_type get_slice_separation(const vector<Frame *> &frames, size_t nslices);
+  static std::vector<size_t> count(const std::vector<Frame *> &frames);
+  static default_type get_slice_separation(const std::vector<Frame *> &frames, size_t nslices);
   static std::string
-  get_DW_scheme(const vector<Frame *> &frames, const size_t nslices, const transform_type &image_transform);
-  static Eigen::MatrixXd get_PE_scheme(const vector<Frame *> &frames, const size_t nslices);
+  get_DW_scheme(const std::vector<Frame *> &frames, const size_t nslices, const transform_type &image_transform);
+  static Eigen::MatrixXd get_PE_scheme(const std::vector<Frame *> &frames, const size_t nslices);
 
   friend std::ostream &operator<<(std::ostream &stream, const Frame &item);
 };
@@ -143,15 +143,15 @@ public:
   size_t images_in_mosaic;
   std::string sequence_name, manufacturer;
   bool is_BE, in_frames;
-  vector<float> mosaic_slices_timing;
+  std::vector<float> mosaic_slices_timing;
 
-  vector<uint32_t> frame_dim;
-  vector<std::shared_ptr<Frame>> frames;
+  std::vector<uint32_t> frame_dim;
+  std::vector<std::shared_ptr<Frame>> frames;
 
   void read();
   void parse_item(Element &item, const std::string &dirname = "");
   void decode_csa(const uint8_t *start, const uint8_t *end);
-  KeyValues read_csa_ascii(const vector<std::string> &data);
+  KeyValues read_csa_ascii(const std::vector<std::string> &data);
 
   bool operator<(const Image &ima) const { return Frame::operator<(ima); }
 

--- a/core/file/dicom/mapper.cpp
+++ b/core/file/dicom/mapper.cpp
@@ -32,7 +32,7 @@ namespace MR {
 namespace File {
 namespace Dicom {
 
-std::unique_ptr<MR::ImageIO::Base> dicom_to_mapper(MR::Header &H, vector<std::shared_ptr<Series>> &series) {
+std::unique_ptr<MR::ImageIO::Base> dicom_to_mapper(MR::Header &H, std::vector<std::shared_ptr<Series>> &series) {
   // ENVVAR name: MRTRIX_PRESERVE_PHILIPS_ISO
   // ENVVAR Do not remove the synthetic isotropically-weighted diffusion
   // ENVVAR image often added at the end of the series on Philips
@@ -62,7 +62,7 @@ std::unique_ptr<MR::ImageIO::Base> dicom_to_mapper(MR::Header &H, vector<std::sh
   H.name() = sbuf;
 
   // build up sorted list of frames:
-  vector<Frame *> frames;
+  std::vector<Frame *> frames;
 
   // loop over series list:
   for (const auto &series_it : series) {
@@ -112,8 +112,8 @@ std::unique_ptr<MR::ImageIO::Base> dicom_to_mapper(MR::Header &H, vector<std::sh
     throw Exception("missing image frames for DICOM image \"" + H.name() + "\"");
 
   if (dim[0] > 1) { // switch axes so slice dim is inner-most:
-    vector<Frame *> list(frames);
-    vector<Frame *>::iterator it = frames.begin();
+    std::vector<Frame *> list(frames);
+    std::vector<Frame *>::iterator it = frames.begin();
     for (size_t k = 0; k < dim[2]; ++k)
       for (size_t i = 0; i < dim[0]; ++i)
         for (size_t j = 0; j < dim[1]; ++j)
@@ -143,7 +143,7 @@ std::unique_ptr<MR::ImageIO::Base> dicom_to_mapper(MR::Header &H, vector<std::sh
   //   write the values as a comma-separated list to the header
   auto import_parameter =
       [&](const std::string key, std::function<default_type(Frame *)> functor, const default_type multiplier) -> void {
-    vector<std::string> values;
+    std::vector<std::string> values;
     for (const auto f : frames) {
       const default_type value = functor(f);
       if (!std::isfinite(value))
@@ -306,8 +306,8 @@ std::unique_ptr<MR::ImageIO::Base> dicom_to_mapper(MR::Header &H, vector<std::sh
   }
 
   // Slice timing may come from a few different potential sources
-  vector<std::string> slices_timing_str;
-  vector<float> slices_timing_float;
+  std::vector<std::string> slices_timing_str;
+  std::vector<float> slices_timing_float;
   if (image.images_in_mosaic) {
     if (image.mosaic_slices_timing.size() < image.images_in_mosaic) {
       WARN("Number of entries in mosaic slice timing (" + str(image.mosaic_slices_timing.size()) +

--- a/core/file/dicom/mapper.h
+++ b/core/file/dicom/mapper.h
@@ -31,7 +31,7 @@ namespace Dicom {
 
 class Series;
 
-std::unique_ptr<MR::ImageIO::Base> dicom_to_mapper(MR::Header &H, vector<std::shared_ptr<Series>> &series);
+std::unique_ptr<MR::ImageIO::Base> dicom_to_mapper(MR::Header &H, std::vector<std::shared_ptr<Series>> &series);
 
 } // namespace Dicom
 } // namespace File

--- a/core/file/dicom/patient.h
+++ b/core/file/dicom/patient.h
@@ -26,7 +26,7 @@ namespace Dicom {
 
 class Study;
 
-class Patient : public vector<std::shared_ptr<Study>> {
+class Patient : public std::vector<std::shared_ptr<Study>> {
 public:
   Patient(const std::string &patient_name, const std::string &patient_ID, const std::string &patient_DOB)
       : name(patient_name), ID(patient_ID), DOB(patient_DOB) {}

--- a/core/file/dicom/select_cmdline.cpp
+++ b/core/file/dicom/select_cmdline.cpp
@@ -24,8 +24,8 @@ namespace MR {
 namespace File {
 namespace Dicom {
 
-vector<std::shared_ptr<Series>> select_cmdline(const Tree &tree) {
-  vector<std::shared_ptr<Series>> series;
+std::vector<std::shared_ptr<Series>> select_cmdline(const Tree &tree) {
+  std::vector<std::shared_ptr<Series>> series;
 
   if (tree.size() == 0)
     throw Exception("DICOM tree its empty");
@@ -54,7 +54,7 @@ vector<std::shared_ptr<Series>> select_cmdline(const Tree &tree) {
 
     // select using environment variables:
 
-    vector<std::shared_ptr<Patient>> patient;
+    std::vector<std::shared_ptr<Patient>> patient;
     for (size_t i = 0; i < tree.size(); i++) {
       if ((!patient_from_env || match(patient_from_env, tree[i]->name, true)) &&
           (!patid_from_env || match(patid_from_env, tree[i]->ID, true)))
@@ -65,7 +65,7 @@ vector<std::shared_ptr<Series>> select_cmdline(const Tree &tree) {
     if (patient.size() > 1)
       throw Exception("too many matching patients in DICOM dataset \"" + tree.description + "\"");
 
-    vector<std::shared_ptr<Study>> study;
+    std::vector<std::shared_ptr<Study>> study;
     for (size_t i = 0; i < patient[0]->size(); i++) {
       if (!study_from_env || match(study_from_env, (*patient[0])[i]->name, true))
         study.push_back((*patient[0])[i]);
@@ -184,7 +184,7 @@ vector<std::shared_ptr<Series>> select_cmdline(const Tree &tree) {
       if (buf[0] == 'q' || buf[0] == 'Q')
         throw CancelException();
       if (isdigit(buf[0])) {
-        vector<uint32_t> seq;
+        std::vector<uint32_t> seq;
         try {
           seq = parse_ints<uint32_t>(buf);
           for (size_t i = 0; i < seq.size(); i++) {
@@ -207,7 +207,7 @@ vector<std::shared_ptr<Series>> select_cmdline(const Tree &tree) {
   return series;
 }
 
-vector<std::shared_ptr<Series>> (*select_func)(const Tree &tree) = select_cmdline;
+std::vector<std::shared_ptr<Series>> (*select_func)(const Tree &tree) = select_cmdline;
 
 } // namespace Dicom
 } // namespace File

--- a/core/file/dicom/series.cpp
+++ b/core/file/dicom/series.cpp
@@ -22,9 +22,9 @@ namespace MR {
 namespace File {
 namespace Dicom {
 
-vector<int> Series::count() const {
-  vector<int> dim(3);
-  vector<int> current_dim(2);
+std::vector<int> Series::count() const {
+  std::vector<int> dim(3);
+  std::vector<int> current_dim(2);
   dim[0] = dim[1] = dim[2] = 0;
   current_dim[0] = current_dim[1] = 1;
 

--- a/core/file/dicom/series.h
+++ b/core/file/dicom/series.h
@@ -28,7 +28,7 @@ namespace Dicom {
 class Study;
 class Image;
 
-class Series : public vector<std::shared_ptr<Image>> {
+class Series : public std::vector<std::shared_ptr<Image>> {
 public:
   Series(Study *parent,
          const std::string &series_name,
@@ -62,7 +62,7 @@ public:
     }
   }
 
-  vector<int> count() const;
+  std::vector<int> count() const;
   bool operator<(const Series &s) const {
     if (number != s.number)
       return number < s.number;

--- a/core/file/dicom/study.h
+++ b/core/file/dicom/study.h
@@ -27,7 +27,7 @@ namespace Dicom {
 class Patient;
 class Series;
 
-class Study : public vector<std::shared_ptr<Series>> {
+class Study : public std::vector<std::shared_ptr<Series>> {
 public:
   Study(Patient *parent,
         const std::string &study_name,

--- a/core/file/dicom/tree.h
+++ b/core/file/dicom/tree.h
@@ -27,7 +27,7 @@ namespace Dicom {
 class Series;
 class Patient;
 
-class Tree : public vector<std::shared_ptr<Patient>> {
+class Tree : public std::vector<std::shared_ptr<Patient>> {
 public:
   std::string description;
   void read(const std::string &filename);
@@ -50,7 +50,7 @@ protected:
 
 std::ostream &operator<<(std::ostream &stream, const Tree &item);
 
-extern vector<std::shared_ptr<Series>> (*select_func)(const Tree &tree);
+extern std::vector<std::shared_ptr<Series>> (*select_func)(const Tree &tree);
 
 } // namespace Dicom
 } // namespace File

--- a/core/file/json_utils.cpp
+++ b/core/file/json_utils.cpp
@@ -79,12 +79,12 @@ KeyValues read(const nlohmann::json &json, const KeyValues &preexisting) {
             all_numeric = false;
         }
         if (all_string) {
-          vector<std::string> lines;
+          std::vector<std::string> lines;
           for (const auto &k : *i)
             lines.push_back(unquote(k));
           result.insert(std::make_pair(i.key(), join(lines, "\n")));
         } else if (all_numeric) {
-          vector<std::string> line;
+          std::vector<std::string> line;
           for (const auto &k : *i)
             line.push_back(str(k));
           result.insert(std::make_pair(i.key(), join(line, ",")));
@@ -92,9 +92,9 @@ KeyValues read(const nlohmann::json &json, const KeyValues &preexisting) {
           throw Exception("JSON entry \"" + i.key() + "\" is array but contains mixed data types");
         }
       } else if (num_subarrays == i->size()) {
-        vector<std::string> s;
+        std::vector<std::string> s;
         for (const auto &j : *i) {
-          vector<std::string> line;
+          std::vector<std::string> line;
           for (const auto &k : j)
             line.push_back(unquote(str(k)));
           s.push_back(join(line, ","));
@@ -174,7 +174,7 @@ bool attempt_matrix(const std::pair<std::string, std::string> &kv, nlohmann::jso
     nlohmann::json temp;
     bool noninteger = false;
     for (ssize_t row = 0; row != M_float.rows(); ++row) {
-      vector<default_type> data(M_float.cols());
+      std::vector<default_type> data(M_float.cols());
       for (ssize_t i = 0; i != M_float.cols(); ++i) {
         data[i] = M_float(row, i);
         if (std::floor(data[i]) != data[i])
@@ -197,7 +197,7 @@ bool attempt_matrix(const std::pair<std::string, std::string> &kv, nlohmann::jso
         M_int.transposeInPlace();
       temp[kv.first] = nlohmann::json({});
       for (ssize_t row = 0; row != M_int.rows(); ++row) {
-        vector<int> data(M_int.cols());
+        std::vector<int> data(M_int.cols());
         for (ssize_t i = 0; i != M_int.cols(); ++i)
           data[i] = M_int(row, i);
         if (row)
@@ -253,8 +253,8 @@ void write(const Header &header, nlohmann::json &json, const std::string &image_
     return;
   }
 
-  vector<size_t> order;
-  vector<bool> flip;
+  std::vector<size_t> order;
+  std::vector<bool> flip;
   File::NIfTI::axes_on_write(header, order, flip);
   if (order[0] == 0 && order[1] == 1 && order[2] == 2 && !flip[0] && !flip[1] && !flip[2]) {
     INFO(

--- a/core/file/json_utils.cpp
+++ b/core/file/json_utils.cpp
@@ -14,6 +14,7 @@
  * For more details, see http://www.mrtrix.org/.
  */
 
+#include <array>
 #include <fstream>
 #include <sstream>
 
@@ -254,7 +255,7 @@ void write(const Header &header, nlohmann::json &json, const std::string &image_
   }
 
   std::vector<size_t> order;
-  std::vector<bool> flip;
+  std::array<bool, 3> flip;
   File::NIfTI::axes_on_write(header, order, flip);
   if (order[0] == 0 && order[1] == 1 && order[2] == 2 && !flip[0] && !flip[1] && !flip[2]) {
     INFO(

--- a/core/file/matrix.h
+++ b/core/file/matrix.h
@@ -51,11 +51,12 @@ void save_matrix_text(const MatrixType &M,
 
 //! read matrix text data into a 2D vector \a filename
 template <class ValueType = default_type>
-vector<vector<ValueType>> load_matrix_2D_vector(const std::string &filename, vector<std::string> *comments = nullptr) {
+std::vector<std::vector<ValueType>> load_matrix_2D_vector(const std::string &filename,
+                                                          std::vector<std::string> *comments = nullptr) {
   std::ifstream stream(filename, std::ios_base::in | std::ios_base::binary);
   if (!stream)
     throw Exception("Unable to open numerical data text file \"" + filename + "\": " + strerror(errno));
-  vector<vector<ValueType>> V;
+  std::vector<std::vector<ValueType>> V;
   std::string sbuf, cbuf;
   size_t hash;
 
@@ -72,7 +73,7 @@ vector<vector<ValueType>> load_matrix_2D_vector(const std::string &filename, vec
       continue;
 
     const auto elements = MR::split(sbuf, " ,;\t", true);
-    V.push_back(vector<ValueType>());
+    V.push_back(std::vector<ValueType>());
     try {
       for (const auto &entry : elements)
         V.back().push_back(to<ValueType>(entry));
@@ -101,7 +102,7 @@ vector<vector<ValueType>> load_matrix_2D_vector(const std::string &filename, vec
 template <class ValueType = default_type>
 Eigen::Matrix<ValueType, Eigen::Dynamic, Eigen::Dynamic> load_matrix_text(const std::string &filename) {
   DEBUG("loading matrix file \"" + filename + "\"...");
-  const vector<vector<ValueType>> V = load_matrix_2D_vector<ValueType>(filename);
+  const std::vector<std::vector<ValueType>> V = load_matrix_2D_vector<ValueType>(filename);
 
   Eigen::Matrix<ValueType, Eigen::Dynamic, Eigen::Dynamic> M(V.size(), V[0].size());
   for (ssize_t i = 0; i < M.rows(); i++)
@@ -154,8 +155,8 @@ Eigen::Matrix<ValueType, Eigen::Dynamic, Eigen::Dynamic> load_matrix(const std::
 template <class VectorType> inline transform_type load_transform(const std::string &filename, VectorType &centre) {
   DEBUG("loading transform file \"" + filename + "\"...");
 
-  vector<std::string> comments;
-  const vector<vector<default_type>> V = load_matrix_2D_vector<>(filename, &comments);
+  std::vector<std::string> comments;
+  const std::vector<std::vector<default_type>> V = load_matrix_2D_vector<>(filename, &comments);
 
   if (V.empty())
     throw Exception("transform in file " + filename + " is empty");
@@ -177,7 +178,7 @@ template <class VectorType> inline transform_type load_transform(const std::stri
     centre[0] = NaN;
     centre[1] = NaN;
     centre[2] = NaN;
-    vector<std::string> elements;
+    std::vector<std::string> elements;
     for (auto &line : comments) {
       if (strncmp(line.c_str(), key.c_str(), key.size()) == 0)
         elements = split(strip(line.substr(key.size())), " ,;\t", true);

--- a/core/file/mgh.h
+++ b/core/file/mgh.h
@@ -421,7 +421,7 @@ template <class Input> void read_other(Header &H, Input &in) {
     const int32_t nentries = fetch<int32_t>(in);
     if (!nentries)
       throw Exception("Error reading colour table from file \"" + H.name() + "\": No entries");
-    vector<std::string> table;
+    std::vector<std::string> table;
     const int32_t filename_length = fetch<int32_t>(in);
     std::string filename(filename_length, '\0');
     in.read(const_cast<char *>(filename.data()), filename_length);
@@ -544,7 +544,7 @@ template <class Output> void write_header(const Header &H, Output &out) {
   if (ndim > 4)
     throw Exception("MGH file format does not support images of more than 4 dimensions");
 
-  vector<size_t> axes;
+  std::vector<size_t> axes;
   auto M = File::NIfTI::adjust_transform(H, axes);
 
   store<int32_t>(1, out);                                // version
@@ -666,7 +666,7 @@ template <class Output> void write_other(const Header &H, Output &out) {
            " volumes, frame data tables has " + str(lines.size()) + " rows); omitting information from output image");
       return;
     }
-    vector<mri_frame> frames(nframes);
+    std::vector<mri_frame> frames(nframes);
     for (size_t frame_index = 0; frame_index != nframes; ++frame_index) {
       const auto entries = split(lines[frame_index], ",", false);
       if (entries.size() != 24 && entries.size() != 45) {
@@ -882,12 +882,12 @@ template <class Output> void write_other(const Header &H, Output &out) {
   float32 ti = 0.0f;         /*!< milliseconds */
   float32 fov = 0.0f;        /*!< IGNORE THIS FIELD (data is inconsistent) */
   Tag transform_tag;
-  vector<Tag> tags; /*!< variable length char strings */
+  std::vector<Tag> tags; /*!< variable length char strings */
   std::unique_ptr<Eigen::Matrix<default_type, 4, 4>> auto_align_matrix;
   std::string pe_dir("UNKNOWN");
   float32 field_strength = NaN;
   std::string mri_frames, colour_table;
-  vector<Tag> cmdline_tags;
+  std::vector<Tag> cmdline_tags;
 
   for (auto entry : H.keyval()) {
     if (entry.first == "command_history") {

--- a/core/file/name_parser.cpp
+++ b/core/file/name_parser.cpp
@@ -23,7 +23,7 @@ namespace File {
 
 namespace {
 
-inline bool in_seq(const vector<uint32_t> &seq, uint32_t val) {
+inline bool in_seq(const std::vector<uint32_t> &seq, uint32_t val) {
   if (seq.size() == 0)
     return true;
   for (size_t i = 0; i < seq.size(); i++)
@@ -96,7 +96,7 @@ std::ostream &operator<<(std::ostream &stream, const NameParser &parser) {
   return stream;
 }
 
-bool NameParser::match(const std::string &file_name, vector<uint32_t> &indices) const {
+bool NameParser::match(const std::string &file_name, std::vector<uint32_t> &indices) const {
   uint32_t current = 0;
   size_t num = 0;
   indices.resize(seq_index.size());
@@ -122,7 +122,7 @@ bool NameParser::match(const std::string &file_name, vector<uint32_t> &indices) 
   return true;
 }
 
-void NameParser::calculate_padding(const vector<uint32_t> &maxvals) {
+void NameParser::calculate_padding(const std::vector<uint32_t> &maxvals) {
   assert(maxvals.size() == seq_index.size());
   for (size_t n = 0; n < seq_index.size(); n++)
     assert(maxvals[n] > 0);
@@ -157,7 +157,7 @@ void NameParser::Item::calc_padding(size_t maxval) {
     seq_length += 1;
 }
 
-std::string NameParser::name(const vector<uint32_t> &indices) {
+std::string NameParser::name(const std::vector<uint32_t> &indices) {
   if (!seq_index.size())
     return Path::join(folder_name, array[0].string());
 
@@ -177,7 +177,7 @@ std::string NameParser::name(const vector<uint32_t> &indices) {
   return Path::join(folder_name, str);
 }
 
-std::string NameParser::get_next_match(vector<uint32_t> &indices, bool return_seq_index) {
+std::string NameParser::get_next_match(std::vector<uint32_t> &indices, bool return_seq_index) {
   if (!folder)
     folder.reset(new Path::Dir(folder_name));
 
@@ -208,13 +208,13 @@ bool ParsedName::operator<(const ParsedName &pn) const {
   return false;
 }
 
-vector<uint32_t> ParsedName::List::parse_scan_check(const std::string &specifier, size_t max_num_sequences) {
+std::vector<uint32_t> ParsedName::List::parse_scan_check(const std::string &specifier, size_t max_num_sequences) {
   NameParser parser;
   parser.parse(specifier);
 
   scan(parser);
   std::sort(list.begin(), list.end(), compare_ptr_contents());
-  vector<uint32_t> dim = count();
+  std::vector<uint32_t> dim = count();
 
   for (size_t n = 0; n < dim.size(); n++)
     if (parser.sequence(n).size())
@@ -225,7 +225,7 @@ vector<uint32_t> ParsedName::List::parse_scan_check(const std::string &specifier
 }
 
 void ParsedName::List::scan(NameParser &parser) {
-  vector<uint32_t> index;
+  std::vector<uint32_t> index;
   if (parser.ndim() == 0) {
     list.push_back(std::shared_ptr<ParsedName>(new ParsedName(parser.name(index), index)));
     return;
@@ -240,15 +240,15 @@ void ParsedName::List::scan(NameParser &parser) {
     throw Exception("no matching files found for image specifier \"" + parser.spec() + "\"");
 }
 
-vector<uint32_t> ParsedName::List::count() const {
+std::vector<uint32_t> ParsedName::List::count() const {
   if (!list[0]->ndim()) {
     if (size() == 1)
-      return (vector<uint32_t>());
+      return (std::vector<uint32_t>());
     else
       throw Exception("image number mismatch");
   }
 
-  vector<uint32_t> dim(list[0]->ndim(), 0);
+  std::vector<uint32_t> dim(list[0]->ndim(), 0);
   size_t current_entry = 0;
 
   count_dim(dim, current_entry, 0);
@@ -256,7 +256,7 @@ vector<uint32_t> ParsedName::List::count() const {
   return dim;
 }
 
-void ParsedName::List::count_dim(vector<uint32_t> &dim, size_t &current_entry, size_t current_dim) const {
+void ParsedName::List::count_dim(std::vector<uint32_t> &dim, size_t &current_entry, size_t current_dim) const {
   uint32_t n;
   bool stop = false;
   std::shared_ptr<const ParsedName> first_entry(list[current_entry]);

--- a/core/file/name_parser.h
+++ b/core/file/name_parser.h
@@ -53,9 +53,9 @@ public:
 
     std::string string() const { return (str); }
 
-    const vector<uint32_t> &sequence() const { return (seq); }
+    const std::vector<uint32_t> &sequence() const { return (seq); }
 
-    vector<uint32_t> &sequence() { return (seq); }
+    std::vector<uint32_t> &sequence() { return (seq); }
 
     bool is_string() const { return (seq_length == 0); }
 
@@ -70,7 +70,7 @@ public:
   protected:
     size_t seq_length;
     std::string str;
-    vector<uint32_t> seq;
+    std::vector<uint32_t> seq;
   };
 
   void parse(const std::string &imagename, size_t max_num_sequences = std::numeric_limits<size_t>::max());
@@ -81,22 +81,22 @@ public:
 
   const Item &operator[](size_t i) const { return (array[i]); }
 
-  const vector<uint32_t> &sequence(size_t index) const { return (array[seq_index[index]].sequence()); }
+  const std::vector<uint32_t> &sequence(size_t index) const { return (array[seq_index[index]].sequence()); }
 
   size_t ndim() const { return (seq_index.size()); }
 
   size_t index_of_sequence(size_t number = 0) const { return (seq_index[number]); }
 
-  bool match(const std::string &file_name, vector<uint32_t> &indices) const;
-  void calculate_padding(const vector<uint32_t> &maxvals);
-  std::string name(const vector<uint32_t> &indices);
-  std::string get_next_match(vector<uint32_t> &indices, bool return_seq_index = false);
+  bool match(const std::string &file_name, std::vector<uint32_t> &indices) const;
+  void calculate_padding(const std::vector<uint32_t> &maxvals);
+  std::string name(const std::vector<uint32_t> &indices);
+  std::string get_next_match(std::vector<uint32_t> &indices, bool return_seq_index = false);
 
   friend std::ostream &operator<<(std::ostream &stream, const NameParser &parser);
 
 private:
-  vector<Item> array;
-  vector<size_t> seq_index;
+  std::vector<Item> array;
+  std::vector<size_t> seq_index;
   std::string folder_name, specification, current_name;
   std::unique_ptr<Path::Dir> folder;
 
@@ -117,17 +117,17 @@ private:
 //! a class to hold a parsed image filename
 class ParsedName {
 public:
-  ParsedName(const std::string &name, const vector<uint32_t> &index) : indices(index), filename(name) {}
+  ParsedName(const std::string &name, const std::vector<uint32_t> &index) : indices(index), filename(name) {}
 
   //! a class to hold a set of parsed image filenames
   class List {
   public:
-    vector<uint32_t> parse_scan_check(const std::string &specifier,
-                                      size_t max_num_sequences = std::numeric_limits<size_t>::max());
+    std::vector<uint32_t> parse_scan_check(const std::string &specifier,
+                                           size_t max_num_sequences = std::numeric_limits<size_t>::max());
 
     void scan(NameParser &parser);
 
-    vector<uint32_t> count() const;
+    std::vector<uint32_t> count() const;
 
     size_t biggest_filename_size() const { return max_name_size; }
 
@@ -138,8 +138,8 @@ public:
     friend std::ostream &operator<<(std::ostream &stream, const List &list);
 
   protected:
-    vector<std::shared_ptr<ParsedName>> list;
-    void count_dim(vector<uint32_t> &dim, size_t &current_entry, size_t current_dim) const;
+    std::vector<std::shared_ptr<ParsedName>> list;
+    void count_dim(std::vector<uint32_t> &dim, size_t &current_entry, size_t current_dim) const;
     size_t max_name_size;
   };
 
@@ -151,7 +151,7 @@ public:
   friend std::ostream &operator<<(std::ostream &stream, const ParsedName &pin);
 
 protected:
-  vector<uint32_t> indices;
+  std::vector<uint32_t> indices;
   std::string filename;
 };
 

--- a/core/file/nifti_utils.cpp
+++ b/core/file/nifti_utils.cpp
@@ -63,7 +63,7 @@ template <> struct Type<nifti_2_header> {
   static char *regular(nifti_2_header &NH) { return nullptr; }
 };
 
-const vector<std::string> suffixes{".nii", ".img"};
+const std::vector<std::string> suffixes{".nii", ".img"};
 } // namespace
 
 bool right_left_warning_issued = false;
@@ -357,7 +357,7 @@ template <class NiftiHeader> void store(NiftiHeader &NH, const Header &H, const 
 
   bool is_BE = H.datatype().is_big_endian();
 
-  vector<size_t> axes;
+  std::vector<size_t> axes;
   auto M = File::NIfTI::adjust_transform(H, axes);
 
   memset(&NH, 0, sizeof(NH));
@@ -544,15 +544,15 @@ template <class NiftiHeader> void store(NiftiHeader &NH, const Header &H, const 
   }
 }
 
-void axes_on_write(const Header &H, vector<size_t> &order, vector<bool> &flip) {
+void axes_on_write(const Header &H, std::vector<size_t> &order, std::vector<bool> &flip) {
   Stride::List strides = Stride::get(H);
   strides.resize(3);
   order = Stride::order(strides);
   flip = {strides[order[0]] < 0, strides[order[1]] < 0, strides[order[2]] < 0};
 }
 
-transform_type adjust_transform(const Header &H, vector<size_t> &axes) {
-  vector<bool> flip;
+transform_type adjust_transform(const Header &H, std::vector<size_t> &axes) {
+  std::vector<bool> flip;
   axes_on_write(H, axes, flip);
 
   if (axes[0] == 0 && axes[1] == 1 && axes[2] == 2 && !flip[0] && !flip[1] && !flip[2])
@@ -578,7 +578,7 @@ transform_type adjust_transform(const Header &H, vector<size_t> &axes) {
   return out;
 }
 
-bool check(int VERSION, Header &H, const size_t num_axes, const vector<std::string> &suffixes) {
+bool check(int VERSION, Header &H, const size_t num_axes, const std::vector<std::string> &suffixes) {
   if (!Path::has_suffix(H.name(), suffixes))
     return false;
 

--- a/core/file/nifti_utils.cpp
+++ b/core/file/nifti_utils.cpp
@@ -544,7 +544,7 @@ template <class NiftiHeader> void store(NiftiHeader &NH, const Header &H, const 
   }
 }
 
-void axes_on_write(const Header &H, std::vector<size_t> &order, std::vector<bool> &flip) {
+void axes_on_write(const Header &H, std::vector<size_t> &order, std::array<bool, 3> &flip) {
   Stride::List strides = Stride::get(H);
   strides.resize(3);
   order = Stride::order(strides);
@@ -552,7 +552,7 @@ void axes_on_write(const Header &H, std::vector<size_t> &order, std::vector<bool
 }
 
 transform_type adjust_transform(const Header &H, std::vector<size_t> &axes) {
-  std::vector<bool> flip;
+  std::array<bool, 3> flip;
   axes_on_write(H, axes, flip);
 
   if (axes[0] == 0 && axes[1] == 1 && axes[2] == 2 && !flip[0] && !flip[1] && !flip[2])

--- a/core/file/nifti_utils.h
+++ b/core/file/nifti_utils.h
@@ -17,6 +17,7 @@
 #ifndef __file_nifti_utils_h__
 #define __file_nifti_utils_h__
 
+#include <array>
 // nifti1_io.h and nifti2_io.h headers must be included after dirent.h (transitively included by header.h)
 // otherwise we run into definitions conflict on Linux
 // clang-format off
@@ -35,7 +36,7 @@ namespace File {
 namespace NIfTI {
 extern bool right_left_warning_issued;
 
-void axes_on_write(const Header &H, std::vector<size_t> &order, std::vector<bool> &flip);
+void axes_on_write(const Header &H, std::vector<size_t> &order, std::array<bool, 3> &flip);
 transform_type adjust_transform(const Header &H, std::vector<size_t> &order);
 
 bool check(int VERSION, Header &H, const size_t num_axes, const std::vector<std::string> &suffixes);

--- a/core/file/nifti_utils.h
+++ b/core/file/nifti_utils.h
@@ -35,10 +35,10 @@ namespace File {
 namespace NIfTI {
 extern bool right_left_warning_issued;
 
-void axes_on_write(const Header &H, vector<size_t> &order, vector<bool> &flip);
-transform_type adjust_transform(const Header &H, vector<size_t> &order);
+void axes_on_write(const Header &H, std::vector<size_t> &order, std::vector<bool> &flip);
+transform_type adjust_transform(const Header &H, std::vector<size_t> &order);
 
-bool check(int VERSION, Header &H, const size_t num_axes, const vector<std::string> &suffixes);
+bool check(int VERSION, Header &H, const size_t num_axes, const std::vector<std::string> &suffixes);
 
 template <int VERSION> std::unique_ptr<ImageIO::Base> read(Header &H);
 template <int VERSION> std::unique_ptr<ImageIO::Base> read_gz(Header &H);

--- a/core/file/npy.cpp
+++ b/core/file/npy.cpp
@@ -185,7 +185,7 @@ KeyValues parse_dict(std::string s) {
   // Expect a dictionary literal; remove curly braces
   s = strip(strip(s, "{", true, false), "}", false, true);
   const std::map<char, char> pairs{{'{', '}'}, {'[', ']'}, {'(', ')'}, {'\'', '\''}, {'"', '"'}};
-  vector<char> openers;
+  std::vector<char> openers;
   bool prev_was_escape = false;
   std::string current, key;
   KeyValues keyval;
@@ -348,7 +348,7 @@ ReadInfo read_header(const std::string &path) {
   return info;
 }
 
-WriteInfo prepare_ND_write(const std::string &path, const DataType data_type, const vector<size_t> &shape) {
+WriteInfo prepare_ND_write(const std::string &path, const DataType data_type, const std::vector<size_t> &shape) {
   assert(shape.size() == 1 || shape.size() == 2);
   WriteInfo info;
   info.data_type = data_type;

--- a/core/file/npy.h
+++ b/core/file/npy.h
@@ -46,7 +46,7 @@ KeyValues parse_dict(std::string);
 struct ReadInfo {
   DataType data_type;
   bool column_major;
-  vector<ssize_t> shape;
+  std::vector<ssize_t> shape;
   KeyValues keyval;
   int64_t data_offset;
 };
@@ -84,7 +84,7 @@ struct WriteInfo {
   DataType data_type;
 };
 
-WriteInfo prepare_ND_write(const std::string &path, const DataType data_type, const vector<size_t> &shape);
+WriteInfo prepare_ND_write(const std::string &path, const DataType data_type, const std::vector<size_t> &shape);
 
 template <class ContType> void save_vector(const ContType &data, const std::string &path) {
   using ValueType = typename container_value_type<ContType>::type;

--- a/core/file/path.h
+++ b/core/file/path.h
@@ -125,7 +125,7 @@ inline bool has_suffix(const std::string &name, const std::initializer_list<cons
       suffix_list.begin(), suffix_list.end(), [&](const std::string &suffix) { return has_suffix(name, suffix); });
 }
 
-inline bool has_suffix(const std::string &name, const vector<std::string> &suffix_list) {
+inline bool has_suffix(const std::string &name, const std::vector<std::string> &suffix_list) {
   return std::any_of(
       suffix_list.begin(), suffix_list.end(), [&](const std::string &suffix) { return has_suffix(name, suffix); });
 }

--- a/core/filter/connected_components.cpp
+++ b/core/filter/connected_components.cpp
@@ -28,8 +28,8 @@ void Connector::Adjacency::initialise(const Header &header, const Voxel2Vector &
   if (header.ndim() > enabled_axes.size())
     enabled_axes.resize(header.ndim(), false);
   // Begin by disabling adjacency offsets for those axes for which adjacency is not permitted
-  vector<vector<int>> offsets;
-  vector<int> o(header.ndim(), -1);
+  std::vector<std::vector<int>> offsets;
+  std::vector<int> o(header.ndim(), -1);
   size_t start_axis = 0;
   for (size_t axis = 0; axis != header.ndim(); ++axis) {
     if (!enabled_axes[axis]) {
@@ -64,12 +64,12 @@ void Connector::Adjacency::initialise(const Header &header, const Voxel2Vector &
   }
   // Now we can generate, for each element in the image, a list of adjacent elements
   // This may appear different to previous code, given the use of the Voxel2Vector class
-  vector<index_t> pos(header.ndim());
-  vector<int> neighbour(header.ndim());
+  std::vector<index_t> pos(header.ndim());
+  std::vector<int> neighbour(header.ndim());
   data.reserve(v2v.size());
   for (size_t i = 0; i != v2v.size(); ++i) {
     pos = v2v[i];
-    vector<index_t> indices;
+    std::vector<index_t> indices;
     for (auto o : offsets) {
       for (size_t axis = 0; axis != header.ndim(); ++axis)
         neighbour[axis] = pos[axis] + o[axis];
@@ -85,7 +85,7 @@ void Connector::Adjacency::initialise(const Header &header, const Voxel2Vector &
   DEBUG("Adjacency data for " + str(data.size()) + " voxels initialised");
 }
 
-void Connector::run(vector<Cluster> &clusters, vector<uint32_t> &labels) const {
+void Connector::run(std::vector<Cluster> &clusters, std::vector<uint32_t> &labels) const {
   assert(adjacency.size());
   labels.resize(adjacency.size(), 0);
   uint32_t current_label = 0;
@@ -101,7 +101,7 @@ void Connector::run(vector<Cluster> &clusters, vector<uint32_t> &labels) const {
     throw Exception("The number of clusters is larger than can be labelled with an unsigned 32bit integer.");
 }
 
-bool Connector::next_neighbour(uint32_t &node, vector<uint32_t> &labels) const {
+bool Connector::next_neighbour(uint32_t &node, std::vector<uint32_t> &labels) const {
   for (auto n : adjacency[node]) {
     if (!labels[n]) {
       node = n;
@@ -111,7 +111,7 @@ bool Connector::next_neighbour(uint32_t &node, vector<uint32_t> &labels) const {
   return false;
 }
 
-void Connector::depth_first_search(const uint32_t root, Cluster &cluster, vector<uint32_t> &labels) const {
+void Connector::depth_first_search(const uint32_t root, Cluster &cluster, std::vector<uint32_t> &labels) const {
   uint32_t node = root;
   std::stack<uint32_t> stack;
   while (true) {

--- a/core/filter/connected_components.h
+++ b/core/filter/connected_components.h
@@ -53,14 +53,14 @@ public:
       data.clear();
     }
 
-    void set_axes(const vector<bool> &i) {
+    void set_axes(const std::vector<bool> &i) {
       enabled_axes = i;
       data.clear();
     }
 
     void initialise(const Header &, const Voxel2Vector &);
 
-    const vector<index_t> &operator[](const size_t index) const {
+    const std::vector<index_t> &operator[](const size_t index) const {
       assert(size());
       assert(index < size());
       return data[index];
@@ -75,8 +75,8 @@ public:
 
   private:
     bool use_26_neighbours;
-    vector<bool> enabled_axes;
-    vector<vector<index_t>> data;
+    std::vector<bool> enabled_axes;
+    std::vector<std::vector<index_t>> data;
   } adjacency;
 
   class Cluster {
@@ -92,24 +92,25 @@ public:
   Connector() {}
 
   // Perform connected components on vectorized binary data
-  void run(vector<Cluster> &, vector<uint32_t> &) const;
-  template <class VectorType> void run(vector<Cluster> &, vector<uint32_t> &, const VectorType &, const float) const;
+  void run(std::vector<Cluster> &, std::vector<uint32_t> &) const;
+  template <class VectorType>
+  void run(std::vector<Cluster> &, std::vector<uint32_t> &, const VectorType &, const float) const;
 
 private:
   // Utility functions that perform the actual connected
   //   components functionality
-  bool next_neighbour(uint32_t &, vector<uint32_t> &) const;
+  bool next_neighbour(uint32_t &, std::vector<uint32_t> &) const;
   template <class VectorType>
-  bool next_neighbour(uint32_t &, vector<uint32_t> &, const VectorType &, const float) const;
+  bool next_neighbour(uint32_t &, std::vector<uint32_t> &, const VectorType &, const float) const;
 
-  void depth_first_search(const uint32_t, Cluster &, vector<uint32_t> &) const;
+  void depth_first_search(const uint32_t, Cluster &, std::vector<uint32_t> &) const;
   template <class VectorType>
-  void depth_first_search(const uint32_t, Cluster &, vector<uint32_t> &, const VectorType &, const float) const;
+  void depth_first_search(const uint32_t, Cluster &, std::vector<uint32_t> &, const VectorType &, const float) const;
 };
 
 template <class VectorType>
-void Connector::run(vector<Cluster> &clusters,
-                    vector<uint32_t> &labels,
+void Connector::run(std::vector<Cluster> &clusters,
+                    std::vector<uint32_t> &labels,
                     const VectorType &data,
                     const float threshold) const {
   assert(adjacency.size());
@@ -129,7 +130,7 @@ void Connector::run(vector<Cluster> &clusters,
 
 template <class VectorType>
 bool Connector::next_neighbour(uint32_t &node,
-                               vector<uint32_t> &labels,
+                               std::vector<uint32_t> &labels,
                                const VectorType &data,
                                const float threshold) const {
   for (auto n : adjacency[node]) {
@@ -144,7 +145,7 @@ bool Connector::next_neighbour(uint32_t &node,
 template <class VectorType>
 void Connector::depth_first_search(const uint32_t root,
                                    Cluster &cluster,
-                                   vector<uint32_t> &labels,
+                                   std::vector<uint32_t> &labels,
                                    const VectorType &data,
                                    const float threshold) const {
   uint32_t node = root;
@@ -213,8 +214,8 @@ public:
     if (progress)
       ++(*progress);
 
-    vector<Connector::Cluster> clusters;
-    vector<uint32_t> labels;
+    std::vector<Connector::Cluster> clusters;
+    std::vector<uint32_t> labels;
     connector.run(clusters, labels);
     // Sort clusters in order from largest to smallest
     std::sort(clusters.begin(), clusters.end(), Connector::largest);
@@ -223,7 +224,7 @@ public:
 
     // Generate a lookup table to map input cluster index to
     //   output cluster index following cluster-size sorting
-    vector<uint32_t> index_lookup(clusters.size() + 1, 0);
+    std::vector<uint32_t> index_lookup(clusters.size() + 1, 0);
     for (uint32_t c = 0; c < clusters.size(); c++) {
       if (clusters[c].size < minsize)
         break;
@@ -246,7 +247,7 @@ public:
     }
   }
 
-  void set_axes(const vector<int> &i) {
+  void set_axes(const std::vector<int> &i) {
     const size_t max_axis = *std::max_element(i.begin(), i.end());
     if (max_axis >= ndim())
       throw Exception("Requested axis for connected-component filter (" + str(max_axis) +
@@ -259,7 +260,7 @@ public:
     }
   }
 
-  void set_axes(const vector<bool> &i) {
+  void set_axes(const std::vector<bool> &i) {
     if (i.size() != ndim())
       throw Exception("Length of axis selection flag vector (" + str(i.size()) +
                       ") does not match dimensionality of connected-component filter (" + str(ndim()) + "D)");
@@ -273,7 +274,7 @@ public:
   void set_minsize(uint32_t value) { minsize = value; }
 
 protected:
-  vector<bool> enabled_axes;
+  std::vector<bool> enabled_axes;
   bool largest_only;
   bool do_26_connectivity;
   uint32_t minsize;

--- a/core/filter/dilate.h
+++ b/core/filter/dilate.h
@@ -59,7 +59,7 @@ public:
     std::shared_ptr<ProgressBar> progress(message.size() ? new ProgressBar(message, npass + 1) : nullptr);
 
     for (unsigned int pass = 0; pass < npass; pass++) {
-      out = make_shared<Image<bool>>(Image<bool>::scratch(input));
+      out = std::make_shared<Image<bool>>(Image<bool>::scratch(input));
       for (auto l = Loop(*in)(*in, *out); l; ++l)
         out->value() = dilate(*in);
       if (pass < npass - 1)

--- a/core/filter/erode.h
+++ b/core/filter/erode.h
@@ -59,13 +59,13 @@ public:
 
   template <class InputImageType, class OutputImageType>
   void operator()(InputImageType &input, OutputImageType &output) {
-    std::shared_ptr<Image<bool>> in = make_shared<Image<bool>>(Image<bool>::scratch(input));
+    std::shared_ptr<Image<bool>> in = std::make_shared<Image<bool>>(Image<bool>::scratch(input));
     copy(input, *in);
     std::shared_ptr<Image<bool>> out;
     std::shared_ptr<ProgressBar> progress(message.size() ? new ProgressBar(message, npass + 1) : nullptr);
 
     for (unsigned int pass = 0; pass < npass; pass++) {
-      out = make_shared<Image<bool>>(Image<bool>::scratch(input));
+      out = std::make_shared<Image<bool>>(Image<bool>::scratch(input));
       for (auto l = Loop(*in)(*in, *out); l; ++l)
         out->value() = erode(*in);
 

--- a/core/filter/fill.h
+++ b/core/filter/fill.h
@@ -54,7 +54,7 @@ public:
     set_message(message);
   }
 
-  void set_axes(const vector<int> &i) {
+  void set_axes(const std::vector<int> &i) {
     const size_t max_axis = *std::max_element(i.begin(), i.end());
     if (max_axis >= ndim())
       throw Exception("Requested axis for interior-filling filter (" + str(max_axis) +
@@ -89,7 +89,7 @@ public:
   }
 
 protected:
-  vector<bool> enabled_axes;
+  std::vector<bool> enabled_axes;
   bool do_26_connectivity;
 };
 //! @}

--- a/core/filter/gradient.h
+++ b/core/filter/gradient.h
@@ -75,7 +75,7 @@ public:
 
   void compute_wrt_scanner(bool do_wrt_scanner) { wrt_scanner = do_wrt_scanner; }
 
-  void set_stdev(const vector<default_type> &stdevs) { stdev = stdevs; }
+  void set_stdev(const std::vector<default_type> &stdevs) { stdev = stdevs; }
 
   template <class InputImageType, class OutputImageType> void operator()(InputImageType &in, OutputImageType &out) {
     if (magnitude) {
@@ -142,7 +142,7 @@ protected:
   Filter::Smooth smoother;
   bool wrt_scanner;
   const bool magnitude;
-  vector<default_type> stdev;
+  std::vector<default_type> stdev;
 };
 //! @}
 } // namespace Filter

--- a/core/filter/median.h
+++ b/core/filter/median.h
@@ -48,12 +48,13 @@ public:
     datatype() = DataType::Float32;
   }
 
-  template <class HeaderType> Median(const HeaderType &in, const vector<uint32_t> &extent) : Base(in), extent(extent) {
+  template <class HeaderType>
+  Median(const HeaderType &in, const std::vector<uint32_t> &extent) : Base(in), extent(extent) {
     datatype() = DataType::Float32;
   }
 
   template <class HeaderType>
-  Median(const HeaderType &in, const std::string &message, const vector<uint32_t> &extent)
+  Median(const HeaderType &in, const std::string &message, const std::vector<uint32_t> &extent)
       : Base(in, message), extent(extent) {
     datatype() = DataType::Float32;
   }
@@ -61,7 +62,7 @@ public:
   //! Set the extent of median filtering neighbourhood in voxels.
   //! This must be set as a single value for all three dimensions
   //! or three values, one for each dimension. Default 3x3x3.
-  void set_extent(const vector<uint32_t> &ext) {
+  void set_extent(const std::vector<uint32_t> &ext) {
     for (size_t i = 0; i < ext.size(); ++i) {
       if (!(ext[i] & int(1)))
         throw Exception("expected odd number for extent");
@@ -78,7 +79,7 @@ public:
   }
 
 protected:
-  vector<uint32_t> extent;
+  std::vector<uint32_t> extent;
 };
 //! @}
 } // namespace Filter

--- a/core/filter/normalise.h
+++ b/core/filter/normalise.h
@@ -51,12 +51,12 @@ public:
   }
 
   template <class HeaderType>
-  Normalise(const HeaderType &in, const vector<uint32_t> &extent) : Base(in), extent(extent) {
+  Normalise(const HeaderType &in, const std::vector<uint32_t> &extent) : Base(in), extent(extent) {
     datatype() = DataType::Float32;
   }
 
   template <class HeaderType>
-  Normalise(const HeaderType &in, const std::string &message, const vector<uint32_t> &extent)
+  Normalise(const HeaderType &in, const std::string &message, const std::vector<uint32_t> &extent)
       : Base(in, message), extent(extent) {
     datatype() = DataType::Float32;
   }
@@ -64,7 +64,7 @@ public:
   //! Set the extent of normalise filtering neighbourhood in voxels.
   //! This must be set as a single value for all three dimensions
   //! or three values, one for each dimension. Default 3x3x3.
-  void set_extent(const vector<uint32_t> &ext) {
+  void set_extent(const std::vector<uint32_t> &ext) {
     for (size_t i = 0; i < ext.size(); ++i) {
       if (!(ext[i] & uint32_t(1)))
         throw Exception("expected odd number for extent");
@@ -81,7 +81,7 @@ public:
   }
 
 protected:
-  vector<uint32_t> extent;
+  std::vector<uint32_t> extent;
 };
 //! @}
 } // namespace Filter

--- a/core/filter/resize.h
+++ b/core/filter/resize.h
@@ -67,11 +67,11 @@ public:
   ~Resize() { delete out_of_bounds_value; }
 
   void set_voxel_size(default_type size) {
-    vector<default_type> voxel_size(3, size);
+    std::vector<default_type> voxel_size(3, size);
     set_voxel_size(voxel_size);
   }
 
-  void set_voxel_size(const vector<default_type> &voxel_size) {
+  void set_voxel_size(const std::vector<default_type> &voxel_size) {
     if (voxel_size.size() != 3)
       throw Exception("the voxel size must be defined using a value for all three dimensions.");
 
@@ -91,10 +91,10 @@ public:
     }
   }
 
-  void set_size(const vector<uint32_t> &image_res) {
+  void set_size(const std::vector<uint32_t> &image_res) {
     if (image_res.size() != 3)
       throw Exception("the image resolution must be defined for 3 spatial dimensions");
-    vector<default_type> new_voxel_size(3);
+    std::vector<default_type> new_voxel_size(3);
     for (size_t d = 0; d < 3; ++d) {
       if (image_res[d] <= 0)
         throw Exception("the image resolution must be larger than zero for all 3 spatial dimensions");
@@ -103,12 +103,12 @@ public:
     set_voxel_size(new_voxel_size);
   }
 
-  void set_scale_factor(default_type scale) { set_scale_factor(vector<default_type>(3, scale)); }
+  void set_scale_factor(default_type scale) { set_scale_factor(std::vector<default_type>(3, scale)); }
 
-  void set_scale_factor(const vector<default_type> &scale) {
+  void set_scale_factor(const std::vector<default_type> &scale) {
     if (scale.size() != 3)
       throw Exception("a scale factor for each spatial dimension is required");
-    vector<default_type> new_voxel_size(3);
+    std::vector<default_type> new_voxel_size(3);
     for (size_t d = 0; d < 3; ++d) {
       if (scale[d] <= 0.0)
         throw Exception("the scale factor must be larger than zero");
@@ -117,7 +117,7 @@ public:
     set_voxel_size(new_voxel_size);
   }
 
-  void set_oversample(vector<uint32_t> oversample) {
+  void set_oversample(std::vector<uint32_t> oversample) {
     if (oversample.size() == 1)
       oversample.resize(3, oversample[0]);
     else if (oversample.size() != 3 and oversample.size() != 0)
@@ -166,7 +166,7 @@ public:
 protected:
   int interp_type;
   transform_type transformation;
-  vector<uint32_t> oversampling;
+  std::vector<uint32_t> oversampling;
   default_type *out_of_bounds_value;
 };
 //! @}

--- a/core/filter/reslice.h
+++ b/core/filter/reslice.h
@@ -46,7 +46,7 @@ template <template <class ImageType> class Interpolator, class ImageTypeDestinat
 void reslice(ImageTypeSource &source,
              ImageTypeDestination &destination,
              const transform_type &transform = Adapter::NoTransform,
-             const vector<uint32_t> &oversampling = Adapter::AutoOverSample,
+             const std::vector<uint32_t> &oversampling = Adapter::AutoOverSample,
              const typename ImageTypeDestination::value_type value_when_out_of_bounds =
                  Interp::Base<ImageTypeDestination>::default_out_of_bounds_value()) {
   Adapter::Reslice<Interpolator, ImageTypeSource> interp(

--- a/core/filter/smooth.h
+++ b/core/filter/smooth.h
@@ -54,7 +54,7 @@ public:
   }
 
   template <class HeaderType>
-  Smooth(const HeaderType &in, const vector<default_type> &stdev_in)
+  Smooth(const HeaderType &in, const std::vector<default_type> &stdev_in)
       : Base(in), extent(3, 0), stdev(3, 0.0), stride_order(Stride::order(in)) {
     set_stdev(stdev_in);
     datatype() = DataType::Float32;
@@ -63,7 +63,7 @@ public:
   //! Set the extent of smoothing kernel in voxels.
   //! This can be set as a single value to be used for the first 3 dimensions
   //! or separate values, one for each dimension. (Default: 4 standard deviations)
-  void set_extent(const vector<uint32_t> &new_extent) {
+  void set_extent(const std::vector<uint32_t> &new_extent) {
     if (new_extent.size() != 1 && new_extent.size() != 3)
       throw Exception("Please supply a single kernel extent value, or three values (one for each spatial dimension)");
     for (size_t i = 0; i < new_extent.size(); ++i) {
@@ -77,7 +77,7 @@ public:
       extent = new_extent;
   }
 
-  void set_stdev(default_type stdev_in) { set_stdev(vector<default_type>(3, stdev_in)); }
+  void set_stdev(default_type stdev_in) { set_stdev(std::vector<default_type>(3, stdev_in)); }
 
   //! ensure the image boundary remains zero. Used to constrain displacement fields during image registration
   void set_zero_boundary(bool do_zero_boundary) { zero_boundary = do_zero_boundary; }
@@ -85,7 +85,7 @@ public:
   //! Set the standard deviation of the Gaussian defined in mm.
   //! This must be set as a single value to be used for the first 3 dimensions
   //! or separate values, one for each dimension. (Default: 1 voxel)
-  void set_stdev(const vector<default_type> &std_dev) {
+  void set_stdev(const std::vector<default_type> &std_dev) {
     for (size_t i = 0; i < std_dev.size(); ++i)
       if (stdev[i] < 0.0)
         throw Exception("the Gaussian stdev values cannot be negative");
@@ -111,7 +111,7 @@ public:
     std::unique_ptr<ProgressBar> progress;
     if (message.size()) {
       size_t axes_to_smooth = 0;
-      for (vector<default_type>::const_iterator i = stdev.begin(); i != stdev.end(); ++i)
+      for (std::vector<default_type>::const_iterator i = stdev.begin(); i != stdev.end(); ++i)
         if (*i)
           ++axes_to_smooth;
       progress.reset(new ProgressBar(message, axes_to_smooth + 1));
@@ -136,7 +136,7 @@ public:
     std::unique_ptr<ProgressBar> progress;
     if (message.size()) {
       size_t axes_to_smooth = 0;
-      for (vector<default_type>::const_iterator i = stdev.begin(); i != stdev.end(); ++i)
+      for (std::vector<default_type>::const_iterator i = stdev.begin(); i != stdev.end(); ++i)
         if (*i)
           ++axes_to_smooth;
       progress.reset(new ProgressBar(message, axes_to_smooth + 1));
@@ -144,7 +144,7 @@ public:
 
     for (size_t dim = 0; dim < 3; dim++) {
       if (stdev[dim] > 0) {
-        vector<size_t> axes(in_and_output.ndim(), dim);
+        std::vector<size_t> axes(in_and_output.ndim(), dim);
         size_t axdim = 1;
         for (size_t i = 0; i < in_and_output.ndim(); ++i) {
           if (stride_order[i] == dim)
@@ -161,9 +161,9 @@ public:
   }
 
 protected:
-  vector<uint32_t> extent;
-  vector<default_type> stdev;
-  const vector<size_t> stride_order;
+  std::vector<uint32_t> extent;
+  std::vector<default_type> stdev;
+  const std::vector<size_t> stride_order;
   bool zero_boundary;
 
   template <class ImageType> class SmoothFunctor1D {

--- a/core/filter/smooth.h
+++ b/core/filter/smooth.h
@@ -104,7 +104,7 @@ public:
   //! Smooth the input image. Both input and output images can be the same image
   template <class InputImageType, class OutputImageType, typename ValueType = float>
   void operator()(InputImageType &input, OutputImageType &output) {
-    std::shared_ptr<Image<ValueType>> in(make_shared<Image<ValueType>>(Image<ValueType>::scratch(input)));
+    std::shared_ptr<Image<ValueType>> in(std::make_shared<Image<ValueType>>(Image<ValueType>::scratch(input)));
     threaded_copy(input, *in);
     std::shared_ptr<Image<ValueType>> out;
 
@@ -120,7 +120,7 @@ public:
     for (size_t dim = 0; dim < 3; dim++) {
       if (stdev[dim] > 0) {
         DEBUG("creating scratch image for smoothing image along dimension " + str(dim));
-        out = make_shared<Image<ValueType>>(Image<ValueType>::scratch(input));
+        out = std::make_shared<Image<ValueType>>(Image<ValueType>::scratch(input));
         Adapter::Gaussian1D<Image<ValueType>> gaussian(*in, stdev[dim], dim, extent[dim], zero_boundary);
         threaded_copy(gaussian, *out, 0, input.ndim(), 2);
         in = out;

--- a/core/filter/warp.h
+++ b/core/filter/warp.h
@@ -65,7 +65,7 @@ void warp(ImageTypeSource &source,
           WarpType &warp,
           const typename ImageTypeDestination::value_type value_when_out_of_bounds =
               Interpolator<ImageTypeSource>::default_out_of_bounds_value(),
-          const vector<uint32_t> oversample = Adapter::AutoOverSample,
+          const std::vector<uint32_t> oversample = Adapter::AutoOverSample,
           const bool jacobian_modulate = false) {
 
   // reslice warp onto destination grid

--- a/core/filter/zclean.h
+++ b/core/filter/zclean.h
@@ -289,7 +289,7 @@ protected:
 
   template <typename ImageType, typename MaskType>
   void calculate_median_mad(ImageType &image, MaskType &mask, size_t nvoxels, float &median, float &mad) {
-    MR::vector<float> vals(nvoxels);
+    std::vector<float> vals(nvoxels);
     size_t idx = 0;
     for (auto l = Loop(0, 3)(mask, image); l; ++l) {
       if (mask.value())

--- a/core/fixel/helpers.h
+++ b/core/fixel/helpers.h
@@ -203,12 +203,12 @@ FORCE_INLINE Header find_index_header(const std::string &fixel_directory_path) {
   return header;
 }
 
-FORCE_INLINE vector<Header> find_data_headers(const std::string &fixel_directory_path,
-                                              const Header &index_header,
-                                              const bool include_directions = false) {
+FORCE_INLINE std::vector<Header> find_data_headers(const std::string &fixel_directory_path,
+                                                   const Header &index_header,
+                                                   const bool include_directions = false) {
   check_index_image(index_header);
   auto dir_walker = Path::Dir(fixel_directory_path);
-  vector<std::string> file_names;
+  std::vector<std::string> file_names;
   {
     std::string temp;
     while ((temp = dir_walker.read_name()).size())
@@ -216,7 +216,7 @@ FORCE_INLINE vector<Header> find_data_headers(const std::string &fixel_directory
   }
   std::sort(file_names.begin(), file_names.end());
 
-  vector<Header> data_headers;
+  std::vector<Header> data_headers;
   for (auto fname : file_names) {
     if (Path::has_suffix(fname, supported_sparse_formats)) {
       try {

--- a/core/formats/mrtrix_utils.cpp
+++ b/core/formats/mrtrix_utils.cpp
@@ -19,8 +19,8 @@
 namespace MR {
 namespace Formats {
 
-vector<ssize_t> parse_axes(size_t ndim, const std::string &specifier) {
-  vector<ssize_t> parsed(ndim);
+std::vector<ssize_t> parse_axes(size_t ndim, const std::string &specifier) {
+  std::vector<ssize_t> parsed(ndim);
 
   size_t sub = 0;
   size_t lim = 0;

--- a/core/formats/mrtrix_utils.h
+++ b/core/formats/mrtrix_utils.h
@@ -47,13 +47,13 @@ void get_mrtrix_file_path(Header &, const std::string &, std::string &, size_t &
 //   this could be an ofstream in the case of .mif, or a stringstream in the case of .mif.gz
 template <class StreamType> void write_mrtrix_header(const Header &, StreamType &);
 
-vector<ssize_t> parse_axes(size_t ndim, const std::string &specifier);
+std::vector<ssize_t> parse_axes(size_t ndim, const std::string &specifier);
 
 template <class SourceType> void read_mrtrix_header(Header &H, SourceType &kv) {
   std::string dtype, layout;
-  vector<uint64_t> dim;
-  vector<default_type> vox, scaling;
-  vector<vector<default_type>> transform;
+  std::vector<uint64_t> dim;
+  std::vector<default_type> vox, scaling;
+  std::vector<std::vector<default_type>> transform;
 
   std::string key, value;
   while (next_keyvalue(kv, key, value)) {

--- a/core/formats/par.cpp
+++ b/core/formats/par.cpp
@@ -125,7 +125,7 @@ std::unique_ptr<ImageIO::Base> PAR::read(Header &H) const {
 
   float version = NaN;
   ParCols cols;
-  vector<SliceData> slices;
+  std::vector<SliceData> slices;
 
   while (in.good()) {
     std::string line;
@@ -163,7 +163,7 @@ std::unique_ptr<ImageIO::Base> PAR::read(Header &H) const {
     }
   }
 
-  vector<std::array<float, 4>> G;
+  std::vector<std::array<float, 4>> G;
 
   int nslices = 0;
   int nvols = 0;

--- a/core/header.cpp
+++ b/core/header.cpp
@@ -461,7 +461,7 @@ Header Header::scratch(const Header &template_header, const std::string &label) 
   H.reset_intensity_scaling();
   H.sanitise();
   H.format_ = "scratch image";
-  H.io = make_unique<ImageIO::Scratch>(H);
+  H.io = std::make_unique<ImageIO::Scratch>(H);
   return H;
 }
 

--- a/core/header.cpp
+++ b/core/header.cpp
@@ -67,8 +67,8 @@ namespace {
 std::string resolve_slice_timing(const std::string &one, const std::string &two) {
   if (one == "variable" || two == "variable")
     return "variable";
-  vector<std::string> one_split = split(one, ",");
-  vector<std::string> two_split = split(two, ",");
+  std::vector<std::string> one_split = split(one, ",");
+  std::vector<std::string> two_split = split(two, ",");
   if (one_split.size() != two_split.size()) {
     DEBUG("Slice timing vectors of inequal length");
     return "invalid";
@@ -132,10 +132,10 @@ void Header::merge_keyval(const Header &H) {
 namespace {
 
 std::string short_description(const Header &H) {
-  vector<std::string> dims;
+  std::vector<std::string> dims;
   for (size_t n = 0; n < H.ndim(); ++n)
     dims.push_back(str(H.size(n)));
-  vector<std::string> vox;
+  std::vector<std::string> vox;
   for (size_t n = 0; n < H.ndim(); ++n)
     vox.push_back(str(H.spacing(n)));
 
@@ -177,7 +177,7 @@ Header Header::open(const std::string &image_name) {
 
       // Convenient to know a priori which loop index corresponds to which image axis
       // This needs to detect unity-sized axes and flag the loop to concatenate data along that axis
-      vector<size_t> loopindex2axis;
+      std::vector<size_t> loopindex2axis;
       size_t axis;
       for (axis = 0; axis != H.ndim(); ++axis) {
         if (H.size(axis) == 1) {
@@ -194,10 +194,10 @@ Header Header::open(const std::string &image_name) {
       // Note that the very first image header has already been opened before this function is
       //   invoked for the first time; "vector<Header>& this_data" is used to propagate this
       //   data to deeper layers when necessary
-      std::function<void(Header &, vector<Header> &, const size_t)> import =
-          [&](Header &result, vector<Header> &this_data, const size_t loop_index) -> void {
+      std::function<void(Header &, std::vector<Header> &, const size_t)> import =
+          [&](Header &result, std::vector<Header> &this_data, const size_t loop_index) -> void {
         if (loop_index == num.size() - 1) {
-          vector<std::unique_ptr<ImageIO::Base>> ios;
+          std::vector<std::unique_ptr<ImageIO::Base>> ios;
           if (this_data.size())
             ios.push_back(std::move(this_data[0].io));
           for (size_t i = this_data.size(); i != size_t(num[loop_index]); ++i) {
@@ -220,7 +220,7 @@ Header Header::open(const std::string &image_name) {
         } // End branch for when loop_index is the maximum, ie. innermost loop
         // For each coordinate along this axis, need to concatenate headers from the
         //   next lower axis
-        vector<Header> nested_data;
+        std::vector<Header> nested_data;
         // The nested concatenation may still include the very first header that has already been read;
         //   this needs to be propagated through to the nested call
         if (this_data.size()) {
@@ -240,7 +240,7 @@ Header Header::open(const std::string &image_name) {
           result.io->merge(*this_data[i].io);
       };
 
-      vector<Header> headers;
+      std::vector<Header> headers;
       headers.push_back(std::move(H));
       import(H, headers, 0);
       H.name() = image_name;
@@ -261,7 +261,7 @@ Header Header::open(const std::string &image_name) {
 }
 
 namespace {
-inline bool check_strides_match(const vector<ssize_t> &a, const vector<ssize_t> &b) {
+inline bool check_strides_match(const std::vector<ssize_t> &a, const std::vector<ssize_t> &b) {
   size_t n = 0;
   for (; n < std::min(a.size(), b.size()); ++n)
     if (a[n] != b[n])
@@ -301,15 +301,15 @@ Header Header::create(const std::string &image_name, const Header &template_head
 
     File::NameParser parser;
     parser.parse(image_name);
-    vector<uint32_t> Pdim(parser.ndim());
+    std::vector<uint32_t> Pdim(parser.ndim());
 
-    vector<int> Hdim(H.ndim());
+    std::vector<int> Hdim(H.ndim());
     for (size_t i = 0; i < H.ndim(); ++i)
       Hdim[i] = H.size(i);
 
     H.name() = image_name;
 
-    const vector<ssize_t> strides(Stride::get_symbolic(H));
+    const std::vector<ssize_t> strides(Stride::get_symbolic(H));
     const Formats::Base **format_handler = Formats::handlers;
     for (; *format_handler; format_handler++)
       if ((*format_handler)->check(H, H.ndim() - Pdim.size()))
@@ -325,7 +325,7 @@ Header Header::create(const std::string &image_name, const Header &template_head
                         "\" (unsupported file extension: " + basename.substr(extension_index) + ")");
     }
 
-    const vector<ssize_t> strides_aftercheck(Stride::get_symbolic(H));
+    const std::vector<ssize_t> strides_aftercheck(Stride::get_symbolic(H));
     if (!check_strides_match(strides, strides_aftercheck)) {
       INFO("output strides for image " + image_name + " modified to " + str(strides_aftercheck) +
            " - requested strides " + str(strides) + " are not supported in " + (*format_handler)->description +
@@ -371,7 +371,7 @@ Header Header::create(const std::string &image_name, const Header &template_head
     }
 
     Header header(H);
-    vector<uint32_t> num(Pdim.size());
+    std::vector<uint32_t> num(Pdim.size());
 
     if (!is_dash(image_name))
       H.name() = parser.name(num);
@@ -684,7 +684,8 @@ void Header::realign_transform() {
   }
 }
 
-Header concatenate(const vector<Header> &headers, const size_t axis_to_concat, const bool permit_datatype_mismatch) {
+Header
+concatenate(const std::vector<Header> &headers, const size_t axis_to_concat, const bool permit_datatype_mismatch) {
   Exception e("Unable to concatenate " + str(headers.size()) + " images along axis " + str(axis_to_concat) + ": ");
 
   auto datatype_test = [&](const bool condition) {

--- a/core/header.h
+++ b/core/header.h
@@ -216,7 +216,7 @@ public:
 
   class NDimProxy {
   public:
-    NDimProxy(vector<Axis> &axes) : axes(axes) {}
+    NDimProxy(std::vector<Axis> &axes) : axes(axes) {}
     NDimProxy(NDimProxy &&) = default;
     NDimProxy(const NDimProxy &) = delete;
     NDimProxy &operator=(NDimProxy &&) = delete;
@@ -233,7 +233,7 @@ public:
     }
 
   private:
-    vector<Axis> &axes;
+    std::vector<Axis> &axes;
   };
 
   //! return the number of dimensions (axes) of image
@@ -378,7 +378,7 @@ public:
   friend std::ostream &operator<<(std::ostream &stream, const Header &H);
 
 protected:
-  vector<Axis> axes_;
+  std::vector<Axis> axes_;
   transform_type transform_;
   std::string name_;
   KeyValues keyval_;
@@ -409,8 +409,8 @@ protected:
   }
 };
 
-// Can't be a static member function due to memory alignment requirements of vector<>
-Header concatenate(const vector<Header> &headers, const size_t axis, const bool permit_datatype_mismatch);
+// Can't be a static member function due to memory alignment requirements of std::vector<>
+Header concatenate(const std::vector<Header> &headers, const size_t axis, const bool permit_datatype_mismatch);
 
 inline const ssize_t &Header::size(size_t axis) const { return axes_[axis].size; }
 inline ssize_t &Header::size(size_t axis) { return axes_[axis].size; }

--- a/core/image.h
+++ b/core/image.h
@@ -207,7 +207,7 @@ protected:
   //! pointer to data address whether in RAM or MMap
   void *data_pointer;
   //! voxel indices
-  vector<ssize_t> x;
+  std::vector<ssize_t> x;
   //! voxel indices
   Stride::List strides;
   //! offset to currently pointed-to voxel
@@ -256,14 +256,14 @@ template <typename ValueType> struct TmpImage : public ImageBase<TmpImage<ValueT
 
   TmpImage(const typename Image<ValueType>::Buffer &b,
            void *const data,
-           vector<ssize_t> x,
+           std::vector<ssize_t> x,
            const Stride::List &strides,
            size_t offset)
       : b(b), data(data), x(x), strides(strides), offset(offset) {}
 
   const typename Image<ValueType>::Buffer &b;
   void *const data;
-  vector<ssize_t> x;
+  std::vector<ssize_t> x;
   const Stride::List &strides;
   size_t offset;
 
@@ -345,7 +345,7 @@ template <typename ValueType> Image<ValueType>::~Image() {
       if (buffer->get_io()->is_image_readwrite() && buffer->data_buffer) {
         auto data_buffer = std::move(buffer->data_buffer);
         TmpImage<ValueType> src = {
-            *buffer, data_buffer.get(), vector<ssize_t>(ndim(), 0), strides, Stride::offset(*this)};
+            *buffer, data_buffer.get(), std::vector<ssize_t>(ndim(), 0), strides, Stride::offset(*this)};
         Image<ValueType> dest(buffer);
         threaded_copy_with_progress_message("writing back direct IO buffer for \"" + name() + "\"", src, dest);
       }
@@ -385,7 +385,7 @@ template <typename ValueType> Image<ValueType> Image<ValueType>::with_direct_io(
     auto src(*this);
     TmpImage<ValueType> dest = {*buffer,
                                 buffer->data_buffer.get(),
-                                vector<ssize_t>(ndim(), 0),
+                                std::vector<ssize_t>(ndim(), 0),
                                 with_strides,
                                 Stride::offset(with_strides, *this)};
     threaded_copy_with_progress_message("preloading data for \"" + name() + "\"", src, dest);

--- a/core/image_helpers.h
+++ b/core/image_helpers.h
@@ -104,7 +104,7 @@ template <class ImageType, typename IntType> struct __assign_pos_axes {
       MR::apply(__assign<DestImageType...>(a, __get_index(ref, a)), std::tie(dest...));
   }
   const ImageType &ref;
-  const vector<IntType> axes;
+  const std::vector<IntType> axes;
 };
 } // namespace
 
@@ -174,7 +174,7 @@ assign_pos_of(const ImageType &reference, size_t from_axis = 0, size_t to_axis =
 //! returns a functor to set the position in ref to other voxels
 /*! this can be used as follows:
  * \code
- * vector<int> axes = { 0, 3, 4 };
+ * std::vector<int> axes = { 0, 3, 4 };
  * assign_pos (src_image, axes) (dest_image1, dest_image2);
  * \endcode
  *
@@ -183,13 +183,13 @@ assign_pos_of(const ImageType &reference, size_t from_axis = 0, size_t to_axis =
  * operator[](size_t) methods). */
 template <class ImageType, typename IntType>
 FORCE_INLINE __assign_pos_axes<ImageType, IntType> assign_pos_of(const ImageType &reference,
-                                                                 const vector<IntType> &axes) {
+                                                                 const std::vector<IntType> &axes) {
   return {reference, axes};
 }
 
 template <class ImageType, typename IntType>
 FORCE_INLINE __assign_pos_axes<ImageType, IntType> assign_pos_of(const ImageType &reference,
-                                                                 const vector<IntType> &&axes) {
+                                                                 const std::vector<IntType> &&axes) {
   return assign_pos_of(reference, axes);
 }
 
@@ -266,7 +266,7 @@ template <class HeaderType> inline size_t voxel_count(const HeaderType &in, cons
 }
 
 //! returns the number of voxel in the relevant subvolume of the data set
-template <class HeaderType> inline int64_t voxel_count(const HeaderType &in, const vector<size_t> &axes) {
+template <class HeaderType> inline int64_t voxel_count(const HeaderType &in, const std::vector<size_t> &axes) {
   int64_t fp = 1;
   for (size_t n = 0; n < axes.size(); ++n) {
     assert(axes[n] < in.ndim());
@@ -320,8 +320,10 @@ inline bool spacings_match(
 }
 
 template <class HeaderType1, class HeaderType2>
-inline bool
-spacings_match(const HeaderType1 &in1, const HeaderType2 &in2, const vector<size_t> &axes, const double tol = 0.0) {
+inline bool spacings_match(const HeaderType1 &in1,
+                           const HeaderType2 &in2,
+                           const std::vector<size_t> &axes,
+                           const double tol = 0.0) {
   for (size_t n = 0; n < axes.size(); ++n) {
     if (in1.ndim() <= axes[n] || in2.ndim() <= axes[n])
       return false;
@@ -353,7 +355,7 @@ inline bool dimensions_match(const HeaderType1 &in1, const HeaderType2 &in2, siz
 }
 
 template <class HeaderType1, class HeaderType2>
-inline bool dimensions_match(const HeaderType1 &in1, const HeaderType2 &in2, const vector<size_t> &axes) {
+inline bool dimensions_match(const HeaderType1 &in1, const HeaderType2 &in2, const std::vector<size_t> &axes) {
   for (size_t n = 0; n < axes.size(); ++n) {
     if (in1.ndim() <= axes[n] || in2.ndim() <= axes[n])
       return false;
@@ -387,7 +389,7 @@ inline void check_dimensions(const HeaderType1 &in1, const HeaderType2 &in2, siz
 }
 
 template <class HeaderType1, class HeaderType2>
-inline void check_dimensions(const HeaderType1 &in1, const HeaderType2 &in2, const vector<size_t> &axes) {
+inline void check_dimensions(const HeaderType1 &in1, const HeaderType2 &in2, const std::vector<size_t> &axes) {
   if (!dimensions_match(in1, in2, axes))
     throw Exception("dimension mismatch between \"" + in1.name() + "\" and \"" + in2.name() + "\" for axes [" +
                     join(axes, ",") + "]" + " (" + dim2str(in1) + " vs. " + dim2str(in2) + ")");

--- a/core/image_io/base.h
+++ b/core/image_io/base.h
@@ -76,7 +76,7 @@ public:
     return segsize;
   }
 
-  vector<File::Entry> files;
+  std::vector<File::Entry> files;
 
   void merge(const Base &B) {
     assert(addresses.empty());
@@ -93,7 +93,7 @@ public:
 
 protected:
   size_t segsize;
-  vector<std::unique_ptr<uint8_t[]>> addresses;
+  std::vector<std::unique_ptr<uint8_t[]>> addresses;
   bool is_new, writable;
 
   void check() const { assert(addresses.size()); }

--- a/core/image_io/default.h
+++ b/core/image_io/default.h
@@ -31,7 +31,7 @@ public:
   Default &operator=(Default &&) = delete;
 
 protected:
-  vector<std::shared_ptr<File::MMap>> mmaps;
+  std::vector<std::shared_ptr<File::MMap>> mmaps;
   int64_t bytes_per_segment;
 
   virtual void load(const Header &, size_t);

--- a/core/image_io/variable_scaling.h
+++ b/core/image_io/variable_scaling.h
@@ -36,7 +36,7 @@ public:
     default_type offset, scale;
   };
 
-  vector<ScaleFactor> scale_factors;
+  std::vector<ScaleFactor> scale_factors;
 
 protected:
   virtual void load(const Header &, size_t);

--- a/core/interp/sinc.h
+++ b/core/interp/sinc.h
@@ -149,7 +149,7 @@ protected:
   const size_t window_size;
   const int kernel_width;
   Math::Sinc<value_type> Sinc_x, Sinc_y, Sinc_z;
-  vector<value_type> y_values, z_values;
+  std::vector<value_type> y_values, z_values;
 };
 
 template <class ImageType, typename... Args> inline Sinc<ImageType> make_sinc(const ImageType &parent, Args &&...args) {

--- a/core/math/SH.h
+++ b/core/math/SH.h
@@ -323,7 +323,7 @@ template <typename ValueType> class PrecomputedFraction {
 public:
   PrecomputedFraction() : f1(0.0), f2(0.0) {}
   ValueType f1, f2;
-  typename vector<ValueType>::const_iterator p1, p2;
+  typename std::vector<ValueType>::const_iterator p1, p2;
 };
 
 //! Precomputed Associated Legrendre Polynomials - used to speed up SH calculation
@@ -346,7 +346,7 @@ public:
     Eigen::Matrix<value_type, Eigen::Dynamic, 1, 0, 64> buf(lmax + 1);
 
     for (int n = 0; n < ndir; n++) {
-      typename vector<value_type>::iterator p = AL.begin() + n * nAL;
+      typename std::vector<value_type>::iterator p = AL.begin() + n * nAL;
       value_type cos_el = std::cos(n * inc);
       for (int m = 0; m <= lmax; m++) {
         Legendre::Plm_sph(buf, lmax, m, cos_el);
@@ -418,7 +418,7 @@ public:
 protected:
   int lmax, ndir, nAL;
   ValueType inc;
-  vector<ValueType> AL;
+  std::vector<ValueType> AL;
 };
 
 //! estimate direction & amplitude of SH peak

--- a/core/math/Sn_scale_estimator.h
+++ b/core/math/Sn_scale_estimator.h
@@ -41,7 +41,7 @@ public:
   }
 
 protected:
-  vector<value_type> diff, med_diff;
+  std::vector<value_type> diff, med_diff;
 };
 
 } // namespace Math

--- a/core/math/average_space.cpp
+++ b/core/math/average_space.cpp
@@ -18,7 +18,7 @@
 
 namespace MR {
 namespace Math {
-double matrix_average(vector<Eigen::MatrixXd> const &mat_in, Eigen::MatrixXd &mat_avg, bool verbose) {
+double matrix_average(std::vector<Eigen::MatrixXd> const &mat_in, Eigen::MatrixXd &mat_avg, bool verbose) {
   const size_t rows = mat_in[0].rows();
   const size_t cols = mat_in[0].cols();
   const size_t N = mat_in.size();
@@ -160,13 +160,13 @@ void compute_average_voxel2scanner(
     Eigen::Transform<default_type, 3, Eigen::Projective> &average_v2s_trafo,
     Eigen::Vector3d &average_space_extent,
     Eigen::Vector3d &projected_voxel_sizes,
-    const vector<Header> &input_headers,
+    const std::vector<Header> &input_headers,
     const Eigen::Matrix<default_type, 4, 1> &padding,
-    const vector<Eigen::Transform<default_type, 3, Eigen::Projective>> &transform_header_with,
+    const std::vector<Eigen::Transform<default_type, 3, Eigen::Projective>> &transform_header_with,
     int voxel_subsampling) {
   const size_t num_images = input_headers.size();
   DEBUG("compute_average_voxel2scanner num_images:" + str(num_images));
-  vector<Eigen::Transform<default_type, 3, Eigen::Projective>> transformation_matrices;
+  std::vector<Eigen::Transform<default_type, 3, Eigen::Projective>> transformation_matrices;
   Eigen::MatrixXd bounding_box_corners = Eigen::MatrixXd::Zero(8 * num_images, 4);
 
   for (size_t iFile = 0; iFile < num_images; iFile++) {
@@ -263,8 +263,8 @@ void compute_average_voxel2scanner(
 }
 
 Header compute_minimum_average_header(
-    const vector<Header> &input_headers,
-    const vector<Eigen::Transform<default_type, 3, Eigen::Projective>> &transform_header_with,
+    const std::vector<Header> &input_headers,
+    const std::vector<Eigen::Transform<default_type, 3, Eigen::Projective>> &transform_header_with,
     int voxel_subsampling,
     Eigen::Matrix<default_type, 4, 1> padding) {
   Eigen::Transform<default_type, 3, Eigen::Projective> average_v2s_trafo;

--- a/core/math/average_space.h
+++ b/core/math/average_space.h
@@ -26,7 +26,7 @@
 
 namespace MR {
 namespace Math {
-double matrix_average(vector<Eigen::MatrixXd> const &mat_in, Eigen::MatrixXd &mat_avg, bool verbose = false);
+double matrix_average(std::vector<Eigen::MatrixXd> const &mat_in, Eigen::MatrixXd &mat_avg, bool verbose = false);
 }
 } // namespace MR
 
@@ -37,8 +37,8 @@ Eigen::Matrix<default_type, 8, 4>
 get_bounding_box(const Header &header, const Eigen::Transform<default_type, 3, Eigen::Projective> &voxel2scanner);
 
 Header compute_minimum_average_header(
-    const vector<Header> &input_headers,
-    const vector<Eigen::Transform<default_type, 3, Eigen::Projective>> &transform_header_with,
+    const std::vector<Header> &input_headers,
+    const std::vector<Eigen::Transform<default_type, 3, Eigen::Projective>> &transform_header_with,
     int voxel_subsampling = 1,
     Eigen::Matrix<default_type, 4, 1> padding = Eigen::Matrix<default_type, 4, 1>(1.0, 1.0, 1.0, 1.0));
 
@@ -52,8 +52,8 @@ Header compute_minimum_average_header(
         Eigen::Transform<default_type, 3, Eigen::Projective>::Identity(),
     Eigen::Matrix<default_type, 4, 1> padding = Eigen::Matrix<default_type, 4, 1>(1.0, 1.0, 1.0, 1.0),
     int voxel_subsampling = 1) {
-  vector<Eigen::Transform<default_type, 3, Eigen::Projective>> init_transforms{transform_1, transform_2};
-  vector<Header> headers{im1, im2};
+  std::vector<Eigen::Transform<default_type, 3, Eigen::Projective>> init_transforms{transform_1, transform_2};
+  std::vector<Header> headers{im1, im2};
   return compute_minimum_average_header(headers, init_transforms, voxel_subsampling, padding);
 }
 } // namespace MR

--- a/core/math/constrained_least_squares.h
+++ b/core/math/constrained_least_squares.h
@@ -345,7 +345,7 @@ protected:
   const Problem<value_type> &P;
   matrix_type BtB, B;
   vector_type y_u, c, c_u, lambda, lambda_prev, l;
-  vector<bool> active;
+  std::vector<bool> active;
 };
 
 } // namespace ICLS

--- a/core/math/erfinv.cpp
+++ b/core/math/erfinv.cpp
@@ -131,8 +131,8 @@ default_type erfcinv(const default_type q) {
 
   private:
     const size_t N;
-    vector<default_type> m_Y;
-    vector<Eigen::Array<default_type, Eigen::Dynamic, 1>> m_P, m_Q;
+    std::vector<default_type> m_Y;
+    std::vector<Eigen::Array<default_type, Eigen::Dynamic, 1>> m_P, m_Q;
   };
   static const Shared shared;
 

--- a/core/math/gaussian.h
+++ b/core/math/gaussian.h
@@ -66,7 +66,8 @@ inline T lnP(const int N, const T *measured, const T *actual, const T one_over_n
   return (0.5 * lnP);
 }
 
-template <typename T> inline T lnP(const Vector<T> &measured, const Vector<T> &actual, const T one_over_noise_squared) {
+template <typename T>
+inline T lnP(const std::vector<T> &measured, const std::vector<T> &actual, const T one_over_noise_squared) {
   assert(one_over_noise_squared > 0.0);
   assert(measured.size() == actual.size());
 
@@ -79,10 +80,10 @@ template <typename T> inline T lnP(const Vector<T> &measured, const Vector<T> &a
 }
 
 template <typename T>
-inline T lnP(const Vector<T> &measured,
-             const Vector<T> &actual,
+inline T lnP(const std::vector<T> &measured,
+             const std::vector<T> &actual,
              const T one_over_noise_squared,
-             Vector<T> &dP_dactual,
+             std::vector<T> &dP_dactual,
              T &dP_dN) {
   assert(one_over_noise_squared > 0.0);
   assert(measured.size() == actual.size());

--- a/core/math/median.h
+++ b/core/math/median.h
@@ -84,7 +84,7 @@ bool median_weiszfeld(const MatrixType &X,
   }
 
   bool convergence = false;
-  vector<default_type> dist(numIter);
+  std::vector<default_type> dist(numIter);
 
   // Minimizing the sum of the squares of the distances between each point in 'X' and the median.
   size_t i = 0;

--- a/core/math/rician.h
+++ b/core/math/rician.h
@@ -96,8 +96,10 @@ inline T lnP(const int N, const T *measured, const T *actual, const T one_over_n
 }
 
 template <typename T>
-inline T
-lnP(const Vector<T> &measured, const Vector<T> &actual, const T one_over_noise_squared, Vector<T> &dP_dactual) {
+inline T lnP(const std::vector<T> &measured,
+             const std::vector<T> &actual,
+             const T one_over_noise_squared,
+             std::vector<T> &dP_dactual) {
   assert(one_over_noise_squared > 0.0);
   assert(measured.size() == actual.size());
   assert(measured.size() == dP_dactual.size());
@@ -125,10 +127,10 @@ lnP(const Vector<T> &measured, const Vector<T> &actual, const T one_over_noise_s
 }
 
 template <typename T>
-inline T lnP(const Vector<T> &measured,
-             const Vector<T> &actual,
+inline T lnP(const std::vector<T> &measured,
+             const std::vector<T> &actual,
              const T one_over_noise_squared,
-             Vector<T> &dP_dactual,
+             std::vector<T> &dP_dactual,
              T &dP_dN) {
   assert(one_over_noise_squared > 0.0);
   assert(measured.size() == actual.size());

--- a/core/math/sinc.h
+++ b/core/math/sinc.h
@@ -111,8 +111,8 @@ public:
 
 private:
   const size_t window_size, max_offset_from_kernel_centre;
-  vector<size_t> indices;
-  vector<value_type> weights;
+  std::vector<size_t> indices;
+  std::vector<value_type> weights;
   value_type current_pos;
 };
 

--- a/core/math/stats/fwe.cpp
+++ b/core/math/stats/fwe.cpp
@@ -29,7 +29,7 @@ matrix_type fwe_pvalue(const matrix_type &null_distributions, const matrix_type 
   assert(null_distributions.cols() == 1 || null_distributions.cols() == statistics.cols());
   matrix_type pvalues(statistics.rows(), statistics.cols());
 
-  auto s2p = [](const vector<value_type> &null_dist, const matrix_type::ConstColXpr in, matrix_type::ColXpr out) {
+  auto s2p = [](const std::vector<value_type> &null_dist, const matrix_type::ConstColXpr in, matrix_type::ColXpr out) {
     for (index_type element = 0; element != index_type(in.size()); ++element) {
       if (in[element] > 0.0) {
         value_type pvalue = 1.0;
@@ -48,7 +48,7 @@ matrix_type fwe_pvalue(const matrix_type &null_distributions, const matrix_type 
 
   if (null_distributions.cols() == 1) { // strong fwe control
 
-    vector<value_type> sorted_null_dist;
+    std::vector<value_type> sorted_null_dist;
     sorted_null_dist.reserve(null_distributions.rows());
     for (index_type shuffle = 0; shuffle != null_distributions.rows(); ++shuffle)
       sorted_null_dist.push_back(null_distributions(shuffle, 0));
@@ -59,7 +59,7 @@ matrix_type fwe_pvalue(const matrix_type &null_distributions, const matrix_type 
   } else { // weak fwe control
 
     for (index_type hypothesis = 0; hypothesis != statistics.cols(); ++hypothesis) {
-      vector<value_type> sorted_null_dist;
+      std::vector<value_type> sorted_null_dist;
       sorted_null_dist.reserve(null_distributions.rows());
       for (index_type shuffle = 0; shuffle != null_distributions.rows(); ++shuffle)
         sorted_null_dist.push_back(null_distributions(shuffle, hypothesis));

--- a/core/math/stats/glm.cpp
+++ b/core/math/stats/glm.cpp
@@ -117,7 +117,7 @@ index_array_type load_variance_groups(const index_type num_inputs) {
       WARN("Only a single variance group is defined in file \"" + opt[0][0] + "\"; variance groups will not be used");
       return index_array_type();
     }
-    vector<index_type> count_per_group(max_coeff + 1, 0);
+    std::vector<index_type> count_per_group(max_coeff + 1, 0);
     for (index_type i = 0; i != index_type(data.size()); ++i)
       count_per_group[data[i]]++;
     for (index_type vg_index = min_coeff; vg_index <= max_coeff; ++vg_index) {
@@ -132,8 +132,8 @@ index_array_type load_variance_groups(const index_type num_inputs) {
   }
 }
 
-vector<Hypothesis> load_hypotheses(const std::string &file_path) {
-  vector<Hypothesis> hypotheses;
+std::vector<Hypothesis> load_hypotheses(const std::string &file_path) {
+  std::vector<Hypothesis> hypotheses;
   const matrix_type contrast_matrix = File::Matrix::load_matrix(file_path);
   for (index_type row = 0; row != index_type(contrast_matrix.rows()); ++row)
     hypotheses.emplace_back(Hypothesis(contrast_matrix.row(row), row));
@@ -157,7 +157,7 @@ vector<Hypothesis> load_hypotheses(const std::string &file_path) {
       hypotheses.emplace_back(Hypothesis(this_f_matrix, ftest_index));
     }
     if (App::get_options("fonly").size()) {
-      vector<Hypothesis> new_hypotheses;
+      std::vector<Hypothesis> new_hypotheses;
       for (index_type index = contrast_matrix.rows(); index != hypotheses.size(); ++index)
         new_hypotheses.push_back(std::move(hypotheses[index]));
       std::swap(hypotheses, new_hypotheses);
@@ -181,7 +181,7 @@ vector_type abs_effect_size(const matrix_type &measurements, const matrix_type &
 }
 
 matrix_type
-abs_effect_size(const matrix_type &measurements, const matrix_type &design, const vector<Hypothesis> &hypotheses) {
+abs_effect_size(const matrix_type &measurements, const matrix_type &design, const std::vector<Hypothesis> &hypotheses) {
   matrix_type result(measurements.cols(), hypotheses.size());
   for (index_type ic = 0; ic != hypotheses.size(); ++ic)
     result.col(ic) = abs_effect_size(measurements, design, hypotheses[ic]);
@@ -230,7 +230,7 @@ vector_type std_effect_size(const matrix_type &measurements, const matrix_type &
 }
 
 matrix_type
-std_effect_size(const matrix_type &measurements, const matrix_type &design, const vector<Hypothesis> &hypotheses) {
+std_effect_size(const matrix_type &measurements, const matrix_type &design, const std::vector<Hypothesis> &hypotheses) {
   const vector_type stdev_reciprocal =
       vector_type::Ones(measurements.cols()) / stdev(measurements, design).array().col(0);
   matrix_type result(measurements.cols(), hypotheses.size());
@@ -241,7 +241,7 @@ std_effect_size(const matrix_type &measurements, const matrix_type &design, cons
 
 void all_stats(const matrix_type &measurements,
                const matrix_type &design,
-               const vector<Hypothesis> &hypotheses,
+               const std::vector<Hypothesis> &hypotheses,
                const index_array_type &variance_groups,
                matrix_type &betas,
                matrix_type &abs_effect_size,
@@ -306,8 +306,8 @@ void all_stats(const matrix_type &measurements,
 
 void all_stats(const matrix_type &measurements,
                const matrix_type &fixed_design,
-               const vector<CohortDataImport> &extra_data,
-               const vector<Hypothesis> &hypotheses,
+               const std::vector<CohortDataImport> &extra_data,
+               const std::vector<Hypothesis> &hypotheses,
                const index_array_type &variance_groups,
                vector_type &cond,
                matrix_type &betas,
@@ -346,8 +346,8 @@ void all_stats(const matrix_type &measurements,
   public:
     Functor(const matrix_type &data,
             const matrix_type &design_fixed,
-            const vector<CohortDataImport> &extra_data,
-            const vector<Hypothesis> &hypotheses,
+            const std::vector<CohortDataImport> &extra_data,
+            const std::vector<Hypothesis> &hypotheses,
             const index_array_type &variance_groups,
             vector_type &cond,
             matrix_type &betas,
@@ -442,8 +442,8 @@ void all_stats(const matrix_type &measurements,
   private:
     const matrix_type &data;
     const matrix_type &design_fixed;
-    const vector<CohortDataImport> &extra_data;
-    const vector<Hypothesis> &hypotheses;
+    const std::vector<CohortDataImport> &extra_data;
+    const std::vector<Hypothesis> &hypotheses;
     const index_array_type &variance_groups;
     vector_type &global_cond;
     matrix_type &global_betas;
@@ -526,7 +526,7 @@ void TestBase::operator()(const matrix_type &shuffling_matrix, matrix_type &outp
 
 TestFixedHomoscedastic::TestFixedHomoscedastic(const matrix_type &measurements,
                                                const matrix_type &design,
-                                               const vector<Hypothesis> &hypotheses)
+                                               const std::vector<Hypothesis> &hypotheses)
     : TestBase(measurements, design, hypotheses),
       pinvM(Math::pinv(M)),
       Rm(matrix_type::Identity(num_inputs(), num_inputs()) - (M * pinvM)) {
@@ -619,7 +619,7 @@ void TestFixedHomoscedastic::operator()(const matrix_type &shuffling_matrix,
 
 TestFixedHeteroscedastic::TestFixedHeteroscedastic(const matrix_type &measurements,
                                                    const matrix_type &design,
-                                                   const vector<Hypothesis> &hypotheses,
+                                                   const std::vector<Hypothesis> &hypotheses,
                                                    const index_array_type &variance_groups)
     : TestFixedHomoscedastic(measurements, design, hypotheses),
       VG(variance_groups),
@@ -767,10 +767,10 @@ void TestFixedHeteroscedastic::operator()(const matrix_type &shuffling_matrix,
   }
 }
 
-TestVariableHomoscedastic::TestVariableHomoscedastic(const vector<CohortDataImport> &importers,
+TestVariableHomoscedastic::TestVariableHomoscedastic(const std::vector<CohortDataImport> &importers,
                                                      const matrix_type &measurements,
                                                      const matrix_type &design,
-                                                     const vector<Hypothesis> &hypotheses,
+                                                     const std::vector<Hypothesis> &hypotheses,
                                                      const bool nans_in_data,
                                                      const bool nans_in_columns)
     : TestBase(measurements, design, hypotheses),
@@ -989,10 +989,10 @@ void TestVariableHomoscedastic::apply_mask(const BitSet &mask,
   }
 }
 
-TestVariableHeteroscedastic::TestVariableHeteroscedastic(const vector<CohortDataImport> &importers,
+TestVariableHeteroscedastic::TestVariableHeteroscedastic(const std::vector<CohortDataImport> &importers,
                                                          const matrix_type &measurements,
                                                          const matrix_type &design,
-                                                         const vector<Hypothesis> &hypotheses,
+                                                         const std::vector<Hypothesis> &hypotheses,
                                                          const index_array_type &variance_groups,
                                                          const bool nans_in_data,
                                                          const bool nans_in_columns)

--- a/core/math/stats/glm.h
+++ b/core/math/stats/glm.h
@@ -99,7 +99,7 @@ void check_design(const matrix_type &, const bool);
 
 index_array_type load_variance_groups(const index_type num_inputs);
 
-vector<Hypothesis> load_hypotheses(const std::string &file_path);
+std::vector<Hypothesis> load_hypotheses(const std::string &file_path);
 
 /** \addtogroup Statistics
   @{ */
@@ -118,7 +118,7 @@ matrix_type solve_betas(const matrix_type &measurements, const matrix_type &desi
  */
 vector_type abs_effect_size(const matrix_type &measurements, const matrix_type &design, const Hypothesis &hypothesis);
 matrix_type
-abs_effect_size(const matrix_type &measurements, const matrix_type &design, const vector<Hypothesis> &hypotheses);
+abs_effect_size(const matrix_type &measurements, const matrix_type &design, const std::vector<Hypothesis> &hypotheses);
 
 /*! Compute the pooled standard deviation
  * @param measurements a matrix storing the measured data across subjects in each column
@@ -142,7 +142,7 @@ matrix_type stdev(const matrix_type &measurements, const matrix_type &design, co
  */
 vector_type std_effect_size(const matrix_type &measurements, const matrix_type &design, const Hypothesis &hypothesis);
 matrix_type
-std_effect_size(const matrix_type &measurements, const matrix_type &design, const vector<Hypothesis> &hypotheses);
+std_effect_size(const matrix_type &measurements, const matrix_type &design, const std::vector<Hypothesis> &hypotheses);
 
 /*! Compute all GLM-related statistics
  * This function can be used when the design matrix remains fixed for all
@@ -157,7 +157,7 @@ std_effect_size(const matrix_type &measurements, const matrix_type &design, cons
  */
 void all_stats(const matrix_type &measurements,
                const matrix_type &design,
-               const vector<Hypothesis> &hypotheses,
+               const std::vector<Hypothesis> &hypotheses,
                const index_array_type &variance_groups,
                matrix_type &betas,
                matrix_type &abs_effect_size,
@@ -178,8 +178,8 @@ void all_stats(const matrix_type &measurements,
  */
 void all_stats(const matrix_type &measurements,
                const matrix_type &design,
-               const vector<CohortDataImport> &extra_columns,
-               const vector<Hypothesis> &hypotheses,
+               const std::vector<CohortDataImport> &extra_columns,
+               const std::vector<Hypothesis> &hypotheses,
                const index_array_type &variance_groups,
                vector_type &cond,
                matrix_type &betas,
@@ -192,7 +192,7 @@ void all_stats(const matrix_type &measurements,
 // Define a base class for GLM tests
 class TestBase {
 public:
-  TestBase(const matrix_type &measurements, const matrix_type &design, const vector<Hypothesis> &hypotheses)
+  TestBase(const matrix_type &measurements, const matrix_type &design, const std::vector<Hypothesis> &hypotheses)
       : y(measurements), M(design), c(hypotheses), stat2z(new Math::Zstatistic()) {
     assert(y.rows() == M.rows());
     // Can no longer apply this assertion here; GLMTTestVariable later
@@ -226,7 +226,7 @@ public:
 
 protected:
   const matrix_type &y, M;
-  const vector<Hypothesis> &c;
+  const std::vector<Hypothesis> &c;
   std::shared_ptr<Math::Zstatistic> stat2z;
 };
 
@@ -250,7 +250,7 @@ public:
    */
   TestFixedHomoscedastic(const matrix_type &measurements,
                          const matrix_type &design,
-                         const vector<Hypothesis> &hypotheses);
+                         const std::vector<Hypothesis> &hypotheses);
 
   /*! Compute the statistics
    * @param shuffling_matrix a matrix to permute / sign flip the residuals (for permutation testing)
@@ -261,11 +261,11 @@ public:
 
 protected:
   // New classes to store information relevant to Freedman-Lane implementation
-  vector<Hypothesis::Partition> partitions;
+  std::vector<Hypothesis::Partition> partitions;
   const matrix_type pinvM;
   const matrix_type Rm;
-  vector<matrix_type> XtX;
-  vector<default_type> one_over_dof;
+  std::vector<matrix_type> XtX;
+  std::vector<default_type> one_over_dof;
 };
 //! @}
 
@@ -291,7 +291,7 @@ public:
    */
   TestFixedHeteroscedastic(const matrix_type &measurements,
                            const matrix_type &design,
-                           const vector<Hypothesis> &hypotheses,
+                           const std::vector<Hypothesis> &hypotheses,
                            const index_array_type &variance_groups);
 
   index_type num_variance_groups() const { return num_vgs; }
@@ -309,7 +309,7 @@ protected:
   // Total number of variance groups
   const index_type num_vgs;
   // Number of inputs that are part of each variance group
-  vector<index_type> inputs_per_vg;
+  std::vector<index_type> inputs_per_vg;
   // Might as well construct this in the functor rather than here,
   //   given 1 value for each VG is computed
   vector_type Rnn_sums;
@@ -337,10 +337,10 @@ protected:
  */
 class TestVariableHomoscedastic : public TestBase {
 public:
-  TestVariableHomoscedastic(const vector<CohortDataImport> &importers,
+  TestVariableHomoscedastic(const std::vector<CohortDataImport> &importers,
                             const matrix_type &measurements,
                             const matrix_type &design,
-                            const vector<Hypothesis> &hypotheses,
+                            const std::vector<Hypothesis> &hypotheses,
                             const bool nans_in_data,
                             const bool nans_in_columns);
 
@@ -357,7 +357,7 @@ public:
   index_type num_factors() const override { return M.cols() + importers.size(); }
 
 protected:
-  const vector<CohortDataImport> &importers;
+  const std::vector<CohortDataImport> &importers;
   const bool nans_in_data, nans_in_columns;
 
   void get_mask(const index_type ie, BitSet &, const matrix_type &extra_columns) const;
@@ -387,10 +387,10 @@ protected:
  */
 class TestVariableHeteroscedastic : public TestVariableHomoscedastic {
 public:
-  TestVariableHeteroscedastic(const vector<CohortDataImport> &importers,
+  TestVariableHeteroscedastic(const std::vector<CohortDataImport> &importers,
                               const matrix_type &measurements,
                               const matrix_type &design,
-                              const vector<Hypothesis> &hypotheses,
+                              const std::vector<Hypothesis> &hypotheses,
                               const index_array_type &variance_groups,
                               const bool nans_in_data,
                               const bool nans_in_columns);

--- a/core/math/stats/import.h
+++ b/core/math/stats/import.h
@@ -99,7 +99,7 @@ public:
   bool allFinite() const;
 
 protected:
-  vector<std::shared_ptr<SubjectDataImportBase>> files;
+  std::vector<std::shared_ptr<SubjectDataImportBase>> files;
 };
 
 template <class SubjectDataImport>
@@ -116,7 +116,7 @@ void CohortDataImport::initialise(const std::string &listpath, const std::string
   //   current working directory
   // Only once a directory is selected that contains all inputs listed in the
   //   text file is an attempt made to load all of those files
-  vector<std::string> lines;
+  std::vector<std::string> lines;
   {
     std::ifstream ifs(listpath.c_str());
     if (!ifs)
@@ -131,7 +131,7 @@ void CohortDataImport::initialise(const std::string &listpath, const std::string
     }
   }
 
-  vector<std::string> directories{Path::dirname(listpath)};
+  std::vector<std::string> directories{Path::dirname(listpath)};
   if (directories[0].empty())
     directories[0] = ".";
   else if (directories[0] != ".")

--- a/core/math/stats/shuffle.cpp
+++ b/core/math/stats/shuffle.cpp
@@ -245,7 +245,7 @@ void Shuffler::initialise(const error_t error_types,
 
   uint64_t max_num_permutations;
   if (eb_within.size()) {
-    vector<index_type> counts(eb_within.maxCoeff() + 1, 0);
+    std::vector<index_type> counts(eb_within.maxCoeff() + 1, 0);
     for (index_type i = 0; i != eb_within.size(); ++i)
       counts[eb_within[i]]++;
     max_num_permutations = 1;
@@ -323,7 +323,7 @@ void Shuffler::initialise(const error_t error_types,
       if (nshuffles == max_shuffles) {
         generate_all_permutations(rows, eb_within, eb_whole);
         assert(permutations.size() == max_num_permutations);
-        vector<PermuteLabels> duplicated_permutations;
+        std::vector<PermuteLabels> duplicated_permutations;
         duplicated_permutations.reserve(max_shuffles);
         for (const auto &p : permutations) {
           for (index_type i = 0; i != max_num_signflips; ++i)
@@ -354,7 +354,7 @@ void Shuffler::initialise(const error_t error_types,
       if (nshuffles == max_shuffles) {
         generate_all_signflips(rows, eb_whole);
         assert(signflips.size() == max_num_signflips);
-        vector<BitSet> duplicated_signflips;
+        std::vector<BitSet> duplicated_signflips;
         duplicated_signflips.reserve(max_shuffles);
         for (index_type i = 0; i != max_num_permutations; ++i)
           duplicated_signflips.insert(duplicated_signflips.end(), signflips.begin(), signflips.end());
@@ -391,7 +391,7 @@ index_array_type Shuffler::load_blocks(const std::string &filename, const bool e
     data.array() -= 1;
     max_coeff--;
   }
-  vector<index_type> counts(max_coeff + 1, 0);
+  std::vector<index_type> counts(max_coeff + 1, 0);
   for (index_type i = 0; i != index_type(data.size()); ++i)
     counts[data[i]]++;
   for (index_type i = 0; i <= max_coeff; ++i) {
@@ -457,7 +457,7 @@ void Shuffler::generate_random_permutations(const index_type num_perms,
     return;
   }
 
-  vector<vector<index_type>> blocks;
+  std::vector<std::vector<index_type>> blocks;
 
   // Within-block exchangeability
   if (eb_within.size()) {
@@ -468,7 +468,7 @@ void Shuffler::generate_random_permutations(const index_type num_perms,
         permuted_labelling = default_labelling;
         // Random permutation within each block independently
         for (index_type ib = 0; ib != blocks.size(); ++ib) {
-          vector<index_type> permuted_block(blocks[ib]);
+          std::vector<index_type> permuted_block(blocks[ib]);
           std::shuffle(permuted_block.begin(), permuted_block.end(), rng);
           for (index_type i = 0; i != permuted_block.size(); ++i)
             permuted_labelling[blocks[ib][i]] = permuted_block[i];
@@ -520,14 +520,14 @@ void Shuffler::generate_all_permutations(const index_type num_rows,
     return;
   }
 
-  vector<vector<index_type>> original;
+  std::vector<std::vector<index_type>> original;
 
   // Within-block exchangeability
   if (eb_within.size()) {
 
     original = indices2blocks(eb_within);
 
-    auto write = [&](const vector<vector<index_type>> &data) {
+    auto write = [&](const std::vector<std::vector<index_type>> &data) {
       PermuteLabels temp(num_rows);
       for (index_type block = 0; block != data.size(); ++block) {
         for (index_type i = 0; i != data[block].size(); ++i)
@@ -536,7 +536,7 @@ void Shuffler::generate_all_permutations(const index_type num_rows,
       permutations.push_back(std::move(temp));
     };
 
-    vector<vector<index_type>> blocks(original);
+    std::vector<std::vector<index_type>> blocks(original);
     write(blocks);
     do {
       index_type ib = 0;
@@ -577,7 +577,7 @@ void Shuffler::generate_all_permutations(const index_type num_rows,
 }
 
 void Shuffler::load_permutations(const std::string &filename) {
-  vector<vector<index_type>> temp = File::Matrix::load_matrix_2D_vector<index_type>(filename);
+  std::vector<std::vector<index_type>> temp = File::Matrix::load_matrix_2D_vector<index_type>(filename);
   if (!temp.size())
     throw Exception("no data found in permutations file: " + str(filename));
 
@@ -695,9 +695,9 @@ void Shuffler::generate_all_signflips(const index_type num_rows, const index_arr
   }
 }
 
-vector<vector<index_type>> Shuffler::indices2blocks(const index_array_type &indices) const {
+std::vector<std::vector<index_type>> Shuffler::indices2blocks(const index_array_type &indices) const {
   const index_type num_blocks = indices.maxCoeff() + 1;
-  vector<vector<index_type>> result;
+  std::vector<std::vector<index_type>> result;
   result.resize(num_blocks);
   for (index_type i = 0; i != indices.size(); ++i)
     result[indices[i]].push_back(i);

--- a/core/math/stats/shuffle.h
+++ b/core/math/stats/shuffle.h
@@ -49,7 +49,7 @@ public:
 
 class Shuffler {
 public:
-  typedef vector<index_type> PermuteLabels;
+  typedef std::vector<index_type> PermuteLabels;
   enum class error_t { EE, ISE, BOTH };
 
   // First version reads command-line options in order to determine parameters prior to running initialise();
@@ -81,8 +81,8 @@ public:
 
 private:
   const index_type rows;
-  vector<PermuteLabels> permutations;
-  vector<BitSet> signflips;
+  std::vector<PermuteLabels> permutations;
+  std::vector<BitSet> signflips;
   index_type nshuffles, counter;
   std::unique_ptr<ProgressBar> progress;
 
@@ -126,7 +126,7 @@ private:
 
   void generate_all_signflips(const index_type num_rows, const index_array_type &blocks);
 
-  vector<vector<index_type>> indices2blocks(const index_array_type &) const;
+  std::vector<std::vector<index_type>> indices2blocks(const index_array_type &) const;
 };
 
 } // namespace Stats

--- a/core/misc/voxel2vector.h
+++ b/core/misc/voxel2vector.h
@@ -43,7 +43,7 @@ public:
 
   size_t size() const { return reverse.size(); }
 
-  const vector<index_t> &operator[](const size_t index) const {
+  const std::vector<index_t> &operator[](const size_t index) const {
     assert(index < reverse.size());
     return reverse[index];
   }
@@ -58,7 +58,7 @@ public:
 
 private:
   Image<index_t> forward;
-  vector<vector<index_t>> reverse;
+  std::vector<std::vector<index_t>> reverse;
 };
 
 template <class MaskType>
@@ -75,7 +75,7 @@ Voxel2Vector::Voxel2Vector(MaskType &mask, const Header &data)
   for (auto l = Loop(data)(r_mask, forward); l; ++l) {
     if (r_mask.value()) {
       forward.value() = counter++;
-      vector<index_t> pos;
+      std::vector<index_t> pos;
       for (size_t index = 0; index != data.ndim(); ++index)
         pos.push_back(forward.index(index));
       reverse.push_back(pos);

--- a/core/mrtrix.cpp
+++ b/core/mrtrix.cpp
@@ -22,8 +22,8 @@ namespace MR {
  *                       Miscellaneous functions                        *
  ************************************************************************/
 
-vector<default_type> parse_floats(const std::string &spec) {
-  vector<default_type> V;
+std::vector<default_type> parse_floats(const std::string &spec) {
+  std::vector<default_type> V;
   if (!spec.size())
     throw Exception("floating-point sequence specifier is empty");
   std::string::size_type start = 0, end;
@@ -63,8 +63,9 @@ vector<default_type> parse_floats(const std::string &spec) {
   return (V);
 }
 
-vector<std::string> split(const std::string &string, const char *delimiters, bool ignore_empty_fields, size_t num) {
-  vector<std::string> V;
+std::vector<std::string>
+split(const std::string &string, const char *delimiters, bool ignore_empty_fields, size_t num) {
+  std::vector<std::string> V;
   if (!string.size())
     return V;
   std::string::size_type start = 0, end;

--- a/core/mrtrix.h
+++ b/core/mrtrix.h
@@ -149,14 +149,14 @@ inline void replace(std::string &str, const std::string &from, const std::string
   }
 }
 
-vector<std::string> split(const std::string &string,
-                          const char *delimiters = " \t\n",
-                          bool ignore_empty_fields = false,
-                          size_t num = std::numeric_limits<size_t>::max());
+std::vector<std::string> split(const std::string &string,
+                               const char *delimiters = " \t\n",
+                               bool ignore_empty_fields = false,
+                               size_t num = std::numeric_limits<size_t>::max());
 
-inline vector<std::string> split_lines(const std::string &string,
-                                       bool ignore_empty_fields = true,
-                                       size_t num = std::numeric_limits<size_t>::max()) {
+inline std::vector<std::string> split_lines(const std::string &string,
+                                            bool ignore_empty_fields = true,
+                                            size_t num = std::numeric_limits<size_t>::max()) {
   return split(string, "\n", ignore_empty_fields, num);
 }
 
@@ -268,7 +268,7 @@ template <> inline cfloat to<cfloat>(const std::string &string) {
     throw Exception("cannot convert empty string to complex float");
 
   const std::string stripped = strip(string);
-  vector<cfloat> candidates;
+  std::vector<cfloat> candidates;
   for (ssize_t i = -1; i <= ssize_t(stripped.size()); ++i) {
     std::string first, second;
     if (i == -1) {
@@ -325,7 +325,7 @@ template <> inline cdouble to<cdouble>(const std::string &string) {
     throw Exception("cannot convert empty string to complex double");
 
   const std::string stripped = strip(string);
-  vector<cdouble> candidates;
+  std::vector<cdouble> candidates;
   for (ssize_t i = -1; i <= ssize_t(stripped.size()); ++i) {
     std::string first, second;
     if (i == -1) {
@@ -366,10 +366,10 @@ template <> inline cdouble to<cdouble>(const std::string &string) {
   return candidates[0];
 }
 
-vector<default_type> parse_floats(const std::string &spec);
+std::vector<default_type> parse_floats(const std::string &spec);
 
 template <typename IntType>
-vector<IntType> parse_ints(const std::string &spec, const IntType last = std::numeric_limits<IntType>::max()) {
+std::vector<IntType> parse_ints(const std::string &spec, const IntType last = std::numeric_limits<IntType>::max()) {
   typedef typename std::make_signed<IntType>::type SignedIntType;
   if (!spec.size())
     throw Exception("integer sequence specifier is empty");
@@ -380,7 +380,7 @@ vector<IntType> parse_ints(const std::string &spec, const IntType last = std::nu
     return IntType(value);
   };
 
-  vector<IntType> V;
+  std::vector<IntType> V;
   std::string::size_type start = 0, end;
   std::array<SignedIntType, 3> num;
   size_t i = 0;
@@ -451,22 +451,22 @@ Eigen::Matrix<ValueType, Eigen::Dynamic, Eigen::Dynamic> parse_matrix(const std:
   return M;
 }
 
-inline std::string join(const vector<std::string> &V, const std::string &delimiter) {
+inline std::string join(const std::vector<std::string> &V, const std::string &delimiter) {
   std::string ret;
   if (V.empty())
     return ret;
   ret = V[0];
-  for (vector<std::string>::const_iterator i = V.begin() + 1; i != V.end(); ++i)
+  for (std::vector<std::string>::const_iterator i = V.begin() + 1; i != V.end(); ++i)
     ret += delimiter + *i;
   return ret;
 }
 
-template <typename T> inline std::string join(const vector<T> &V, const std::string &delimiter) {
+template <typename T> inline std::string join(const std::vector<T> &V, const std::string &delimiter) {
   std::string ret;
   if (V.empty())
     return ret;
   ret = str(V[0]);
-  for (typename vector<T>::const_iterator i = V.begin() + 1; i != V.end(); ++i)
+  for (typename std::vector<T>::const_iterator i = V.begin() + 1; i != V.end(); ++i)
     ret += delimiter + str(*i);
   return ret;
 }

--- a/core/ordered_thread_queue.h
+++ b/core/ordered_thread_queue.h
@@ -161,7 +161,7 @@ template <class Item, class Functor> struct __Sink<__Ordered<Item>, Functor> {
 
 template <class Item> struct Type<__Ordered<__Batch<Item>>> {
   using item = Item;
-  using queue = Queue<__Ordered<vector<Item>>>;
+  using queue = Queue<__Ordered<std::vector<Item>>>;
   using reader = typename queue::Reader;
   using writer = typename queue::Writer;
   using read_item = typename reader::Item;
@@ -170,7 +170,7 @@ template <class Item> struct Type<__Ordered<__Batch<Item>>> {
 
 template <class Item, class Functor> struct __Source<__Ordered<__Batch<Item>>, Functor> {
 
-  using queued_t = __Ordered<vector<Item>>;
+  using queued_t = __Ordered<std::vector<Item>>;
   using passed_t = __Ordered<__Batch<Item>>;
   using queue_t = typename Type<queued_t>::queue;
   using writer_t = typename Type<queued_t>::writer;
@@ -204,8 +204,8 @@ template <class Item, class Functor> struct __Source<__Ordered<__Batch<Item>>, F
 template <class Item1, class Functor, class Item2>
 struct __Pipe<__Ordered<__Batch<Item1>>, Functor, __Ordered<__Batch<Item2>>> {
 
-  using queued1_t = __Ordered<vector<Item1>>;
-  using queued2_t = __Ordered<vector<Item2>>;
+  using queued1_t = __Ordered<std::vector<Item1>>;
+  using queued2_t = __Ordered<std::vector<Item2>>;
   using passed2_t = __Ordered<__Batch<Item2>>;
   using queue1_t = typename Type<queued1_t>::queue;
   using queue2_t = typename Type<queued2_t>::queue;
@@ -244,7 +244,7 @@ struct __Pipe<__Ordered<__Batch<Item1>>, Functor, __Ordered<__Batch<Item2>>> {
 
 template <class Item, class Functor> struct __Sink<__Ordered<__Batch<Item>>, Functor> {
 
-  using queued_t = __Ordered<vector<Item>>;
+  using queued_t = __Ordered<std::vector<Item>>;
   using queue_t = typename Type<queued_t>::queue;
   using reader_t = typename Type<queued_t>::reader;
   using functor_t = typename __job<Functor>::member_type;

--- a/core/phase_encoding.h
+++ b/core/phase_encoding.h
@@ -191,8 +191,8 @@ Eigen::MatrixXd transform_for_image_load(const MatrixType &pe_scheme, const Head
 //! Modifies a phase encoding scheme if being exported alongside a NIfTI image
 template <class MatrixType, class HeaderType>
 Eigen::MatrixXd transform_for_nifti_write(const MatrixType &pe_scheme, const HeaderType &H) {
-  vector<size_t> order;
-  vector<bool> flip;
+  std::vector<size_t> order;
+  std::vector<bool> flip;
   File::NIfTI::axes_on_write(H, order, flip);
   if (order[0] == 0 && order[1] == 1 && order[2] == 2 && !flip[0] && !flip[1] && !flip[2]) {
     INFO("No transformation of phase encoding data required for export to file");

--- a/core/phase_encoding.h
+++ b/core/phase_encoding.h
@@ -18,6 +18,7 @@
 #define __phaseencoding_h__
 
 #include <Eigen/Dense>
+#include <array>
 
 #include "app.h"
 #include "axes.h"
@@ -192,7 +193,7 @@ Eigen::MatrixXd transform_for_image_load(const MatrixType &pe_scheme, const Head
 template <class MatrixType, class HeaderType>
 Eigen::MatrixXd transform_for_nifti_write(const MatrixType &pe_scheme, const HeaderType &H) {
   std::vector<size_t> order;
-  std::vector<bool> flip;
+  std::array<bool, 3> flip;
   File::NIfTI::axes_on_write(H, order, flip);
   if (order[0] == 0 && order[1] == 1 && order[2] == 2 && !flip[0] && !flip[1] && !flip[2]) {
     INFO("No transformation of phase encoding data required for export to file");

--- a/core/stats.h
+++ b/core/stats.h
@@ -68,7 +68,7 @@ public:
     }
   }
 
-  template <class ImageType> void print(ImageType &ima, const vector<std::string> &fields) {
+  template <class ImageType> void print(ImageType &ima, const std::vector<std::string> &fields) {
 
     if (count > 1) {
       std = complex_type(sqrt(m2.real() / value_type(count - 1)), sqrt(m2.imag() / value_type(count - 1)));
@@ -136,7 +136,7 @@ private:
   complex_type mean, delta, delta2, m2, std, std_rv, min, max;
   size_t count;
   const bool is_complex, ignore_zero;
-  vector<float> values;
+  std::vector<float> values;
 };
 
 inline void print_header(bool is_complex) {

--- a/core/stride.cpp
+++ b/core/stride.cpp
@@ -32,7 +32,7 @@ const OptionGroup Options = OptionGroup("Stride options") +
                                    "format can support it.") +
                             Argument("spec").type_various();
 
-List &sanitise(List &current, const List &desired, const vector<ssize_t> &dims) {
+List &sanitise(List &current, const List &desired, const std::vector<ssize_t> &dims) {
   // remove duplicates
   for (size_t i = 0; i < current.size() - 1; ++i) {
     if (dims[i] == 1)

--- a/core/stride.h
+++ b/core/stride.h
@@ -58,7 +58,7 @@ namespace MR {
  * manipulate the strides and convert symbolic into actual strides. */
 namespace Stride {
 
-using List = vector<ssize_t>;
+using List = std::vector<ssize_t>;
 
 extern const App::OptionGroup Options;
 
@@ -101,7 +101,7 @@ private:
 } // namespace
 //! \endcond
 
-//! return the strides of \a header as a vector<ssize_t>
+//! return the strides of \a header as a std::vector<ssize_t>
 template <class HeaderType> List get(const HeaderType &header) {
   List ret(header.ndim());
   for (size_t i = 0; i < header.ndim(); ++i)
@@ -109,7 +109,7 @@ template <class HeaderType> List get(const HeaderType &header) {
   return ret;
 }
 
-//! set the strides of \a header from a vector<ssize_t>
+//! set the strides of \a header from a std::vector<ssize_t>
 template <class HeaderType> void set(HeaderType &header, const List &stride) {
   size_t n = 0;
   for (; n < std::min<size_t>(header.ndim(), stride.size()); ++n)
@@ -128,11 +128,11 @@ template <class HeaderType, class FromHeaderType> void set(HeaderType &header, c
  * absolute stride.
  * \note all strides should be valid (i.e. non-zero). */
 template <class HeaderType>
-vector<size_t>
+std::vector<size_t>
 order(const HeaderType &header, size_t from_axis = 0, size_t to_axis = std::numeric_limits<size_t>::max()) {
   to_axis = std::min<size_t>(to_axis, header.ndim());
   assert(to_axis > from_axis);
-  vector<size_t> ret(to_axis - from_axis);
+  std::vector<size_t> ret(to_axis - from_axis);
   for (size_t i = 0; i < ret.size(); ++i)
     ret[i] = from_axis + i;
   Compare<HeaderType> compare(header);
@@ -144,7 +144,7 @@ order(const HeaderType &header, size_t from_axis = 0, size_t to_axis = std::nume
 /*! \return a vector of indices of the axes in order of increasing
  * absolute stride.
  * \note all strides should be valid (i.e. non-zero). */
-template <> inline vector<size_t> order<List>(const List &strides, size_t from_axis, size_t to_axis) {
+template <> inline std::vector<size_t> order<List>(const List &strides, size_t from_axis, size_t to_axis) {
   const Wrapper wrapper(const_cast<List &>(strides));
   return order(wrapper, from_axis, to_axis);
 }
@@ -197,12 +197,12 @@ template <class HeaderType> inline void sanitise(List &strides, const HeaderType
  * zero) or duplicate (absolute) strides, and assigning to each a
  * suitable value. The value chosen for each sanitised stride is the
  * lowest number greater than any of the currently valid strides. */
-List &sanitise(List &current, const List &desired, const vector<ssize_t> &header);
+List &sanitise(List &current, const List &desired, const std::vector<ssize_t> &header);
 
 //! convert strides from symbolic to actual strides
 template <class HeaderType> void actualise(HeaderType &header) {
   sanitise(header);
-  vector<size_t> x(order(header));
+  std::vector<size_t> x(order(header));
   ssize_t skip = 1;
   for (size_t i = 0; i < header.ndim(); ++i) {
     header.stride(x[i]) = header.stride(x[i]) < 0 ? -skip : skip;
@@ -233,7 +233,7 @@ template <class HeaderType> inline List get_actual(const List &strides, const He
 
 //! convert strides from actual to symbolic strides
 template <class HeaderType> void symbolise(HeaderType &header) {
-  vector<size_t> p(order(header));
+  std::vector<size_t> p(order(header));
   for (ssize_t i = 0; i < ssize_t(p.size()); ++i)
     if (header.stride(p[i]) != 0)
       header.stride(p[i]) = header.stride(p[i]) < 0 ? -(i + 1) : i + 1;
@@ -304,7 +304,7 @@ template <class HeaderType> List get_nearest_match(const HeaderType &current, co
   List in(get_symbolic(current)), out(desired);
   out.resize(in.size(), 0);
 
-  vector<ssize_t> dims(current.ndim());
+  std::vector<ssize_t> dims(current.ndim());
   for (size_t n = 0; n < dims.size(); ++n)
     dims[n] = current.size(n);
 

--- a/core/thread.h
+++ b/core/thread.h
@@ -195,8 +195,8 @@ public:
   }
 
 protected:
-  vector<std::future<void>> threads;
-  vector<typename std::remove_reference<Functor>::type> functors;
+  std::vector<std::future<void>> threads;
+  std::vector<typename std::remove_reference<Functor>::type> functors;
 };
 
 template <class Functor> class __Multi {

--- a/core/thread_queue.h
+++ b/core/thread_queue.h
@@ -481,8 +481,8 @@ private:
   T **back;
   size_t capacity;
   size_t writer_count, reader_count;
-  std::stack<T *, vector<T *>> item_stack;
-  vector<std::unique_ptr<T>> items;
+  std::stack<T *, std::vector<T *>> item_stack;
+  std::vector<std::unique_ptr<T>> items;
   std::string name;
 
   void register_writer() {
@@ -604,7 +604,7 @@ template <class Item> struct Type {
 
 template <class Item> struct Type<__Batch<Item>> {
   using item = Item;
-  using queue = Queue<vector<Item>>;
+  using queue = Queue<std::vector<Item>>;
   using reader = typename queue::Reader;
   using writer = typename queue::Writer;
   using read_item = typename reader::Item;

--- a/core/types.h
+++ b/core/types.h
@@ -179,14 +179,6 @@ template <class ValueType>
 struct is_data_type
     : std::integral_constant<bool, std::is_arithmetic<ValueType>::value || is_complex<ValueType>::value> {};
 
-template <typename X, typename... Args> inline std::shared_ptr<X> make_shared(Args &&...args) {
-  return std::shared_ptr<X>(new X(std::forward<Args>(args)...));
-}
-
-template <typename X, typename... Args> inline std::unique_ptr<X> make_unique(Args &&...args) {
-  return std::unique_ptr<X>(new X(std::forward<Args>(args)...));
-}
-
 // required to allow use of abs() call on unsigned integers in template
 // functions, etc, since the standard labels such calls ill-formed:
 // http://en.cppreference.com/w/cpp/numeric/math/abs

--- a/core/types.h
+++ b/core/types.h
@@ -104,7 +104,7 @@ template <class ImageType> class Row;
 
 #ifdef MRTRIX_NO_VLA
 #define VLA(name, type, num)                                                                                           \
-  vector<type> __vla__##name(num);                                                                                     \
+  std::vector<type> __vla__##name(num);                                                                                \
   type *name = &__vla__##name[0]
 #define VLA_MAX(name, type, num, max) type name[max]
 #else
@@ -131,7 +131,7 @@ template <class ImageType> class Row;
 
 #ifdef MRTRIX_NO_NON_POD_VLA
 #define NON_POD_VLA(name, type, num)                                                                                   \
-  vector<type> __vla__##name(num);                                                                                     \
+  std::vector<type> __vla__##name(num);                                                                                \
   type *name = &__vla__##name[0]
 #define NON_POD_VLA_MAX(name, type, num, max) type name[max]
 #else
@@ -179,32 +179,6 @@ template <class ValueType>
 struct is_data_type
     : std::integral_constant<bool, std::is_arithmetic<ValueType>::value || is_complex<ValueType>::value> {};
 
-template <typename X, int N = (alignof(X) > ::MR::malloc_align)>
-class vector : public ::std::vector<X, Eigen::aligned_allocator<X>> {
-public:
-  using ::std::vector<X, Eigen::aligned_allocator<X>>::vector;
-  vector() {}
-};
-
-template <typename X> class vector<X, 0> : public ::std::vector<X> {
-public:
-  using ::std::vector<X>::vector;
-  vector() {}
-};
-
-template <typename X, int N = (alignof(X) > ::MR::malloc_align)>
-class deque : public ::std::deque<X, Eigen::aligned_allocator<X>> {
-public:
-  using ::std::deque<X, Eigen::aligned_allocator<X>>::deque;
-  deque() {}
-};
-
-template <typename X> class deque<X, 0> : public ::std::deque<X> {
-public:
-  using ::std::deque<X>::deque;
-  deque() {}
-};
-
 template <typename X, typename... Args> inline std::shared_ptr<X> make_shared(Args &&...args) {
   return std::shared_ptr<X>(new X(std::forward<Args>(args)...));
 }
@@ -229,7 +203,7 @@ abs(X x) {
 
 namespace std {
 
-template <class T> inline ostream &operator<<(ostream &stream, const vector<T> &V) {
+template <class T> inline ostream &operator<<(ostream &stream, const std::vector<T> &V) {
   stream << "[ ";
   for (size_t n = 0; n < V.size(); n++)
     stream << V[n] << " ";

--- a/src/connectome/enhance.cpp
+++ b/src/connectome/enhance.cpp
@@ -36,7 +36,7 @@ void NBS::operator()(in_column_type in, const value_type T, out_column_type out)
 
       visited.clear();
       visited[seed] = true;
-      vector<size_t> to_expand(1, seed);
+      std::vector<size_t> to_expand(1, seed);
       size_t cluster_size = 0;
 
       while (to_expand.size()) {
@@ -45,7 +45,7 @@ void NBS::operator()(in_column_type in, const value_type T, out_column_type out)
         to_expand.pop_back();
         cluster_size++;
 
-        for (vector<size_t>::const_iterator i = (*adjacency)[index].begin(); i != (*adjacency)[index].end(); ++i) {
+        for (std::vector<size_t>::const_iterator i = (*adjacency)[index].begin(); i != (*adjacency)[index].end(); ++i) {
           if (!visited[*i] && std::isfinite(in[*i]) && in[*i] >= T) {
             visited[*i] = true;
             to_expand.push_back(*i);
@@ -63,12 +63,12 @@ void NBS::initialise(const node_t num_nodes) {
   const Mat2Vec mat2vec(num_nodes);
   const size_t num_edges = mat2vec.vec_size();
   ProgressBar progress("Pre-computing statistical correlation matrix...", num_edges);
-  adjacency.reset(new vector<vector<size_t>>(num_edges, vector<size_t>()));
+  adjacency.reset(new std::vector<std::vector<size_t>>(num_edges, std::vector<size_t>()));
   for (node_t row = 0; row != num_nodes; ++row) {
     for (node_t column = row; column != num_nodes; ++column) {
 
       const size_t index = mat2vec(row, column);
-      vector<size_t> &vector = (*adjacency)[index];
+      std::vector<size_t> &vector = (*adjacency)[index];
       vector.reserve(2 * (num_nodes - 1));
       // Should be able to expand from this edge to any other edge connected to either row or column
       for (node_t r = 0; r != num_nodes; ++r) {

--- a/src/connectome/enhance.h
+++ b/src/connectome/enhance.h
@@ -57,7 +57,7 @@ public:
   void operator()(in_column_type, const value_type, out_column_type) const override;
 
 protected:
-  std::shared_ptr<vector<vector<size_t>>> adjacency;
+  std::shared_ptr<std::vector<std::vector<size_t>>> adjacency;
   value_type threshold;
 
 private:

--- a/src/connectome/lut.cpp
+++ b/src/connectome/lut.cpp
@@ -119,7 +119,7 @@ LUT::file_format LUT::guess_file_format(const std::string &path) {
   std::ifstream in_lut(path, std::ios_base::in);
   if (!in_lut)
     throw Exception("Unable to open lookup table file");
-  vector<Column> columns;
+  std::vector<Column> columns;
   std::string line;
   size_t line_counter = 0;
   while (std::getline(in_lut, line)) {
@@ -267,10 +267,10 @@ void LUT::check_and_insert(const node_t index, const LUT_node &data) {
   insert(std::make_pair(index, data));
 }
 
-vector<node_t> get_lut_mapping(const LUT &in, const LUT &out) {
+std::vector<node_t> get_lut_mapping(const LUT &in, const LUT &out) {
   if (in.empty())
-    return vector<node_t>();
-  vector<node_t> map(in.rbegin()->first + 1, 0);
+    return std::vector<node_t>();
+  std::vector<node_t> map(in.rbegin()->first + 1, 0);
   for (const auto &node_in : in) {
     node_t target = 0;
     for (const auto &node_out : out) {
@@ -278,7 +278,7 @@ vector<node_t> get_lut_mapping(const LUT &in, const LUT &out) {
         if (target) {
           throw Exception("Cannot perform LUT conversion: Node " + str(node_in.first) + " (" +
                           node_in.second.get_name() + ") has multiple possible targets");
-          return vector<node_t>();
+          return std::vector<node_t>();
         }
         target = node_out.first;
         break;

--- a/src/connectome/lut.h
+++ b/src/connectome/lut.h
@@ -94,7 +94,7 @@ private:
 // Convenience function for constructing a mapping from one lookup table to another
 // NOTE: If the TARGET LUT contains multiple entries for a particular index, and a
 //   mapping TO that index is required, the conversion is ill-formed.
-vector<node_t> get_lut_mapping(const LUT &, const LUT &);
+std::vector<node_t> get_lut_mapping(const LUT &, const LUT &);
 
 } // namespace Connectome
 } // namespace MR

--- a/src/degibbs/unring1d.h
+++ b/src/degibbs/unring1d.h
@@ -131,7 +131,7 @@ public:
 private:
   Math::FFT1D &fft;
   Eigen::MatrixXcd shifted;
-  vector<int> shifts;
+  std::vector<int> shifts;
 };
 
 } // namespace Degibbs

--- a/src/degibbs/unring2d.h
+++ b/src/degibbs/unring2d.h
@@ -108,8 +108,8 @@ private:
 
 class Unring2DFunctor {
 public:
-  Unring2DFunctor(const vector<size_t> &outer_axes,
-                  const vector<size_t> &slice_axes,
+  Unring2DFunctor(const std::vector<size_t> &outer_axes,
+                  const std::vector<size_t> &slice_axes,
                   const int &nsh,
                   const int &minW,
                   const int &maxW,
@@ -137,8 +137,8 @@ public:
   }
 
 protected:
-  const vector<size_t> &outer_axes;
-  const vector<size_t> &slice_axes;
+  const std::vector<size_t> &outer_axes;
+  const std::vector<size_t> &slice_axes;
   Image<value_type> in, out;
   Eigen::MatrixXcd slice;
   Unring2D unring2d;

--- a/src/degibbs/unring3d.h
+++ b/src/degibbs/unring3d.h
@@ -130,7 +130,7 @@ protected:
   OutputImageType output;
   const int minW, maxW, num_shifts;
   Math::FFT1D fft;
-  vector<Math::FFT1D> ifft;
+  std::vector<Math::FFT1D> ifft;
 
   int optimumshift(int n, int lsize) {
     int ind = 0;
@@ -161,7 +161,7 @@ protected:
   }
 };
 
-inline vector<size_t> strides_for_axis(int axis) {
+inline std::vector<size_t> strides_for_axis(int axis) {
   switch (axis) {
   case 0:
     return {0, 1, 2};

--- a/src/dwi/bootstrap.h
+++ b/src/dwi/bootstrap.h
@@ -66,7 +66,7 @@ public:
   void clear() {
     voxels.clear();
     if (voxel_buffer.empty())
-      voxel_buffer.push_back(vector<value_type>(NUM_VOX_PER_CHUNK * size(3)));
+      voxel_buffer.push_back(std::vector<value_type>(NUM_VOX_PER_CHUNK * size(3)));
     next_voxel = &voxel_buffer[0][0];
     last_voxel = next_voxel + NUM_VOX_PER_CHUNK * size(3);
     current_chunk = 0;
@@ -75,7 +75,7 @@ public:
 protected:
   Functor func;
   std::map<Eigen::Vector3i, value_type *, IndexCompare> voxels;
-  vector<vector<value_type>> voxel_buffer;
+  std::vector<std::vector<value_type>> voxel_buffer;
   value_type *next_voxel;
   value_type *last_voxel;
   size_t current_chunk;
@@ -84,7 +84,7 @@ protected:
     if (next_voxel == last_voxel) {
       ++current_chunk;
       if (current_chunk >= voxel_buffer.size())
-        voxel_buffer.push_back(vector<value_type>(NUM_VOX_PER_CHUNK * size(3)));
+        voxel_buffer.push_back(std::vector<value_type>(NUM_VOX_PER_CHUNK * size(3)));
       assert(current_chunk < voxel_buffer.size());
       next_voxel = &voxel_buffer.back()[0];
       last_voxel = next_voxel + NUM_VOX_PER_CHUNK * size(3);

--- a/src/dwi/directions/mask.cpp
+++ b/src/dwi/directions/mask.cpp
@@ -25,7 +25,8 @@ void Mask::erode(const size_t iterations) {
     Mask temp(*this);
     for (size_t d = 0; d != size(); ++d) {
       if (!temp[d]) {
-        for (vector<index_type>::const_iterator i = dirs->get_adj_dirs(d).begin(); i != dirs->get_adj_dirs(d).end();
+        for (std::vector<index_type>::const_iterator i = dirs->get_adj_dirs(d).begin();
+             i != dirs->get_adj_dirs(d).end();
              ++i)
           reset(*i);
       }
@@ -38,7 +39,8 @@ void Mask::dilate(const size_t iterations) {
     Mask temp(*this);
     for (size_t d = 0; d != size(); ++d) {
       if (temp[d]) {
-        for (vector<index_type>::const_iterator i = dirs->get_adj_dirs(d).begin(); i != dirs->get_adj_dirs(d).end();
+        for (std::vector<index_type>::const_iterator i = dirs->get_adj_dirs(d).begin();
+             i != dirs->get_adj_dirs(d).end();
              ++i)
           set(*i);
       }
@@ -54,7 +56,8 @@ size_t Mask::get_min_linkage(const Mask &that) {
 }
 
 bool Mask::is_adjacent(const size_t d) const {
-  for (vector<index_type>::const_iterator i = dirs->get_adj_dirs(d).begin(); i != dirs->get_adj_dirs(d).end(); ++i) {
+  for (std::vector<index_type>::const_iterator i = dirs->get_adj_dirs(d).begin(); i != dirs->get_adj_dirs(d).end();
+       ++i) {
     if (test(*i))
       return true;
   }

--- a/src/dwi/directions/set.cpp
+++ b/src/dwi/directions/set.cpp
@@ -32,14 +32,14 @@ index_type Set::get_min_linkage(const index_type one, const index_type two) cons
   if (one == two)
     return 0;
 
-  vector<bool> processed(size(), 0);
-  vector<index_type> to_expand;
+  std::vector<bool> processed(size(), 0);
+  std::vector<index_type> to_expand;
   processed[one] = true;
   to_expand.push_back(one);
   index_type min_linkage = 0;
   do {
     ++min_linkage;
-    vector<index_type> next_to_expand;
+    std::vector<index_type> next_to_expand;
     for (const auto &i : to_expand) {
       for (const auto &j : adj_dirs[i]) {
         if (j == two) {
@@ -87,7 +87,7 @@ void Set::load_predefined(Eigen::MatrixXd &az_el_pairs, const size_t i) {
 }
 
 void Set::initialise_adjacency() {
-  adj_dirs.assign(size(), vector<index_type>());
+  adj_dirs.assign(size(), std::vector<index_type>());
 
   // New algorithm for determining direction adjacency
   // * Duplicate all directions to get a full spherical set
@@ -113,7 +113,7 @@ void Set::initialise_adjacency() {
 
   class Plane {
   public:
-    Plane(const vector<Vertex> &vertices, const index_type one, const index_type two, const index_type three)
+    Plane(const std::vector<Vertex> &vertices, const index_type one, const index_type two, const index_type three)
         : indices{{one, two, three}},
           normal(((vertices[two].dir - vertices[one].dir).cross(vertices[three].dir - vertices[two].dir)).normalized()),
           dist(std::max(
@@ -129,7 +129,7 @@ void Set::initialise_adjacency() {
     bool operator()(const Plane &one, const Plane &two) const { return (one.dist < two.dist); }
   };
 
-  vector<Vertex> vertices;
+  std::vector<Vertex> vertices;
   // Generate antipodal vertices
   for (index_type i = 0; i != size(); ++i) {
     vertices.push_back(Vertex(*this, i, false));
@@ -152,7 +152,7 @@ void Set::initialise_adjacency() {
   }
 
   // Find the two most distant points out of these six
-  vector<index_type> all_extrema;
+  std::vector<index_type> all_extrema;
   for (size_t axis = 0; axis != 3; ++axis) {
     all_extrema.push_back(extremum_indices[axis][0]);
     all_extrema.push_back(extremum_indices[axis][1]);
@@ -211,7 +211,7 @@ void Set::initialise_adjacency() {
   planes.push_back(Plane(vertices, base_plane.indices[1], fourth_point, base_plane.indices[2]));
   planes.push_back(Plane(vertices, base_plane.indices[2], fourth_point, base_plane.indices[0]));
 
-  vector<Plane> hull;
+  std::vector<Plane> hull;
 
   // Speedup: Only test those directions that have not yet been incorporated into any plane
   BitSet assigned(vertices.size());
@@ -246,7 +246,7 @@ void Set::initialise_adjacency() {
 
       // TODO Using an alternative data structure, where both faces connected to each
       //   edge are stored and tracked, would speed this up considerably
-      vector<std::list<Plane>::iterator> all_planes;
+      std::vector<std::list<Plane>::iterator> all_planes;
       for (std::list<Plane>::iterator p = planes.begin(); p != planes.end(); ++p) {
         if (!p->includes(max_index) && vertices[max_index].dir.dot(p->normal) > p->dist)
           all_planes.push_back(p);
@@ -387,7 +387,7 @@ void FastLookupSet::initialise() {
   default_type adj_dot_product_sum = 0.0;
   size_t adj_dot_product_count = 0;
   for (size_t i = 0; i != size(); ++i) {
-    for (vector<index_type>::const_iterator j = adj_dirs[i].begin(); j != adj_dirs[i].end(); ++j) {
+    for (std::vector<index_type>::const_iterator j = adj_dirs[i].begin(); j != adj_dirs[i].end(); ++j) {
       if (*j > i) {
         adj_dot_product_sum += abs(unit_vectors[i].dot(unit_vectors[*j]));
         ++adj_dot_product_count;
@@ -408,7 +408,7 @@ void FastLookupSet::initialise() {
   az_begin = -Math::pi;
   el_begin = 0.0;
 
-  grid_lookup.assign(total_num_angle_grids, vector<index_type>());
+  grid_lookup.assign(total_num_angle_grids, std::vector<index_type>());
   for (size_t i = 0; i != size(); ++i) {
     const size_t grid_index = dir2gridindex(get_dir(i));
     grid_lookup[grid_index].push_back(i);
@@ -441,7 +441,8 @@ void FastLookupSet::initialise() {
       const Eigen::Vector3d p(cos(az) * sin(el), sin(az) * sin(el), cos(el));
       const index_type nearest_dir = select_direction_slow(p);
       bool dir_present = false;
-      for (vector<index_type>::const_iterator d = grid_lookup[i].begin(); !dir_present && d != grid_lookup[i].end();
+      for (std::vector<index_type>::const_iterator d = grid_lookup[i].begin();
+           !dir_present && d != grid_lookup[i].end();
            ++d)
         dir_present = (*d == nearest_dir);
       if (!dir_present)
@@ -450,11 +451,11 @@ void FastLookupSet::initialise() {
   }
 
   for (size_t grid_index = 0; grid_index != total_num_angle_grids; ++grid_index) {
-    vector<index_type> &this_grid(grid_lookup[grid_index]);
+    std::vector<index_type> &this_grid(grid_lookup[grid_index]);
     const size_t num_to_expand = this_grid.size();
     for (size_t index_to_expand = 0; index_to_expand != num_to_expand; ++index_to_expand) {
       const index_type dir_to_expand = this_grid[index_to_expand];
-      for (vector<index_type>::const_iterator adj = get_adj_dirs(dir_to_expand).begin();
+      for (std::vector<index_type>::const_iterator adj = get_adj_dirs(dir_to_expand).begin();
            adj != get_adj_dirs(dir_to_expand).end();
            ++adj) {
 
@@ -462,7 +463,7 @@ void FastLookupSet::initialise() {
         // in the lookup table for this grid
 
         bool is_present = false;
-        for (vector<index_type>::const_iterator i = this_grid.begin(); !is_present && i != this_grid.end(); ++i)
+        for (std::vector<index_type>::const_iterator i = this_grid.begin(); !is_present && i != this_grid.end(); ++i)
           is_present = (*i == *adj);
         if (!is_present)
           this_grid.push_back(*adj);

--- a/src/dwi/directions/set.h
+++ b/src/dwi/directions/set.h
@@ -73,7 +73,7 @@ public:
     assert(i < size());
     return unit_vectors[i];
   }
-  const vector<index_type> &get_adj_dirs(const size_t i) const {
+  const std::vector<index_type> &get_adj_dirs(const size_t i) const {
     assert(i < size());
     return adj_dirs[i];
   }
@@ -89,15 +89,15 @@ public:
 
   index_type get_min_linkage(const index_type one, const index_type two) const;
 
-  const vector<Eigen::Vector3d> &get_dirs() const { return unit_vectors; }
+  const std::vector<Eigen::Vector3d> &get_dirs() const { return unit_vectors; }
   const Eigen::Vector3d &operator[](const size_t i) const {
     assert(i < size());
     return unit_vectors[i];
   }
 
 protected:
-  vector<Eigen::Vector3d> unit_vectors;
-  vector<vector<index_type>> adj_dirs; // Note: not self-inclusive
+  std::vector<Eigen::Vector3d> unit_vectors;
+  std::vector<std::vector<index_type>> adj_dirs; // Note: not self-inclusive
 
 private:
   size_t dir_mask_bytes, dir_mask_excess_bits;
@@ -152,7 +152,7 @@ public:
   index_type select_direction(const Eigen::Vector3d &) const;
 
 private:
-  vector<vector<index_type>> grid_lookup;
+  std::vector<std::vector<index_type>> grid_lookup;
   unsigned int num_az_grids, num_el_grids, total_num_angle_grids;
   default_type az_grid_step, el_grid_step;
   default_type az_begin, el_begin;

--- a/src/dwi/fixel_map.h
+++ b/src/dwi/fixel_map.h
@@ -67,7 +67,7 @@ public:
   const ::MR::Header &header() const { return _header; }
 
 protected:
-  vector<Fixel> fixels;
+  std::vector<Fixel> fixels;
 
 private:
   const class HeaderHelper : public ::MR::Header {

--- a/src/dwi/fmls.cpp
+++ b/src/dwi/fmls.cpp
@@ -163,11 +163,11 @@ bool Segmenter::operator()(const SH_coefs &in, FOD_lobes &out) const {
   if (data_in_order.begin()->first <= 0.0)
     return true;
 
-  vector<std::pair<index_type, uint32_t>> retrospective_assignments;
+  std::vector<std::pair<index_type, uint32_t>> retrospective_assignments;
 
   for (const auto &i : data_in_order) {
 
-    vector<uint32_t> adj_lobes;
+    std::vector<uint32_t> adj_lobes;
     for (uint32_t l = 0; l != out.size(); ++l) {
       if ((((i.first <= 0.0) && out[l].is_negative()) || ((i.first > 0.0) && !out[l].is_negative())) &&
           (out[l].get_mask().is_adjacent(i.second))) {
@@ -214,7 +214,7 @@ bool Segmenter::operator()(const SH_coefs &in, FOD_lobes &out) const {
           }
         }
         for (size_t j = adj_lobes.size() - 1; j; --j) {
-          vector<FOD_lobe>::iterator ptr = out.begin();
+          std::vector<FOD_lobe>::iterator ptr = out.begin();
           advance(ptr, adj_lobes[j]);
           out.erase(ptr);
         }
@@ -295,15 +295,15 @@ bool Segmenter::operator()(const SH_coefs &in, FOD_lobes &out) const {
     if (dilate_lookup_table && out.size()) {
 
       DWI::Directions::Mask processed(dirs);
-      for (vector<FOD_lobe>::iterator i = out.begin(); i != out.end(); ++i)
+      for (std::vector<FOD_lobe>::iterator i = out.begin(); i != out.end(); ++i)
         processed |= i->get_mask();
 
-      NON_POD_VLA(new_assignments, vector<uint32_t>, dirs.size());
+      NON_POD_VLA(new_assignments, std::vector<uint32_t>, dirs.size());
       while (!processed.full()) {
 
         for (index_type dir = 0; dir != dirs.size(); ++dir) {
           if (!processed[dir]) {
-            for (vector<index_type>::const_iterator neighbour = dirs.get_adj_dirs(dir).begin();
+            for (std::vector<index_type>::const_iterator neighbour = dirs.get_adj_dirs(dir).begin();
                  neighbour != dirs.get_adj_dirs(dir).end();
                  ++neighbour) {
               if (processed[*neighbour])
@@ -322,7 +322,7 @@ bool Segmenter::operator()(const SH_coefs &in, FOD_lobes &out) const {
 
             uint32_t best_lobe = 0;
             default_type max_integral = 0.0;
-            for (vector<uint32_t>::const_iterator lobe_no = new_assignments[dir].begin();
+            for (std::vector<uint32_t>::const_iterator lobe_no = new_assignments[dir].begin();
                  lobe_no != new_assignments[dir].end();
                  ++lobe_no) {
               if (out[*lobe_no].get_integral() > max_integral) {
@@ -341,7 +341,7 @@ bool Segmenter::operator()(const SH_coefs &in, FOD_lobes &out) const {
 
   if (create_null_lobe) {
     DWI::Directions::Mask null_mask(dirs, true);
-    for (vector<FOD_lobe>::iterator i = out.begin(); i != out.end(); ++i)
+    for (std::vector<FOD_lobe>::iterator i = out.begin(); i != out.end(); ++i)
       null_mask &= i->get_mask();
     out.push_back(FOD_lobe(null_mask));
   }

--- a/src/dwi/fmls.h
+++ b/src/dwi/fmls.h
@@ -138,16 +138,16 @@ private:
   DWI::Directions::Mask mask;
   Eigen::Array<default_type, Eigen::Dynamic, 1> values;
   default_type max_peak_value;
-  vector<Eigen::Vector3d> peak_dirs;
+  std::vector<Eigen::Vector3d> peak_dirs;
   Eigen::Vector3d mean_dir;
   default_type integral;
   bool neg;
 };
 
-class FOD_lobes : public vector<FOD_lobe> {
+class FOD_lobes : public std::vector<FOD_lobe> {
 public:
   Eigen::Array3i vox;
-  vector<uint8_t> lut;
+  std::vector<uint8_t> lut;
 };
 
 class SH_coefs : public Eigen::Matrix<default_type, Eigen::Dynamic, 1> {

--- a/src/dwi/sdeconv/csd.h
+++ b/src/dwi/sdeconv/csd.h
@@ -190,7 +190,7 @@ public:
     Eigen::MatrixXd DW_dirs, HR_dirs;
     Eigen::MatrixXd rconv, HR_trans, M, Mt_M;
     default_type neg_lambda, norm_lambda, threshold;
-    vector<size_t> dwis;
+    std::vector<size_t> dwis;
     uint32_t lmax_response, lmax_data, lmax_cmdline, lmax;
     size_t niter;
   };
@@ -252,7 +252,7 @@ protected:
   Eigen::MatrixXd work, HR_T;
   Eigen::VectorXd F, init_F, HR_amps, Mt_b;
   Eigen::LLT<Eigen::MatrixXd> llt;
-  vector<int> neg, old_neg;
+  std::vector<int> neg, old_neg;
 };
 
 } // namespace SDeconv

--- a/src/dwi/sdeconv/msmt_csd.h
+++ b/src/dwi/sdeconv/msmt_csd.h
@@ -68,7 +68,7 @@ public:
         constraint_min_norm_regularisation = opt[0][0];
     }
 
-    void set_responses(const vector<std::string> &files) {
+    void set_responses(const std::vector<std::string> &files) {
       lmax_response.clear();
       for (const auto &s : files) {
         Eigen::MatrixXd r;
@@ -83,7 +83,7 @@ public:
       response_files = files;
     }
 
-    void set_responses(const vector<Eigen::MatrixXd> &matrices) {
+    void set_responses(const std::vector<Eigen::MatrixXd> &matrices) {
       responses = matrices;
       prepare_responses();
     }
@@ -130,7 +130,7 @@ public:
 
       Eigen::MatrixXd C = Eigen::MatrixXd::Zero(grad.rows(), nparams);
 
-      vector<size_t> dwilist;
+      std::vector<size_t> dwilist;
       for (size_t i = 0; i != size_t(grad.rows()); i++)
         dwilist.push_back(i);
 
@@ -173,7 +173,7 @@ public:
             }
             li++;
           }
-          vector<size_t> vols = shells[shell_idx].get_volumes();
+          std::vector<size_t> vols = shells[shell_idx].get_volumes();
           for (size_t idx = 0; idx < vols.size(); idx++) {
             Eigen::VectorXd SHT_(SHT.row(vols[idx]).head(tissue_n));
             SHT_ = (SHT_.array() * fconv.array()).matrix();
@@ -183,8 +183,8 @@ public:
         pbegin += tissue_n;
       }
 
-      vector<size_t> m(num_tissues());
-      vector<size_t> n(num_tissues());
+      std::vector<size_t> m(num_tissues());
+      std::vector<size_t> n(num_tissues());
       size_t M = 0;
       size_t N = 0;
 
@@ -220,9 +220,9 @@ public:
     const Eigen::MatrixXd grad;
     DWI::Shells shells;
     Eigen::MatrixXd HR_dirs;
-    vector<uint32_t> lmax, lmax_response;
-    vector<Eigen::MatrixXd> responses;
-    vector<std::string> response_files;
+    std::vector<uint32_t> lmax, lmax_response;
+    std::vector<Eigen::MatrixXd> responses;
+    std::vector<std::string> response_files;
     Math::ICLS::Problem<double> problem;
     double solution_min_norm_regularisation, constraint_min_norm_regularisation;
 

--- a/src/dwi/tractography/ACT/gmwmi.cpp
+++ b/src/dwi/tractography/ACT/gmwmi.cpp
@@ -31,12 +31,12 @@ Eigen::Vector3f GMWMI_finder::normal(const Eigen::Vector3f &p) const {
   return get_normal(p, interp);
 }
 
-Eigen::Vector3f GMWMI_finder::find_interface(const vector<Eigen::Vector3f> &tck, const bool end) const {
+Eigen::Vector3f GMWMI_finder::find_interface(const std::vector<Eigen::Vector3f> &tck, const bool end) const {
   Interp interp(interp_template);
   return find_interface(tck, end, interp);
 }
 
-void GMWMI_finder::crop_track(vector<Eigen::Vector3f> &tck) const {
+void GMWMI_finder::crop_track(std::vector<Eigen::Vector3f> &tck) const {
   if (tck.size() < 3)
     return;
   Interp interp(interp_template);
@@ -153,7 +153,8 @@ Eigen::Vector3f GMWMI_finder::get_cf_min_step(const Eigen::Vector3f &p, Interp &
   return step;
 }
 
-Eigen::Vector3f GMWMI_finder::find_interface(const vector<Eigen::Vector3f> &tck, const bool end, Interp &interp) const {
+Eigen::Vector3f
+GMWMI_finder::find_interface(const std::vector<Eigen::Vector3f> &tck, const bool end, Interp &interp) const {
 
   if (tck.size() == 0)
     return {NaN, NaN, NaN};

--- a/src/dwi/tractography/ACT/gmwmi.h
+++ b/src/dwi/tractography/ACT/gmwmi.h
@@ -54,8 +54,8 @@ public:
   bool find_interface(Eigen::Vector3f &) const;
   Eigen::Vector3f normal(const Eigen::Vector3f &) const;
 
-  Eigen::Vector3f find_interface(const vector<Eigen::Vector3f> &, const bool) const;
-  void crop_track(vector<Eigen::Vector3f> &) const;
+  Eigen::Vector3f find_interface(const std::vector<Eigen::Vector3f> &, const bool) const;
+  void crop_track(std::vector<Eigen::Vector3f> &) const;
 
 protected:
   const Interp interp_template;
@@ -71,7 +71,7 @@ protected:
   Eigen::Vector3f get_normal(const Eigen::Vector3f &, Interp &) const;
   Eigen::Vector3f get_cf_min_step(const Eigen::Vector3f &, Interp &) const;
 
-  Eigen::Vector3f find_interface(const vector<Eigen::Vector3f> &, const bool, Interp &) const;
+  Eigen::Vector3f find_interface(const std::vector<Eigen::Vector3f> &, const bool, Interp &) const;
 
   friend class Track_extender;
   friend class Tractography::Seeding::Dynamic_ACT_additions;

--- a/src/dwi/tractography/ACT/shared.h
+++ b/src/dwi/tractography/ACT/shared.h
@@ -39,7 +39,7 @@ public:
   bool backtrack() const { return bt; }
 
   bool crop_at_gmwmi() const { return bool(gmwmi_finder); }
-  void crop_at_gmwmi(vector<Eigen::Vector3f> &tck) const {
+  void crop_at_gmwmi(std::vector<Eigen::Vector3f> &tck) const {
     assert(gmwmi_finder);
     tck.back() = gmwmi_finder->find_interface(tck, true);
   }

--- a/src/dwi/tractography/GT/externalenergy.h
+++ b/src/dwi/tractography/GT/externalenergy.h
@@ -78,10 +78,10 @@ protected:
 
   Math::ICLS::Problem<double> nnls;
 
-  vector<Eigen::Vector3i> changes_vox;
-  vector<Eigen::VectorXd> changes_tod;
-  vector<Eigen::VectorXd> changes_fiso;
-  vector<double> changes_eext;
+  std::vector<Eigen::Vector3i> changes_vox;
+  std::vector<Eigen::VectorXd> changes_tod;
+  std::vector<Eigen::VectorXd> changes_fiso;
+  std::vector<double> changes_eext;
 
   void add(const Point_t &pos, const Point_t &dir, const double factor = 1.);
 

--- a/src/dwi/tractography/GT/gt.h
+++ b/src/dwi/tractography/GT/gt.h
@@ -57,7 +57,7 @@ struct Properties {
   double ppot;
 
   Eigen::MatrixXf resp_WM;
-  vector<Eigen::VectorXf> resp_ISO;
+  std::vector<Eigen::VectorXf> resp_ISO;
 };
 
 class Stats {

--- a/src/dwi/tractography/GT/internalenergy.h
+++ b/src/dwi/tractography/GT/internalenergy.h
@@ -91,7 +91,7 @@ public:
 protected:
   ParticleGrid &pGrid;
   double cpot, dEint;
-  vector<ParticleEnd> neighbourhood;
+  std::vector<ParticleEnd> neighbourhood;
   double normalization;
   Math::RNG::Uniform<double> rng_uniform;
 

--- a/src/dwi/tractography/GT/mhsampler.h
+++ b/src/dwi/tractography/GT/mhsampler.h
@@ -88,7 +88,7 @@ protected:
       *E; // Polymorphic copy requires call to EnergyComputer::clone(), hence references or smart pointers won't do.
 
   Transform T;
-  vector<size_t> dims;
+  std::vector<size_t> dims;
   Image<bool> mask;
 
   std::shared_ptr<SpatialLock<float>> lock;

--- a/src/dwi/tractography/GT/mhsampler.h
+++ b/src/dwi/tractography/GT/mhsampler.h
@@ -46,7 +46,7 @@ public:
         T(dwi),
         dims{size_t(dwi.size(0)), size_t(dwi.size(1)), size_t(dwi.size(2))},
         mask(m),
-        lock(make_shared<SpatialLock<float>>(5 * Particle::L)),
+        lock(std::make_shared<SpatialLock<float>>(5 * Particle::L)),
         sigpos(Particle::L / 8.),
         sigdir(0.2) {
     DEBUG("Initialise Metropolis Hastings sampler.");

--- a/src/dwi/tractography/GT/particlegrid.cpp
+++ b/src/dwi/tractography/GT/particlegrid.cpp
@@ -60,7 +60,7 @@ void ParticleGrid::exportTracks(Tractography::Writer<float> &writer) {
   Particle *par;
   Particle *nextpar;
   int alpha = 0;
-  vector<Point_t> track;
+  std::vector<Point_t> track;
   // Loop through all unvisited particles
   for (ParticleVectorType &gridvox : grid) {
     for (Particle *par0 : gridvox) {

--- a/src/dwi/tractography/GT/particlegrid.h
+++ b/src/dwi/tractography/GT/particlegrid.h
@@ -37,7 +37,7 @@ namespace GT {
  */
 class ParticleGrid {
 public:
-  using ParticleVectorType = vector<Particle *>;
+  using ParticleVectorType = std::vector<Particle *>;
 
   template <class HeaderType> ParticleGrid(const HeaderType &image) {
     DEBUG("Initialise particle grid.");
@@ -79,7 +79,7 @@ public:
 protected:
   std::mutex mutex;
   ParticlePool pool;
-  vector<ParticleVectorType> grid;
+  std::vector<ParticleVectorType> grid;
   Math::RNG rng;
   transform_type T_s2g;
   size_t dims[3];

--- a/src/dwi/tractography/GT/particlepool.h
+++ b/src/dwi/tractography/GT/particlepool.h
@@ -94,14 +94,14 @@ public:
   void clear() {
     std::lock_guard<std::mutex> lock(mutex);
     pool.clear();
-    std::stack<Particle *, deque<Particle *>> e{};
+    std::stack<Particle *, std::deque<Particle *>> e{};
     avail.swap(e);
   }
 
 protected:
   std::mutex mutex;
-  deque<Particle> pool;
-  std::stack<Particle *, deque<Particle *>> avail;
+  std::deque<Particle> pool;
+  std::stack<Particle *, std::deque<Particle *>> avail;
   Math::RNG rng;
 };
 

--- a/src/dwi/tractography/GT/spatiallock.h
+++ b/src/dwi/tractography/GT/spatiallock.h
@@ -69,7 +69,7 @@ public:
 
 protected:
   std::mutex mutex;
-  vector<std::pair<point_type, bool>> lockcentres;
+  std::vector<std::pair<point_type, bool>> lockcentres;
   value_type _tx, _ty, _tz;
 
   bool try_lock(const point_type &pos, ssize_t &idx) {

--- a/src/dwi/tractography/SIFT/gradient_sort.h
+++ b/src/dwi/tractography/SIFT/gradient_sort.h
@@ -68,7 +68,7 @@ private:
 //     from all other blocks
 class MT_gradient_vector_sorter {
 
-  using VecType = vector<Cost_fn_gradient_sort>;
+  using VecType = std::vector<Cost_fn_gradient_sort>;
   using VecItType = VecType::iterator;
 
   class Comparator {

--- a/src/dwi/tractography/SIFT/output.h
+++ b/src/dwi/tractography/SIFT/output.h
@@ -212,7 +212,7 @@ template <class Fixel> void ModelBase<Fixel>::output_scatterplot(const std::stri
   out << "# " << App::command_history_string << "\n";
   const default_type current_mu = mu();
   out << "#Fibre density,Track density (unscaled),Track density (scaled),Weight,\n";
-  for (typename vector<Fixel>::const_iterator i = fixels.begin(); i != fixels.end(); ++i)
+  for (typename std::vector<Fixel>::const_iterator i = fixels.begin(); i != fixels.end(); ++i)
     out << str(i->get_FOD()) << "," << str(i->get_TD()) << "," << str(i->get_TD() * current_mu) << ","
         << str(i->get_weight()) << ",\n";
   out.close();

--- a/src/dwi/tractography/SIFT/sifter.cpp
+++ b/src/dwi/tractography/SIFT/sifter.cpp
@@ -49,7 +49,7 @@ void SIFTer::perform_filtering() {
   // For streamlines that do not contribute to the map, remove an equivalent proportion of length to those that do
   // contribute
   double sum_contributing_length = 0.0, sum_noncontributing_length = 0.0;
-  vector<track_t> noncontributing_indices;
+  std::vector<track_t> noncontributing_indices;
   for (track_t i = 0; i != contributions.size(); ++i) {
     if (contributions[i]) {
       if (contributions[i]->get_total_contribution()) {
@@ -64,7 +64,7 @@ void SIFTer::perform_filtering() {
   // Randomise the order or removal here; faster than trying to select at random later
   std::shuffle(noncontributing_indices.begin(), noncontributing_indices.end(), Math::RNG());
 
-  vector<Cost_fn_gradient_sort> gradient_vector;
+  std::vector<Cost_fn_gradient_sort> gradient_vector;
   try {
     gradient_vector.assign(
         num_tracks(),
@@ -180,7 +180,7 @@ void SIFTer::perform_filtering() {
 
       } else { // Proceed as normal
 
-        const vector<Cost_fn_gradient_sort>::iterator candidate = sorter.get();
+        const std::vector<Cost_fn_gradient_sort>::iterator candidate = sorter.get();
         if (candidate == gradient_vector.end()) {
           recalculate = POS_GRADIENT;
           if (!removed_this_iteration)
@@ -374,7 +374,7 @@ void SIFTer::output_selection(const std::string &path) const {
   }
 }
 
-void SIFTer::set_regular_outputs(const vector<uint32_t> &in, const std::string &dirpath) {
+void SIFTer::set_regular_outputs(const std::vector<uint32_t> &in, const std::string &dirpath) {
   for (auto i : in) {
     if (i > 0 && i <= contributions.size())
       output_at_counts.push_back(i);
@@ -387,7 +387,7 @@ void SIFTer::test_sorting_block_size(const size_t num_tracks) const {
 
   Math::RNG::Normal<float> rng;
 
-  vector<Cost_fn_gradient_sort> gradient_vector;
+  std::vector<Cost_fn_gradient_sort> gradient_vector;
   gradient_vector.assign(num_tracks, Cost_fn_gradient_sort(num_tracks, 0.0, 0.0));
   // Fill the gradient vector with random Gaussian data
   for (track_t index = 0; index != num_tracks; ++index) {
@@ -395,16 +395,16 @@ void SIFTer::test_sorting_block_size(const size_t num_tracks) const {
     gradient_vector[index].set(index, value, value);
   }
 
-  vector<size_t> block_sizes;
+  std::vector<size_t> block_sizes;
   for (size_t i = 16; i < num_tracks; i *= 2)
     block_sizes.push_back(i);
   block_sizes.push_back(num_tracks);
 
-  for (vector<size_t>::const_iterator i = block_sizes.begin(); i != block_sizes.end(); ++i) {
+  for (std::vector<size_t>::const_iterator i = block_sizes.begin(); i != block_sizes.end(); ++i) {
     const size_t block_size = *i;
 
     // Make a copy of the gradient vector, so the same data is sorted each time
-    vector<Cost_fn_gradient_sort> temp_gv(gradient_vector);
+    std::vector<Cost_fn_gradient_sort> temp_gv(gradient_vector);
 
     Timer timer;
     // Simulate sorting and filtering
@@ -425,7 +425,7 @@ void SIFTer::test_sorting_block_size(const size_t num_tracks) const {
 double SIFTer::calc_roc_cost_function() const {
   const double current_mu = mu();
   double roc_cost = 0.0;
-  vector<Fixel>::const_iterator i = fixels.begin();
+  std::vector<Fixel>::const_iterator i = fixels.begin();
   for (++i; i != fixels.end(); ++i)
     roc_cost += i->get_d_cost_d_mu(current_mu);
   return roc_cost;

--- a/src/dwi/tractography/SIFT/sifter.h
+++ b/src/dwi/tractography/SIFT/sifter.h
@@ -62,7 +62,7 @@ public:
   void set_term_mu(const float i) { term_mu = i; }
   void set_csv_path(const std::string &i) { csv_path = i; }
 
-  void set_regular_outputs(const vector<uint32_t> &, const std::string &);
+  void set_regular_outputs(const std::vector<uint32_t> &, const std::string &);
 
   // DEBUGGING
   void test_sorting_block_size(const size_t) const;
@@ -77,7 +77,7 @@ protected:
   using MapType::TD_sum;
 
   // User-controllable settings
-  vector<track_t> output_at_counts;
+  std::vector<track_t> output_at_counts;
   std::string debug_dir;
   track_t term_number;
   float term_ratio;
@@ -92,13 +92,16 @@ protected:
   // For calculating the streamline removal gradients in a multi-threaded fashion
   class TrackGradientCalculator {
   public:
-    TrackGradientCalculator(const SIFTer &sifter, vector<Cost_fn_gradient_sort> &v, const double mu, const double r)
+    TrackGradientCalculator(const SIFTer &sifter,
+                            std::vector<Cost_fn_gradient_sort> &v,
+                            const double mu,
+                            const double r)
         : master(sifter), gradient_vector(v), current_mu(mu), current_roc_cost(r) {}
     bool operator()(const TrackIndexRange &) const;
 
   private:
     const SIFTer &master;
-    vector<Cost_fn_gradient_sort> &gradient_vector;
+    std::vector<Cost_fn_gradient_sort> &gradient_vector;
     const double current_mu, current_roc_cost;
   };
 };

--- a/src/dwi/tractography/SIFT/track_contribution.h
+++ b/src/dwi/tractography/SIFT/track_contribution.h
@@ -107,7 +107,7 @@ class Track_fixel_contribution
 class TrackContribution : public Min_mem_array<Track_fixel_contribution> {
 
 public:
-  TrackContribution(const vector<Track_fixel_contribution> &in, const float c, const float l)
+  TrackContribution(const std::vector<Track_fixel_contribution> &in, const float c, const float l)
       : Min_mem_array<Track_fixel_contribution>(in), total_contribution(c), total_length(l) {}
 
   TrackContribution() : Min_mem_array<Track_fixel_contribution>(), total_contribution(0.0), total_length(0.0) {}

--- a/src/dwi/tractography/SIFT2/fixel_updater.h
+++ b/src/dwi/tractography/SIFT2/fixel_updater.h
@@ -41,9 +41,9 @@ private:
   TckFactor &master;
 
   // Each thread needs a local copy of these
-  vector<double> fixel_coeff_sums;
-  vector<double> fixel_TDs;
-  vector<SIFT::track_t> fixel_counts;
+  std::vector<double> fixel_coeff_sums;
+  std::vector<double> fixel_TDs;
+  std::vector<SIFT::track_t> fixel_counts;
 };
 
 } // namespace SIFT2

--- a/src/dwi/tractography/SIFT2/line_search.cpp
+++ b/src/dwi/tractography/SIFT2/line_search.cpp
@@ -46,7 +46,7 @@ LineSearchFunctor::Result LineSearchFunctor::get(const double dFs) const {
 
   Result data_result, tik_result, tv_result;
 
-  for (vector<Fixel>::const_iterator i = fixels.begin(); i != fixels.end(); ++i) {
+  for (std::vector<Fixel>::const_iterator i = fixels.begin(); i != fixels.end(); ++i) {
 
     const double contribution = i->length * factor;
     const double scaled_contribution = mu * contribution;
@@ -76,7 +76,7 @@ LineSearchFunctor::Result LineSearchFunctor::get(const double dFs) const {
 double LineSearchFunctor::operator()(const double dFs) const {
   double cf_data = 0.0;
   double cf_reg_tv = 0.0;
-  for (vector<Fixel>::const_iterator i = fixels.begin(); i != fixels.end(); ++i) {
+  for (std::vector<Fixel>::const_iterator i = fixels.begin(); i != fixels.end(); ++i) {
     cf_data += i->cost_frac * i->PM *
                Math::pow2((mu * (i->TD + (i->length * std::exp(Fs + dFs)) + (i->dTD_dFs * dFs))) - i->FOD);
     cf_reg_tv += i->SL_eff * SIFT2::tvreg(Fs + dFs, i->meanFs);

--- a/src/dwi/tractography/SIFT2/line_search.h
+++ b/src/dwi/tractography/SIFT2/line_search.h
@@ -79,7 +79,7 @@ protected:
   const double Fs;
   const double reg_tik, reg_tv;
 
-  vector<Fixel> fixels;
+  std::vector<Fixel> fixels;
 };
 
 } // namespace SIFT2

--- a/src/dwi/tractography/SIFT2/tckfactor.cpp
+++ b/src/dwi/tractography/SIFT2/tckfactor.cpp
@@ -50,7 +50,7 @@ void TckFactor::set_reg_lambdas(const double lambda_tikhonov, const double lambd
 }
 
 void TckFactor::store_orig_TDs() {
-  for (vector<Fixel>::iterator i = fixels.begin(); i != fixels.end(); ++i)
+  for (std::vector<Fixel>::iterator i = fixels.begin(); i != fixels.end(); ++i)
     i->store_orig_TD();
 }
 
@@ -66,7 +66,7 @@ void TckFactor::remove_excluded_fixels(const float min_td_frac) {
   const double cf = calc_cost_function();
   SIFT::track_t excluded_count = 0, zero_TD_count = 0;
   double zero_TD_cf_sum = 0.0, excluded_cf_sum = 0.0;
-  for (vector<Fixel>::iterator i = fixels.begin(); i != fixels.end(); ++i) {
+  for (std::vector<Fixel>::iterator i = fixels.begin(); i != fixels.end(); ++i) {
     if (!i->get_orig_TD()) {
       ++zero_TD_count;
       zero_TD_cf_sum += i->get_cost(fixed_mu);
@@ -90,7 +90,7 @@ void TckFactor::remove_excluded_fixels(const float min_td_frac) {
 void TckFactor::test_streamline_length_scaling() {
   VAR(calc_cost_function());
 
-  for (vector<Fixel>::iterator i = fixels.begin(); i != fixels.end(); ++i)
+  for (std::vector<Fixel>::iterator i = fixels.begin(); i != fixels.end(); ++i)
     i->clear_TD();
 
   coefficients.resize(num_tracks(), 0.0);
@@ -165,7 +165,7 @@ void TckFactor::calc_afcsa() {
     Thread::run_queue(writer, SIFT::TrackIndexRange(), Thread::multi(functor));
   }
 
-  for (vector<Fixel>::iterator i = fixels.begin(); i != fixels.end(); ++i) {
+  for (std::vector<Fixel>::iterator i = fixels.begin(); i != fixels.end(); ++i) {
     i->clear_TD();
     i->clear_mean_coeff();
   }
@@ -233,7 +233,7 @@ void TckFactor::estimate_factors() {
   // Initial estimates of how each weighting coefficient is going to change
   // The ProjectionCalculator classes overwrite these in place, so do an initial allocation but
   //   don't bother wiping it at every iteration
-  // vector<float> projected_steps (num_tracks(), 0.0);
+  // std::vector<float> projected_steps (num_tracks(), 0.0);
 
   // Logging which fixels need to be excluded from optimisation in subsequent iterations,
   //   due to driving streamlines to unwanted high weights
@@ -274,7 +274,7 @@ void TckFactor::estimate_factors() {
     }
 
     // Multi-threaded calculation of updated streamline density, and mean weighting coefficient, in each fixel
-    for (vector<Fixel>::iterator i = fixels.begin(); i != fixels.end(); ++i) {
+    for (std::vector<Fixel>::iterator i = fixels.begin(); i != fixels.end(); ++i) {
       i->clear_TD();
       i->clear_mean_coeff();
     }
@@ -284,7 +284,7 @@ void TckFactor::estimate_factors() {
       Thread::run_queue(writer, SIFT::TrackIndexRange(), Thread::multi(worker));
     }
     // Scale the fixel mean coefficient terms (each streamline in the fixel is weighted by its length)
-    for (vector<Fixel>::iterator i = fixels.begin(); i != fixels.end(); ++i)
+    for (std::vector<Fixel>::iterator i = fixels.begin(); i != fixels.end(); ++i)
       i->normalise_mean_coeff();
     indicate_progress();
 
@@ -391,10 +391,10 @@ void TckFactor::output_all_debug_images(const std::string &dirpath, const std::s
   if (!coefficients.size())
     return;
 
-  vector<double> mins(fixels.size(), std::numeric_limits<double>::infinity());
-  vector<double> stdevs(fixels.size(), 0.0);
-  vector<double> maxs(fixels.size(), -std::numeric_limits<double>::infinity());
-  vector<size_t> zeroed(fixels.size(), 0);
+  std::vector<double> mins(fixels.size(), std::numeric_limits<double>::infinity());
+  std::vector<double> stdevs(fixels.size(), 0.0);
+  std::vector<double> maxs(fixels.size(), -std::numeric_limits<double>::infinity());
+  std::vector<size_t> zeroed(fixels.size(), 0);
 
   {
     ProgressBar progress("Generating streamline coefficient statistic images", num_tracks());

--- a/src/dwi/tractography/algorithms/calibrator.h
+++ b/src/dwi/tractography/algorithms/calibrator.h
@@ -32,9 +32,9 @@ namespace Algorithms {
 
 using namespace MR::DWI::Tractography::Tracking;
 
-FORCE_INLINE vector<Eigen::Vector3f> direction_grid(float max_angle, float spacing) {
+FORCE_INLINE std::vector<Eigen::Vector3f> direction_grid(float max_angle, float spacing) {
   const float maxR = Math::pow2(max_angle / spacing);
-  vector<Eigen::Vector3f> list;
+  std::vector<Eigen::Vector3f> list;
   ssize_t extent = std::ceil(max_angle / spacing);
 
   for (ssize_t i = -extent; i <= extent; ++i) {
@@ -67,7 +67,7 @@ template <class Method> void calibrate(Method &method) {
   const float sqrt3 = std::sqrt(3.0);
   const float max_angle = std::isfinite(method.S.max_angle_ho) ? method.S.max_angle_ho : method.S.max_angle_1o;
 
-  vector<Pair> amps;
+  std::vector<Pair> amps;
   for (float el = 0.0; el < max_angle; el += 0.001) {
     amps.push_back(Pair(el, calibrate_func(el)));
     if (!std::isfinite(amps.back().amp) || amps.back().amp <= 0.0)

--- a/src/dwi/tractography/algorithms/iFOD1.h
+++ b/src/dwi/tractography/algorithms/iFOD1.h
@@ -212,7 +212,7 @@ protected:
   float calibrate_ratio;
   size_t mean_sample_num, num_sample_runs, num_truncations;
   float max_truncation;
-  vector<Eigen::Vector3f> calibrate_list;
+  std::vector<Eigen::Vector3f> calibrate_list;
 
   float FOD(const Eigen::Vector3f &d) const {
     return (S.precomputer ? S.precomputer.value(values, d) : Math::SH::value(values, d, S.lmax));

--- a/src/dwi/tractography/algorithms/iFOD2.h
+++ b/src/dwi/tractography/algorithms/iFOD2.h
@@ -302,11 +302,11 @@ private:
   float calibrate_ratio, half_log_prob0, last_half_log_probN, half_log_prob0_seed;
   size_t mean_sample_num, num_sample_runs, num_truncations;
   float max_truncation;
-  vector<Eigen::Vector3f> calibrate_list;
+  std::vector<Eigen::Vector3f> calibrate_list;
 
   // Store list of points in the currently-calculated arc
-  vector<Eigen::Vector3f> positions, calib_positions;
-  vector<Eigen::Vector3f> tangents, calib_tangents;
+  std::vector<Eigen::Vector3f> positions, calib_positions;
+  std::vector<Eigen::Vector3f> tangents, calib_tangents;
 
   // Generate an arc only when required, and on the majority of next() calls, simply return the next point
   //   in the arc - more dense structural image sampling
@@ -327,7 +327,7 @@ private:
     return path_prob(positions, tangents);
   }
 
-  float path_prob(vector<Eigen::Vector3f> &positions, vector<Eigen::Vector3f> &tangents) {
+  float path_prob(std::vector<Eigen::Vector3f> &positions, std::vector<Eigen::Vector3f> &tangents) {
 
     // Early exit for ACT when path is not sensible
     if (S.is_act()) {
@@ -358,8 +358,8 @@ private:
   }
 
 protected:
-  void get_path(vector<Eigen::Vector3f> &positions,
-                vector<Eigen::Vector3f> &tangents,
+  void get_path(std::vector<Eigen::Vector3f> &positions,
+                std::vector<Eigen::Vector3f> &tangents,
                 const Eigen::Vector3f &end_dir) const {
     float cos_theta = end_dir.dot(dir);
     cos_theta = std::min(cos_theta, float(1.0));
@@ -428,7 +428,7 @@ private:
     Eigen::VectorXf &fod;
     const float vox;
     float init_log_prob;
-    vector<Eigen::Vector3f> positions, tangents;
+    std::vector<Eigen::Vector3f> positions, tangents;
   };
 
   friend void calibrate<iFOD2>(iFOD2 &method);

--- a/src/dwi/tractography/algorithms/nulldist.h
+++ b/src/dwi/tractography/algorithms/nulldist.h
@@ -144,7 +144,7 @@ protected:
   const Shared &S;
   Interpolator<Image<float>>::type source;
 
-  vector<Eigen::Vector3f> positions, tangents;
+  std::vector<Eigen::Vector3f> positions, tangents;
   size_t sample_idx;
 };
 

--- a/src/dwi/tractography/algorithms/tensor_prob.h
+++ b/src/dwi/tractography/algorithms/tensor_prob.h
@@ -101,7 +101,7 @@ protected:
         raw_signals.push_back(Eigen::VectorXf(size(3)));
     }
 
-    vector<Eigen::VectorXf> raw_signals;
+    std::vector<Eigen::VectorXf> raw_signals;
 
     bool get(const Eigen::Vector3f &pos, Eigen::VectorXf &data) {
       if (!scanner(pos)) {

--- a/src/dwi/tractography/connectome/exemplar.cpp
+++ b/src/dwi/tractography/connectome/exemplar.cpp
@@ -140,7 +140,7 @@ void Exemplar::finalize(const float step_size) {
   // Start from the midpoint, resample backwards to the start of the exemplar,
   //   reverse the data, then do the second half of the exemplar
   int32_t index = (size() + 1) / 2;
-  vector<point_type> vertices(1, (*this)[index]);
+  std::vector<point_type> vertices(1, (*this)[index]);
   const float step_sq = Math::pow2(step_size);
   for (int32_t step = -1; step <= 1; step += 2) {
     if (step == 1) {

--- a/src/dwi/tractography/connectome/extract.cpp
+++ b/src/dwi/tractography/connectome/extract.cpp
@@ -24,7 +24,7 @@ namespace Tractography {
 namespace Connectome {
 
 bool Selector::operator()(const node_t node) const {
-  for (vector<node_t>::const_iterator i = list.begin(); i != list.end(); ++i) {
+  for (std::vector<node_t>::const_iterator i = list.begin(); i != list.end(); ++i) {
     if (*i == node)
       return true;
   }
@@ -37,7 +37,7 @@ bool Selector::operator()(const NodePair &nodes) const {
   if (exact_match && list.size() == 2)
     return ((nodes.first == list[0] && nodes.second == list[1]) || (nodes.first == list[1] && nodes.second == list[0]));
   bool found_first = false, found_second = false;
-  for (vector<node_t>::const_iterator i = list.begin(); i != list.end(); ++i) {
+  for (std::vector<node_t>::const_iterator i = list.begin(); i != list.end(); ++i) {
     if (*i == nodes.first)
       found_first = true;
     if (*i == nodes.second)
@@ -49,9 +49,9 @@ bool Selector::operator()(const NodePair &nodes) const {
     return (found_first || found_second);
 }
 
-bool Selector::operator()(const vector<node_t> &nodes) const {
+bool Selector::operator()(const std::vector<node_t> &nodes) const {
   BitSet found(list.size());
-  for (vector<node_t>::const_iterator n = nodes.begin(); n != nodes.end(); ++n) {
+  for (std::vector<node_t>::const_iterator n = nodes.begin(); n != nodes.end(); ++n) {
     for (size_t i = 0; i != list.size(); ++i)
       if (*n == list[i])
         found[i] = true;
@@ -63,10 +63,10 @@ bool Selector::operator()(const vector<node_t> &nodes) const {
 }
 
 WriterExemplars::WriterExemplars(const Tractography::Properties &properties,
-                                 const vector<node_t> &nodes,
+                                 const std::vector<node_t> &nodes,
                                  const bool exclusive,
                                  const node_t first_node,
-                                 const vector<Eigen::Vector3f> &COMs)
+                                 const std::vector<Eigen::Vector3f> &COMs)
     : step_size(properties.get_stepsize()) {
   if (!std::isfinite(step_size))
     step_size = 1.0f;
@@ -124,7 +124,7 @@ bool WriterExemplars::operator()(const Tractography::Connectome::Streamline_node
 // TODO Multi-thread
 void WriterExemplars::finalize() {
   ProgressBar progress("finalizing exemplars", exemplars.size());
-  for (vector<Exemplar>::iterator i = exemplars.begin(); i != exemplars.end(); ++i) {
+  for (std::vector<Exemplar>::iterator i = exemplars.begin(); i != exemplars.end(); ++i) {
     i->finalize(step_size);
     ++progress;
   }
@@ -175,17 +175,17 @@ void WriterExemplars::write(const std::string &path, const std::string &weights_
   Tractography::Properties properties;
   properties["step_size"] = str(step_size);
   Tractography::Writer<float> writer(path, properties);
-  for (vector<Exemplar>::const_iterator i = exemplars.begin(); i != exemplars.end(); ++i)
+  for (std::vector<Exemplar>::const_iterator i = exemplars.begin(); i != exemplars.end(); ++i)
     writer(i->get());
   if (weights_path.size()) {
     File::OFStream output(weights_path);
-    for (vector<Exemplar>::const_iterator i = exemplars.begin(); i != exemplars.end(); ++i)
+    for (std::vector<Exemplar>::const_iterator i = exemplars.begin(); i != exemplars.end(); ++i)
       output << str(i->get_weight()) << "\n";
   }
 }
 
 WriterExtraction::WriterExtraction(const Tractography::Properties &p,
-                                   const vector<node_t> &nodes,
+                                   const std::vector<node_t> &nodes,
                                    const bool exclusive,
                                    const bool keep_self)
     : properties(p), node_list(nodes), exclusive(exclusive), keep_self(keep_self) {}
@@ -209,7 +209,9 @@ void WriterExtraction::add(const node_t node_one,
   }
 }
 
-void WriterExtraction::add(const vector<node_t> &list, const std::string &path, const std::string weights_path = "") {
+void WriterExtraction::add(const std::vector<node_t> &list,
+                           const std::string &path,
+                           const std::string weights_path = "") {
   selectors.emplace_back(Selector(list, exclusive, keep_self));
   writers.emplace_back(new Tractography::WriterUnbuffered<float>(path, properties));
   if (weights_path.size())
@@ -226,7 +228,7 @@ bool WriterExtraction::operator()(const Connectome::Streamline_nodepair &in) con
     // Make sure that both nodes are within the list of nodes of interest;
     //   if not, don't bother passing to any of the selectors
     bool first_in_list = false, second_in_list = false;
-    for (vector<node_t>::const_iterator i = node_list.begin(); i != node_list.end(); ++i) {
+    for (std::vector<node_t>::const_iterator i = node_list.begin(); i != node_list.end(); ++i) {
       if (*i == in.get_nodes().first)
         first_in_list = true;
       if (*i == in.get_nodes().second)
@@ -252,7 +254,7 @@ bool WriterExtraction::operator()(const Connectome::Streamline_nodelist &in) con
     // Make sure _all_ nodes are within the list of nodes of interest;
     //   if not, don't pass to any of the selectors
     BitSet in_list(in.get_nodes().size());
-    for (vector<node_t>::const_iterator i = node_list.begin(); i != node_list.end(); ++i) {
+    for (std::vector<node_t>::const_iterator i = node_list.begin(); i != node_list.end(); ++i) {
       for (size_t n = 0; n != in.get_nodes().size(); ++n)
         if (*i == in.get_nodes()[n])
           in_list[n] = true;

--- a/src/dwi/tractography/connectome/extract.h
+++ b/src/dwi/tractography/connectome/extract.h
@@ -36,7 +36,7 @@ public:
     list.push_back(node_one);
     list.push_back(node_two);
   }
-  Selector(const vector<node_t> &node_list, const bool both, const bool keep_self = false)
+  Selector(const std::vector<node_t> &node_list, const bool both, const bool keep_self = false)
       : list(node_list), exact_match(both), keep_self(keep_self) {}
   Selector(const Selector &that) : list(that.list), exact_match(that.exact_match), keep_self(that.keep_self) {}
   Selector(Selector &&that) : list(std::move(that.list)), exact_match(that.exact_match), keep_self(that.keep_self) {}
@@ -44,20 +44,20 @@ public:
   bool operator()(const node_t) const;
   bool operator()(const NodePair &) const;
   bool operator()(const node_t one, const node_t two) const { return (*this)(NodePair(one, two)); }
-  bool operator()(const vector<node_t> &) const;
+  bool operator()(const std::vector<node_t> &) const;
 
 private:
-  vector<node_t> list;
+  std::vector<node_t> list;
   bool exact_match, keep_self;
 };
 
 class WriterExemplars {
 public:
   WriterExemplars(const Tractography::Properties &,
-                  const vector<node_t> &,
+                  const std::vector<node_t> &,
                   const bool,
                   const node_t,
-                  const vector<Eigen::Vector3f> &);
+                  const std::vector<Eigen::Vector3f> &);
 
   bool operator()(const Tractography::Connectome::Streamline_nodepair &);
   bool operator()(const Tractography::Connectome::Streamline_nodelist &);
@@ -70,18 +70,18 @@ public:
 
 private:
   float step_size;
-  vector<Selector> selectors;
-  vector<Exemplar> exemplars;
+  std::vector<Selector> selectors;
+  std::vector<Exemplar> exemplars;
 };
 
 class WriterExtraction {
 
 public:
-  WriterExtraction(const Tractography::Properties &, const vector<node_t> &, const bool, const bool);
+  WriterExtraction(const Tractography::Properties &, const std::vector<node_t> &, const bool, const bool);
 
   void add(const node_t, const std::string &, const std::string);
   void add(const node_t, const node_t, const std::string &, const std::string);
-  void add(const vector<node_t> &, const std::string &, const std::string);
+  void add(const std::vector<node_t> &, const std::string &, const std::string);
 
   void clear();
 
@@ -92,11 +92,11 @@ public:
 
 private:
   const Tractography::Properties &properties;
-  const vector<node_t> &node_list;
+  const std::vector<node_t> &node_list;
   const bool exclusive;
   const bool keep_self;
-  vector<Selector> selectors;
-  vector<std::unique_ptr<Tractography::WriterUnbuffered<float>>> writers;
+  std::vector<Selector> selectors;
+  std::vector<std::unique_ptr<Tractography::WriterUnbuffered<float>>> writers;
   Tractography::Streamline<> empty_tck;
 };
 

--- a/src/dwi/tractography/connectome/mapped_track.h
+++ b/src/dwi/tractography/connectome/mapped_track.h
@@ -65,13 +65,13 @@ public:
   Mapped_track_nodelist() : Mapped_track_base(), nodes() {}
 
   void add_node(const node_t i) { nodes.push_back(i); }
-  void set_nodes(const vector<node_t> &i) { nodes = i; }
-  void set_nodes(vector<node_t> &&i) { std::swap(nodes, i); }
+  void set_nodes(const std::vector<node_t> &i) { nodes = i; }
+  void set_nodes(std::vector<node_t> &&i) { std::swap(nodes, i); }
 
-  const vector<node_t> &get_nodes() const { return nodes; }
+  const std::vector<node_t> &get_nodes() const { return nodes; }
 
 private:
-  vector<node_t> nodes;
+  std::vector<node_t> nodes;
 };
 
 } // namespace Connectome

--- a/src/dwi/tractography/connectome/mapper.h
+++ b/src/dwi/tractography/connectome/mapper.h
@@ -46,7 +46,7 @@ public:
   bool operator()(const Tractography::Streamline<float> &in, Mapped_track_nodelist &out) {
     assert(!tck2nodes.provides_pair());
     out.set_track_index(in.get_index());
-    vector<node_t> nodes;
+    std::vector<node_t> nodes;
     tck2nodes(in, nodes);
     out.set_nodes(std::move(nodes));
     out.set_factor(metric(in, out.get_nodes()));

--- a/src/dwi/tractography/connectome/matrix.cpp
+++ b/src/dwi/tractography/connectome/matrix.cpp
@@ -75,8 +75,8 @@ template <typename T> bool Matrix<T>::operator()(const Mapped_track_nodepair &in
 template <typename T> bool Matrix<T>::operator()(const Mapped_track_nodelist &in) {
   assert(assignments_single.empty());
   assert(assignments_pairs.empty());
-  vector<node_t> list(in.get_nodes());
-  for (vector<node_t>::const_iterator i = list.begin(); i != list.end(); ++i) {
+  std::vector<node_t> list(in.get_nodes());
+  for (std::vector<node_t>::const_iterator i = list.begin(); i != list.end(); ++i) {
     assert(*i < data.rows());
   }
   if (is_vector()) {
@@ -85,7 +85,7 @@ template <typename T> bool Matrix<T>::operator()(const Mapped_track_nodelist &in
       inc_count(0, in.get_weight());
       list.push_back(0);
     } else {
-      for (vector<node_t>::const_iterator n = list.begin(); n != list.end(); ++n) {
+      for (std::vector<node_t>::const_iterator n = list.begin(); n != list.end(); ++n) {
         apply_data(*n, in.get_factor(), in.get_weight());
         inc_count(*n, in.get_weight());
       }
@@ -114,7 +114,7 @@ template <typename T> bool Matrix<T>::operator()(const Mapped_track_nodelist &in
     } else if (in.get_track_index() < assignments_lists.size()) {
       assignments_lists[in.get_track_index()] = std::move(list);
     } else {
-      assignments_lists.resize(in.get_track_index() + 1, vector<node_t>());
+      assignments_lists.resize(in.get_track_index() + 1, std::vector<node_t>());
       assignments_lists[in.get_track_index()] = std::move(list);
     }
   }
@@ -159,7 +159,7 @@ template <typename T> void Matrix<T>::error_check(const std::set<node_t> &missin
       visited[nodes.second] = true;
     }
   }
-  vector<std::string> empty_nodes;
+  std::vector<std::string> empty_nodes;
   for (node_t i = 1; i != visited.size(); ++i) {
     if (!visited[i] && missing_nodes.find(i) == missing_nodes.end())
       empty_nodes.push_back(str(i));

--- a/src/dwi/tractography/connectome/matrix.h
+++ b/src/dwi/tractography/connectome/matrix.h
@@ -83,9 +83,9 @@ private:
   const std::unique_ptr<MR::Connectome::Mat2Vec> mat2vec;
 
   vector_type data, counts;
-  vector<node_t> assignments_single;
-  vector<NodePair> assignments_pairs;
-  vector<vector<node_t>> assignments_lists;
+  std::vector<node_t> assignments_single;
+  std::vector<NodePair> assignments_pairs;
+  std::vector<std::vector<node_t>> assignments_lists;
 
   FORCE_INLINE void apply_data(const size_t, const T, const T);
   FORCE_INLINE void apply_data(const size_t, const size_t, const T, const T);

--- a/src/dwi/tractography/connectome/metric.h
+++ b/src/dwi/tractography/connectome/metric.h
@@ -52,10 +52,10 @@ public:
     return (*this)(tck);
   }
 
-  double operator()(const Streamline<> &tck, const vector<node_t> &nodes) const {
+  double operator()(const Streamline<> &tck, const std::vector<node_t> &nodes) const {
     if (scale_by_invnodevol) {
       double sum_volumes = 0.0;
-      for (vector<node_t>::const_iterator n = nodes.begin(); n != nodes.end(); ++n) {
+      for (std::vector<node_t>::const_iterator n = nodes.begin(); n != nodes.end(); ++n) {
         assert(*n < node_volumes.size());
         sum_volumes += node_volumes[*n];
       }

--- a/src/dwi/tractography/connectome/streamline.h
+++ b/src/dwi/tractography/connectome/streamline.h
@@ -42,11 +42,11 @@ public:
   Streamline_nodelist() : Tractography::Streamline<>(), nodes() {}
   Streamline_nodelist(const size_t i) : Tractography::Streamline<>(i), nodes() {}
 
-  void set_nodes(const vector<node_t> &i) { nodes = i; }
-  const vector<node_t> &get_nodes() const { return nodes; }
+  void set_nodes(const std::vector<node_t> &i) { nodes = i; }
+  const std::vector<node_t> &get_nodes() const { return nodes; }
 
 private:
-  vector<node_t> nodes;
+  std::vector<node_t> nodes;
 };
 
 } // namespace Connectome

--- a/src/dwi/tractography/connectome/tck2nodes.cpp
+++ b/src/dwi/tractography/connectome/tck2nodes.cpp
@@ -65,7 +65,8 @@ node_t Tck2nodes_radial::select_node(const Tractography::Streamline<> &tck, Imag
   const Eigen::Vector3d v_float = transform->scanner2voxel * p;
   const voxel_type centre{int(std::round(v_float[0])), int(std::round(v_float[1])), int(std::round(v_float[2]))};
 
-  for (vector<voxel_type>::const_iterator offset = radial_search.begin(); offset != radial_search.end(); ++offset) {
+  for (std::vector<voxel_type>::const_iterator offset = radial_search.begin(); offset != radial_search.end();
+       ++offset) {
 
     const voxel_type this_voxel(centre + *offset);
     const Eigen::Vector3d p_voxel(transform->voxel2scanner * this_voxel.matrix().cast<default_type>());
@@ -196,7 +197,7 @@ Tck2nodes_forwardsearch::get_cf(const Eigen::Vector3d &p, const Eigen::Vector3d 
   return (cf > max_dist ? NAN : cf);
 }
 
-void Tck2nodes_all_voxels::select_nodes(const Streamline<> &tck, Image<node_t> &v, vector<node_t> &out) const {
+void Tck2nodes_all_voxels::select_nodes(const Streamline<> &tck, Image<node_t> &v, std::vector<node_t> &out) const {
   std::set<node_t> result;
   for (Streamline<>::const_iterator p = tck.begin(); p != tck.end(); ++p) {
     const Eigen::Vector3d v_float = transform->scanner2voxel * p->cast<default_type>();

--- a/src/dwi/tractography/connectome/tck2nodes.h
+++ b/src/dwi/tractography/connectome/tck2nodes.h
@@ -51,7 +51,7 @@ public:
     return std::make_pair(node_one, node_two);
   }
 
-  bool operator()(const Streamline<> &tck, vector<node_t> &out) const {
+  bool operator()(const Streamline<> &tck, std::vector<node_t> &out) const {
     assert(!pair);
     Image<node_t> v(nodes);
     select_nodes(tck, v, out);
@@ -69,7 +69,7 @@ protected:
     throw Exception("Calling empty virtual function Tck2nodes_base::select_node()");
   }
 
-  virtual void select_nodes(const Streamline<> &tck, Image<node_t> &v, vector<node_t> &out) const {
+  virtual void select_nodes(const Streamline<> &tck, Image<node_t> &v, std::vector<node_t> &out) const {
     throw Exception("Calling empty virtual function Tck2nodes_base::select_nodes()");
   }
 
@@ -123,7 +123,7 @@ private:
   node_t select_node(const Tractography::Streamline<> &, Image<node_t> &, const bool) const override;
 
   void initialise_search();
-  vector<voxel_type> radial_search;
+  std::vector<voxel_type> radial_search;
   const default_type max_dist;
   // Distances are sub-voxel from the precise streamline termination point, so the search order is imperfect.
   //   This parameter controls when to stop the radial search because no voxel within the search space can be closer
@@ -181,7 +181,7 @@ public:
   ~Tck2nodes_all_voxels() {}
 
 private:
-  void select_nodes(const Streamline<> &, Image<node_t> &, vector<node_t> &) const override;
+  void select_nodes(const Streamline<> &, Image<node_t> &, std::vector<node_t> &) const override;
 };
 
 } // namespace Connectome

--- a/src/dwi/tractography/editing/loader.h
+++ b/src/dwi/tractography/editing/loader.h
@@ -34,13 +34,13 @@ namespace Editing {
 class Loader {
 
 public:
-  Loader(const vector<std::string> &files)
+  Loader(const std::vector<std::string> &files)
       : file_list(files), dummy_properties(), reader(new Reader<>(file_list[0], dummy_properties)), file_index(0) {}
 
   bool operator()(Streamline<> &);
 
 private:
-  const vector<std::string> &file_list;
+  const std::vector<std::string> &file_list;
   Properties dummy_properties;
   std::unique_ptr<Reader<>> reader;
   size_t file_index;

--- a/src/dwi/tractography/editing/worker.cpp
+++ b/src/dwi/tractography/editing/worker.cpp
@@ -81,8 +81,8 @@ bool Worker::operator()(Streamline<> &in, Streamline<> &out) const {
   }
 
   // Split tck into separate tracks based on the mask
-  vector<vector<Eigen::Vector3f>> cropped_tracks;
-  vector<Eigen::Vector3f> temp;
+  std::vector<std::vector<Eigen::Vector3f>> cropped_tracks;
+  std::vector<Eigen::Vector3f> temp;
 
   for (const auto &p : in) {
     const bool contains = properties.mask.contains(p);

--- a/src/dwi/tractography/file_base.cpp
+++ b/src/dwi/tractography/file_base.cpp
@@ -33,7 +33,7 @@ void __ReaderBase__::open(const std::string &file, const std::string &type, Prop
     const std::string key = lowercase(kv.key());
     if (key == "roi" || key == "prior_roi") {
       try {
-        vector<std::string> V(split(kv.value(), " \t", true, 2));
+        std::vector<std::string> V(split(kv.value(), " \t", true, 2));
         if (V.size() != 2)
           throw 1;
         properties.prior_rois.insert(std::pair<std::string, std::string>(V[0], V[1]));

--- a/src/dwi/tractography/mapping/buffer_scratch_dump.h
+++ b/src/dwi/tractography/mapping/buffer_scratch_dump.h
@@ -86,7 +86,7 @@ void BufferScratchDump<value_type>::dump_to_file(const std::string &path, const 
   for (const auto &i : H.keyval())
     out_header << "\n" << i.first << ": " << i.second;
 
-  for (vector<std::string>::const_iterator i = H.comments().begin(); i != H.comments().end(); i++)
+  for (std::vector<std::string>::const_iterator i = H.comments().begin(); i != H.comments().end(); i++)
     out_header << "\ncomments: " << *i;
 
   if (H.transform().is_set()) {

--- a/src/dwi/tractography/mapping/gaussian/mapper.cpp
+++ b/src/dwi/tractography/mapping/gaussian/mapper.cpp
@@ -32,7 +32,7 @@ void TrackMapper::set_factor(const Streamline<> &tck, SetVoxelExtras &out) const
 
 void TrackMapper::gaussian_smooth_factors(const Streamline<> &tck) const {
 
-  vector<default_type> unsmoothed(factors);
+  std::vector<default_type> unsmoothed(factors);
 
   for (size_t i = 0; i != unsmoothed.size(); ++i) {
 

--- a/src/dwi/tractography/mapping/mapper.cpp
+++ b/src/dwi/tractography/mapping/mapper.cpp
@@ -204,7 +204,7 @@ void TrackMapperTWI::add_twdfc_static_image(Image<float> &image) {
 }
 
 void TrackMapperTWI::add_twdfc_dynamic_image(Image<float> &image,
-                                             const vector<float> &kernel,
+                                             const std::vector<float> &kernel,
                                              const ssize_t timepoint) {
   if (image_plugin)
     throw Exception("Cannot add more than one associated image to TWI");
@@ -239,7 +239,7 @@ void TrackMapperTWI::load_factors(const Streamline<> &tck) const {
   if (contrast != CURVATURE)
     throw Exception("Unsupported contrast in function TrackMapperTWI::load_factors()");
 
-  vector<Eigen::Vector3d> tangents;
+  std::vector<Eigen::Vector3d> tangents;
   tangents.reserve(tck.size());
 
   // Would like to be able to manipulate the length over which the tangent calculation is affected
@@ -252,7 +252,7 @@ void TrackMapperTWI::load_factors(const Streamline<> &tck) const {
 
   // Need to know the distance along the spline between every point and every other point
   // Start by logging the length of each step
-  vector<default_type> step_sizes;
+  std::vector<default_type> step_sizes;
   step_sizes.reserve(tck.size());
 
   for (size_t i = 0; i != tck.size(); ++i) {
@@ -311,7 +311,7 @@ void TrackMapperTWI::load_factors(const Streamline<> &tck) const {
   // Smooth both the tangent vectors and the principal normal vectors according to a Gaussuan kernel
   // Remember: tangent vectors are unit length, but for principal normal vectors length must be preserved!
 
-  vector<Eigen::Vector3d> smoothed_tangents;
+  std::vector<Eigen::Vector3d> smoothed_tangents;
   smoothed_tangents.reserve(tangents.size());
 
   static const default_type gaussian_theta = CURVATURE_TRACK_SMOOTHING_FWHM / (2.0 * sqrt(2.0 * log(2.0)));

--- a/src/dwi/tractography/mapping/mapper.h
+++ b/src/dwi/tractography/mapping/mapper.h
@@ -332,7 +332,7 @@ public:
   void set_backtrack();
   void add_fod_image(const std::string &);
   void add_twdfc_static_image(Image<float> &);
-  void add_twdfc_dynamic_image(Image<float> &, const vector<float> &, const ssize_t);
+  void add_twdfc_dynamic_image(Image<float> &, const std::vector<float> &, const ssize_t);
   void add_vector_data(const std::string &);
 
 protected:
@@ -340,7 +340,7 @@ protected:
   const tck_stat_t track_statistic;
 
   // Members for when the contribution of a track is not constant along its length
-  mutable vector<default_type> factors;
+  mutable std::vector<default_type> factors;
   void load_factors(const Streamline<> &) const;
 
   // Member for incorporating additional information from an external image into the TWI process

--- a/src/dwi/tractography/mapping/mapper_plugins.cpp
+++ b/src/dwi/tractography/mapping/mapper_plugins.cpp
@@ -89,7 +89,7 @@ const Streamline<>::point_type TWIImagePluginBase::get_end_point(const Streamlin
   return tck[index];
 }
 
-void TWIScalarImagePlugin::load_factors(const Streamline<> &tck, vector<default_type> &factors) const {
+void TWIScalarImagePlugin::load_factors(const Streamline<> &tck, std::vector<default_type> &factors) const {
   if (statistic == ENDS_MIN || statistic == ENDS_MEAN || statistic == ENDS_MAX || statistic == ENDS_PROD) {
 
     // Only the track endpoints contribute
@@ -117,7 +117,7 @@ void TWIScalarImagePlugin::load_factors(const Streamline<> &tck, vector<default_
   }
 }
 
-void TWIFODImagePlugin::load_factors(const Streamline<> &tck, vector<default_type> &factors) const {
+void TWIFODImagePlugin::load_factors(const Streamline<> &tck, std::vector<default_type> &factors) const {
   assert(statistic != ENDS_CORR);
   if (statistic == ENDS_MAX || statistic == ENDS_MEAN || statistic == ENDS_MIN || statistic == ENDS_PROD) {
 
@@ -158,11 +158,11 @@ void TWIFODImagePlugin::load_factors(const Streamline<> &tck, vector<default_typ
   }
 }
 
-void TWDFCStaticImagePlugin::load_factors(const Streamline<> &tck, vector<default_type> &factors) const {
+void TWDFCStaticImagePlugin::load_factors(const Streamline<> &tck, std::vector<default_type> &factors) const {
   // Use trilinear interpolation
   // Store values into local vectors, since it's a two-pass operation
   factors.assign(1, NaN);
-  vector<float> values[2];
+  std::vector<float> values[2];
   for (size_t tck_end_index = 0; tck_end_index != 2; ++tck_end_index) {
     const ssize_t index = get_end_index(tck, bool(tck_end_index));
     if (index < 0)
@@ -197,13 +197,13 @@ void TWDFCStaticImagePlugin::load_factors(const Streamline<> &tck, vector<defaul
     factors[0] = product_expectation / (stdevs[0] * stdevs[1]);
 }
 
-void TWDFCDynamicImagePlugin::load_factors(const Streamline<> &tck, vector<default_type> &factors) const {
+void TWDFCDynamicImagePlugin::load_factors(const Streamline<> &tck, std::vector<default_type> &factors) const {
   assert(statistic == ENDS_CORR);
   factors.assign(1, NaN);
 
   // Use trilinear interpolation
   // Store values into local vectors, since it's a two-pass operation
-  vector<default_type> values[2];
+  std::vector<default_type> values[2];
   for (size_t tck_end_index = 0; tck_end_index != 2; ++tck_end_index) {
     const ssize_t index = get_end_index(tck, tck_end_index);
     if (index < 0)

--- a/src/dwi/tractography/mapping/mapper_plugins.h
+++ b/src/dwi/tractography/mapping/mapper_plugins.h
@@ -73,7 +73,7 @@ public:
 
   void set_backtrack();
 
-  virtual void load_factors(const Streamline<> &, vector<default_type> &) const = 0;
+  virtual void load_factors(const Streamline<> &, std::vector<default_type> &) const = 0;
 
 protected:
   const tck_stat_t statistic;
@@ -110,7 +110,7 @@ public:
 
   TWIScalarImagePlugin *clone() const override { return new TWIScalarImagePlugin(*this); }
 
-  void load_factors(const Streamline<> &, vector<default_type> &) const override;
+  void load_factors(const Streamline<> &, std::vector<default_type> &) const override;
 };
 
 class TWIFODImagePlugin : public TWIImagePluginBase {
@@ -129,7 +129,7 @@ public:
 
   TWIFODImagePlugin *clone() const override { return new TWIFODImagePlugin(*this); }
 
-  void load_factors(const Streamline<> &, vector<default_type> &) const override;
+  void load_factors(const Streamline<> &, std::vector<default_type> &) const override;
 
 private:
   mutable Eigen::Matrix<default_type, Eigen::Dynamic, 1> sh_coeffs;
@@ -144,12 +144,12 @@ public:
 
   TWDFCStaticImagePlugin *clone() const override { return new TWDFCStaticImagePlugin(*this); }
 
-  void load_factors(const Streamline<> &, vector<default_type> &) const override;
+  void load_factors(const Streamline<> &, std::vector<default_type> &) const override;
 };
 
 class TWDFCDynamicImagePlugin : public TWIImagePluginBase {
 public:
-  TWDFCDynamicImagePlugin(Image<float> &input_image, const vector<float> &kernel, const ssize_t timepoint)
+  TWDFCDynamicImagePlugin(Image<float> &input_image, const std::vector<float> &kernel, const ssize_t timepoint)
       : TWIImagePluginBase(input_image, ENDS_CORR),
         kernel(kernel),
         kernel_centre((kernel.size() - 1) / 2),
@@ -159,10 +159,10 @@ public:
 
   TWDFCDynamicImagePlugin *clone() const override { return new TWDFCDynamicImagePlugin(*this); }
 
-  void load_factors(const Streamline<> &, vector<default_type> &) const override;
+  void load_factors(const Streamline<> &, std::vector<default_type> &) const override;
 
 protected:
-  const vector<float> kernel;
+  const std::vector<float> kernel;
   const ssize_t kernel_centre, sample_centre;
 };
 

--- a/src/dwi/tractography/mapping/mapping.cpp
+++ b/src/dwi/tractography/mapping/mapping.cpp
@@ -41,7 +41,7 @@ size_t determine_upsample_ratio(const Header &header, const Tractography::Proper
   return determine_upsample_ratio(header, properties.get_stepsize(), ratio);
 }
 
-void generate_header(Header &header, const std::string &tck_file_path, const vector<default_type> &voxel_size) {
+void generate_header(Header &header, const std::string &tck_file_path, const std::vector<default_type> &voxel_size) {
 
   Properties properties;
   Reader<> file(tck_file_path, properties);
@@ -84,7 +84,7 @@ void generate_header(Header &header, const std::string &tck_file_path, const vec
   file.close();
 }
 
-void oversample_header(Header &header, const vector<default_type> &voxel_size) {
+void oversample_header(Header &header, const std::vector<default_type> &voxel_size) {
   INFO("oversampling header...");
 
   header.transform().translation() +=

--- a/src/dwi/tractography/mapping/mapping.h
+++ b/src/dwi/tractography/mapping/mapping.h
@@ -35,9 +35,9 @@ size_t determine_upsample_ratio(const Header &, const std::string &, const float
 size_t determine_upsample_ratio(const Header &, const Tractography::Properties &, const float);
 
 #define MAX_TRACKS_READ_FOR_HEADER 1000000
-void generate_header(Header &, const std::string &, const vector<default_type> &);
+void generate_header(Header &, const std::string &, const std::vector<default_type> &);
 
-void oversample_header(Header &, const vector<default_type> &);
+void oversample_header(Header &, const std::vector<default_type> &);
 
 } // namespace Mapping
 } // namespace Tractography

--- a/src/dwi/tractography/properties.cpp
+++ b/src/dwi/tractography/properties.cpp
@@ -115,7 +115,7 @@ std::ostream &operator<<(std::ostream &stream, const Properties &P) {
   for (KeyValues::const_iterator i = P.begin(); i != P.end(); ++i)
     stream << "[ " << i->first << ": " << i->second << " ], ";
   stream << "comments: ";
-  for (vector<std::string>::const_iterator i = P.comments.begin(); i != P.comments.end(); ++i)
+  for (std::vector<std::string>::const_iterator i = P.comments.begin(); i != P.comments.end(); ++i)
     stream << "\"" << *i << "\", ";
   return (stream);
 }

--- a/src/dwi/tractography/properties.h
+++ b/src/dwi/tractography/properties.h
@@ -60,7 +60,7 @@ public:
   // As stored within the header of an existing .tck file
   std::multimap<std::string, std::string> prior_rois;
 
-  vector<std::string> comments;
+  std::vector<std::string> comments;
 
   friend std::ostream &operator<<(std::ostream &stream, const Properties &P);
 };

--- a/src/dwi/tractography/resampling/arc.h
+++ b/src/dwi/tractography/resampling/arc.h
@@ -46,7 +46,7 @@ private:
     value_type d;
   };
 
-  vector<Plane> planes;
+  std::vector<Plane> planes;
 
 public:
   Arc(const size_t n, const point_type &s, const point_type &e)

--- a/src/dwi/tractography/resampling/fixed_num_points.cpp
+++ b/src/dwi/tractography/resampling/fixed_num_points.cpp
@@ -34,7 +34,7 @@ bool FixedNumPoints::operator()(const Streamline<> &in, Streamline<> &out) const
   if (in.size() < 2)
     return true;
   value_type length = 0.0;
-  vector<value_type> steps;
+  std::vector<value_type> steps;
   for (size_t i = 1; i != in.size(); ++i) {
     const value_type dist = (in[i] - in[i - 1]).norm();
     length += dist;

--- a/src/dwi/tractography/resampling/resampling.cpp
+++ b/src/dwi/tractography/resampling/resampling.cpp
@@ -70,7 +70,7 @@ namespace {
 using value_type = float;
 using point_type = Eigen::Vector3f;
 
-point_type get_pos(const vector<default_type> &s) {
+point_type get_pos(const std::vector<default_type> &s) {
   if (s.size() != 3)
     throw Exception("position expected as a comma-seperated list of 3 values");
   return {value_type(s[0]), value_type(s[1]), value_type(s[2])};

--- a/src/dwi/tractography/roi.cpp
+++ b/src/dwi/tractography/roi.cpp
@@ -75,7 +75,7 @@ void load_rois(Properties &properties) {
 
 Image<bool> Mask::__get_mask(const std::string &name) {
   auto data = Image<bool>::open(name);
-  vector<size_t> bottom(3, 0), top(3, 0);
+  std::vector<size_t> bottom(3, 0), top(3, 0);
   std::fill_n(bottom.begin(), 3, std::numeric_limits<size_t>::max());
 
   size_t sum = 0;

--- a/src/dwi/tractography/roi.h
+++ b/src/dwi/tractography/roi.h
@@ -124,7 +124,7 @@ public:
   friend inline std::ostream &operator<<(std::ostream &stream, const ROISetBase &R) {
     if (R.R.empty())
       return (stream);
-    vector<ROI>::const_iterator i = R.R.begin();
+    std::vector<ROI>::const_iterator i = R.R.begin();
     stream << *i;
     ++i;
     for (; i != R.R.end(); ++i)
@@ -133,7 +133,7 @@ public:
   }
 
 protected:
-  vector<ROI> R;
+  std::vector<ROI> R;
 };
 
 class ROIUnorderedSet : public ROISetBase {

--- a/src/dwi/tractography/scalar_file.h
+++ b/src/dwi/tractography/scalar_file.h
@@ -180,7 +180,7 @@ public:
     if (buffer_size + tck_scalar.size() > buffer_capacity)
       commit();
 
-    for (typename vector<value_type>::const_iterator i = tck_scalar.begin(); i != tck_scalar.end(); ++i) {
+    for (typename std::vector<value_type>::const_iterator i = tck_scalar.begin(); i != tck_scalar.end(); ++i) {
       assert(std::isfinite(*i));
       add_scalar(*i);
     }

--- a/src/dwi/tractography/seeding/basic.cpp
+++ b/src/dwi/tractography/seeding/basic.cpp
@@ -124,8 +124,8 @@ Rejection::Rejection(const std::string &in)
   auto vox = Image<float>::open(in);
   if (!(vox.ndim() == 3 || (vox.ndim() == 4 && vox.size(3) == 1)))
     throw Exception("Seed image must be a 3D image");
-  vector<size_t> bottom(3, std::numeric_limits<size_t>::max());
-  vector<size_t> top(3, 0);
+  std::vector<size_t> bottom(3, std::numeric_limits<size_t>::max());
+  std::vector<size_t> top(3, 0);
 
   for (auto i = Loop(0, 3)(vox); i; ++i) {
     const float value = vox.value();

--- a/src/dwi/tractography/seeding/dynamic.cpp
+++ b/src/dwi/tractography/seeding/dynamic.cpp
@@ -252,7 +252,7 @@ bool Dynamic::operator()(const FMLS::FOD_lobes &in) {
 void Dynamic::write_seed(const Eigen::Vector3f &p) {
   static std::mutex mutex;
   std::lock_guard<std::mutex> lock(mutex);
-  vector<Eigen::Vector3f> tck;
+  std::vector<Eigen::Vector3f> tck;
   tck.push_back(p);
   seed_output(tck);
 }

--- a/src/dwi/tractography/seeding/list.h
+++ b/src/dwi/tractography/seeding/list.h
@@ -53,7 +53,7 @@ public:
   }
 
 private:
-  vector<std::unique_ptr<Base>> seeders;
+  std::vector<std::unique_ptr<Base>> seeders;
   float total_volume;
   uint32_t total_count;
 };

--- a/src/dwi/tractography/streamline.h
+++ b/src/dwi/tractography/streamline.h
@@ -53,43 +53,44 @@ private:
 };
 
 // A class for track scalars
-template <typename ValueType = float> class TrackScalar : public vector<ValueType>, public DataIndex {
+template <typename ValueType = float> class TrackScalar : public std::vector<ValueType>, public DataIndex {
 public:
   using value_type = ValueType;
-  using vector<ValueType>::vector;
+  using std::vector<ValueType>::vector;
   TrackScalar() = default;
   TrackScalar(const TrackScalar &) = default;
-  TrackScalar(TrackScalar &&that) : vector<value_type>(std::move(that)), DataIndex(std::move(that)) {}
+  TrackScalar(TrackScalar &&that) : std::vector<value_type>(std::move(that)), DataIndex(std::move(that)) {}
   TrackScalar &operator=(const TrackScalar &that) = default;
   void clear() {
-    vector<ValueType>::clear();
+    std::vector<ValueType>::clear();
     DataIndex::clear();
   }
 };
 
 template <typename ValueType = float>
-class Streamline : public vector<Eigen::Matrix<ValueType, 3, 1>>, public DataIndex {
+class Streamline : public std::vector<Eigen::Matrix<ValueType, 3, 1>>, public DataIndex {
 public:
   using point_type = Eigen::Matrix<ValueType, 3, 1>;
   using value_type = ValueType;
 
   Streamline() : weight(1.0f) {}
 
-  Streamline(size_t size) : vector<point_type>(size), weight(value_type(1.0)) {}
+  Streamline(size_t size) : std::vector<point_type>(size), weight(value_type(1.0)) {}
 
-  Streamline(size_t size, const point_type &fill) : vector<point_type>(size, fill), weight(value_type(1.0)) {}
+  Streamline(size_t size, const point_type &fill) : std::vector<point_type>(size, fill), weight(value_type(1.0)) {}
 
   Streamline(const Streamline &) = default;
   Streamline &operator=(const Streamline &that) = default;
 
-  Streamline(Streamline &&that) : vector<point_type>(std::move(that)), DataIndex(std::move(that)), weight(that.weight) {
+  Streamline(Streamline &&that)
+      : std::vector<point_type>(std::move(that)), DataIndex(std::move(that)), weight(that.weight) {
     that.weight = 1.0f;
   }
 
-  Streamline(const vector<point_type> &tck) : vector<point_type>(tck), DataIndex(), weight(1.0) {}
+  Streamline(const std::vector<point_type> &tck) : std::vector<point_type>(tck), DataIndex(), weight(1.0) {}
 
   Streamline &operator=(Streamline &&that) {
-    vector<point_type>::operator=(std::move(that));
+    std::vector<point_type>::operator=(std::move(that));
     DataIndex::operator=(std::move(that));
     weight = that.weight;
     that.weight = 0.0f;
@@ -97,7 +98,7 @@ public:
   }
 
   void clear() {
-    vector<point_type>::clear();
+    std::vector<point_type>::clear();
     DataIndex::clear();
     weight = 1.0;
   }
@@ -108,7 +109,7 @@ public:
   float weight;
 };
 
-template <typename PointType> typename PointType::Scalar length(const vector<PointType> &tck) {
+template <typename PointType> typename PointType::Scalar length(const std::vector<PointType> &tck) {
   if (tck.empty())
     return std::numeric_limits<typename PointType::Scalar>::quiet_NaN();
   typename PointType::Scalar value = typename PointType::Scalar(0);

--- a/src/dwi/tractography/tracking/exec.h
+++ b/src/dwi/tractography/tracking/exec.h
@@ -401,7 +401,7 @@ private:
     return false;
   }
 
-  bool satisfy_wm_requirement(const vector<Eigen::Vector3f> &tck) {
+  bool satisfy_wm_requirement(const std::vector<Eigen::Vector3f> &tck) {
     // If using the Seed_test algorithm (indicated by max_num_points == 2), don't want to execute this check
     if (S.max_num_points_preds == 2)
       return true;
@@ -424,7 +424,7 @@ private:
     return false;
   }
 
-  void truncate_exit_sgm(vector<Eigen::Vector3f> &tck) {
+  void truncate_exit_sgm(std::vector<Eigen::Vector3f> &tck) {
     const size_t sgm_start = tck.size() - method.act().sgm_depth;
     assert(sgm_start >= 0 && sgm_start < tck.size());
     size_t best_termination = tck.size() - 1;

--- a/src/dwi/tractography/tracking/generated_track.h
+++ b/src/dwi/tractography/tracking/generated_track.h
@@ -26,10 +26,10 @@ namespace DWI {
 namespace Tractography {
 namespace Tracking {
 
-class GeneratedTrack : public vector<Eigen::Vector3f> {
+class GeneratedTrack : public std::vector<Eigen::Vector3f> {
 
 public:
-  using BaseType = vector<Eigen::Vector3f>;
+  using BaseType = std::vector<Eigen::Vector3f>;
 
   enum class status_t { INVALID, SEED_REJECTED, TRACK_REJECTED, ACCEPTED };
 

--- a/src/fixel/filter/connect.cpp
+++ b/src/fixel/filter/connect.cpp
@@ -50,14 +50,14 @@ void Connect::operator()(Image<float> &input, Image<float> &output) const {
 
   BitSet processed(input.size(0));
   using IndexAndSize = std::pair<size_t, size_t>;
-  vector<IndexAndSize> cluster_sizes;
+  std::vector<IndexAndSize> cluster_sizes;
   for (index_type seed = 0; seed != input.size(0); ++seed) {
     if (!processed[seed]) {
       input.index(0) = seed;
       if (input.value() >= value_threshold) {
         processed[seed] = true;
         size_t cluster_size = 1;
-        std::stack<index_type, vector<index_type>> to_expand;
+        std::stack<index_type, std::vector<index_type>> to_expand;
         to_expand.push(seed);
         const size_t cluster_index = cluster_sizes.size() + 1;
         while (to_expand.size()) {
@@ -90,7 +90,7 @@ void Connect::operator()(Image<float> &input, Image<float> &output) const {
   // For a given value in the output image (as determined by the order in which the
   //   clusters were segmented), what should the new value be, such that the clusters
   //   are indexed sequentially according to size, with 1 being the biggest cluster?
-  vector<size_t> index_remapper(cluster_sizes.size() + 1);
+  std::vector<size_t> index_remapper(cluster_sizes.size() + 1);
   index_remapper[0] = 0;
   for (size_t index = 0; index != cluster_sizes.size(); ++index)
     index_remapper[cluster_sizes[index].first] = index + 1;

--- a/src/fixel/filter/smooth.h
+++ b/src/fixel/filter/smooth.h
@@ -67,7 +67,7 @@ public:
 protected:
   Image<bool> mask_image;
   Matrix::Reader matrix;
-  vector<Eigen::Vector3f> fixel_positions;
+  std::vector<Eigen::Vector3f> fixel_positions;
   float stdev, gaussian_const1, gaussian_const2, threshold;
 };
 //! @}

--- a/src/fixel/index_remapper.h
+++ b/src/fixel/index_remapper.h
@@ -51,8 +51,8 @@ public:
 
 private:
   bool mapping_is_default;
-  vector<index_type> external2internal;
-  vector<index_type> internal2external;
+  std::vector<index_type> external2internal;
+  std::vector<index_type> internal2external;
 };
 
 } // namespace Fixel

--- a/src/fixel/matrix.h
+++ b/src/fixel/matrix.h
@@ -31,9 +31,9 @@ using fixel_index_type = MR::Fixel::index_type;
 using count_type = uint32_t;
 using connectivity_value_type = float;
 
-class MappedTrack : public vector<fixel_index_type> {
+class MappedTrack : public std::vector<fixel_index_type> {
 public:
-  using BaseType = vector<fixel_index_type>;
+  using BaseType = std::vector<fixel_index_type>;
   default_type get_weight() const { return weight; }
   void set_weight(const default_type w) { weight = w; }
 
@@ -109,9 +109,9 @@ private:
   ValueType sum_weights;
 };
 
-template <class ElementType> class InitFixelBase : public vector<ElementType> {
+template <class ElementType> class InitFixelBase : public std::vector<ElementType> {
 public:
-  using BaseType = vector<ElementType>;
+  using BaseType = std::vector<ElementType>;
   virtual ~InitFixelBase() {}
   void add(const MappedTrack &mapped_track);
   virtual default_type norm_factor() const = 0;
@@ -145,8 +145,8 @@ private:
   void increment(InitElementWeighted &element, const MappedTrack &data) override { element += data.get_weight(); }
 };
 
-using InitMatrixUnweighted = vector<InitFixelUnweighted>;
-using InitMatrixWeighted = vector<InitFixelWeighted>;
+using InitMatrixUnweighted = std::vector<InitFixelUnweighted>;
+using InitMatrixWeighted = std::vector<InitFixelWeighted>;
 
 // A class to store fixel index / connectivity value pairs
 //   only after the connectivity matrix has been thresholded / normalised
@@ -167,10 +167,10 @@ private:
 
 // With the internally normalised CFE expression, want to store a
 //   multiplicative factor per fixel
-class NormFixel : public vector<NormElement> {
+class NormFixel : public std::vector<NormElement> {
 public:
   using ElementType = NormElement;
-  using BaseType = vector<NormElement>;
+  using BaseType = std::vector<NormElement>;
   using ValueType = connectivity_value_type;
   NormFixel() : norm_multiplier(ValueType(1)) {}
   NormFixel(const BaseType &i) : BaseType(i), norm_multiplier(ValueType(1)) {}

--- a/src/gui/dialog/dicom.cpp
+++ b/src/gui/dialog/dicom.cpp
@@ -177,8 +177,8 @@ public:
 
 } // namespace
 
-vector<std::shared_ptr<Series>> select_dicom(const Tree &tree) {
-  vector<std::shared_ptr<Series>> ret;
+std::vector<std::shared_ptr<Series>> select_dicom(const Tree &tree) {
+  std::vector<std::shared_ptr<Series>> ret;
   if (tree.size() == 1) {
     if (tree[0]->size() == 1) {
       if ((*tree[0])[0]->size() == 1) {

--- a/src/gui/dialog/dicom.h
+++ b/src/gui/dialog/dicom.h
@@ -26,7 +26,7 @@ namespace Dialog {
 
 using namespace MR::File::Dicom;
 
-vector<std::shared_ptr<Series>> select_dicom(const Tree &tree);
+std::vector<std::shared_ptr<Series>> select_dicom(const Tree &tree);
 
 } // namespace Dialog
 } // namespace GUI

--- a/src/gui/dialog/file.cpp
+++ b/src/gui/dialog/file.cpp
@@ -61,12 +61,12 @@ std::string get_file(QWidget *parent, const std::string &caption, const std::str
   return filename;
 }
 
-vector<std::string>
+std::vector<std::string>
 get_files(QWidget *parent, const std::string &caption, const std::string &filter, std::string *folder) {
   QStringList qlist = QFileDialog::getOpenFileNames(
       parent, qstr(caption), folder ? qstr(*folder) : QString(), qstr(filter), 0, FILE_DIALOG_OPTIONS);
 
-  vector<std::string> list;
+  std::vector<std::string> list;
   if (qlist.size()) {
     for (int n = 0; n < qlist.size(); ++n)
       list.push_back(qlist[n].toUtf8().data());

--- a/src/gui/dialog/file.h
+++ b/src/gui/dialog/file.h
@@ -33,10 +33,10 @@ std::string get_file(QWidget *parent,
                      const std::string &caption,
                      const std::string &filter = std::string(),
                      std::string *folder = nullptr);
-vector<std::string> get_files(QWidget *parent,
-                              const std::string &caption,
-                              const std::string &filter = std::string(),
-                              std::string *folder = nullptr);
+std::vector<std::string> get_files(QWidget *parent,
+                                   const std::string &caption,
+                                   const std::string &filter = std::string(),
+                                   std::string *folder = nullptr);
 std::string get_save_name(QWidget *parent,
                           const std::string &caption,
                           const std::string &suggested_name = std::string(),
@@ -47,7 +47,7 @@ inline std::string get_image(QWidget *parent, const std::string &caption, std::s
   return get_file(parent, caption, image_filter_string, folder);
 }
 
-inline vector<std::string> get_images(QWidget *parent, const std::string &caption, std::string *folder = nullptr) {
+inline std::vector<std::string> get_images(QWidget *parent, const std::string &caption, std::string *folder = nullptr) {
   return get_files(parent, caption, image_filter_string, folder);
 }
 

--- a/src/gui/dwi/renderer.cpp
+++ b/src/gui/dwi/renderer.cpp
@@ -341,7 +341,7 @@ void Renderer::SH::update_mesh(const size_t lod, const int lmax) {
   QApplication::restoreOverrideCursor();
 }
 
-void Renderer::SH::update_transform(const vector<Shapes::HalfSphere::Vertex> &vertices, int lmax) {
+void Renderer::SH::update_transform(const std::vector<Shapes::HalfSphere::Vertex> &vertices, int lmax) {
   // order is r, del, daz
 
   transform = decltype(transform)::Zero(3 * vertices.size(), Math::SH::NforL(lmax));
@@ -521,8 +521,8 @@ void Renderer::Dixel::update_mesh(const MR::DWI::Directions::Set &dirs) {
 }
 
 void Renderer::Dixel::update_dixels(const MR::DWI::Directions::Set &dirs) {
-  vector<Eigen::Vector3f> directions_data;
-  vector<std::array<GLint, 3>> indices_data;
+  std::vector<Eigen::Vector3f> directions_data;
+  std::vector<std::array<GLint, 3>> indices_data;
 
   for (size_t i = 0; i != dirs.size(); ++i) {
     directions_data.push_back(dirs[i].cast<float>());

--- a/src/gui/dwi/renderer.h
+++ b/src/gui/dwi/renderer.h
@@ -175,7 +175,7 @@ public:
     GL::VertexBuffer surface_buffer;
     GL::VertexArrayObject VAO;
 
-    void update_transform(const vector<Shapes::HalfSphere::Vertex> &, int);
+    void update_transform(const std::vector<Shapes::HalfSphere::Vertex> &, int);
 
   } sh;
 

--- a/src/gui/mrview/colourmap_button.h
+++ b/src/gui/mrview/colourmap_button.h
@@ -49,7 +49,7 @@ public:
   void set_scale_inverted(bool yesno);
   void set_show_colourbar(bool yesno);
   void set_fixed_colour();
-  vector<QAction *> colourmap_actions;
+  std::vector<QAction *> colourmap_actions;
   void open_menu(const QPoint &p) { colourmap_menu->exec(p); }
 
 private:
@@ -59,8 +59,8 @@ private:
   void init_special_colour_menu_items(bool create_shortcuts);
   void init_customise_state_menu_items();
 
-  static const vector<ColourMap::Entry> core_colourmaps_entries;
-  static const vector<ColourMap::Entry> special_colourmaps_entries;
+  static const std::vector<ColourMap::Entry> core_colourmaps_entries;
+  static const std::vector<ColourMap::Entry> special_colourmaps_entries;
 
   ColourMapButtonObserver &observer;
   QActionGroup *core_colourmaps_actions;

--- a/src/gui/mrview/gui_image.cpp
+++ b/src/gui/mrview/gui_image.cpp
@@ -142,7 +142,7 @@ void Image::update_texture2D(int plane, int slice) {
   const ssize_t xsize = header().size(x), ysize = header().size(y);
 
   type = gl::FLOAT;
-  vector<float> data;
+  std::vector<float> data;
 
   std::string cmap_name = ColourMap::maps[colourmap].name;
 
@@ -458,7 +458,7 @@ template <typename ValueType> inline void Image::copy_texture_3D() {
   } V(image);
 
   const size_t N = (format == gl::RED ? 1 : 3);
-  vector<ValueType> data(N * V.size(0) * V.size(1));
+  std::vector<ValueType> data(N * V.size(0) * V.size(1));
 
   ProgressBar progress("loading image data", V.size(2));
 
@@ -525,7 +525,7 @@ template <typename ValueType> inline void Image::copy_texture_3D() {
 }
 
 inline void Image::copy_texture_3D_complex() {
-  vector<float> data(2 * image.size(0) * image.size(1));
+  std::vector<float> data(2 * image.size(0) * image.size(1));
 
   ProgressBar progress("loading image data", image.size(2));
 

--- a/src/gui/mrview/gui_image.h
+++ b/src/gui/mrview/gui_image.h
@@ -53,7 +53,7 @@ public:
 
 protected:
   GL::Texture texture2D[3];
-  vector<ssize_t> tex_positions;
+  std::vector<ssize_t> tex_positions;
 };
 
 class Image : public ImageBase {
@@ -74,7 +74,7 @@ public:
   cfloat nearest_neighbour_value(const Eigen::Vector3f &) const;
 
   const transform_type &transform() const { return image.transform(); }
-  const vector<std::string> &comments() const { return _comments; }
+  const std::vector<std::string> &comments() const { return _comments; }
 
   void reset_windowing(const int, const bool);
 
@@ -97,7 +97,7 @@ private:
   void lookup_texture_4D_cache();
   void update_texture_4D_cache();
 
-  vector<std::string> _comments;
+  std::vector<std::string> _comments;
 };
 
 } // namespace MRView

--- a/src/gui/mrview/mode/ortho.h
+++ b/src/gui/mrview/mode/ortho.h
@@ -44,7 +44,7 @@ public slots:
   void set_show_as_row_slot(bool state);
 
 protected:
-  vector<Projection> projections;
+  std::vector<Projection> projections;
   int current_plane;
   GL::VertexBuffer frame_VB;
   GL::VertexArrayObject frame_VAO;

--- a/src/gui/mrview/mode/volume.cpp
+++ b/src/gui/mrview/mode/volume.cpp
@@ -50,10 +50,10 @@ std::string Volume::Shader::vertex_shader_source(const Displayable &) {
 }
 
 std::string Volume::Shader::fragment_shader_source(const Displayable &object) {
-  vector<std::pair<GL::vec4, bool>> clip = mode.get_active_clip_planes();
+  std::vector<std::pair<GL::vec4, bool>> clip = mode.get_active_clip_planes();
   const bool AND = mode.get_clipintersectionmodestate();
   std::string clip_color_spec = File::Config::get("MRViewClipPlaneColour");
-  vector<float> clip_color = {1.0, 0.0, 0.0, 0.1};
+  std::vector<float> clip_color = {1.0, 0.0, 0.0, 0.1};
   if (clip_color_spec.size()) {
     auto colour = parse_floats(clip_color_spec);
     if (colour.size() != 4)
@@ -430,7 +430,7 @@ void Volume::paint(Projection &projection) {
   GL_CHECK_ERROR;
   gl::Uniform1i(gl::GetUniformLocation(volume_shader, "depth_sampler"), 1);
 
-  vector<std::pair<GL::vec4, bool>> clip = get_active_clip_planes();
+  std::vector<std::pair<GL::vec4, bool>> clip = get_active_clip_planes();
   GL_CHECK_ERROR;
 
   for (size_t n = 0; n < clip.size(); ++n) {
@@ -491,14 +491,14 @@ inline Tool::View *Volume::get_view_tool() const {
   return dynamic_cast<Tool::View *>(dock->tool);
 }
 
-inline vector<std::pair<GL::vec4, bool>> Volume::get_active_clip_planes() const {
+inline std::vector<std::pair<GL::vec4, bool>> Volume::get_active_clip_planes() const {
   Tool::View *view = get_view_tool();
-  return view ? view->get_active_clip_planes() : vector<std::pair<GL::vec4, bool>>();
+  return view ? view->get_active_clip_planes() : std::vector<std::pair<GL::vec4, bool>>();
 }
 
-inline vector<GL::vec4 *> Volume::get_clip_planes_to_be_edited() const {
+inline std::vector<GL::vec4 *> Volume::get_clip_planes_to_be_edited() const {
   Tool::View *view = get_view_tool();
-  return view ? view->get_clip_planes_to_be_edited() : vector<GL::vec4 *>();
+  return view ? view->get_clip_planes_to_be_edited() : std::vector<GL::vec4 *>();
 }
 
 inline bool Volume::get_cliphighlightstate() const {

--- a/src/gui/mrview/mode/volume.h
+++ b/src/gui/mrview/mode/volume.h
@@ -43,7 +43,7 @@ protected:
   GL::VertexBuffer volume_VB, volume_VI;
   GL::VertexArrayObject volume_VAO;
   GL::Texture depth_texture;
-  vector<GL::vec4> clip;
+  std::vector<GL::vec4> clip;
 
   class Shader : public Displayable::Shader {
   public:
@@ -59,8 +59,8 @@ protected:
   } volume_shader;
 
   Tool::View *get_view_tool() const;
-  vector<std::pair<GL::vec4, bool>> get_active_clip_planes() const;
-  vector<GL::vec4 *> get_clip_planes_to_be_edited() const;
+  std::vector<std::pair<GL::vec4, bool>> get_active_clip_planes() const;
+  std::vector<GL::vec4 *> get_clip_planes_to_be_edited() const;
   bool get_cliphighlightstate() const;
   bool get_clipintersectionmodestate() const;
 };

--- a/src/gui/mrview/sync/interprocesscommunicator.cpp
+++ b/src/gui/mrview/sync/interprocesscommunicator.cpp
@@ -101,9 +101,9 @@ InterprocessCommunicator::InterprocessCommunicator() : QObject(0) {
 void InterprocessCommunicator::OnNewIncomingConnection() {
   LocalSocketReader *lsr = new LocalSocketReader(receiver->nextPendingConnection());
   connect(lsr,
-          SIGNAL(DataReceived(vector<std::shared_ptr<QByteArray>>)),
+          SIGNAL(DataReceived(std::vector<std::shared_ptr<QByteArray>>)),
           this,
-          SLOT(OnDataReceived(vector<std::shared_ptr<QByteArray>>)));
+          SLOT(OnDataReceived(std::vector<std::shared_ptr<QByteArray>>)));
 }
 
 /**
@@ -148,8 +148,8 @@ void InterprocessCommunicator::TryConnectTo(int connectToId) {
 /**
  * Fires when 1+ messages are received from another process.
  */
-void InterprocessCommunicator::OnDataReceived(vector<std::shared_ptr<QByteArray>> allMessages) {
-  vector<std::shared_ptr<QByteArray>> toSync;
+void InterprocessCommunicator::OnDataReceived(std::vector<std::shared_ptr<QByteArray>> allMessages) {
+  std::vector<std::shared_ptr<QByteArray>> toSync;
 
   for (size_t i = 0; i < allMessages.size(); i++) {
     std::shared_ptr<QByteArray> dat = allMessages[i];

--- a/src/gui/mrview/sync/interprocesscommunicator.h
+++ b/src/gui/mrview/sync/interprocesscommunicator.h
@@ -44,18 +44,18 @@ public:
 
 private slots:
   void OnNewIncomingConnection();
-  void OnDataReceived(vector<std::shared_ptr<QByteArray>> dat);
+  void OnDataReceived(std::vector<std::shared_ptr<QByteArray>> dat);
 
 signals:
-  void
-  SyncDataReceived(vector<std::shared_ptr<QByteArray>> data); // fires when data is received which is for syncing. It is
-                                                              // up to listeners to validate and store this value
+  void SyncDataReceived(
+      std::vector<std::shared_ptr<QByteArray>> data); // fires when data is received which is for syncing. It is
+                                                      // up to listeners to validate and store this value
 
 private:
-  int id;                                                     // id which is unique between mrview processes
-  vector<std::shared_ptr<GUI::MRView::Sync::Client>> senders; // send information
-  QLocalServer *receiver;                                     // listens for information
-  void TryConnectTo(int connectToId);                         // tries to connect with another interprocesscommunicator
+  int id;                                                          // id which is unique between mrview processes
+  std::vector<std::shared_ptr<GUI::MRView::Sync::Client>> senders; // send information
+  QLocalServer *receiver;                                          // listens for information
+  void TryConnectTo(int connectToId); // tries to connect with another interprocesscommunicator
 };
 
 } // namespace Sync

--- a/src/gui/mrview/sync/localsocketreader.cpp
+++ b/src/gui/mrview/sync/localsocketreader.cpp
@@ -30,7 +30,7 @@ LocalSocketReader::LocalSocketReader(QLocalSocket *mySocket) : QObject(0) {
  * Fires when data is received from another process
  */
 void LocalSocketReader::OnDataReceived() {
-  vector<std::shared_ptr<QByteArray>> messagesReceived;
+  std::vector<std::shared_ptr<QByteArray>> messagesReceived;
   while (socket->bytesAvailable() > 0) {
     // First byte must always by an unsigned int32 stating how much data to read
     // Wait until we've read all of that

--- a/src/gui/mrview/sync/localsocketreader.h
+++ b/src/gui/mrview/sync/localsocketreader.h
@@ -37,7 +37,7 @@ public:
   LocalSocketReader(QLocalSocket *mySocket);
 
 signals:
-  void DataReceived(vector<std::shared_ptr<QByteArray>> dat); // emits every message currently available
+  void DataReceived(std::vector<std::shared_ptr<QByteArray>> dat); // emits every message currently available
 
 private slots:
   void OnDataReceived();

--- a/src/gui/mrview/sync/syncmanager.cpp
+++ b/src/gui/mrview/sync/syncmanager.cpp
@@ -25,9 +25,9 @@ SyncManager::SyncManager() : QObject(0) {
   try {
     ips = new InterprocessCommunicator(); // will throw exception if it fails to set up a server
     connect(ips,
-            SIGNAL(SyncDataReceived(vector<std::shared_ptr<QByteArray>>)),
+            SIGNAL(SyncDataReceived(std::vector<std::shared_ptr<QByteArray>>)),
             this,
-            SLOT(OnIPSDataReceived(vector<std::shared_ptr<QByteArray>>)));
+            SLOT(OnIPSDataReceived(std::vector<std::shared_ptr<QByteArray>>)));
   } catch (...) {
     ips = 0;
     WARN("Sync set up failed.");
@@ -66,7 +66,7 @@ bool SyncManager::SendData(DataKey code, QByteArray dat) {
 /**
  * Receives a signal from another process that a value to sync has changed
  */
-void SyncManager::OnIPSDataReceived(vector<std::shared_ptr<QByteArray>> all_messages) {
+void SyncManager::OnIPSDataReceived(std::vector<std::shared_ptr<QByteArray>> all_messages) {
   // WARNING This code assumes that the order of syncing operations does not matter
 
   // We have a list of messages found

--- a/src/gui/mrview/sync/syncmanager.h
+++ b/src/gui/mrview/sync/syncmanager.h
@@ -41,7 +41,7 @@ public:
 
 private slots:
   void OnWindowFocusChanged();
-  void OnIPSDataReceived(vector<std::shared_ptr<QByteArray>> all_messages);
+  void OnIPSDataReceived(std::vector<std::shared_ptr<QByteArray>> all_messages);
 
 private:
   InterprocessCommunicator *ips;                                       // used to communicate with other processes

--- a/src/gui/mrview/tool/connectome/connectome.cpp
+++ b/src/gui/mrview/tool/connectome/connectome.cpp
@@ -876,7 +876,7 @@ bool Connectome::process_commandline_option(const MR::App::ParsedOption &opt) {
   }
   if (opt.opt->is("connectome.load")) {
     try {
-      vector<std::string> list(1, opt[0]);
+      std::vector<std::string> list(1, opt[0]);
       add_matrices(list);
     } catch (Exception &e) {
       e.display();
@@ -907,7 +907,7 @@ void Connectome::image_open_slot() {
 void Connectome::hide_all_slot() { window().updateGL(); }
 
 void Connectome::matrix_open_slot() {
-  vector<std::string> list =
+  std::vector<std::string> list =
       Dialog::File::get_files(&window(), "Select connectome file(s) to open", "", &current_folder);
   if (list.empty())
     return;
@@ -2443,9 +2443,9 @@ void Connectome::initialise(const std::string &path) {
     buffer.reset(new MR::Image<node_t>(H.get_image<node_t>().with_direct_io()));
   }
   MR::Transform transform(H);
-  vector<Eigen::Vector3f> node_coms;
-  vector<size_t> node_volumes;
-  vector<Eigen::Array3i> node_lower_corners, node_upper_corners;
+  std::vector<Eigen::Vector3f> node_coms;
+  std::vector<size_t> node_volumes;
+  std::vector<Eigen::Array3i> node_lower_corners, node_upper_corners;
   size_t max_index = 0;
 
   {
@@ -2485,7 +2485,7 @@ void Connectome::initialise(const std::string &path) {
     for (size_t node_index = 1; node_index <= max_index; ++node_index) {
       if (node_volumes[node_index]) {
 
-        vector<int> from(3), dim(3);
+        std::vector<int> from(3), dim(3);
         for (size_t axis = 0; axis != 3; ++axis) {
           from[axis] = node_lower_corners[node_index][axis];
           dim[axis] = node_upper_corners[node_index][axis] - node_lower_corners[node_index][axis] + 1;
@@ -2531,8 +2531,8 @@ void Connectome::initialise(const std::string &path) {
   dynamic_cast<Node_list *>(node_list->tool)->initialize();
 }
 
-void Connectome::add_matrices(const vector<std::string> &list) {
-  vector<FileDataVector> data;
+void Connectome::add_matrices(const std::vector<std::string> &list) {
+  std::vector<FileDataVector> data;
   for (size_t i = 0; i < list.size(); ++i) {
     try {
       MR::Connectome::matrix_type matrix = File::Matrix::load_matrix<default_type>(list[i]);
@@ -2971,7 +2971,7 @@ void Connectome::load_properties() {
         nodes[node_index].set_name(lut.find(node_index)->second.get_name());
       } else if (count > 1) {
         ++duplicate_entry_count;
-        vector<std::string> names;
+        std::vector<std::string> names;
         const auto range = lut.equal_range(node_index);
         for (auto i = range.first; i != range.second; ++i)
           names.push_back(i->second.get_name());
@@ -3719,10 +3719,10 @@ void Connectome::calculate_edge_alphas() {
   }
 }
 
-void Connectome::node_selection_changed(const vector<node_t> &list) {
+void Connectome::node_selection_changed(const std::vector<node_t> &list) {
   selected_nodes.clear();
   selected_node_count = list.size();
-  for (vector<node_t>::const_iterator n = list.begin(); n != list.end(); ++n)
+  for (std::vector<node_t>::const_iterator n = list.begin(); n != list.end(); ++n)
     selected_nodes[*n] = true;
   if (node_visibility == node_visibility_t::CONNECTOME || node_visibility == node_visibility_t::MATRIX_FILE) {
     if (selected_node_count >= 2) {

--- a/src/gui/mrview/tool/connectome/connectome.h
+++ b/src/gui/mrview/tool/connectome/connectome.h
@@ -228,8 +228,8 @@ private:
   // have access to the parcellation image
   std::unique_ptr<MR::Image<node_t>> buffer;
 
-  vector<Node> nodes;
-  vector<Edge> edges;
+  std::vector<Node> nodes;
+  std::vector<Edge> edges;
 
   // For converting connectome matrices to vectors
   std::unique_ptr<MR::Connectome::Mat2Vec> mat2vec;
@@ -327,7 +327,7 @@ private:
   void clear_all();
   void enable_all(const bool);
   void initialise(const std::string &);
-  void add_matrices(const vector<std::string> &);
+  void add_matrices(const std::vector<std::string> &);
 
   void draw_nodes(const Projection &);
   void draw_edges(const Projection &);
@@ -351,7 +351,7 @@ private:
 
   // Helper functions for determining actual node / edge visual properties
   //   given current selection status
-  void node_selection_changed(const vector<node_t> &);
+  void node_selection_changed(const std::vector<node_t> &);
   bool node_visibility_given_selection(const node_t);
   Eigen::Array3f node_colour_given_selection(const node_t);
   float node_size_given_selection(const node_t);

--- a/src/gui/mrview/tool/connectome/edge.cpp
+++ b/src/gui/mrview/tool/connectome/edge.cpp
@@ -96,7 +96,7 @@ Edge::~Edge() {
 }
 
 Edge::Line::Line(const Edge &parent) {
-  vector<Eigen::Vector3f> data;
+  std::vector<Eigen::Vector3f> data;
   data.push_back(parent.get_node_centre(0));
   data.push_back(parent.get_node_centre(1));
 
@@ -221,10 +221,10 @@ Edge::Streamtube::Streamtube(const Exemplar &data) : count(data.vertices.size())
 
   shared.check_num_points(count);
 
-  vector<Eigen::Vector3f> vertices;
+  std::vector<Eigen::Vector3f> vertices;
   const size_t N = shared.points_per_vertex();
   vertices.reserve(N * data.vertices.size());
-  for (vector<Eigen::Vector3f>::const_iterator i = data.vertices.begin(); i != data.vertices.end(); ++i) {
+  for (std::vector<Eigen::Vector3f>::const_iterator i = data.vertices.begin(); i != data.vertices.end(); ++i) {
     for (size_t j = 0; j != N; ++j)
       vertices.push_back(*i);
   }
@@ -233,9 +233,9 @@ Edge::Streamtube::Streamtube(const Exemplar &data) : count(data.vertices.size())
   if (vertices.size())
     gl::BufferData(gl::ARRAY_BUFFER, vertices.size() * sizeof(Eigen::Vector3f), &vertices[0][0], gl::STATIC_DRAW);
 
-  vector<Eigen::Vector3f> tangents;
+  std::vector<Eigen::Vector3f> tangents;
   tangents.reserve(vertices.size());
-  for (vector<Eigen::Vector3f>::const_iterator i = data.tangents.begin(); i != data.tangents.end(); ++i) {
+  for (std::vector<Eigen::Vector3f>::const_iterator i = data.tangents.begin(); i != data.tangents.end(); ++i) {
     for (size_t j = 0; j != N; ++j)
       tangents.push_back(*i);
   }
@@ -244,14 +244,15 @@ Edge::Streamtube::Streamtube(const Exemplar &data) : count(data.vertices.size())
   if (tangents.size())
     gl::BufferData(gl::ARRAY_BUFFER, tangents.size() * sizeof(Eigen::Vector3f), &tangents[0][0], gl::STATIC_DRAW);
 
-  vector<std::pair<float, float>> normal_multipliers;
+  std::vector<std::pair<float, float>> normal_multipliers;
   const float angle_multiplier = 2.0 * Math::pi / float(shared.points_per_vertex());
   for (size_t i = 0; i != shared.points_per_vertex(); ++i)
     normal_multipliers.push_back(std::make_pair(std::cos(i * angle_multiplier), std::sin(i * angle_multiplier)));
-  vector<Eigen::Vector3f> normals;
+  std::vector<Eigen::Vector3f> normals;
   normals.reserve(vertices.size());
   for (size_t i = 0; i != data.vertices.size(); ++i) {
-    for (vector<std::pair<float, float>>::const_iterator j = normal_multipliers.begin(); j != normal_multipliers.end();
+    for (std::vector<std::pair<float, float>>::const_iterator j = normal_multipliers.begin();
+         j != normal_multipliers.end();
          ++j)
       normals.push_back((j->first * data.normals[i]) + (j->second * data.binormals[i]));
   }

--- a/src/gui/mrview/tool/connectome/edge.h
+++ b/src/gui/mrview/tool/connectome/edge.h
@@ -164,7 +164,7 @@ private:
 
   private:
     const Eigen::Vector3f endpoints[2];
-    vector<Eigen::Vector3f> vertices, tangents, normals, binormals;
+    std::vector<Eigen::Vector3f> vertices, tangents, normals, binormals;
     friend class Streamline;
     friend class Streamtube;
   };

--- a/src/gui/mrview/tool/connectome/matrix_list.cpp
+++ b/src/gui/mrview/tool/connectome/matrix_list.cpp
@@ -25,7 +25,7 @@ namespace Tool {
 
 Matrix_list_model::Matrix_list_model(Connectome *parent) : QAbstractItemModel(dynamic_cast<QObject *>(parent)) {}
 
-void Matrix_list_model::add_items(vector<FileDataVector> &list) {
+void Matrix_list_model::add_items(std::vector<FileDataVector> &list) {
   beginInsertRows(QModelIndex(), items.size(), items.size() + list.size());
   items.reserve(items.size() + list.size());
   std::move(std::begin(list), std::end(list), std::back_inserter(items));

--- a/src/gui/mrview/tool/connectome/matrix_list.h
+++ b/src/gui/mrview/tool/connectome/matrix_list.h
@@ -81,7 +81,7 @@ public:
     endRemoveRows();
   }
 
-  void add_items(vector<FileDataVector> &);
+  void add_items(std::vector<FileDataVector> &);
 
   const FileDataVector &get(const size_t index) {
     assert(index < items.size());
@@ -93,7 +93,7 @@ public:
   }
 
 protected:
-  vector<FileDataVector> items;
+  std::vector<FileDataVector> items;
 };
 
 } // namespace Tool

--- a/src/gui/mrview/tool/connectome/node.cpp
+++ b/src/gui/mrview/tool/connectome/node.cpp
@@ -48,7 +48,7 @@ Node::Mesh::Mesh(MR::Surface::Mesh &in) : count(3 * in.num_triangles()) {
   GL::Context::Grab context;
   GL::assert_context_is_current();
 
-  vector<float> vertices;
+  std::vector<float> vertices;
   vertices.reserve(3 * in.num_vertices());
   for (size_t v = 0; v != in.num_vertices(); ++v) {
     for (size_t axis = 0; axis != 3; ++axis)
@@ -61,7 +61,7 @@ Node::Mesh::Mesh(MR::Surface::Mesh &in) : count(3 * in.num_triangles()) {
 
   if (!in.have_normals())
     in.calculate_normals();
-  vector<float> normals;
+  std::vector<float> normals;
   normals.reserve(3 * in.num_vertices());
   for (size_t n = 0; n != in.num_vertices(); ++n) {
     for (size_t axis = 0; axis != 3; ++axis)
@@ -81,7 +81,7 @@ Node::Mesh::Mesh(MR::Surface::Mesh &in) : count(3 * in.num_triangles()) {
   gl::EnableVertexAttribArray(1);
   gl::VertexAttribPointer(1, 3, gl::FLOAT, gl::FALSE_, 0, (void *)(0));
 
-  vector<unsigned int> indices;
+  std::vector<unsigned int> indices;
   indices.reserve(3 * in.num_triangles());
   for (size_t i = 0; i != in.num_triangles(); ++i) {
     for (size_t v = 0; v != 3; ++v)

--- a/src/gui/mrview/tool/connectome/node_list.cpp
+++ b/src/gui/mrview/tool/connectome/node_list.cpp
@@ -139,7 +139,7 @@ int Node_list::row_height() const { return node_list_view->fontMetrics().height(
 
 void Node_list::clear_selection_slot() {
   node_list_view->clearSelection();
-  vector<node_t> empty_node_list;
+  std::vector<node_t> empty_node_list;
   connectome.node_selection_changed(empty_node_list);
 }
 
@@ -152,7 +152,7 @@ void Node_list::node_selection_settings_dialog_slot() {
 
 void Node_list::node_selection_changed_slot(const QItemSelection &, const QItemSelection &) {
   QModelIndexList list = node_list_view->selectionModel()->selectedRows();
-  vector<node_t> nodes;
+  std::vector<node_t> nodes;
   for (int i = 0; i != list.size(); ++i)
     nodes.push_back(list[i].row());
   connectome.node_selection_changed(nodes);

--- a/src/gui/mrview/tool/connectome/node_overlay.cpp
+++ b/src/gui/mrview/tool/connectome/node_overlay.cpp
@@ -68,7 +68,7 @@ void NodeOverlay::update_texture2D(const int plane, const int slice) {
   get_axes(plane, x, y);
   const ssize_t xsize = data.size(x), ysize = data.size(y);
 
-  vector<float> texture_data;
+  std::vector<float> texture_data;
   texture_data.resize(4 * xsize * ysize, 0.0f);
   if (tex_positions[plane] >= 0 && tex_positions[plane] < data.size(plane)) {
     data.index(plane) = slice;

--- a/src/gui/mrview/tool/fixel/base_fixel.cpp
+++ b/src/gui/mrview/tool/fixel/base_fixel.cpp
@@ -433,7 +433,7 @@ void BaseFixel::load_image(const std::string &filename) {
 
   set_colour_type_index(colour_index);
 
-  regular_grid_buffer_pos = vector<Eigen::Vector3f>(pos_buffer_store.size());
+  regular_grid_buffer_pos = std::vector<Eigen::Vector3f>(pos_buffer_store.size());
 
   regular_grid_vao.gen();
 

--- a/src/gui/mrview/tool/fixel/base_fixel.h
+++ b/src/gui/mrview/tool/fixel/base_fixel.h
@@ -214,28 +214,28 @@ protected:
   virtual FixelValue &get_fixel_value(const std::string &key) const { return fixel_values[key]; }
 
   MR::Header header;
-  vector<std::string> colour_types;
-  vector<std::string> value_types;
-  vector<std::string> threshold_types;
+  std::vector<std::string> colour_types;
+  std::vector<std::string> value_types;
+  std::vector<std::string> threshold_types;
   mutable std::map<const std::string, FixelValue> fixel_values;
   mutable FixelValue dummy_fixel_val_state;
 
-  vector<Eigen::Vector3f> pos_buffer_store;
-  vector<Eigen::Vector3f> dir_buffer_store;
+  std::vector<Eigen::Vector3f> pos_buffer_store;
+  std::vector<Eigen::Vector3f> dir_buffer_store;
 
-  vector<Eigen::Vector3f> regular_grid_buffer_pos;
-  vector<Eigen::Vector3f> regular_grid_buffer_dir;
-  vector<float> regular_grid_buffer_colour;
-  vector<float> regular_grid_buffer_val;
-  vector<float> regular_grid_buffer_threshold;
+  std::vector<Eigen::Vector3f> regular_grid_buffer_pos;
+  std::vector<Eigen::Vector3f> regular_grid_buffer_dir;
+  std::vector<float> regular_grid_buffer_colour;
+  std::vector<float> regular_grid_buffer_val;
+  std::vector<float> regular_grid_buffer_threshold;
 
-  vector<vector<vector<GLint>>> slice_fixel_indices;
-  vector<vector<vector<GLsizei>>> slice_fixel_sizes;
-  vector<vector<GLsizei>> slice_fixel_counts;
+  std::vector<std::vector<std::vector<GLint>>> slice_fixel_indices;
+  std::vector<std::vector<std::vector<GLsizei>>> slice_fixel_sizes;
+  std::vector<std::vector<GLsizei>> slice_fixel_counts;
 
   // Flattened buffer used when cropping to slice
   // To support off-axis rendering, we maintain dict mapping voxels to buffer_pos indices
-  std::unordered_map<std::array<int, 3>, vector<GLint>, IntPointHasher> voxel_to_indices_map;
+  std::unordered_map<std::array<int, 3>, std::vector<GLint>, IntPointHasher> voxel_to_indices_map;
 
   FixelColourType colour_type;
   FixelScaleType scale_type;

--- a/src/gui/mrview/tool/fixel/fixel.cpp
+++ b/src/gui/mrview/tool/fixel/fixel.cpp
@@ -36,7 +36,7 @@ class Fixel::Model : public ListModelBase {
 public:
   Model(QObject *parent) : ListModelBase(parent) {}
 
-  void add_items(vector<std::string> &filenames, Fixel &fixel_tool) {
+  void add_items(std::vector<std::string> &filenames, Fixel &fixel_tool) {
 
     size_t old_size = items.size();
     for (size_t i = 0, N = filenames.size(); i < N; ++i) {
@@ -309,12 +309,12 @@ void Fixel::render_fixel_colourbar(const Tool::BaseFixel &fixel) {
 }
 
 void Fixel::fixel_open_slot() {
-  vector<std::string> list = Dialog::File::get_files(
+  std::vector<std::string> list = Dialog::File::get_files(
       this, "Select fixel images to open", GUI::Dialog::File::image_filter_string, &current_folder);
   add_images(list);
 }
 
-void Fixel::add_images(vector<std::string> &list) {
+void Fixel::add_images(std::vector<std::string> &list) {
   if (list.empty())
     return;
   size_t previous_size = fixel_list_model->rowCount();
@@ -337,7 +337,7 @@ void Fixel::dropEvent(QDropEvent *event) {
 
   const QMimeData *mimeData = event->mimeData();
   if (mimeData->hasUrls()) {
-    vector<std::string> list;
+    std::vector<std::string> list;
     QList<QUrl> urlList = mimeData->urls();
     for (int i = 0; i < urlList.size() && i < max_files; ++i) {
       list.push_back(urlList.at(i).path().toUtf8().constData());
@@ -748,7 +748,7 @@ void Fixel::add_commandline_options(MR::App::OptionList &options) {
 
 bool Fixel::process_commandline_option(const MR::App::ParsedOption &opt) {
   if (opt.opt->is("fixel.load")) {
-    vector<std::string> list(1, std::string(opt[0]));
+    std::vector<std::string> list(1, std::string(opt[0]));
     try {
       fixel_list_model->add_items(list, *this);
     } catch (Exception &E) {

--- a/src/gui/mrview/tool/fixel/fixel.h
+++ b/src/gui/mrview/tool/fixel/fixel.h
@@ -100,7 +100,7 @@ protected:
   QSlider *line_thickness_slider;
   QSlider *opacity_slider;
 
-  void add_images(vector<std::string> &list);
+  void add_images(std::vector<std::string> &list);
   void dropEvent(QDropEvent *event) override;
 
 private:

--- a/src/gui/mrview/tool/fixel/image4D.cpp
+++ b/src/gui/mrview/tool/fixel/image4D.cpp
@@ -54,8 +54,8 @@ void Image4D::reload_image_buffer() {
   fixel_val_store.clear();
 
   for (size_t axis = 0; axis < 3; ++axis) {
-    std::fill(slice_fixel_indices[axis].begin(), slice_fixel_indices[axis].end(), vector<GLint>());
-    std::fill(slice_fixel_sizes[axis].begin(), slice_fixel_sizes[axis].end(), vector<GLsizei>());
+    std::fill(slice_fixel_indices[axis].begin(), slice_fixel_indices[axis].end(), std::vector<GLint>());
+    std::fill(slice_fixel_sizes[axis].begin(), slice_fixel_sizes[axis].end(), std::vector<GLsizei>());
     std::fill(slice_fixel_counts[axis].begin(), slice_fixel_counts[axis].end(), 0);
   }
 

--- a/src/gui/mrview/tool/fixel/vector_structs.h
+++ b/src/gui/mrview/tool/fixel/vector_structs.h
@@ -30,7 +30,7 @@ struct FixelValue {
   float value_max = std::numeric_limits<float>::min();
   float lessthan = value_min, greaterthan = value_max;
   float current_min = value_min, current_max = value_max;
-  vector<float> buffer_store;
+  std::vector<float> buffer_store;
 
   void clear() {
     buffer_store.clear();

--- a/src/gui/mrview/tool/list_model_base.h
+++ b/src/gui/mrview/tool/list_model_base.h
@@ -83,7 +83,7 @@ public:
     if (count < 1 || row < 0 || row > rowCount() || count != swapped_rows.second)
       return false;
 
-    vector<std::unique_ptr<Displayable>> swapped_items;
+    std::vector<std::unique_ptr<Displayable>> swapped_items;
 
     swapped_items.insert(swapped_items.begin(),
                          std::make_move_iterator(items.begin() + row),
@@ -140,7 +140,7 @@ public:
     endRemoveRows();
   }
 
-  vector<std::unique_ptr<Displayable>> items;
+  std::vector<std::unique_ptr<Displayable>> items;
 
 private:
   std::pair<int, int> swapped_rows;

--- a/src/gui/mrview/tool/odf/item.cpp
+++ b/src/gui/mrview/tool/odf/item.cpp
@@ -110,7 +110,7 @@ void ODF_Item::DixelPlugin::set_shell(size_t index) {
   const std::vector<size_t> &volumes = (*shells)[index].get_volumes();
   for (size_t row = 0; row != volumes.size(); ++row)
     shell_dirs.row(row) = grad.row(volumes[row]).head<3>().cast<float>();
-  auto new_dirs = MR::make_unique<MR::DWI::Directions::Set>(shell_dirs);
+  auto new_dirs = std::make_unique<MR::DWI::Directions::Set>(shell_dirs);
   std::swap(dirs, new_dirs);
   shell_index = index;
   dir_type = DixelPlugin::dir_t::DW_SCHEME;
@@ -119,13 +119,13 @@ void ODF_Item::DixelPlugin::set_shell(size_t index) {
 void ODF_Item::DixelPlugin::set_header() {
   if (!header_dirs.rows())
     throw Exception("No direction scheme defined in header");
-  auto new_dirs = MR::make_unique<MR::DWI::Directions::Set>(header_dirs);
+  auto new_dirs = std::make_unique<MR::DWI::Directions::Set>(header_dirs);
   std::swap(dirs, new_dirs);
   dir_type = DixelPlugin::dir_t::HEADER;
 }
 
 void ODF_Item::DixelPlugin::set_internal(const size_t n) {
-  auto new_dirs = MR::make_unique<MR::DWI::Directions::Set>(n);
+  auto new_dirs = std::make_unique<MR::DWI::Directions::Set>(n);
   std::swap(dirs, new_dirs);
   dir_type = DixelPlugin::dir_t::INTERNAL;
 }
@@ -137,7 +137,7 @@ void ODF_Item::DixelPlugin::set_none() {
 }
 
 void ODF_Item::DixelPlugin::set_from_file(const std::string &path) {
-  auto new_dirs = MR::make_unique<MR::DWI::Directions::Set>(path);
+  auto new_dirs = std::make_unique<MR::DWI::Directions::Set>(path);
   std::swap(dirs, new_dirs);
   dir_type = DixelPlugin::dir_t::FILE;
 }

--- a/src/gui/mrview/tool/odf/item.cpp
+++ b/src/gui/mrview/tool/odf/item.cpp
@@ -107,7 +107,7 @@ void ODF_Item::DixelPlugin::set_shell(size_t index) {
   if (index >= shells->count())
     throw Exception("Shell index is outside valid range");
   Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic> shell_dirs((*shells)[index].count(), 3);
-  const vector<size_t> &volumes = (*shells)[index].get_volumes();
+  const std::vector<size_t> &volumes = (*shells)[index].get_volumes();
   for (size_t row = 0; row != volumes.size(); ++row)
     shell_dirs.row(row) = grad.row(volumes[row]).head<3>().cast<float>();
   auto new_dirs = MR::make_unique<MR::DWI::Directions::Set>(shell_dirs);
@@ -144,7 +144,7 @@ void ODF_Item::DixelPlugin::set_from_file(const std::string &path) {
 
 Eigen::VectorXf ODF_Item::DixelPlugin::get_shell_data(const Eigen::VectorXf &values) const {
   assert(shells);
-  const vector<size_t> &volumes((*shells)[shell_index].get_volumes());
+  const std::vector<size_t> &volumes((*shells)[shell_index].get_volumes());
   Eigen::VectorXf result(volumes.size());
   for (size_t i = 0; i != volumes.size(); ++i)
     result[i] = values[volumes[i]];

--- a/src/gui/mrview/tool/odf/model.cpp
+++ b/src/gui/mrview/tool/odf/model.cpp
@@ -23,12 +23,12 @@ namespace GUI {
 namespace MRView {
 namespace Tool {
 
-size_t ODF_Model::add_items(const vector<std::string> &list,
+size_t ODF_Model::add_items(const std::vector<std::string> &list,
                             const odf_type_t type,
                             const bool colour_by_direction,
                             const bool hide_negative_lobes,
                             const float scale) {
-  vector<std::unique_ptr<MR::Header>> hlist;
+  std::vector<std::unique_ptr<MR::Header>> hlist;
   for (size_t i = 0; i < list.size(); ++i) {
     try {
       auto header = make_unique<MR::Header>(MR::Header::open(list[i]));

--- a/src/gui/mrview/tool/odf/model.cpp
+++ b/src/gui/mrview/tool/odf/model.cpp
@@ -31,7 +31,7 @@ size_t ODF_Model::add_items(const std::vector<std::string> &list,
   std::vector<std::unique_ptr<MR::Header>> hlist;
   for (size_t i = 0; i < list.size(); ++i) {
     try {
-      auto header = make_unique<MR::Header>(MR::Header::open(list[i]));
+      auto header = std::make_unique<MR::Header>(MR::Header::open(list[i]));
       switch (type) {
       case odf_type_t::SH:
         Math::SH::check(*header);
@@ -59,7 +59,7 @@ size_t ODF_Model::add_items(const std::vector<std::string> &list,
     beginInsertRows(QModelIndex(), items.size(), items.size() + hlist.size());
     for (size_t i = 0; i < hlist.size(); ++i)
       items.push_back(
-          make_unique<ODF_Item>(std::move(*hlist[i]), type, scale, hide_negative_lobes, colour_by_direction));
+          std::make_unique<ODF_Item>(std::move(*hlist[i]), type, scale, hide_negative_lobes, colour_by_direction));
     endInsertRows();
   }
 

--- a/src/gui/mrview/tool/odf/model.h
+++ b/src/gui/mrview/tool/odf/model.h
@@ -64,7 +64,7 @@ public:
     return 1;
   }
 
-  size_t add_items(const vector<std::string> &list,
+  size_t add_items(const std::vector<std::string> &list,
                    const odf_type_t type,
                    bool colour_by_direction,
                    bool hide_negative_lobes,
@@ -85,7 +85,7 @@ public:
     return index.isValid() ? dynamic_cast<ODF_Item *>(items[index.row()].get()) : NULL;
   }
 
-  vector<std::unique_ptr<ODF_Item>> items;
+  std::vector<std::unique_ptr<ODF_Item>> items;
 };
 
 } // namespace Tool

--- a/src/gui/mrview/tool/odf/odf.cpp
+++ b/src/gui/mrview/tool/odf/odf.cpp
@@ -445,7 +445,7 @@ void ODF::setup_ODFtype_UI(const ODF_Item *image) {
     preview->set_lod_enabled(image->odf_type != odf_type_t::DIXEL);
 }
 
-void ODF::add_images(vector<std::string> &list, const odf_type_t mode) {
+void ODF::add_images(std::vector<std::string> &list, const odf_type_t mode) {
   size_t previous_size = image_list_model->rowCount();
   if (!image_list_model->add_items(
           list, mode, colour_by_direction_box->isChecked(), hide_negative_values_box->isChecked(), scale->value()))
@@ -468,7 +468,8 @@ void ODF::closeEvent(QCloseEvent *) { window().disconnect(this); }
 void ODF::onPreviewClosed() { show_preview_button->setChecked(false); }
 
 void ODF::sh_open_slot() {
-  vector<std::string> list = Dialog::File::get_images(&window(), "Select SH-based ODF images to open", &current_folder);
+  std::vector<std::string> list =
+      Dialog::File::get_images(&window(), "Select SH-based ODF images to open", &current_folder);
   if (list.empty())
     return;
 
@@ -476,7 +477,7 @@ void ODF::sh_open_slot() {
 }
 
 void ODF::tensor_open_slot() {
-  vector<std::string> list = Dialog::File::get_images(&window(), "Select tensor images to open", &current_folder);
+  std::vector<std::string> list = Dialog::File::get_images(&window(), "Select tensor images to open", &current_folder);
   if (list.empty())
     return;
 
@@ -484,7 +485,7 @@ void ODF::tensor_open_slot() {
 }
 
 void ODF::dixel_open_slot() {
-  vector<std::string> list =
+  std::vector<std::string> list =
       Dialog::File::get_images(&window(), "Select dixel-based ODF images to open", &current_folder);
   if (list.empty())
     return;
@@ -780,7 +781,7 @@ void ODF::add_commandline_options(MR::App::OptionList &options) {
 bool ODF::process_commandline_option(const MR::App::ParsedOption &opt) {
   if (opt.opt->is("odf.load_sh")) {
     try {
-      vector<std::string> list(1, opt[0]);
+      std::vector<std::string> list(1, opt[0]);
       add_images(list, odf_type_t::SH);
     } catch (Exception &e) {
       e.display();
@@ -790,7 +791,7 @@ bool ODF::process_commandline_option(const MR::App::ParsedOption &opt) {
 
   if (opt.opt->is("odf.load_tensor")) {
     try {
-      vector<std::string> list(1, opt[0]);
+      std::vector<std::string> list(1, opt[0]);
       add_images(list, odf_type_t::TENSOR);
     } catch (Exception &e) {
       e.display();
@@ -800,7 +801,7 @@ bool ODF::process_commandline_option(const MR::App::ParsedOption &opt) {
 
   if (opt.opt->is("odf.load_dixel")) {
     try {
-      vector<std::string> list(1, opt[0]);
+      std::vector<std::string> list(1, opt[0]);
       add_images(list, odf_type_t::DIXEL);
     } catch (Exception &e) {
       e.display();

--- a/src/gui/mrview/tool/odf/odf.h
+++ b/src/gui/mrview/tool/odf/odf.h
@@ -97,7 +97,7 @@ protected:
 
   int lmax;
 
-  void add_images(vector<std::string> &list, const odf_type_t mode);
+  void add_images(std::vector<std::string> &list, const odf_type_t mode);
 
   virtual void closeEvent(QCloseEvent *event) override;
 

--- a/src/gui/mrview/tool/overlay.cpp
+++ b/src/gui/mrview/tool/overlay.cpp
@@ -38,12 +38,12 @@ class Overlay::Model : public ListModelBase {
 public:
   Model(QObject *parent) : ListModelBase(parent) {}
 
-  void add_items(vector<std::unique_ptr<MR::Header>> &list);
+  void add_items(std::vector<std::unique_ptr<MR::Header>> &list);
 
   Item *get_image(QModelIndex &index) { return dynamic_cast<Item *>(items[index.row()].get()); }
 };
 
-void Overlay::Model::add_items(vector<std::unique_ptr<MR::Header>> &list) {
+void Overlay::Model::add_items(std::vector<std::unique_ptr<MR::Header>> &list) {
   beginInsertRows(QModelIndex(), items.size(), items.size() + list.size());
   for (size_t i = 0; i < list.size(); ++i) {
     Item *overlay = new Item(std::move(*list[i]));
@@ -174,10 +174,11 @@ Overlay::Overlay(Dock *parent) : Base(parent) {
 }
 
 void Overlay::image_open_slot() {
-  vector<std::string> overlay_names = Dialog::File::get_images(this, "Select overlay images to open", &current_folder);
+  std::vector<std::string> overlay_names =
+      Dialog::File::get_images(this, "Select overlay images to open", &current_folder);
   if (overlay_names.empty())
     return;
-  vector<std::unique_ptr<MR::Header>> list;
+  std::vector<std::unique_ptr<MR::Header>> list;
   for (size_t n = 0; n < overlay_names.size(); ++n) {
     try {
       list.push_back(make_unique<MR::Header>(MR::Header::open(overlay_names[n])));
@@ -188,7 +189,7 @@ void Overlay::image_open_slot() {
   add_images(list);
 }
 
-void Overlay::add_images(vector<std::unique_ptr<MR::Header>> &list) {
+void Overlay::add_images(std::vector<std::unique_ptr<MR::Header>> &list) {
   size_t previous_size = image_list_model->rowCount();
   image_list_model->add_items(list);
 
@@ -202,7 +203,7 @@ void Overlay::dropEvent(QDropEvent *event) {
 
   const QMimeData *mimeData = event->mimeData();
   if (mimeData->hasUrls()) {
-    vector<std::unique_ptr<MR::Header>> list;
+    std::vector<std::unique_ptr<MR::Header>> list;
     QList<QUrl> urlList = mimeData->urls();
     for (int i = 0; i < urlList.size() && i < max_files; ++i) {
       try {
@@ -660,7 +661,7 @@ void Overlay::add_commandline_options(MR::App::OptionList &options) {
 
 bool Overlay::process_commandline_option(const MR::App::ParsedOption &opt) {
   if (opt.opt->is("overlay.load")) {
-    vector<std::unique_ptr<MR::Header>> list;
+    std::vector<std::unique_ptr<MR::Header>> list;
     try {
       list.push_back(make_unique<MR::Header>(MR::Header::open(opt[0])));
     } catch (Exception &e) {

--- a/src/gui/mrview/tool/overlay.cpp
+++ b/src/gui/mrview/tool/overlay.cpp
@@ -181,7 +181,7 @@ void Overlay::image_open_slot() {
   std::vector<std::unique_ptr<MR::Header>> list;
   for (size_t n = 0; n < overlay_names.size(); ++n) {
     try {
-      list.push_back(make_unique<MR::Header>(MR::Header::open(overlay_names[n])));
+      list.push_back(std::make_unique<MR::Header>(MR::Header::open(overlay_names[n])));
     } catch (Exception &e) {
       e.display();
     }
@@ -207,7 +207,7 @@ void Overlay::dropEvent(QDropEvent *event) {
     QList<QUrl> urlList = mimeData->urls();
     for (int i = 0; i < urlList.size() && i < max_files; ++i) {
       try {
-        list.push_back(make_unique<MR::Header>(MR::Header::open(urlList.at(i).path().toUtf8().constData())));
+        list.push_back(std::make_unique<MR::Header>(MR::Header::open(urlList.at(i).path().toUtf8().constData())));
       } catch (Exception &e) {
         e.display();
       }
@@ -663,7 +663,7 @@ bool Overlay::process_commandline_option(const MR::App::ParsedOption &opt) {
   if (opt.opt->is("overlay.load")) {
     std::vector<std::unique_ptr<MR::Header>> list;
     try {
-      list.push_back(make_unique<MR::Header>(MR::Header::open(opt[0])));
+      list.push_back(std::make_unique<MR::Header>(MR::Header::open(opt[0])));
     } catch (Exception &e) {
       e.display();
     }

--- a/src/gui/mrview/tool/overlay.h
+++ b/src/gui/mrview/tool/overlay.h
@@ -99,7 +99,7 @@ protected:
     window().updateGL();
   }
 
-  void add_images(vector<std::unique_ptr<MR::Header>> &list);
+  void add_images(std::vector<std::unique_ptr<MR::Header>> &list);
   void dropEvent(QDropEvent *event) override;
 };
 

--- a/src/gui/mrview/tool/roi_editor/item.cpp
+++ b/src/gui/mrview/tool/roi_editor/item.cpp
@@ -78,7 +78,7 @@ void ROI_Item::zero() {
   GL::Context::Grab context;
   GL::assert_context_is_current();
   bind();
-  vector<GLubyte> data(header().size(0) * header().size(1));
+  std::vector<GLubyte> data(header().size(0) * header().size(1));
   for (int n = 0; n < header().size(2); ++n)
     upload_data({{0, 0, n}}, {{header().size(0), header().size(1), 1}}, reinterpret_cast<void *>(&data[0]));
   GL::assert_context_is_current();
@@ -89,7 +89,7 @@ void ROI_Item::load() {
   GL::assert_context_is_current();
   bind();
   auto image = header().get_image<bool>();
-  vector<GLubyte> data(image.size(0) * image.size(1));
+  std::vector<GLubyte> data(image.size(0) * image.size(1));
   ProgressBar progress("loading ROI image \"" + header().name() + "\"");
   for (auto outer = MR::Loop(2)(image); outer; ++outer) {
     auto p = data.begin();

--- a/src/gui/mrview/tool/roi_editor/item.h
+++ b/src/gui/mrview/tool/roi_editor/item.h
@@ -57,7 +57,7 @@ public:
   float min_brush_size, max_brush_size, brush_size;
 
 private:
-  vector<ROI_UndoEntry> undo_list;
+  std::vector<ROI_UndoEntry> undo_list;
   int current_undo;
 
   static int number_of_undos;

--- a/src/gui/mrview/tool/roi_editor/model.cpp
+++ b/src/gui/mrview/tool/roi_editor/model.cpp
@@ -22,7 +22,7 @@ namespace GUI {
 namespace MRView {
 namespace Tool {
 
-void ROI_Model::load(vector<std::unique_ptr<MR::Header>> &list) {
+void ROI_Model::load(std::vector<std::unique_ptr<MR::Header>> &list) {
   beginInsertRows(QModelIndex(), items.size(), items.size() + list.size());
   for (size_t i = 0; i < list.size(); ++i) {
     GL::Context::Grab context;

--- a/src/gui/mrview/tool/roi_editor/model.h
+++ b/src/gui/mrview/tool/roi_editor/model.h
@@ -31,7 +31,7 @@ class ROI_Model : public ListModelBase {
 public:
   ROI_Model(QObject *parent) : ListModelBase(parent) {}
 
-  void load(vector<std::unique_ptr<MR::Header>> &);
+  void load(std::vector<std::unique_ptr<MR::Header>> &);
   void create(MR::Header &&);
 
   ROI_Item *get(QModelIndex &index) { return dynamic_cast<ROI_Item *>(items[index.row()].get()); }

--- a/src/gui/mrview/tool/roi_editor/roi.cpp
+++ b/src/gui/mrview/tool/roi_editor/roi.cpp
@@ -272,10 +272,10 @@ void ROI::new_slot() {
 }
 
 void ROI::open_slot() {
-  vector<std::string> names = Dialog::File::get_images(this, "Select ROI images to open", &current_folder);
+  std::vector<std::string> names = Dialog::File::get_images(this, "Select ROI images to open", &current_folder);
   if (names.empty())
     return;
-  vector<std::unique_ptr<MR::Header>> list;
+  std::vector<std::unique_ptr<MR::Header>> list;
   for (size_t n = 0; n < names.size(); ++n)
     list.push_back(make_unique<MR::Header>(MR::Header::open(names[n])));
 
@@ -288,7 +288,7 @@ void ROI::dropEvent(QDropEvent *event) {
 
   const QMimeData *mimeData = event->mimeData();
   if (mimeData->hasUrls()) {
-    vector<std::unique_ptr<MR::Header>> list;
+    std::vector<std::unique_ptr<MR::Header>> list;
     QList<QUrl> urlList = mimeData->urls();
     for (int i = 0; i < urlList.size() && i < max_files; ++i) {
       try {
@@ -306,7 +306,7 @@ void ROI::dropEvent(QDropEvent *event) {
 }
 
 void ROI::save(ROI_Item *roi) {
-  vector<GLubyte> data(roi->header().size(0) * roi->header().size(1) * roi->header().size(2));
+  std::vector<GLubyte> data(roi->header().size(0) * roi->header().size(1) * roi->header().size(2));
   {
     GL::Context::Grab context;
     GL::assert_context_is_current();
@@ -349,7 +349,7 @@ void ROI::save_slot() {
   save(roi);
 }
 
-void ROI::load(vector<std::unique_ptr<MR::Header>> &list) {
+void ROI::load(std::vector<std::unique_ptr<MR::Header>> &list) {
   list_model->load(list);
   list_view->selectionModel()->clear();
   list_view->selectionModel()->select(list_model->index(list_model->rowCount() - 1, 0, QModelIndex()),
@@ -705,7 +705,7 @@ void ROI::add_commandline_options(MR::App::OptionList &options) {
 
 bool ROI::process_commandline_option(const MR::App::ParsedOption &opt) {
   if (opt.opt->is("roi.load")) {
-    vector<std::unique_ptr<MR::Header>> list;
+    std::vector<std::unique_ptr<MR::Header>> list;
     try {
       list.push_back(make_unique<MR::Header>(MR::Header::open(opt[0])));
     } catch (Exception &e) {

--- a/src/gui/mrview/tool/roi_editor/roi.cpp
+++ b/src/gui/mrview/tool/roi_editor/roi.cpp
@@ -277,7 +277,7 @@ void ROI::open_slot() {
     return;
   std::vector<std::unique_ptr<MR::Header>> list;
   for (size_t n = 0; n < names.size(); ++n)
-    list.push_back(make_unique<MR::Header>(MR::Header::open(names[n])));
+    list.push_back(std::make_unique<MR::Header>(MR::Header::open(names[n])));
 
   load(list);
   in_insert_mode = false;
@@ -292,7 +292,7 @@ void ROI::dropEvent(QDropEvent *event) {
     QList<QUrl> urlList = mimeData->urls();
     for (int i = 0; i < urlList.size() && i < max_files; ++i) {
       try {
-        list.push_back(make_unique<MR::Header>(MR::Header::open(urlList.at(i).path().toUtf8().constData())));
+        list.push_back(std::make_unique<MR::Header>(MR::Header::open(urlList.at(i).path().toUtf8().constData())));
       } catch (Exception &e) {
         e.display();
       }
@@ -707,7 +707,7 @@ bool ROI::process_commandline_option(const MR::App::ParsedOption &opt) {
   if (opt.opt->is("roi.load")) {
     std::vector<std::unique_ptr<MR::Header>> list;
     try {
-      list.push_back(make_unique<MR::Header>(MR::Header::open(opt[0])));
+      list.push_back(std::make_unique<MR::Header>(MR::Header::open(opt[0])));
     } catch (Exception &e) {
       e.display();
     }

--- a/src/gui/mrview/tool/roi_editor/roi.h
+++ b/src/gui/mrview/tool/roi_editor/roi.h
@@ -98,7 +98,7 @@ protected:
     window().updateGL();
   }
 
-  void load(vector<std::unique_ptr<MR::Header>> &list);
+  void load(std::vector<std::unique_ptr<MR::Header>> &list);
   void save(ROI_Item *);
 
   int normal2axis(const Eigen::Vector3f &, const ROI_Item &) const;

--- a/src/gui/mrview/tool/roi_editor/undoentry.cpp
+++ b/src/gui/mrview/tool/roi_editor/undoentry.cpp
@@ -405,7 +405,7 @@ void ROI_UndoEntry::draw_fill(ROI_Item &roi, const Eigen::Vector3f &pos, const b
   if (existing_value == insert_mode_value)
     return;
   after[seed_index] = fill_value;
-  vector<std::array<int, 3>> buffer(1, seed_voxel);
+  std::vector<std::array<int, 3>> buffer(1, seed_voxel);
   while (buffer.size()) {
     const std::array<int, 3> v(buffer.back());
     buffer.pop_back();

--- a/src/gui/mrview/tool/roi_editor/undoentry.h
+++ b/src/gui/mrview/tool/roi_editor/undoentry.h
@@ -54,7 +54,7 @@ struct ROI_UndoEntry {
 
   std::array<GLint, 3> from, size;
   std::array<GLint, 2> tex_size, slice_axes;
-  vector<GLubyte> before, after;
+  std::vector<GLubyte> before, after;
 
   class Shared {
   public:

--- a/src/gui/mrview/tool/tractography/tractogram.cpp
+++ b/src/gui/mrview/tool/tractography/tractogram.cpp
@@ -548,9 +548,9 @@ void Tractogram::load_tracks() {
 
   DWI::Tractography::Reader<float> file(filename, properties);
   DWI::Tractography::Streamline<float> tck;
-  vector<Eigen::Vector3f> buffer;
-  vector<GLint> starts;
-  vector<GLint> sizes;
+  std::vector<Eigen::Vector3f> buffer;
+  std::vector<GLint> starts;
+  std::vector<GLint> sizes;
   size_t tck_count = 0;
 
   on_FOV_changed();
@@ -605,7 +605,7 @@ void Tractogram::load_end_colours() {
   for (size_t buffer_index = 0, N = vertex_buffers.size(); buffer_index < N; ++buffer_index) {
 
     const size_t num_tracks = num_tracks_per_buffer[buffer_index];
-    vector<Eigen::Vector3f> buffer;
+    std::vector<Eigen::Vector3f> buffer;
     for (size_t buffer_tck_counter = 0; buffer_tck_counter != num_tracks; ++buffer_tck_counter) {
 
       const Eigen::Vector3f &tangent(endpoint_tangents[total_tck_counter++]);
@@ -633,7 +633,7 @@ void Tractogram::load_intensity_track_scalars(const std::string &filename) {
   erase_intensity_scalar_data();
   value_min = std::numeric_limits<float>::infinity();
   value_max = -std::numeric_limits<float>::infinity();
-  vector<float> buffer;
+  std::vector<float> buffer;
   DWI::Tractography::TrackScalar<float> tck_scalar;
 
   if (Path::has_suffix(filename, ".tsf")) {
@@ -674,7 +674,7 @@ void Tractogram::load_intensity_track_scalars(const std::string &filename) {
   } else {
     const Eigen::VectorXf scalars = File::Matrix::load_vector<float>(filename);
     size_t total_num_tracks = 0;
-    for (vector<size_t>::const_iterator i = num_tracks_per_buffer.begin(); i != num_tracks_per_buffer.end(); ++i)
+    for (std::vector<size_t>::const_iterator i = num_tracks_per_buffer.begin(); i != num_tracks_per_buffer.end(); ++i)
       total_num_tracks += *i;
     if (size_t(scalars.size()) != total_num_tracks)
       throw Exception("The scalar text file does not contain the same number of elements as the selected tractogram");
@@ -683,7 +683,7 @@ void Tractogram::load_intensity_track_scalars(const std::string &filename) {
     for (size_t buffer_index = 0; buffer_index != vertex_buffers.size(); ++buffer_index) {
 
       size_t num_tracks = num_tracks_per_buffer[buffer_index];
-      vector<GLint> &track_lengths(original_track_sizes[buffer_index]);
+      std::vector<GLint> &track_lengths(original_track_sizes[buffer_index]);
 
       for (size_t index = 0; index != num_tracks; ++index, ++running_index) {
         const float value = scalars[running_index];
@@ -725,7 +725,7 @@ void Tractogram::load_threshold_track_scalars(const std::string &filename) {
   erase_threshold_scalar_data();
   threshold_min = std::numeric_limits<float>::infinity();
   threshold_max = -std::numeric_limits<float>::infinity();
-  vector<float> buffer;
+  std::vector<float> buffer;
   DWI::Tractography::TrackScalar<float> tck_scalar;
 
   if (Path::has_suffix(filename, ".tsf")) {
@@ -766,7 +766,7 @@ void Tractogram::load_threshold_track_scalars(const std::string &filename) {
   } else {
     const Eigen::VectorXf scalars = File::Matrix::load_vector<float>(filename);
     size_t total_num_tracks = 0;
-    for (vector<size_t>::const_iterator i = num_tracks_per_buffer.begin(); i != num_tracks_per_buffer.end(); ++i)
+    for (std::vector<size_t>::const_iterator i = num_tracks_per_buffer.begin(); i != num_tracks_per_buffer.end(); ++i)
       total_num_tracks += *i;
     if (size_t(scalars.size()) != total_num_tracks)
       throw Exception("The scalar text file does not contain the same number of elements as the selected tractogram");
@@ -775,7 +775,7 @@ void Tractogram::load_threshold_track_scalars(const std::string &filename) {
     for (size_t buffer_index = 0; buffer_index != vertex_buffers.size(); ++buffer_index) {
 
       size_t num_tracks = num_tracks_per_buffer[buffer_index];
-      vector<GLint> &track_lengths(original_track_sizes[buffer_index]);
+      std::vector<GLint> &track_lengths(original_track_sizes[buffer_index]);
 
       for (size_t index = 0; index != num_tracks; ++index, ++running_index) {
         const float value = scalars[running_index];
@@ -868,9 +868,9 @@ void Tractogram::set_geometry_type(const TrackGeometryType t) {
   should_update_stride = true;
 }
 
-void Tractogram::load_tracks_onto_GPU(vector<Eigen::Vector3f> &buffer,
-                                      vector<GLint> &starts,
-                                      vector<GLint> &sizes,
+void Tractogram::load_tracks_onto_GPU(std::vector<Eigen::Vector3f> &buffer,
+                                      std::vector<GLint> &starts,
+                                      std::vector<GLint> &sizes,
                                       size_t &tck_count) {
   GL::assert_context_is_current();
 
@@ -898,7 +898,7 @@ void Tractogram::load_tracks_onto_GPU(vector<Eigen::Vector3f> &buffer,
   GL::assert_context_is_current();
 }
 
-void Tractogram::load_end_colours_onto_GPU(vector<Eigen::Vector3f> &buffer) {
+void Tractogram::load_end_colours_onto_GPU(std::vector<Eigen::Vector3f> &buffer) {
   GL::assert_context_is_current();
 
   GLuint vertexbuffer;
@@ -913,7 +913,7 @@ void Tractogram::load_end_colours_onto_GPU(vector<Eigen::Vector3f> &buffer) {
   GL::assert_context_is_current();
 }
 
-void Tractogram::load_intensity_scalars_onto_GPU(vector<float> &buffer, size_t &tck_count) {
+void Tractogram::load_intensity_scalars_onto_GPU(std::vector<float> &buffer, size_t &tck_count) {
   GL::assert_context_is_current();
 
   assert(num_tracks_per_buffer[intensity_scalar_buffers.size()] == tck_count);
@@ -932,7 +932,7 @@ void Tractogram::load_intensity_scalars_onto_GPU(vector<float> &buffer, size_t &
   GL::assert_context_is_current();
 }
 
-void Tractogram::load_threshold_scalars_onto_GPU(vector<float> &buffer, size_t &tck_count) {
+void Tractogram::load_threshold_scalars_onto_GPU(std::vector<float> &buffer, size_t &tck_count) {
   GL::assert_context_is_current();
 
   assert(num_tracks_per_buffer[threshold_scalar_buffers.size()] == tck_count);

--- a/src/gui/mrview/tool/tractography/tractogram.h
+++ b/src/gui/mrview/tool/tractography/tractogram.h
@@ -129,19 +129,19 @@ private:
   //   streamline tangents and store them; then, if colour by
   //   endpoint is requested, generate the buffer based on these
   //   and the known track sizes
-  vector<Eigen::Vector3f> endpoint_tangents;
+  std::vector<Eigen::Vector3f> endpoint_tangents;
 
-  vector<GLuint> vertex_buffers;
-  vector<GLuint> vertex_array_objects;
-  vector<GLuint> colour_buffers;
-  vector<GLuint> intensity_scalar_buffers;
-  vector<GLuint> threshold_scalar_buffers;
+  std::vector<GLuint> vertex_buffers;
+  std::vector<GLuint> vertex_array_objects;
+  std::vector<GLuint> colour_buffers;
+  std::vector<GLuint> intensity_scalar_buffers;
+  std::vector<GLuint> threshold_scalar_buffers;
   MR::DWI::Tractography::Properties properties;
-  vector<vector<GLint>> track_starts;
-  vector<vector<GLint>> track_sizes;
-  vector<vector<GLint>> original_track_sizes;
-  vector<vector<GLint>> original_track_starts;
-  vector<size_t> num_tracks_per_buffer;
+  std::vector<std::vector<GLint>> track_starts;
+  std::vector<std::vector<GLint>> track_sizes;
+  std::vector<std::vector<GLint>> original_track_sizes;
+  std::vector<std::vector<GLint>> original_track_starts;
+  std::vector<size_t> num_tracks_per_buffer;
   GLint sample_stride;
   bool vao_dirty;
 
@@ -149,13 +149,15 @@ private:
   //   may be used for streamline colouring and thresholding
   float threshold_min, threshold_max;
 
-  void
-  load_tracks_onto_GPU(vector<Eigen::Vector3f> &buffer, vector<GLint> &starts, vector<GLint> &sizes, size_t &tck_count);
+  void load_tracks_onto_GPU(std::vector<Eigen::Vector3f> &buffer,
+                            std::vector<GLint> &starts,
+                            std::vector<GLint> &sizes,
+                            size_t &tck_count);
 
-  void load_end_colours_onto_GPU(vector<Eigen::Vector3f> &);
+  void load_end_colours_onto_GPU(std::vector<Eigen::Vector3f> &);
 
-  void load_intensity_scalars_onto_GPU(vector<float> &buffer, size_t &tck_count);
-  void load_threshold_scalars_onto_GPU(vector<float> &buffer, size_t &tck_count);
+  void load_intensity_scalars_onto_GPU(std::vector<float> &buffer, size_t &tck_count);
+  void load_threshold_scalars_onto_GPU(std::vector<float> &buffer, size_t &tck_count);
 
   void render_streamlines();
 

--- a/src/gui/mrview/tool/tractography/tractography.cpp
+++ b/src/gui/mrview/tool/tractography/tractography.cpp
@@ -61,7 +61,7 @@ class Tractography::Model : public ListModelBase {
 public:
   Model(QObject *parent) : ListModelBase(parent) {}
 
-  void add_items(vector<std::string> &filenames, Tractography &tractography_tool) {
+  void add_items(std::vector<std::string> &filenames, Tractography &tractography_tool) {
 
     for (size_t i = 0; i < filenames.size(); ++i) {
       Tractogram *tractogram = new Tractogram(tractography_tool, filenames[i]);
@@ -345,12 +345,12 @@ size_t Tractography::visible_number_colourbars() {
 
 void Tractography::tractogram_open_slot() {
 
-  vector<std::string> list =
+  std::vector<std::string> list =
       Dialog::File::get_files(this, "Select tractograms to open", "Tractograms (*.tck)", &current_folder);
   add_tractogram(list);
 }
 
-void Tractography::add_tractogram(vector<std::string> &list) {
+void Tractography::add_tractogram(std::vector<std::string> &list) {
   if (list.empty()) {
     return;
   }
@@ -367,7 +367,7 @@ void Tractography::dropEvent(QDropEvent *event) {
 
   const QMimeData *mimeData = event->mimeData();
   if (mimeData->hasUrls()) {
-    vector<std::string> list;
+    std::vector<std::string> list;
     QList<QUrl> urlList = mimeData->urls();
     for (int i = 0; i < urlList.size() && i < max_files; ++i) {
       list.push_back(urlList.at(i).path().toUtf8().constData());
@@ -833,7 +833,7 @@ void Tractography::select_last_added_tractogram() {
 bool Tractography::process_commandline_option(const MR::App::ParsedOption &opt) {
 
   if (opt.opt->is("tractography.load")) {
-    vector<std::string> list(1, std::string(opt[0]));
+    std::vector<std::string> list(1, std::string(opt[0]));
     add_tractogram(list);
     return true;
   }
@@ -865,7 +865,7 @@ bool Tractography::process_commandline_option(const MR::App::ParsedOption &opt) 
   if (opt.opt->is("tractography.tsf_range")) {
     try {
       // Set the tsf visualisation range
-      vector<default_type> range;
+      std::vector<default_type> range;
       if (process_commandline_option_tsf_option(opt, 2, range))
         scalar_file_options->set_scaling(range[0], range[1]);
     } catch (Exception &E) {
@@ -877,7 +877,7 @@ bool Tractography::process_commandline_option(const MR::App::ParsedOption &opt) 
   if (opt.opt->is("tractography.tsf_thresh")) {
     try {
       // Set the tsf visualisation threshold
-      vector<default_type> range;
+      std::vector<default_type> range;
       if (process_commandline_option_tsf_option(opt, 2, range))
         scalar_file_options->set_threshold(TrackThresholdType::UseColourFile, range[0], range[1]);
     } catch (Exception &E) {
@@ -1030,7 +1030,7 @@ bool Tractography::process_commandline_option_tsf_check_tracto_loaded() {
  * parsed from the options, or null on fail*/
 bool Tractography::process_commandline_option_tsf_option(const MR::App::ParsedOption &opt,
                                                          uint reqArgSize,
-                                                         vector<default_type> &range) {
+                                                         std::vector<default_type> &range) {
   if (process_commandline_option_tsf_check_tracto_loaded()) {
     QModelIndexList indices = tractogram_list_view->selectionModel()->selectedIndexes();
     range = opt[0].as_sequence_float();

--- a/src/gui/mrview/tool/tractography/tractography.h
+++ b/src/gui/mrview/tool/tractography/tractography.h
@@ -112,10 +112,10 @@ protected:
 
   void dropEvent(QDropEvent *event) override;
   void update_scalar_options();
-  void add_tractogram(vector<std::string> &list);
+  void add_tractogram(std::vector<std::string> &list);
   void select_last_added_tractogram();
   bool process_commandline_option_tsf_check_tracto_loaded();
-  bool process_commandline_option_tsf_option(const MR::App::ParsedOption &, uint, vector<default_type> &range);
+  bool process_commandline_option_tsf_option(const MR::App::ParsedOption &, uint, std::vector<default_type> &range);
   void update_geometry_type_gui();
 };
 } // namespace Tool

--- a/src/gui/mrview/tool/view.cpp
+++ b/src/gui/mrview/tool/view.cpp
@@ -139,7 +139,7 @@ public:
     endInsertRows();
   }
 
-  vector<ClipPlane> planes;
+  std::vector<ClipPlane> planes;
 };
 
 View::View(Dock *parent) : Base(parent) {
@@ -792,8 +792,8 @@ void View::clip_planes_clear_slot() {
   window().updateGL();
 }
 
-vector<std::pair<GL::vec4, bool>> View::get_active_clip_planes() const {
-  vector<std::pair<GL::vec4, bool>> ret;
+std::vector<std::pair<GL::vec4, bool>> View::get_active_clip_planes() const {
+  std::vector<std::pair<GL::vec4, bool>> ret;
   QItemSelectionModel *selection = clip_planes_list_view->selectionModel();
   if (clip_box->isChecked()) {
     for (int i = 0; i < clip_planes_model->rowCount(); ++i) {
@@ -809,8 +809,8 @@ vector<std::pair<GL::vec4, bool>> View::get_active_clip_planes() const {
   return ret;
 }
 
-vector<GL::vec4 *> View::get_clip_planes_to_be_edited() const {
-  vector<GL::vec4 *> ret;
+std::vector<GL::vec4 *> View::get_clip_planes_to_be_edited() const {
+  std::vector<GL::vec4 *> ret;
   if (clip_box->isChecked()) {
     QModelIndexList indices = clip_planes_list_view->selectionModel()->selectedIndexes();
     for (int i = 0; i < indices.size(); ++i)
@@ -930,7 +930,9 @@ void View::update_lightbox_mode_gui(const Mode::LightBox &mode) {
   reset_light_box_gui_controls();
 }
 
-void View::move_clip_planes_in_out(const ModelViewProjection &projection, vector<GL::vec4 *> &clip, float distance) {
+void View::move_clip_planes_in_out(const ModelViewProjection &projection,
+                                   std::vector<GL::vec4 *> &clip,
+                                   float distance) {
   Eigen::Vector3f d = projection.screen_normal();
   for (size_t n = 0; n < clip.size(); ++n) {
     GL::vec4 &p(*clip[n]);
@@ -939,7 +941,7 @@ void View::move_clip_planes_in_out(const ModelViewProjection &projection, vector
   window().updateGL();
 }
 
-void View::rotate_clip_planes(vector<GL::vec4 *> &clip, const Eigen::Quaternionf &rot) {
+void View::rotate_clip_planes(std::vector<GL::vec4 *> &clip, const Eigen::Quaternionf &rot) {
   const auto &focus(window().focus());
   for (size_t n = 0; n < clip.size(); ++n) {
     GL::vec4 &p(*clip[n]);
@@ -957,7 +959,7 @@ void View::rotate_clip_planes(vector<GL::vec4 *> &clip, const Eigen::Quaternionf
 void View::deactivate() { clip_planes_list_view->selectionModel()->clear(); }
 
 bool View::slice_move_event(const ModelViewProjection &projection, float x) {
-  vector<GL::vec4 *> clip = get_clip_planes_to_be_edited();
+  std::vector<GL::vec4 *> clip = get_clip_planes_to_be_edited();
   if (!clip.size())
     return false;
   const auto &header = window().image()->header();
@@ -967,7 +969,7 @@ bool View::slice_move_event(const ModelViewProjection &projection, float x) {
 }
 
 bool View::pan_event(const ModelViewProjection &projection) {
-  vector<GL::vec4 *> clip = get_clip_planes_to_be_edited();
+  std::vector<GL::vec4 *> clip = get_clip_planes_to_be_edited();
   if (!clip.size())
     return false;
   Eigen::Vector3f move = projection.screen_to_model_direction(window().mouse_displacement(), window().target());
@@ -980,7 +982,7 @@ bool View::pan_event(const ModelViewProjection &projection) {
 }
 
 bool View::panthrough_event(const ModelViewProjection &projection) {
-  vector<GL::vec4 *> clip = get_clip_planes_to_be_edited();
+  std::vector<GL::vec4 *> clip = get_clip_planes_to_be_edited();
   if (!clip.size())
     return false;
   move_clip_planes_in_out(
@@ -989,7 +991,7 @@ bool View::panthrough_event(const ModelViewProjection &projection) {
 }
 
 bool View::tilt_event(const ModelViewProjection &projection) {
-  vector<GL::vec4 *> clip = get_clip_planes_to_be_edited();
+  std::vector<GL::vec4 *> clip = get_clip_planes_to_be_edited();
   if (!clip.size())
     return false;
   const Eigen::Quaternionf rot = window().get_current_mode()->get_tilt_rotation(projection);
@@ -1000,7 +1002,7 @@ bool View::tilt_event(const ModelViewProjection &projection) {
 }
 
 bool View::rotate_event(const ModelViewProjection &projection) {
-  vector<GL::vec4 *> clip = get_clip_planes_to_be_edited();
+  std::vector<GL::vec4 *> clip = get_clip_planes_to_be_edited();
   if (!clip.size())
     return false;
   const Eigen::Quaternionf rot = window().get_current_mode()->get_rotate_rotation(projection);

--- a/src/gui/mrview/tool/view.h
+++ b/src/gui/mrview/tool/view.h
@@ -44,8 +44,8 @@ public:
 
   QPushButton *clip_on_button[3], *clip_edit_button[3], *clip_modify_button;
 
-  vector<std::pair<GL::vec4, bool>> get_active_clip_planes() const;
-  vector<GL::vec4 *> get_clip_planes_to_be_edited() const;
+  std::vector<std::pair<GL::vec4, bool>> get_active_clip_planes() const;
+  std::vector<GL::vec4 *> get_clip_planes_to_be_edited() const;
   bool get_cliphighlightstate() const;
   bool get_clipintersectionmodestate() const;
 
@@ -137,8 +137,8 @@ private:
   void reset_light_box_gui_controls();
   void set_transparency_from_image();
 
-  void move_clip_planes_in_out(const ModelViewProjection &projection, vector<GL::vec4 *> &clip, float distance);
-  void rotate_clip_planes(vector<GL::vec4 *> &clip, const Eigen::Quaternionf &rot);
+  void move_clip_planes_in_out(const ModelViewProjection &projection, std::vector<GL::vec4 *> &clip, float distance);
+  void rotate_clip_planes(std::vector<GL::vec4 *> &clip, const Eigen::Quaternionf &rot);
 };
 
 } // namespace Tool

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -138,7 +138,7 @@ QSize Window::GLArea::sizeHint() const {
   // CONF Initial window size of MRView in pixels.
   // CONF default: 512,512
   std::string init_size_string = lowercase(MR::File::Config::get("MRViewInitWindowSize"));
-  vector<uint32_t> init_window_size;
+  std::vector<uint32_t> init_window_size;
   if (init_size_string.length())
     init_window_size = parse_ints<uint32_t>(init_size_string);
   if (init_window_size.size() == 2)
@@ -152,7 +152,7 @@ void Window::GLArea::dragLeaveEvent(QDragLeaveEvent *event) { event->accept(); }
 void Window::GLArea::dropEvent(QDropEvent *event) {
   const QMimeData *mimeData = event->mimeData();
   if (mimeData->hasUrls()) {
-    vector<std::unique_ptr<MR::Header>> list;
+    std::vector<std::unique_ptr<MR::Header>> list;
     QList<QUrl> urlList = mimeData->urls();
     for (int i = 0; i < urlList.size() && i < 32; ++i) {
       try {
@@ -742,7 +742,7 @@ void Window::parse_arguments() {
       }
     }
 
-    vector<std::unique_ptr<MR::Header>> list;
+    std::vector<std::unique_ptr<MR::Header>> list;
     for (size_t n = 0; n < MR::App::argument.size(); ++n) {
       try {
         list.push_back(make_unique<MR::Header>(MR::Header::open(MR::App::argument[n])));
@@ -789,11 +789,11 @@ Window::~Window() {
 void Window::sync_slot() { emit syncChanged(); }
 
 void Window::image_open_slot() {
-  vector<std::string> image_list = Dialog::File::get_images(this, "Select images to open", &current_folder);
+  std::vector<std::string> image_list = Dialog::File::get_images(this, "Select images to open", &current_folder);
   if (image_list.empty())
     return;
 
-  vector<std::unique_ptr<MR::Header>> list;
+  std::vector<std::unique_ptr<MR::Header>> list;
   for (size_t n = 0; n < image_list.size(); ++n) {
     try {
       list.push_back(make_unique<MR::Header>(MR::Header::open(image_list[n])));
@@ -810,7 +810,7 @@ void Window::image_import_DICOM_slot() {
     return;
 
   try {
-    vector<std::unique_ptr<MR::Header>> list;
+    std::vector<std::unique_ptr<MR::Header>> list;
     list.push_back(make_unique<MR::Header>(MR::Header::open(folder)));
     add_images(list);
   } catch (CancelException &E) {
@@ -820,7 +820,7 @@ void Window::image_import_DICOM_slot() {
   }
 }
 
-void Window::add_images(vector<std::unique_ptr<MR::Header>> &list) {
+void Window::add_images(std::vector<std::unique_ptr<MR::Header>> &list) {
   if (list.empty())
     return;
 
@@ -1676,7 +1676,7 @@ void Window::process_commandline_option() {
     }
 
     if (opt.opt->is("size")) {
-      vector<uint32_t> glsize = parse_ints<uint32_t>(opt[0]);
+      std::vector<uint32_t> glsize = parse_ints<uint32_t>(opt[0]);
       if (glsize.size() != 2)
         throw Exception("invalid argument \"" + std::string(opt.args[0]) + "\" to -size batch command");
       if (glsize[0] < 1 || glsize[1] < 1)
@@ -1718,7 +1718,7 @@ void Window::process_commandline_option() {
 
     if (opt.opt->is("target")) {
       if (image()) {
-        vector<default_type> pos = parse_floats(opt[0]);
+        std::vector<default_type> pos = parse_floats(opt[0]);
         if (pos.size() != 3)
           throw Exception("-target option expects a comma-separated list of 3 floating-point values");
         set_target(Eigen::Vector3f{float(pos[0]), float(pos[1]), float(pos[2])});
@@ -1729,7 +1729,7 @@ void Window::process_commandline_option() {
 
     if (opt.opt->is("orientation")) {
       if (image()) {
-        vector<default_type> pos = parse_floats(opt[0]);
+        std::vector<default_type> pos = parse_floats(opt[0]);
         if (pos.size() != 4)
           throw Exception("-orientation option expects a comma-separated list of 4 floating-point values");
         set_orientation({float(pos[0]), float(pos[1]), float(pos[2]), float(pos[3])});
@@ -1740,7 +1740,7 @@ void Window::process_commandline_option() {
 
     if (opt.opt->is("voxel")) {
       if (image()) {
-        vector<default_type> pos = parse_floats(opt[0]);
+        std::vector<default_type> pos = parse_floats(opt[0]);
         if (pos.size() != 3)
           throw Exception("-voxel option expects a comma-separated list of 3 floating-point values");
         set_focus(image()->voxel2scanner() * Eigen::Vector3f{float(pos[0]), float(pos[1]), float(pos[2])});
@@ -1793,7 +1793,7 @@ void Window::process_commandline_option() {
     }
 
     if (opt.opt->is("load")) {
-      vector<std::unique_ptr<MR::Header>> list;
+      std::vector<std::unique_ptr<MR::Header>> list;
       try {
         list.push_back(make_unique<MR::Header>(MR::Header::open(opt[0])));
       } catch (Exception &e) {
@@ -1828,7 +1828,7 @@ void Window::process_commandline_option() {
 
     if (opt.opt->is("intensity_range")) {
       if (image()) {
-        vector<default_type> param = parse_floats(opt[0]);
+        std::vector<default_type> param = parse_floats(opt[0]);
         if (param.size() != 2)
           throw Exception("-intensity_range options expects comma-separated list of two floating-point values");
         image()->set_windowing(param[0], param[1]);
@@ -1838,7 +1838,7 @@ void Window::process_commandline_option() {
     }
 
     if (opt.opt->is("position")) {
-      vector<int> pos = parse_ints<int>(opt[0]);
+      std::vector<int> pos = parse_ints<int>(opt[0]);
       if (pos.size() != 2)
         throw Exception("invalid argument \"" + std::string(opt[0]) + "\" to -position option");
       move(pos[0], pos[1]);

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -156,7 +156,7 @@ void Window::GLArea::dropEvent(QDropEvent *event) {
     QList<QUrl> urlList = mimeData->urls();
     for (int i = 0; i < urlList.size() && i < 32; ++i) {
       try {
-        list.push_back(make_unique<MR::Header>(MR::Header::open(urlList.at(i).path().toUtf8().constData())));
+        list.push_back(std::make_unique<MR::Header>(MR::Header::open(urlList.at(i).path().toUtf8().constData())));
       } catch (Exception &e) {
         e.display();
       }
@@ -745,7 +745,7 @@ void Window::parse_arguments() {
     std::vector<std::unique_ptr<MR::Header>> list;
     for (size_t n = 0; n < MR::App::argument.size(); ++n) {
       try {
-        list.push_back(make_unique<MR::Header>(MR::Header::open(MR::App::argument[n])));
+        list.push_back(std::make_unique<MR::Header>(MR::Header::open(MR::App::argument[n])));
       } catch (CancelException &e) {
         for (const auto &msg : e.description)
           CONSOLE(msg);
@@ -796,7 +796,7 @@ void Window::image_open_slot() {
   std::vector<std::unique_ptr<MR::Header>> list;
   for (size_t n = 0; n < image_list.size(); ++n) {
     try {
-      list.push_back(make_unique<MR::Header>(MR::Header::open(image_list[n])));
+      list.push_back(std::make_unique<MR::Header>(MR::Header::open(image_list[n])));
     } catch (Exception &E) {
       E.display();
     }
@@ -811,7 +811,7 @@ void Window::image_import_DICOM_slot() {
 
   try {
     std::vector<std::unique_ptr<MR::Header>> list;
-    list.push_back(make_unique<MR::Header>(MR::Header::open(folder)));
+    list.push_back(std::make_unique<MR::Header>(MR::Header::open(folder)));
     add_images(list);
   } catch (CancelException &E) {
     E.display(-1);
@@ -1795,7 +1795,7 @@ void Window::process_commandline_option() {
     if (opt.opt->is("load")) {
       std::vector<std::unique_ptr<MR::Header>> list;
       try {
-        list.push_back(make_unique<MR::Header>(MR::Header::open(opt[0])));
+        list.push_back(std::make_unique<MR::Header>(MR::Header::open(opt[0])));
       } catch (Exception &e) {
         e.display();
       }

--- a/src/gui/mrview/window.h
+++ b/src/gui/mrview/window.h
@@ -77,7 +77,7 @@ public:
   ~Window();
 
   void parse_arguments();
-  void add_images(vector<std::unique_ptr<MR::Header>> &list);
+  void add_images(std::vector<std::unique_ptr<MR::Header>> &list);
 
   const QPoint &mouse_position() const { return mouse_position_; }
   const QPoint &mouse_displacement() const { return mouse_displacement_; }
@@ -315,7 +315,7 @@ private:
 
   Tool::Base *tool_has_focus;
 
-  vector<double> render_times;
+  std::vector<double> render_times;
   double best_FPS, best_FPS_time;
   bool show_FPS;
   size_t current_option;

--- a/src/gui/projection.cpp
+++ b/src/gui/projection.cpp
@@ -31,7 +31,7 @@ public:
 } // namespace
 
 void Projection::draw_orientation_labels() const {
-  vector<OrientationLabel> labels;
+  std::vector<OrientationLabel> labels;
   labels.push_back(OrientationLabel(model_to_screen_direction(Eigen::Vector3f{-1.0, 0.0, 0.0}), 'L'));
   labels.push_back(OrientationLabel(model_to_screen_direction(Eigen::Vector3f{1.0, 0.0, 0.0}), 'R'));
   labels.push_back(OrientationLabel(model_to_screen_direction(Eigen::Vector3f{0.0, -1.0, 0.0}), 'P'));

--- a/src/gui/shapes/cylinder.cpp
+++ b/src/gui/shapes/cylinder.cpp
@@ -26,8 +26,8 @@ namespace Shapes {
 
 void Cylinder::LOD(const size_t level_of_detail) {
 
-  vector<Eigen::Vector3f> vertices, normals;
-  vector<Eigen::Array3i> indices;
+  std::vector<Eigen::Vector3f> vertices, normals;
+  std::vector<Eigen::Array3i> indices;
 
   // Want to be able to display using a single DrawElements call; not worth faffing about
   //   with combinations of GL_TRIANGLES and GL_TRIANGLE_FAN

--- a/src/gui/shapes/halfsphere.cpp
+++ b/src/gui/shapes/halfsphere.cpp
@@ -92,9 +92,9 @@ public:
 } // namespace
 
 void HalfSphere::LOD(const size_t level_of_detail) {
-  // vector<Vertex> vertices;
+  // std::vector<Vertex> vertices;
   vertices.clear();
-  vector<Triangle> indices;
+  std::vector<Triangle> indices;
 
   for (size_t n = 0; n < NUM_VERTICES; n++)
     vertices.push_back(initial_vertices[n]);

--- a/src/gui/shapes/halfsphere.h
+++ b/src/gui/shapes/halfsphere.h
@@ -61,7 +61,7 @@ public:
     float p[3];
   };
 
-  vector<Vertex> vertices;
+  std::vector<Vertex> vertices;
 };
 
 } // namespace Shapes

--- a/src/gui/shapes/sphere.cpp
+++ b/src/gui/shapes/sphere.cpp
@@ -123,9 +123,9 @@ public:
 } // namespace
 
 void Sphere::LOD(const size_t level_of_detail) {
-  // vector<Vertex> vertices;
+  // std::vector<Vertex> vertices;
   vertices.clear();
-  vector<Triangle> indices;
+  std::vector<Triangle> indices;
 
   for (size_t n = 0; n < NUM_VERTICES; n++)
     vertices.push_back(initial_vertices[n]);

--- a/src/gui/shapes/sphere.h
+++ b/src/gui/shapes/sphere.h
@@ -61,7 +61,7 @@ public:
     float p[3];
   };
 
-  vector<Vertex> vertices;
+  std::vector<Vertex> vertices;
 };
 
 } // namespace Shapes

--- a/src/min_mem_array.h
+++ b/src/min_mem_array.h
@@ -28,8 +28,8 @@ namespace MR {
 
 // This class allows for construction and management of a c-style array, where the
 //   memory overhead is minimal (a pointer and a size_t)
-// vector<>'s have some amount of overhead, which can add up if many are being stored
-// Typical usage is to gather the required data using a vector<>, and use that vector
+// std::vector<>'s have some amount of overhead, which can add up if many are being stored
+// Typical usage is to gather the required data using a std::vector<>, and use that vector
 //   to construct a Min_mem_array<>
 
 template <class T> class Min_mem_array {

--- a/src/registration/linear.cpp
+++ b/src/registration/linear.cpp
@@ -45,7 +45,7 @@ void parse_general_options(Registration::Linear &registration) {
     registration.init.init_rotation.search.run_global = true;
   auto opt = get_options("init_rotation.search.angles");
   if (opt.size()) {
-    vector<default_type> angles = parse_floats(opt[0][0]);
+    std::vector<default_type> angles = parse_floats(opt[0][0]);
     for (auto &a : angles) {
       if (a < 0.0 or a > 180.0)
         throw Exception("init_rotation.search.angles have to be between 0 and 180 degree.");
@@ -124,7 +124,7 @@ void parse_general_options(Registration::Linear &registration) {
     const auto iterations = parse_ints<uint32_t>(opt[0][0]);
     registration.set_stage_iterations(iterations);
   } else {
-    registration.set_stage_iterations(vector<uint32_t>{1});
+    registration.set_stage_iterations(std::vector<uint32_t>{1});
   }
 
   opt = get_options("linstage.diagnostics.prefix");

--- a/src/registration/linear.h
+++ b/src/registration/linear.h
@@ -87,11 +87,11 @@ struct StageSetting {
   }
   size_t stage_iterations, gd_max_iter;
   default_type scale_factor;
-  vector<OptimiserAlgoType> optimisers;
+  std::vector<OptimiserAlgoType> optimisers;
   OptimiserAlgoType optimiser_default, optimiser_first, optimiser_last;
   default_type loop_density;
   ssize_t fod_lmax;
-  vector<std::string> diagnostics_images;
+  std::vector<std::string> diagnostics_images;
 };
 
 class Linear {
@@ -123,7 +123,7 @@ public:
   }
 
   // set_scale_factor needs to be the first option that is set as it overwrites the stage vector
-  void set_scale_factor(const vector<default_type> &scalefactor) {
+  void set_scale_factor(const std::vector<default_type> &scalefactor) {
     stages.resize(scalefactor.size());
     for (size_t level = 0; level < scalefactor.size(); ++level) {
       if (scalefactor[level] <= 0 || scalefactor[level] > 1.0)
@@ -150,7 +150,7 @@ public:
       stage.optimiser_last = type;
   }
 
-  void set_stage_iterations(const vector<uint32_t> &it) {
+  void set_stage_iterations(const std::vector<uint32_t> &it) {
     for (size_t i = 0; i < it.size(); ++i)
       if (!it[i])
         throw Exception("the number of stage iterations must be positive");
@@ -171,7 +171,7 @@ public:
     }
   }
 
-  void set_max_iter(const vector<uint32_t> &maxiter) {
+  void set_max_iter(const std::vector<uint32_t> &maxiter) {
     if (maxiter.size() == stages.size()) {
       for (size_t i = 0; i < stages.size(); ++i)
         stages[i].gd_max_iter = maxiter[i];
@@ -189,7 +189,7 @@ public:
     do_reorientation = true;
   }
 
-  void set_lmax(const vector<uint32_t> &lmax) {
+  void set_lmax(const std::vector<uint32_t> &lmax) {
     for (size_t i = 0; i < lmax.size(); ++i)
       if (lmax[i] % 2)
         throw Exception("the input lmax must be even");
@@ -204,9 +204,9 @@ public:
   }
 
   // needs to be set after set_lmax
-  void set_mc_parameters(const vector<MultiContrastSetting> &mcs) { contrasts = mcs; }
+  void set_mc_parameters(const std::vector<MultiContrastSetting> &mcs) { contrasts = mcs; }
 
-  void set_loop_density(const vector<default_type> &loop_density_) {
+  void set_loop_density(const std::vector<default_type> &loop_density_) {
     for (size_t d = 0; d < loop_density_.size(); ++d)
       if (loop_density_[d] < 0.0 or loop_density_[d] > 1.0)
         throw Exception("loop density must be between 0.0 and 1.0");
@@ -234,7 +234,7 @@ public:
     }
   }
 
-  void set_extent(const vector<size_t> extent) {
+  void set_extent(const std::vector<size_t> extent) {
     for (size_t d = 0; d < extent.size(); ++d) {
       if (extent[d] < 1)
         throw Exception("the neighborhood kernel extent must be at least 1 voxel");
@@ -574,9 +574,9 @@ public:
   // }
 
 protected:
-  vector<StageSetting> stages;
-  vector<MultiContrastSetting> contrasts, stage_contrasts;
-  vector<size_t> kernel_extent;
+  std::vector<StageSetting> stages;
+  std::vector<MultiContrastSetting> contrasts, stage_contrasts;
+  std::vector<size_t> kernel_extent;
   default_type grad_tolerance;
   default_type step_tolerance;
   std::streambuf *log_stream;

--- a/src/registration/metric/cc_helper.h
+++ b/src/registration/metric/cc_helper.h
@@ -36,7 +36,7 @@ void cc_precompute(Im1ImageType &im1_image,
                    DerivedImageType &C,
                    DerivedImageType &im1_meansubtr,
                    DerivedImageType &im2_meansubtr,
-                   const vector<size_t> &extent) {
+                   const std::vector<size_t> &extent) {
   // TODO check extent
   int nmax = extent[0] * extent[1] * extent[2];
   Eigen::VectorXd n1 = Eigen::VectorXd(nmax);

--- a/src/registration/metric/demons4D.h
+++ b/src/registration/metric/demons4D.h
@@ -35,7 +35,7 @@ public:
            const Im2ImageType &im2_image,
            const Im1MaskType im1_mask,
            const Im2MaskType im2_mask,
-           const vector<MultiContrastSetting> *contrast_settings = nullptr)
+           const std::vector<MultiContrastSetting> *contrast_settings = nullptr)
       : global_cost(global_energy),
         global_voxel_count(global_voxel_count),
         thread_cost(0.0),
@@ -160,7 +160,7 @@ protected:
   Im1MaskType im1_mask;
   Im2MaskType im2_mask;
 
-  const vector<MultiContrastSetting> *contrast_settings;
+  const std::vector<MultiContrastSetting> *contrast_settings;
   const ssize_t nvols;
   Eigen::VectorXd weight;
 

--- a/src/registration/metric/evaluate.h
+++ b/src/registration/metric/evaluate.h
@@ -87,8 +87,8 @@ public:
       DEBUG("Reorienting FODs...");
       std::shared_ptr<Image<default_type>> im1_image_reoriented;
       std::shared_ptr<Image<default_type>> im2_image_reoriented;
-      im1_image_reoriented = make_shared<Image<default_type>>(Image<default_type>::scratch(params.im1_image));
-      im2_image_reoriented = make_shared<Image<default_type>>(Image<default_type>::scratch(params.im2_image));
+      im1_image_reoriented = std::make_shared<Image<default_type>>(Image<default_type>::scratch(params.im1_image));
+      im2_image_reoriented = std::make_shared<Image<default_type>>(Image<default_type>::scratch(params.im2_image));
 
       {
         if (params.mc_settings.size()) {
@@ -183,8 +183,8 @@ public:
       DEBUG("Reorienting FODs...");
       std::shared_ptr<Image<default_type>> im1_image_reoriented;
       std::shared_ptr<Image<default_type>> im2_image_reoriented;
-      im1_image_reoriented = make_shared<Image<default_type>>(Image<default_type>::scratch(params.im1_image));
-      im2_image_reoriented = make_shared<Image<default_type>>(Image<default_type>::scratch(params.im2_image));
+      im1_image_reoriented = std::make_shared<Image<default_type>>(Image<default_type>::scratch(params.im1_image));
+      im2_image_reoriented = std::make_shared<Image<default_type>>(Image<default_type>::scratch(params.im2_image));
 
       {
         if (params.mc_settings.size()) {

--- a/src/registration/metric/evaluate.h
+++ b/src/registration/metric/evaluate.h
@@ -269,7 +269,7 @@ public:
 protected:
   MetricType metric;
   ParamType params;
-  vector<size_t> extent;
+  std::vector<size_t> extent;
   size_t iteration;
   Eigen::MatrixXd directions;
   ssize_t overlap_count;

--- a/src/registration/metric/local_cross_correlation.h
+++ b/src/registration/metric/local_cross_correlation.h
@@ -112,12 +112,12 @@ template <typename ImageType1, typename ImageType2> struct LCCPrecomputeFunctorM
                      .finished();
   }
 
-  LCCPrecomputeFunctorMasked_Naive(const vector<size_t> &ext, ImageType1 &adapter1, ImageType2 &adapter2)
+  LCCPrecomputeFunctorMasked_Naive(const std::vector<size_t> &ext, ImageType1 &adapter1, ImageType2 &adapter2)
       : extent(ext), in1(adapter1), in2(adapter2) { /* TODO check dimensions and extent */
   }
 
 protected:
-  vector<size_t> extent;
+  std::vector<size_t> extent;
   ImageType1 in1; // store reslice adapter in functor to avoid iterating over it when mask is false
   ImageType2 in2; // TODO: cache interpolated values for neighbourhood iteration
 };
@@ -163,7 +163,7 @@ public:
 
     auto cc_image =
         cc_image_header.template get_image<ProcessedImageValueType>().with_direct_io(Stride::contiguous_along_axis(3));
-    vector<uint32_t> NoOversample;
+    std::vector<uint32_t> NoOversample;
     {
       LogLevelLatch log_level(0);
       if (parameters.im1_mask.valid() or parameters.im2_mask.valid())

--- a/src/registration/metric/params.h
+++ b/src/registration/metric/params.h
@@ -81,9 +81,9 @@ public:
     update_control_points();
   }
 
-  void set_extent(vector<size_t> extent_vector) { extent = std::move(extent_vector); }
+  void set_extent(std::vector<size_t> extent_vector) { extent = std::move(extent_vector); }
 
-  void set_mc_settings(const vector<MultiContrastSetting> &mc_vector) {
+  void set_mc_settings(const std::vector<MultiContrastSetting> &mc_vector) {
     mc_settings = mc_vector;
 
     // set multi contrast weights
@@ -125,7 +125,7 @@ public:
     control_points.block<3, 4>(0, 0).colwise() += centre;
   }
 
-  const vector<size_t> &get_extent() const { return extent; }
+  const std::vector<size_t> &get_extent() const { return extent; }
 
   template <class OptimiserType> void optimiser_update(OptimiserType &optim, const ssize_t overlap_count) {
     DEBUG("gradient descent ran using " + str(optim.function_evaluations()) + " cost function evaluations.");
@@ -155,7 +155,7 @@ public:
     header.keyval()["trafo2"] = str(trafo2.matrix());
     auto check = Image<default_type>::create(image_path, header);
 
-    vector<uint32_t> no_oversampling(3, 1);
+    std::vector<uint32_t> no_oversampling(3, 1);
     Adapter::Reslice<Interp::Linear, Im1ImageType> im1_reslicer(im1_image, midway_image, trafo1, no_oversampling, NAN);
     Adapter::Reslice<Interp::Linear, Im2ImageType> im2_reslicer(im2_image, midway_image, trafo2, no_oversampling, NAN);
 
@@ -222,15 +222,15 @@ public:
 
   bool robust_estimate_subset;
   bool robust_estimate_use_score;
-  MR::vector<int> robust_estimate_subset_from;
-  MR::vector<int> robust_estimate_subset_size;
+  std::vector<int> robust_estimate_subset_from;
+  std::vector<int> robust_estimate_subset_size;
   Image<float> robust_estimate_score1, robust_estimate_score2;
   MR::copy_ptr<Interp::Linear<Image<float>>> robust_estimate_score1_interp;
   MR::copy_ptr<Interp::Linear<Image<float>>> robust_estimate_score2_interp;
 
   Eigen::Matrix<default_type, Eigen::Dynamic, Eigen::Dynamic> control_points;
-  vector<size_t> extent;
-  vector<MultiContrastSetting> mc_settings;
+  std::vector<size_t> extent;
+  std::vector<MultiContrastSetting> mc_settings;
 
   ProcImageType processed_image;
   MR::copy_ptr<ProcImageInterpolatorType> processed_image_interp;

--- a/src/registration/metric/thread_kernel.h
+++ b/src/registration/metric/thread_kernel.h
@@ -318,7 +318,7 @@ protected:
 
 template <class MetricType, class ParamType> struct StochasticThreadKernel {
 public:
-  StochasticThreadKernel(const vector<size_t> &inner_axes,
+  StochasticThreadKernel(const std::vector<size_t> &inner_axes,
                          const default_type density,
                          const MetricType &metric,
                          const ParamType &parameters,
@@ -361,7 +361,7 @@ public:
   }
 
 protected:
-  vector<size_t> inner_axes;
+  std::vector<size_t> inner_axes;
   default_type density;
   MetricType metric;
   ParamType params;

--- a/src/registration/multi_contrast.cpp
+++ b/src/registration/multi_contrast.cpp
@@ -54,7 +54,9 @@ protected:
   size_t start_vol;
 };
 
-void preload_data(vector<Header> &input, Image<default_type> &images, const vector<MultiContrastSetting> &mc_params) {
+void preload_data(std::vector<Header> &input,
+                  Image<default_type> &images,
+                  const std::vector<MultiContrastSetting> &mc_params) {
   const size_t n_images = input.size();
   assert(mc_params.size() == input.size());
   size_t sumvols(0);
@@ -78,8 +80,8 @@ void preload_data(vector<Header> &input, Image<default_type> &images, const vect
   } else {
     for (size_t idx = 0; idx < n_images; idx++) {
       size_t ndim = input[idx].ndim();
-      vector<size_t> from(ndim, 0);
-      vector<size_t> size(ndim, 1);
+      std::vector<size_t> from(ndim, 0);
+      std::vector<size_t> size(ndim, 1);
       for (size_t dim = 0; dim < 3; ++dim)
         size[dim] = input[idx].size(dim);
       if (ndim == 4)

--- a/src/registration/multi_contrast.h
+++ b/src/registration/multi_contrast.h
@@ -34,7 +34,7 @@ namespace MR {
 namespace Registration {
 
 FORCE_INLINE void check_image_output(const std::string &image_name, const Header &reference) {
-  vector<std::string> V;
+  std::vector<std::string> V;
   if (!image_name.size())
     throw Exception("image output path is empty");
   if (Path::exists(image_name) && !App::overwrite_files)
@@ -43,7 +43,7 @@ FORCE_INLINE void check_image_output(const std::string &image_name, const Header
   Header H = reference;
   File::NameParser parser;
   parser.parse(image_name);
-  vector<int> Pdim(parser.ndim());
+  std::vector<int> Pdim(parser.ndim());
 
   H.name() = image_name;
 
@@ -106,7 +106,9 @@ inline std::ostream &operator<<(std::ostream &o, const MultiContrastSetting &a) 
   return o;
 }
 
-void preload_data(vector<Header> &input, Image<default_type> &images, const vector<MultiContrastSetting> &mc_params);
+void preload_data(std::vector<Header> &input,
+                  Image<default_type> &images,
+                  const std::vector<MultiContrastSetting> &mc_params);
 
 } // namespace Registration
 } // namespace MR

--- a/src/registration/multi_resolution_lmax.h
+++ b/src/registration/multi_resolution_lmax.h
@@ -30,15 +30,15 @@ FORCE_INLINE ImageType multi_resolution_lmax(ImageType &input,
                                              const default_type scale_factor,
                                              const bool do_reorientation = false,
                                              const uint32_t lmax = 0) {
-  vector<uint32_t> from(input.ndim(), 0);
-  vector<uint32_t> size(input.ndim());
+  std::vector<uint32_t> from(input.ndim(), 0);
+  std::vector<uint32_t> size(input.ndim());
   for (size_t dim = 0; dim < input.ndim(); ++dim)
     size[dim] = input.size(dim);
   if (do_reorientation)
     size[3] = Math::SH::NforL(lmax);
   Adapter::Subset<ImageType> subset(input, from, size);
   Filter::Smooth smooth_filter(subset);
-  vector<default_type> stdev(3);
+  std::vector<default_type> stdev(3);
   for (size_t dim = 0; dim < 3; ++dim)
     stdev[dim] = input.spacing(dim) / (2.0 * scale_factor);
 
@@ -57,9 +57,9 @@ template <class ImageType>
 FORCE_INLINE ImageType multi_resolution_lmax(ImageType &input,
                                              const default_type scale_factor,
                                              const bool do_reorientation,
-                                             const vector<MultiContrastSetting> &contrast,
-                                             vector<MultiContrastSetting> *contrast_updated = nullptr) {
-  vector<uint32_t> volume_indices;
+                                             const std::vector<MultiContrastSetting> &contrast,
+                                             std::vector<MultiContrastSetting> *contrast_updated = nullptr) {
+  std::vector<uint32_t> volume_indices;
   size_t start = 0;
   for (size_t ic = 0; ic < contrast.size(); ic++) {
     const auto &mc = contrast[ic];
@@ -74,7 +74,7 @@ FORCE_INLINE ImageType multi_resolution_lmax(ImageType &input,
   Adapter::Extract1D<ImageType> subset(input, 3, volume_indices);
 
   Filter::Smooth smooth_filter(subset);
-  vector<default_type> stdev(3);
+  std::vector<default_type> stdev(3);
   for (size_t dim = 0; dim < 3; ++dim)
     stdev[dim] = input.spacing(dim) / (2.0 * scale_factor);
 

--- a/src/registration/nonlinear.h
+++ b/src/registration/nonlinear.h
@@ -175,19 +175,19 @@ public:
       field_header.ndim() = 4;
       field_header.size(3) = 3;
 
-      im1_to_mid_new = make_shared<Image<default_type>>(Image<default_type>::scratch(field_header));
-      im2_to_mid_new = make_shared<Image<default_type>>(Image<default_type>::scratch(field_header));
-      im1_update = make_shared<Image<default_type>>(Image<default_type>::scratch(field_header));
-      im2_update = make_shared<Image<default_type>>(Image<default_type>::scratch(field_header));
-      im1_update_new = make_shared<Image<default_type>>(Image<default_type>::scratch(field_header));
-      im2_update_new = make_shared<Image<default_type>>(Image<default_type>::scratch(field_header));
+      im1_to_mid_new = std::make_shared<Image<default_type>>(Image<default_type>::scratch(field_header));
+      im2_to_mid_new = std::make_shared<Image<default_type>>(Image<default_type>::scratch(field_header));
+      im1_update = std::make_shared<Image<default_type>>(Image<default_type>::scratch(field_header));
+      im2_update = std::make_shared<Image<default_type>>(Image<default_type>::scratch(field_header));
+      im1_update_new = std::make_shared<Image<default_type>>(Image<default_type>::scratch(field_header));
+      im2_update_new = std::make_shared<Image<default_type>>(Image<default_type>::scratch(field_header));
 
       if (!is_initialised) {
         if (level == 0) {
-          im1_to_mid = make_shared<Image<default_type>>(Image<default_type>::scratch(field_header));
-          im2_to_mid = make_shared<Image<default_type>>(Image<default_type>::scratch(field_header));
-          mid_to_im1 = make_shared<Image<default_type>>(Image<default_type>::scratch(field_header));
-          mid_to_im2 = make_shared<Image<default_type>>(Image<default_type>::scratch(field_header));
+          im1_to_mid = std::make_shared<Image<default_type>>(Image<default_type>::scratch(field_header));
+          im2_to_mid = std::make_shared<Image<default_type>>(Image<default_type>::scratch(field_header));
+          mid_to_im1 = std::make_shared<Image<default_type>>(Image<default_type>::scratch(field_header));
+          mid_to_im2 = std::make_shared<Image<default_type>>(Image<default_type>::scratch(field_header));
         } else {
           DEBUG("Upsampling fields");
           {
@@ -383,22 +383,22 @@ public:
     field_header.ndim() = 4;
     field_header.size(3) = 3;
 
-    im1_to_mid = make_shared<Image<default_type>>(Image<default_type>::scratch(field_header));
+    im1_to_mid = std::make_shared<Image<default_type>>(Image<default_type>::scratch(field_header));
     input_warps.index(4) = 0;
     threaded_copy(input_warps, *im1_to_mid, 0, 4);
     Registration::Warp::deformation2displacement(*im1_to_mid, *im1_to_mid);
 
-    mid_to_im1 = make_shared<Image<default_type>>(Image<default_type>::scratch(field_header));
+    mid_to_im1 = std::make_shared<Image<default_type>>(Image<default_type>::scratch(field_header));
     input_warps.index(4) = 1;
     threaded_copy(input_warps, *mid_to_im1, 0, 4);
     Registration::Warp::deformation2displacement(*mid_to_im1, *mid_to_im1);
 
-    im2_to_mid = make_shared<Image<default_type>>(Image<default_type>::scratch(field_header));
+    im2_to_mid = std::make_shared<Image<default_type>>(Image<default_type>::scratch(field_header));
     input_warps.index(4) = 2;
     threaded_copy(input_warps, *im2_to_mid, 0, 4);
     Registration::Warp::deformation2displacement(*im2_to_mid, *im2_to_mid);
 
-    mid_to_im2 = make_shared<Image<default_type>>(Image<default_type>::scratch(field_header));
+    mid_to_im2 = std::make_shared<Image<default_type>>(Image<default_type>::scratch(field_header));
     input_warps.index(4) = 3;
     threaded_copy(input_warps, *mid_to_im2, 0, 4);
     Registration::Warp::deformation2displacement(*mid_to_im2, *mid_to_im2);
@@ -508,7 +508,8 @@ public:
 
 protected:
   std::shared_ptr<Image<default_type>> reslice(Image<default_type> &image, Header &header) {
-    std::shared_ptr<Image<default_type>> temp = make_shared<Image<default_type>>(Image<default_type>::scratch(header));
+    std::shared_ptr<Image<default_type>> temp =
+        std::make_shared<Image<default_type>>(Image<default_type>::scratch(header));
     Filter::reslice<Interp::Linear>(image, *temp);
     return temp;
   }

--- a/src/registration/nonlinear.h
+++ b/src/registration/nonlinear.h
@@ -75,7 +75,7 @@ public:
       im2_to_mid_linear = linear_transform.get_transform_half_inverse();
 
       INFO("Estimating halfway space");
-      vector<Eigen::Transform<double, 3, Eigen::Projective>> init_transforms;
+      std::vector<Eigen::Transform<double, 3, Eigen::Projective>> init_transforms;
       // define transfomations that will be applied to the image header when the common space is calculated
       midway_image_header = compute_minimum_average_header(
           im1_image, im2_image, linear_transform.get_transform_half_inverse(), linear_transform.get_transform_half());
@@ -405,9 +405,9 @@ public:
     is_initialised = true;
   }
 
-  void set_max_iter(const vector<uint32_t> &maxiter) { max_iter = maxiter; }
+  void set_max_iter(const std::vector<uint32_t> &maxiter) { max_iter = maxiter; }
 
-  void set_scale_factor(const vector<default_type> &scalefactor) {
+  void set_scale_factor(const std::vector<default_type> &scalefactor) {
     for (size_t level = 0; level < scalefactor.size(); ++level) {
       if (scalefactor[level] <= 0 || scalefactor[level] > 1)
         throw Exception(
@@ -416,7 +416,7 @@ public:
     scale_factor = scalefactor;
   }
 
-  vector<default_type> get_scale_factor() const { return scale_factor; }
+  std::vector<default_type> get_scale_factor() const { return scale_factor; }
 
   void set_init_grad_step(const default_type step) { gradient_step = step; }
 
@@ -429,7 +429,7 @@ public:
 
   void set_disp_smoothing(const default_type voxel_fwhm) { disp_smoothing = voxel_fwhm; }
 
-  void set_lmax(const vector<uint32_t> &lmax) {
+  void set_lmax(const std::vector<uint32_t> &lmax) {
     for (size_t i = 0; i < lmax.size(); ++i)
       if (lmax[i] % 2)
         throw Exception("the input nonlinear lmax must be even");
@@ -437,7 +437,7 @@ public:
   }
 
   // needs to be set after set_lmax
-  void set_mc_parameters(const vector<MultiContrastSetting> &mcs) { contrasts = mcs; }
+  void set_mc_parameters(const std::vector<MultiContrastSetting> &mcs) { contrasts = mcs; }
 
   ssize_t get_lmax() { return (ssize_t)*std::max_element(fod_lmax.begin(), fod_lmax.end()); }
 
@@ -501,7 +501,7 @@ public:
       throw Exception("CC radius needs to be larger than 1");
     use_cc = true;
     INFO("Cross correlation radius: " + str(radius));
-    cc_extent = vector<size_t>(3, radius * 2 + 1);
+    cc_extent = std::vector<size_t>(3, radius * 2 + 1);
   }
 
   void set_diagnostics_image(const std::basic_string<char> &path) { diagnostics_image_prefix = path; }
@@ -523,24 +523,24 @@ protected:
   }
 
   bool is_initialised;
-  vector<uint32_t> max_iter;
-  vector<default_type> scale_factor;
+  std::vector<uint32_t> max_iter;
+  std::vector<default_type> scale_factor;
   default_type update_smoothing;
   default_type disp_smoothing;
   default_type gradient_step;
   Eigen::MatrixXd aPSF_directions;
   bool do_reorientation;
-  vector<uint32_t> fod_lmax;
+  std::vector<uint32_t> fod_lmax;
   bool use_cc;
   std::basic_string<char> diagnostics_image_prefix;
 
-  vector<size_t> cc_extent;
+  std::vector<size_t> cc_extent;
 
   transform_type im1_to_mid_linear;
   transform_type im2_to_mid_linear;
   Header midway_image_header;
 
-  vector<MultiContrastSetting> contrasts, stage_contrasts;
+  std::vector<MultiContrastSetting> contrasts, stage_contrasts;
 
   // Internally the warp is stored as a displacement field to enable easy smoothing near the boundaries
   std::shared_ptr<Image<default_type>> im1_to_mid_new;

--- a/src/registration/transform/affine.cpp
+++ b/src/registration/transform/affine.cpp
@@ -308,7 +308,7 @@ void Affine::get_parameter_vector(Eigen::Matrix<Affine::ParameterType, Eigen::Dy
 }
 
 bool Affine::robust_estimate(Eigen::Matrix<default_type, Eigen::Dynamic, 1> &gradient,
-                             vector<Eigen::Matrix<default_type, Eigen::Dynamic, 1>> &grad_estimates,
+                             std::vector<Eigen::Matrix<default_type, Eigen::Dynamic, 1>> &grad_estimates,
                              const Eigen::Matrix<default_type, 4, 4> &control_points,
                              const Eigen::Matrix<default_type, Eigen::Dynamic, 1> &parameter_vector,
                              const default_type &weiszfeld_precision = 1.0e-6,

--- a/src/registration/transform/affine.h
+++ b/src/registration/transform/affine.h
@@ -113,7 +113,7 @@ public:
   UpdateType *get_gradient_descent_updator() { return &gradient_descent_updator; }
 
   bool robust_estimate(Eigen::Matrix<default_type, Eigen::Dynamic, 1> &gradient,
-                       vector<Eigen::Matrix<default_type, Eigen::Dynamic, 1>> &grad_estimates,
+                       std::vector<Eigen::Matrix<default_type, Eigen::Dynamic, 1>> &grad_estimates,
                        const Eigen::Matrix<default_type, 4, 4> &control_points,
                        const Eigen::Matrix<default_type, Eigen::Dynamic, 1> &parameter_vector,
                        const default_type &weiszfeld_precision,

--- a/src/registration/transform/base.h
+++ b/src/registration/transform/base.h
@@ -211,7 +211,7 @@ public:
 
   template <class ParamType, class VectorType>
   bool robust_estimate(VectorType &gradient,
-                       vector<VectorType> &grad_estimates,
+                       std::vector<VectorType> &grad_estimates,
                        const ParamType &params,
                        const VectorType &parameter_vector,
                        const default_type &weiszfeld_precision,

--- a/src/registration/transform/initialiser.cpp
+++ b/src/registration/transform/initialiser.cpp
@@ -28,7 +28,7 @@ void set_centre_via_mass(Image<default_type> &im1,
                          Image<default_type> &mask2,
                          Registration::Transform::Base &transform,
                          Registration::Transform::Init::LinearInitialisationParams &init,
-                         const vector<MultiContrastSetting> &contrast_settings) {
+                         const std::vector<MultiContrastSetting> &contrast_settings) {
 
   CONSOLE("initialising centre of rotation using centre of mass");
   Eigen::Vector3d im1_centre_mass, im2_centre_mass;
@@ -92,7 +92,7 @@ void initialise_using_image_moments(Image<default_type> &im1,
                                     Image<default_type> &mask2,
                                     Registration::Transform::Base &transform,
                                     Registration::Transform::Init::LinearInitialisationParams &init,
-                                    const vector<MultiContrastSetting> &contrast_settings) {
+                                    const std::vector<MultiContrastSetting> &contrast_settings) {
 
   Image<default_type> bogus_mask;
   CONSOLE("initialising using image moments");
@@ -132,7 +132,7 @@ void initialise_using_rotation_search(Image<default_type> &im1,
                                       Image<default_type> &mask2,
                                       Registration::Transform::Base &transform,
                                       Registration::Transform::Init::LinearInitialisationParams &init,
-                                      const vector<MultiContrastSetting> &contrast_settings);
+                                      const std::vector<MultiContrastSetting> &contrast_settings);
 
 void initialise_using_image_mass(Image<default_type> &im1,
                                  Image<default_type> &im2,
@@ -140,7 +140,7 @@ void initialise_using_image_mass(Image<default_type> &im1,
                                  Image<default_type> &mask2,
                                  Registration::Transform::Base &transform,
                                  Registration::Transform::Init::LinearInitialisationParams &init,
-                                 const vector<MultiContrastSetting> &contrast_settings);
+                                 const std::vector<MultiContrastSetting> &contrast_settings);
 } // namespace Init
 } // namespace Transform
 } // namespace Registration

--- a/src/registration/transform/initialiser.h
+++ b/src/registration/transform/initialiser.h
@@ -38,7 +38,7 @@ struct LinearInitialisationParams {
     bool unmasked1;
     bool unmasked2;
     struct rot_search {
-      vector<default_type> angles;
+      std::vector<default_type> angles;
       default_type scale;
       size_t directions;
       bool run_global;
@@ -69,7 +69,7 @@ extern void set_centre_via_mass(Image<default_type> &im1,
                                 Image<default_type> &mask2,
                                 Registration::Transform::Base &transform,
                                 Registration::Transform::Init::LinearInitialisationParams &init,
-                                const vector<MultiContrastSetting> &contrast_settings);
+                                const std::vector<MultiContrastSetting> &contrast_settings);
 
 extern void set_centre_via_image_centres(const Image<default_type> &im1,
                                          const Image<default_type> &im2,
@@ -91,7 +91,7 @@ extern void initialise_using_image_moments(Image<default_type> &im1,
                                            Image<default_type> &mask2,
                                            Registration::Transform::Base &transform,
                                            Registration::Transform::Init::LinearInitialisationParams &init,
-                                           const vector<MultiContrastSetting> &contrast_settings);
+                                           const std::vector<MultiContrastSetting> &contrast_settings);
 
 extern void initialise_using_FOD(Image<default_type> &im1,
                                  Image<default_type> &im2,
@@ -106,7 +106,7 @@ extern void initialise_using_rotation_search(Image<default_type> &im1,
                                              Image<default_type> &mask2,
                                              Registration::Transform::Base &transform,
                                              Registration::Transform::Init::LinearInitialisationParams &init,
-                                             const vector<MultiContrastSetting> &contrast_settings);
+                                             const std::vector<MultiContrastSetting> &contrast_settings);
 
 extern void initialise_using_image_mass(Image<default_type> &im1,
                                         Image<default_type> &im2,
@@ -114,7 +114,7 @@ extern void initialise_using_image_mass(Image<default_type> &im1,
                                         Image<default_type> &mask2,
                                         Registration::Transform::Base &transform,
                                         Registration::Transform::Init::LinearInitialisationParams &init,
-                                        const vector<MultiContrastSetting> &contrast_settings);
+                                        const std::vector<MultiContrastSetting> &contrast_settings);
 } // namespace Init
 } // namespace Transform
 } // namespace Registration

--- a/src/registration/transform/initialiser_helpers.cpp
+++ b/src/registration/transform/initialiser_helpers.cpp
@@ -45,7 +45,7 @@ bool get_sorted_eigen_vecs_vals(const Eigen::Matrix<default_type, 3, 3> &mat,
   eigenvals.resize(eval.size());
 
   // sort eigenvectors by eigenvalue, largest first
-  vector<std::pair<default_type, ssize_t>> eval_idx_vec;
+  std::vector<std::pair<default_type, ssize_t>> eval_idx_vec;
   for (ssize_t i = 0; i < eval.size(); ++i) {
     eval_idx_vec.emplace_back(eval[i], i);
   }
@@ -65,7 +65,7 @@ public:
                          const Eigen::Matrix<default_type, 3, 1> &centre,
                          Eigen::VectorXd &weighted_m,
                          Eigen::VectorXd &weighted_mu,
-                         const vector<MultiContrastSetting> &contrast_settings)
+                         const std::vector<MultiContrastSetting> &contrast_settings)
       : transform(image), mask(mask), centre(centre), global_m(weighted_m), global_mu(weighted_mu) {
     local_m.resize(4);
     local_m.setZero();
@@ -133,8 +133,8 @@ protected:
   Eigen::VectorXd &global_mu;
   Eigen::VectorXd local_m;
   Eigen::VectorXd local_mu;
-  vector<size_t> start_vol;
-  vector<default_type> weight;
+  std::vector<size_t> start_vol;
+  std::vector<default_type> weight;
   Eigen::Vector3d voxel_pos, scanner_pos;
 };
 
@@ -222,7 +222,7 @@ public:
                       const MaskType &mask,
                       default_type &weighted_mass,
                       Eigen::Vector3d &weighted_centre_of_mass,
-                      const vector<MultiContrastSetting> &contrast_settings)
+                      const std::vector<MultiContrastSetting> &contrast_settings)
       : transform(image),
         mask(mask),
         mass(0.0),
@@ -269,15 +269,15 @@ protected:
   default_type &global_mass;
   Eigen::Vector3d &global_centre_of_mass;
   Eigen::Vector3d centre_of_mass;
-  vector<size_t> start_vol;
-  vector<default_type> weight;
+  std::vector<size_t> start_vol;
+  std::vector<default_type> weight;
   Eigen::Vector3d voxel_pos, scanner;
 };
 
 void get_centre_of_mass(Image<default_type> &im,
                         Image<default_type> &mask,
                         Eigen::Vector3d &centre_of_mass,
-                        const vector<MultiContrastSetting> &contrast_settings) {
+                        const std::vector<MultiContrastSetting> &contrast_settings) {
   centre_of_mass.setZero();
   default_type mass(0.0);
 
@@ -298,7 +298,7 @@ void initialise_using_rotation_search(Image<default_type> &im1,
                                       Image<default_type> &mask2,
                                       Registration::Transform::Base &transform,
                                       Registration::Transform::Init::LinearInitialisationParams &init,
-                                      const vector<MultiContrastSetting> &contrast_settings) {
+                                      const std::vector<MultiContrastSetting> &contrast_settings) {
 
   CONSOLE("searching for best rotation");
   Registration::Metric::MeanSquaredNoGradient metric; // replace with CrossCorrelationNoGradient?
@@ -322,7 +322,7 @@ void initialise_using_image_mass(Image<default_type> &im1,
                                  Image<default_type> &mask2,
                                  Registration::Transform::Base &transform,
                                  Registration::Transform::Init::LinearInitialisationParams &init,
-                                 const vector<MultiContrastSetting> &contrast_settings) {
+                                 const std::vector<MultiContrastSetting> &contrast_settings) {
 
   CONSOLE("initialising translation and centre of rotation using centre of mass");
   Image<default_type> bogus_mask;

--- a/src/registration/transform/initialiser_helpers.h
+++ b/src/registration/transform/initialiser_helpers.h
@@ -43,7 +43,7 @@ void get_geometric_centre(const ImageType &image, Eigen::Matrix<ValueType, 3, 1>
 void get_centre_of_mass(Image<default_type> &im,
                         Image<default_type> &mask,
                         Eigen::Vector3d &centre_of_mass,
-                        const vector<MultiContrastSetting> &contrast_settings);
+                        const std::vector<MultiContrastSetting> &contrast_settings);
 
 bool get_sorted_eigen_vecs_vals(const Eigen::Matrix<default_type, 3, 3> &mat,
                                 Eigen::Matrix<default_type, Eigen::Dynamic, Eigen::Dynamic> &eigenvectors,
@@ -96,7 +96,7 @@ public:
                      Image<default_type> &mask1,
                      Image<default_type> &mask2,
                      Registration::Transform::Base &transform,
-                     const vector<MultiContrastSetting> &contrast)
+                     const std::vector<MultiContrastSetting> &contrast)
       : im1(image1), im2(image2), transform(transform), mask1(mask1), mask2(mask2), contrast_settings(contrast) {}
 
   void run();
@@ -114,7 +114,7 @@ private:
   Registration::Transform::Base &transform;
   Image<default_type> &mask1;
   Image<default_type> &mask2;
-  const vector<MultiContrastSetting> &contrast_settings;
+  const std::vector<MultiContrastSetting> &contrast_settings;
   Eigen::Vector3d im1_centre, im2_centre;
   Eigen::Matrix<default_type, 3, 1> im1_centre_of_mass, im2_centre_of_mass;
   Eigen::Matrix<default_type, 3, 3> im1_covariance_matrix, im2_covariance_matrix;

--- a/src/registration/transform/reorient.h
+++ b/src/registration/transform/reorient.h
@@ -35,10 +35,10 @@ FORCE_INLINE Eigen::MatrixXd aPSF_weights_to_FOD_transform(const int num_SH, con
   return delta_matrix.transpose();
 }
 
-FORCE_INLINE vector<vector<ssize_t>> multiContrastSetting2start_nvols(const vector<MultiContrastSetting> &mcsettings,
-                                                                      size_t &max_n_SH) {
+FORCE_INLINE std::vector<std::vector<ssize_t>>
+multiContrastSetting2start_nvols(const std::vector<MultiContrastSetting> &mcsettings, size_t &max_n_SH) {
   max_n_SH = 0;
-  vector<vector<ssize_t>> start_nvols;
+  std::vector<std::vector<ssize_t>> start_nvols;
   if (mcsettings.size() != 0) {
     for (const auto &mc : mcsettings) {
       if (mc.do_reorientation && mc.lmax > 0) {
@@ -59,7 +59,7 @@ public:
                             ssize_t max_n_SH,
                             const transform_type &linear_transform,
                             const Eigen::MatrixXd &directions,
-                            const vector<vector<ssize_t>> &vstart_nvols,
+                            const std::vector<std::vector<ssize_t>> &vstart_nvols,
                             const bool modulate)
       : fod(n_vol), max_n_SH(max_n_SH), start_nvols(vstart_nvols) {
     assert(n_vol > max_n_SH);
@@ -96,7 +96,7 @@ public:
 protected:
   Eigen::VectorXd fod;
   ssize_t max_n_SH;
-  vector<vector<ssize_t>> start_nvols;
+  std::vector<std::vector<ssize_t>> start_nvols;
   Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> transform;
 };
 
@@ -148,9 +148,9 @@ void reorient(FODImageType &input_fod_image,
               const transform_type &transform,
               const Eigen::MatrixXd &directions,
               bool modulate = false,
-              vector<MultiContrastSetting> multi_contrast_settings = vector<MultiContrastSetting>()) {
+              std::vector<MultiContrastSetting> multi_contrast_settings = std::vector<MultiContrastSetting>()) {
   assert(directions.cols() > directions.rows());
-  vector<vector<ssize_t>> start_nvols;
+  std::vector<std::vector<ssize_t>> start_nvols;
   size_t max_n_SH(0);
   if (multi_contrast_settings.size())
     start_nvols = multiContrastSetting2start_nvols(multi_contrast_settings, max_n_SH);
@@ -181,9 +181,9 @@ void reorient(const std::string progress_message,
               const transform_type &transform,
               const Eigen::MatrixXd &directions,
               bool modulate = false,
-              vector<MultiContrastSetting> multi_contrast_settings = vector<MultiContrastSetting>()) {
+              std::vector<MultiContrastSetting> multi_contrast_settings = std::vector<MultiContrastSetting>()) {
   assert(directions.cols() > directions.rows());
-  vector<vector<ssize_t>> start_nvols;
+  std::vector<std::vector<ssize_t>> start_nvols;
   size_t max_n_SH(0);
   if (multi_contrast_settings.size())
     start_nvols = multiContrastSetting2start_nvols(multi_contrast_settings, max_n_SH);
@@ -210,7 +210,7 @@ public:
                                ssize_t max_n_SH,
                                Image<default_type> &warp,
                                const Eigen::MatrixXd &directions,
-                               const vector<vector<ssize_t>> &vstart_nvols,
+                               const std::vector<std::vector<ssize_t>> &vstart_nvols,
                                const bool modulate)
       : max_n_SH(max_n_SH),
         n_dirs(directions.cols()),
@@ -278,7 +278,7 @@ protected:
   Adapter::Jacobian<Image<default_type>> jacobian_adapter;
   const Eigen::MatrixXd &directions;
   const bool modulate;
-  const vector<vector<ssize_t>> start_nvols;
+  const std::vector<std::vector<ssize_t>> start_nvols;
   Eigen::VectorXd fod;
   std::map<ssize_t, Eigen::MatrixXd> map_FOD_to_aPSF_transform;
   ssize_t max_n_SHvox;
@@ -340,10 +340,10 @@ void reorient_warp(const std::string progress_message,
                    Image<default_type> &warp,
                    const Eigen::MatrixXd &directions,
                    const bool modulate = false,
-                   vector<MultiContrastSetting> multi_contrast_settings = vector<MultiContrastSetting>()) {
+                   std::vector<MultiContrastSetting> multi_contrast_settings = std::vector<MultiContrastSetting>()) {
   assert(directions.cols() > directions.rows());
   check_dimensions(fod_image, warp, 0, 3);
-  vector<vector<ssize_t>> start_nvols;
+  std::vector<std::vector<ssize_t>> start_nvols;
   size_t max_n_SH(0);
   if (multi_contrast_settings.size())
     start_nvols = multiContrastSetting2start_nvols(multi_contrast_settings, max_n_SH);
@@ -365,10 +365,10 @@ void reorient_warp(FODImageType &fod_image,
                    Image<default_type> &warp,
                    const Eigen::MatrixXd &directions,
                    const bool modulate = false,
-                   vector<MultiContrastSetting> multi_contrast_settings = vector<MultiContrastSetting>()) {
+                   std::vector<MultiContrastSetting> multi_contrast_settings = std::vector<MultiContrastSetting>()) {
   assert(directions.cols() > directions.rows());
   check_dimensions(fod_image, warp, 0, 3);
-  vector<vector<ssize_t>> start_nvols;
+  std::vector<std::vector<ssize_t>> start_nvols;
   size_t max_n_SH(0);
   if (multi_contrast_settings.size())
     start_nvols = multiContrastSetting2start_nvols(multi_contrast_settings, max_n_SH);

--- a/src/registration/transform/rigid.cpp
+++ b/src/registration/transform/rigid.cpp
@@ -293,7 +293,7 @@ void Rigid::get_parameter_vector(Eigen::Matrix<Rigid::ParameterType, Eigen::Dyna
 }
 
 bool Rigid::robust_estimate(Eigen::Matrix<default_type, Eigen::Dynamic, 1> &gradient,
-                            vector<Eigen::Matrix<default_type, Eigen::Dynamic, 1>> &grad_estimates,
+                            std::vector<Eigen::Matrix<default_type, Eigen::Dynamic, 1>> &grad_estimates,
                             const Eigen::Matrix<default_type, 4, 4> &control_points,
                             const Eigen::Matrix<default_type, Eigen::Dynamic, 1> &parameter_vector,
                             const default_type &weiszfeld_precision = 1.0e-6,

--- a/src/registration/transform/rigid.h
+++ b/src/registration/transform/rigid.h
@@ -100,7 +100,7 @@ public:
   UpdateType *get_gradient_descent_updator() { return &gradient_descent_updator; }
 
   bool robust_estimate(Eigen::Matrix<default_type, Eigen::Dynamic, 1> &gradient,
-                       vector<Eigen::Matrix<default_type, Eigen::Dynamic, 1>> &grad_estimates,
+                       std::vector<Eigen::Matrix<default_type, Eigen::Dynamic, 1>> &grad_estimates,
                        const Eigen::Matrix<default_type, 4, 4> &control_points,
                        const Eigen::Matrix<default_type, Eigen::Dynamic, 1> &parameter_vector,
                        const default_type &weiszfeld_precision,

--- a/src/registration/transform/search.h
+++ b/src/registration/transform/search.h
@@ -232,7 +232,7 @@ public:
 private:
   FORCE_INLINE ParamType get_parameters() {
     // create resized midway image
-    // vector<Eigen::Transform<default_type, 3, Eigen::Projective>> init_transforms;
+    // std::vector<Eigen::Transform<default_type, 3, Eigen::Projective>> init_transforms;
     // {
     //   Eigen::Transform<default_type, 3, Eigen::Projective> init_trafo_1 = ;
     //   Eigen::Transform<default_type, 3, Eigen::Projective> init_trafo_2 = local_trafo.get_transform_half();
@@ -241,7 +241,7 @@ private:
     // }
     // auto padding = Eigen::Matrix<default_type, 4, 1>(1.0, 1.0, 1.0, 1.0);
     // int subsample = 1;
-    // vector<Header> headers;
+    // std::vector<Header> headers;
     // headers.push_back (Header (im1));
     // headers.push_back (Header (im2));
     midway_image_header = compute_minimum_average_header(
@@ -329,10 +329,10 @@ private:
   transform_type best_trafo;
   Header midway_image_header;
   default_type min_cost;
-  vector<default_type> vec_cost;
-  vector<size_t> vec_overlap;
+  std::vector<default_type> vec_cost;
+  std::vector<size_t> vec_overlap;
   size_t global_search_iterations;
-  vector<default_type> rot_angles;
+  std::vector<default_type> rot_angles;
   size_t local_search_directions;
   default_type image_scale_factor;
   bool global_search;
@@ -342,7 +342,7 @@ private:
   Eigen::Matrix<default_type, Eigen::Dynamic, 2> az_el;
   Eigen::Matrix<default_type, Eigen::Dynamic, 3> xyz;
   Eigen::Matrix<default_type, Eigen::Dynamic, 1> overlap_it, cost_it;
-  vector<transform_type> trafo_it;
+  std::vector<transform_type> trafo_it;
 };
 } // namespace RotationSearch
 } // namespace Registration

--- a/src/registration/warp/compose.h
+++ b/src/registration/warp/compose.h
@@ -180,9 +180,9 @@ FORCE_INLINE void update_displacement_scaling_and_squaring(Image<default_type> &
     scale_factor = std::pow(2, std::ceil(std::log((max_norm * step) / (min_vox_size / 2.0)) / std::log(2.0)));
 
     std::shared_ptr<Image<default_type>> scaled_update =
-        make_shared<Image<default_type>>(Image<default_type>::scratch(update));
+        std::make_shared<Image<default_type>>(Image<default_type>::scratch(update));
     std::shared_ptr<Image<default_type>> composed =
-        make_shared<Image<default_type>>(Image<default_type>::scratch(update));
+        std::make_shared<Image<default_type>>(Image<default_type>::scratch(update));
 
     // Scaling
     default_type scaled_step = step / scale_factor; // apply the step size and scale factor at once

--- a/src/registration/warp/compose.h
+++ b/src/registration/warp/compose.h
@@ -255,7 +255,7 @@ template <class WarpType> FORCE_INLINE WarpType compute_midway_deformation(WarpT
   WarpType deformation = WarpType::scratch(midway_header);
 
   transform_type linear;
-  vector<uint32_t> index(1);
+  std::vector<uint32_t> index(1);
   if (from == 1) {
     linear = Registration::Warp::parse_linear_transform(warp, "linear1");
     index[0] = 0;
@@ -278,7 +278,7 @@ FORCE_INLINE WarpType compute_full_deformation(WarpType &warp, TemplateType &tem
   transform_type linear1 = Registration::Warp::parse_linear_transform(warp, "linear1");
   transform_type linear2 = Registration::Warp::parse_linear_transform(warp, "linear2");
 
-  vector<uint32_t> index(1);
+  std::vector<uint32_t> index(1);
   if (from == 1) {
     index[0] = 0;
     Adapter::Extract1D<Image<default_type>> im1_to_mid(warp, 4, index);

--- a/src/stats/cfe.cpp
+++ b/src/stats/cfe.cpp
@@ -29,7 +29,7 @@ CFE::CFE(const Fixel::Matrix::Reader &connectivity_matrix,
 
 void CFE::operator()(in_column_type stats, out_column_type enhanced_stats) const {
   enhanced_stats.setZero();
-  vector<default_type> connected_stats;
+  std::vector<default_type> connected_stats;
   for (size_t fixel = 0; fixel < matrix.size(); ++fixel) {
     if (stats[fixel] < dh)
       continue;
@@ -47,8 +47,8 @@ void CFE::operator()(in_column_type stats, out_column_type enhanced_stats) const
     //   divide statistic by dh to determine the number of cluster sizes that should
     //   be incremented, and dynamically increment all cluster sizes for that
     //   particular connected fixel
-    vector<Fixel::Matrix::connectivity_value_type> extents(std::floor(stats[fixel] / dh),
-                                                           Fixel::Matrix::connectivity_value_type(0));
+    std::vector<Fixel::Matrix::connectivity_value_type> extents(std::floor(stats[fixel] / dh),
+                                                                Fixel::Matrix::connectivity_value_type(0));
     for (const auto &connection : connections) {
       const default_type connection_stat = stats[connection.index()];
       if (connection_stat > dh) {

--- a/src/stats/cfe.h
+++ b/src/stats/cfe.h
@@ -44,7 +44,7 @@ protected:
   const value_type dh, E, H, C;
   const bool normalise;
 
-  mutable vector<value_type> h_pow_H;
+  mutable std::vector<value_type> h_pow_H;
 
   void operator()(in_column_type, out_column_type) const override;
 };

--- a/src/stats/cluster.cpp
+++ b/src/stats/cluster.cpp
@@ -21,8 +21,8 @@ namespace Stats {
 namespace Cluster {
 
 void ClusterSize::operator()(in_column_type input, const value_type T, out_column_type output) const {
-  vector<Filter::Connector::Cluster> clusters;
-  vector<uint32_t> labels(input.size(), 0);
+  std::vector<Filter::Connector::Cluster> clusters;
+  std::vector<uint32_t> labels(input.size(), 0);
   connector.run(clusters, labels, input, T);
   output.resize(input.size());
   for (size_t i = 0; i < size_t(input.size()); ++i)

--- a/src/surface/algo/image2mesh.h
+++ b/src/surface/algo/image2mesh.h
@@ -88,7 +88,7 @@ template <class ImageType> void image2mesh_blocky(const ImageType &input_image, 
           // Break this voxel face into two triangles
 
           // Get the integer positions of the four vertices
-          vector<Vox> voxels(4, p);
+          std::vector<Vox> voxels(4, p);
           voxels[1][plane_axes[adj][0]]++;
           voxels[2][plane_axes[adj][0]]++;
           voxels[2][plane_axes[adj][1]]++;

--- a/src/surface/filter/smooth.cpp
+++ b/src/surface/filter/smooth.cpp
@@ -47,7 +47,7 @@ void Smooth::operator()(const Mesh &in, Mesh &out) const {
 
   // Pre-compute polygon centroids and areas
   VertexList centroids;
-  vector<default_type> areas;
+  std::vector<default_type> areas;
   for (TriangleList::const_iterator p = in.triangles.begin(); p != in.triangles.end(); ++p) {
     centroids.push_back((in.vertices[(*p)[0]] + in.vertices[(*p)[1]] + in.vertices[(*p)[2]]) * (1.0 / 3.0));
     areas.push_back(area(in, *p));
@@ -64,10 +64,10 @@ void Smooth::operator()(const Mesh &in, Mesh &out) const {
   //
   // Initialisation is different to iterations: Need a single pass to find those
   //   polygons that actually use the vertex
-  vector<std::set<uint32_t>> vert_polys(V, std::set<uint32_t>());
+  std::vector<std::set<uint32_t>> vert_polys(V, std::set<uint32_t>());
   // For each vertex, don't just want to store the polygons within the neighbourhood;
   //   also want to store those that will be expanded from in the next iteration
-  vector<vector<uint32_t>> vert_polys_to_expand(V, vector<uint32_t>());
+  std::vector<std::vector<uint32_t>> vert_polys_to_expand(V, std::vector<uint32_t>());
 
   for (uint32_t t = 0; t != T; ++t) {
     for (uint32_t i = 0; i != 3; ++i) {
@@ -81,7 +81,7 @@ void Smooth::operator()(const Mesh &in, Mesh &out) const {
   // Now, we want to expand this selection outwards for each vertex
   // To do this, also want to produce a list for each polygon: containing those polygons
   //   that share a common edge (i.e. two vertices)
-  vector<vector<uint32_t>> poly_neighbours(T, vector<uint32_t>());
+  std::vector<std::vector<uint32_t>> poly_neighbours(T, std::vector<uint32_t>());
   for (uint32_t i = 0; i != T; ++i) {
     for (uint32_t j = i + 1; j != T; ++j) {
       if (in.triangles[i].shares_edge(in.triangles[j])) {
@@ -98,11 +98,11 @@ void Smooth::operator()(const Mesh &in, Mesh &out) const {
     for (uint32_t v = 0; v != V; ++v) {
 
       // Find polygons at the outer edge of this expanding front, and add them to the neighbourhood for this vertex
-      vector<uint32_t> next_front;
-      for (vector<uint32_t>::const_iterator front = vert_polys_to_expand[v].begin();
+      std::vector<uint32_t> next_front;
+      for (std::vector<uint32_t>::const_iterator front = vert_polys_to_expand[v].begin();
            front != vert_polys_to_expand[v].end();
            ++front) {
-        for (vector<uint32_t>::const_iterator expansion = poly_neighbours[*front].begin();
+        for (std::vector<uint32_t>::const_iterator expansion = poly_neighbours[*front].begin();
              expansion != poly_neighbours[*front].end();
              ++expansion) {
           const std::set<uint32_t>::const_iterator existing = vert_polys[v].find(*expansion);

--- a/src/surface/filter/vertex_transform.cpp
+++ b/src/surface/filter/vertex_transform.cpp
@@ -84,7 +84,7 @@ void VertexTransform::operator()(const Mesh &in, Mesh &out) const {
     break;
 
   case transform_t::FS2REAL:
-    vector<size_t> axes(3);
+    std::vector<size_t> axes(3);
     auto M = File::NIfTI::adjust_transform(header, axes);
     Eigen::Vector3d cras(3, 1);
     for (size_t i = 0; i < 3; i++) {

--- a/src/surface/freesurfer.cpp
+++ b/src/surface/freesurfer.cpp
@@ -28,7 +28,7 @@ void read_annot(const std::string &path, label_vector_type &labels, Connectome::
     throw Exception("Error opening input file!");
 
   const int32_t num_vertices = get_BE<int32_t>(in);
-  vector<int32_t> vertices, vertex_labels;
+  std::vector<int32_t> vertices, vertex_labels;
   vertices.reserve(num_vertices);
   vertex_labels.reserve(num_vertices);
   for (int32_t i = 0; i != num_vertices; ++i) {

--- a/src/surface/mesh.cpp
+++ b/src/surface/mesh.cpp
@@ -76,7 +76,7 @@ void Mesh::calculate_normals() {
 
 namespace {
 template <typename T>
-void load_vtk_points_binary(std::ifstream &in, const size_t num_vertices, vector<Eigen::Matrix<T, 3, 1>> &out) {
+void load_vtk_points_binary(std::ifstream &in, const size_t num_vertices, std::vector<Eigen::Matrix<T, 3, 1>> &out) {
   out.reserve(num_vertices);
   Eigen::Matrix<T, 3, 1> v;
   for (size_t i = 0; i != num_vertices; ++i) {
@@ -127,7 +127,7 @@ void Mesh::load_vtk(const std::string &path) {
   bool change_endianness = false;
 
   // If both float and big-endian, need to store natively as floats and swap endianness later
-  vector<Eigen::Matrix<float, 3, 1>> vertices_float;
+  std::vector<Eigen::Matrix<float, 3, 1>> vertices_float;
 
   // From here, don't necessarily know which parts of the data will come first
   while (!in.eof()) {
@@ -205,7 +205,7 @@ void Mesh::load_vtk(const std::string &path) {
           if (vertex_count != 3 && vertex_count != 4)
             throw Exception("Could not parse file \"" + path + "\": only support 3- and 4-vertex polygons");
 
-          vector<unsigned int> t(vertex_count, 0);
+          std::vector<unsigned int> t(vertex_count, 0);
 
           if (is_ascii) {
             for (int index = 0; index != vertex_count; ++index) {
@@ -321,7 +321,7 @@ void Mesh::load_stl(const std::string &path) {
       if (attribute_byte_count)
         warn_attribute = true;
 
-      triangles.push_back(vector<uint32_t>{
+      triangles.push_back(std::vector<uint32_t>{
           uint32_t(vertices.size() - 3), uint32_t(vertices.size() - 2), uint32_t(vertices.size() - 1)});
       const Eigen::Vector3d computed_normal = Surface::normal(*this, triangles.back());
       if (computed_normal.dot(normal.cast<default_type>()) < 0.0)
@@ -387,7 +387,7 @@ void Mesh::load_stl(const std::string &path) {
         if (vertex_index != 3)
           throw Exception("Error parsing STL file " + Path::basename(path) + ": facet ended with " + str(vertex_index) +
                           " vertices");
-        triangles.push_back(vector<uint32_t>{
+        triangles.push_back(std::vector<uint32_t>{
             uint32_t(vertices.size() - 3), uint32_t(vertices.size() - 2), uint32_t(vertices.size() - 1)});
         vertex_index = 0;
         const Eigen::Vector3d computed_normal = Surface::normal(*this, triangles.back());
@@ -465,7 +465,7 @@ void Mesh::load_obj(const std::string &path) {
       // Need to handle:
       // * Either 3 or 4 vertices - write to either triangles or quads
       // * Vertices only, vertices & texture coordinates, vertices & normals, all 3
-      vector<std::string> elements;
+      std::vector<std::string> elements;
       do {
         const size_t first_space = data.find_first_of(' ');
         if (first_space == data.npos) {
@@ -480,9 +480,9 @@ void Mesh::load_obj(const std::string &path) {
       if (elements.size() != 3 && elements.size() != 4)
         throw Exception("Malformed face information in input OBJ file (face with neither 3 nor 4 vertices; line " +
                         str(counter) + ")");
-      vector<FaceData> face_data;
+      std::vector<FaceData> face_data;
       size_t values_per_element = 0;
-      for (vector<std::string>::iterator i = elements.begin(); i != elements.end(); ++i) {
+      for (std::vector<std::string>::iterator i = elements.begin(); i != elements.end(); ++i) {
         FaceData temp;
         temp.vertex = 0;
         temp.texture = 0;
@@ -513,10 +513,10 @@ void Mesh::load_obj(const std::string &path) {
         face_data.push_back(temp);
       }
       if (face_data.size() == 3) {
-        vector<uint32_t> temp{face_data[0].vertex, face_data[1].vertex, face_data[2].vertex};
+        std::vector<uint32_t> temp{face_data[0].vertex, face_data[1].vertex, face_data[2].vertex};
         triangles.push_back(Triangle(temp));
       } else {
-        vector<uint32_t> temp{face_data[0].vertex, face_data[1].vertex, face_data[2].vertex, face_data[3].vertex};
+        std::vector<uint32_t> temp{face_data[0].vertex, face_data[1].vertex, face_data[2].vertex, face_data[3].vertex};
         quads.push_back(Quad(temp));
       }
       // The OBJ format allows defining different vertex-based normals for different faces that reference the same

--- a/src/surface/mesh_multi.cpp
+++ b/src/surface/mesh_multi.cpp
@@ -69,7 +69,7 @@ void MeshMulti::load(const std::string &path) {
     } else if (prefix == "f") {
       if (index < 0)
         throw Exception("Malformed OBJ file; face outside object (line " + str(counter) + ")");
-      vector<std::string> elements;
+      std::vector<std::string> elements;
       do {
         const size_t first_space = data.find_first_of(' ');
         if (first_space == data.npos) {
@@ -84,9 +84,9 @@ void MeshMulti::load(const std::string &path) {
       if (elements.size() != 3 && elements.size() != 4)
         throw Exception("Malformed face information in input OBJ file (face with neither 3 nor 4 vertices; line " +
                         str(counter) + ")");
-      vector<FaceData> face_data;
+      std::vector<FaceData> face_data;
       size_t values_per_element = 0;
-      for (vector<std::string>::iterator i = elements.begin(); i != elements.end(); ++i) {
+      for (std::vector<std::string>::iterator i = elements.begin(); i != elements.end(); ++i) {
         FaceData temp;
         temp.vertex = 0;
         temp.texture = 0;
@@ -116,10 +116,10 @@ void MeshMulti::load(const std::string &path) {
         face_data.push_back(temp);
       }
       if (face_data.size() == 3) {
-        vector<uint32_t> temp{face_data[0].vertex, face_data[1].vertex, face_data[2].vertex};
+        std::vector<uint32_t> temp{face_data[0].vertex, face_data[1].vertex, face_data[2].vertex};
         triangles.push_back(Triangle(temp));
       } else {
-        vector<uint32_t> temp{face_data[0].vertex, face_data[1].vertex, face_data[2].vertex, face_data[3].vertex};
+        std::vector<uint32_t> temp{face_data[0].vertex, face_data[1].vertex, face_data[2].vertex, face_data[3].vertex};
         quads.push_back(Quad(temp));
       }
     } else if (prefix == "g") {

--- a/src/surface/mesh_multi.h
+++ b/src/surface/mesh_multi.h
@@ -30,9 +30,9 @@ namespace Surface {
 //   (would allow embedding binary data within the file, rather than
 //   everything being ASCII as in .obj)
 
-class MeshMulti : public vector<Mesh> {
+class MeshMulti : public std::vector<Mesh> {
 public:
-  using vector<Mesh>::vector;
+  using std::vector<Mesh>::vector;
 
   void load(const std::string &);
   void save(const std::string &) const;

--- a/src/surface/types.h
+++ b/src/surface/types.h
@@ -24,11 +24,11 @@ namespace MR {
 namespace Surface {
 
 using Vertex = Eigen::Vector3d;
-using VertexList = vector<Vertex>;
+using VertexList = std::vector<Vertex>;
 using Triangle = Polygon<3>;
-using TriangleList = vector<Triangle>;
+using TriangleList = std::vector<Triangle>;
 using Quad = Polygon<4>;
-using QuadList = vector<Quad>;
+using QuadList = std::vector<Quad>;
 
 class Vox : public Eigen::Array3i {
 public:

--- a/testing/tools/testing_diff_tck.cpp
+++ b/testing/tools/testing_diff_tck.cpp
@@ -79,7 +79,7 @@ within_haussdorf(const DWI::Tractography::Streamline<> &tck1, const DWI::Tractog
 }
 
 inline bool within_haussdorf(const DWI::Tractography::Streamline<> &tck,
-                             const vector<DWI::Tractography::Streamline<>> &list,
+                             const std::vector<DWI::Tractography::Streamline<>> &list,
                              float tol) {
   for (auto &tck2 : list) {
     if (within_haussdorf(tck, tck2, tol))
@@ -100,7 +100,7 @@ void run() {
 
   if (get_options("unordered").size()) {
 
-    vector<DWI::Tractography::Streamline<>> ref_list;
+    std::vector<DWI::Tractography::Streamline<>> ref_list;
     DWI::Tractography::Streamline<> tck;
 
     while (reader2(tck))

--- a/testing/tools/testing_gen_data.cpp
+++ b/testing/tools/testing_gen_data.cpp
@@ -39,7 +39,7 @@ void usage() {
 }
 
 void run() {
-  vector<int> dim = argument[0];
+  std::vector<int> dim = argument[0];
 
   Header header;
 

--- a/testing/tools/testing_unit_tests_npyread.cpp
+++ b/testing/tools/testing_unit_tests_npyread.cpp
@@ -131,7 +131,7 @@ bool verify_advanced(const std::string &filepath, const File::NPY::ReadInfo &inf
 
 void run() {
   Path::Dir dir(argument[0]);
-  vector<std::string> errors_basic, errors_advanced;
+  std::vector<std::string> errors_basic, errors_advanced;
   size_t check_count = 0;
   size_t wrong_endianness_count = 0;
   size_t advanced_boolean_count = 0;

--- a/testing/unit_tests/bitset.cpp
+++ b/testing/unit_tests/bitset.cpp
@@ -29,7 +29,7 @@ void usage() {
 }
 
 void run() {
-  vector<std::string> failed_tests;
+  std::vector<std::string> failed_tests;
   auto test = [&](const bool result, const std::string msg) {
     if (!result)
       failed_tests.push_back(msg);

--- a/testing/unit_tests/parse_ints.cpp
+++ b/testing/unit_tests/parse_ints.cpp
@@ -31,7 +31,7 @@ void usage() {
   REQUIRES_AT_LEAST_ONE_ARGUMENT = false;
 }
 
-vector<std::string> failures;
+std::vector<std::string> failures;
 
 void run() {
 

--- a/testing/unit_tests/shuffle.cpp
+++ b/testing/unit_tests/shuffle.cpp
@@ -33,7 +33,7 @@ using MR::Math::Stats::matrix_type;
 #define ROWS size_t(6)
 #define BLOCK_INDICES 0, 1, 0, 1, 2, 2 // Must increment from zero, and must be equal number in each
 enum exchange_t { NONE, WITHIN, WHOLE };
-vector<std::string> exchange_strings{"Unrestricted", "within-block", "whole-block"};
+std::vector<std::string> exchange_strings{"Unrestricted", "within-block", "whole-block"};
 
 void usage() {
   AUTHOR = "Robert E. Smith (robert.smith@florey.edu.au)";
@@ -42,7 +42,7 @@ void usage() {
 }
 
 void run() {
-  vector<std::string> failed_tests;
+  std::vector<std::string> failed_tests;
 
   vector_type dummy_data(ROWS);
   for (ssize_t row = 0; row != ROWS; ++row)
@@ -51,7 +51,7 @@ void run() {
   index_array_type block_indices(ROWS);
   block_indices << BLOCK_INDICES;
   assert(block_indices.size() == ROWS);
-  vector<std::set<size_t>> blocks(block_indices.maxCoeff() + 1);
+  std::vector<std::set<size_t>> blocks(block_indices.maxCoeff() + 1);
   for (ssize_t i = 0; i != block_indices.size(); ++i)
     blocks[block_indices[i]].insert(i);
 
@@ -127,7 +127,7 @@ void run() {
 
   auto test_unique = [&](Shuffler &in, const std::string &msg) {
     in.reset();
-    vector<Shuffle> matrices;
+    std::vector<Shuffle> matrices;
     Shuffle temp;
     bool duplicate_index = false, duplicate_data = false;
     while (in(temp)) {

--- a/testing/unit_tests/to.cpp
+++ b/testing/unit_tests/to.cpp
@@ -31,9 +31,9 @@ void usage() {
   REQUIRES_AT_LEAST_ONE_ARGUMENT = false;
 }
 
-vector<std::string> failures;
+std::vector<std::string> failures;
 
-template <class T> void test(const vector<std::string> &strings, const vector<bool> &results) {
+template <class T> void test(const std::vector<std::string> &strings, const std::vector<bool> &results) {
   for (size_t i = 0; i != strings.size(); ++i) {
     try {
       to<T>(strings[i]);
@@ -47,14 +47,14 @@ template <class T> void test(const vector<std::string> &strings, const vector<bo
 }
 
 void run() {
-  const vector<std::string> data = {
+  const std::vector<std::string> data = {
       "0",         "1",     "2",     "0 ",   " 1",     "0 0",   "0a",       "a0",          "true", "TRUE",     "tru",
       "truee",     "false", "FALSE", "fals", "falsee", "true ", "yes",      "YES",         "yeah", "yess",     "no",
       "NO",        "nope",  "na",    "0.0",  "1e",     "1e-1",  "1e-1a",    "inf",         "INF",  "infinity", "-inf",
       "-infinity", "nan",   "NAN",   "nana", "-nan",   "i",     "I",        "j",           "J",    "-i",       "1i",
       "1i0",       "1+i",   "1+ii",  "a1+i", "1+1+i",  "-1-i",  "inf+infi", " -inf+-nani "};
 
-  const vector<bool> bool_tests = {
+  const std::vector<bool> bool_tests = {
       true,  // "0"
       true,  // "1"
       true,  // "2"
@@ -109,7 +109,7 @@ void run() {
       false  // " -inf+-nani "
   };
 
-  const vector<bool> int_tests = {
+  const std::vector<bool> int_tests = {
       true,  // "0"
       true,  // "1"
       true,  // "2"
@@ -164,7 +164,7 @@ void run() {
       false  // " -inf+-nani "
   };
 
-  const vector<bool> float_tests = {
+  const std::vector<bool> float_tests = {
       true,  // "0"
       true,  // "1"
       true,  // "2"
@@ -219,7 +219,7 @@ void run() {
       false  // " -inf+-nani "
   };
 
-  const vector<bool> complex_tests = {
+  const std::vector<bool> complex_tests = {
       true,  // "0"
       true,  // "1"
       true,  // "2"


### PR DESCRIPTION
This PR supersedes #2650 and #2651. It replaces the use of custom `MR::vector` and `MR::deque` with `std::vector` and `std::deque`. It also replaces `MR::make_shared` and `MR::make_unique` with `std::make_shared` and `std::make_unique`. 