### PR TITLE
Fix memory leaks related to PNG handling

### DIFF
--- a/core/file/png.cpp
+++ b/core/file/png.cpp
@@ -289,6 +289,7 @@ void Writer::save(uint8_t *data) {
       row_pointers[row] = to_write + row * row_bytes;
     png_write_image(png_ptr, row_pointers);
     png_write_end(png_ptr, info_ptr);
+    delete[] row_pointers;
   };
 
   if (bit_depth == 1 || data_type == DataType::UInt8 || data_type == DataType::UInt16BE) {

--- a/core/file/png.cpp
+++ b/core/file/png.cpp
@@ -284,12 +284,11 @@ void Writer::save(uint8_t *data) {
   const size_t row_bytes = png_get_rowbytes(png_ptr, info_ptr);
 
   auto finish = [&](uint8_t *to_write) {
-    png_bytepp row_pointers = new png_bytep[height];
+    std::unique_ptr<png_bytep[]> row_pointers(new png_bytep[height]);
     for (size_t row = 0; row != height; ++row)
       row_pointers[row] = to_write + row * row_bytes;
-    png_write_image(png_ptr, row_pointers);
+    png_write_image(png_ptr, row_pointers.get());
     png_write_end(png_ptr, info_ptr);
-    delete[] row_pointers;
   };
 
   if (bit_depth == 1 || data_type == DataType::UInt8 || data_type == DataType::UInt16BE) {

--- a/core/image_io/png.cpp
+++ b/core/image_io/png.cpp
@@ -69,7 +69,7 @@ void PNG::unload(const Header &header) {
       }
     }
     DEBUG("deleting buffer for PNG image \"" + header.name() + "\"...");
-    addresses[0].release();
+    addresses[0].reset();
   }
 }
 


### PR DESCRIPTION
Addresses two of the issues reported in #2772.

Simple coding errors that were seemingly never checked with `valgrind`.