### PR TITLE
Fix buffer overflow in DWI bootstrapping

### DIFF
--- a/src/dwi/bootstrap.h
+++ b/src/dwi/bootstrap.h
@@ -69,7 +69,6 @@ public:
       voxel_buffer.push_back(vector<value_type>(NUM_VOX_PER_CHUNK * size(3)));
     next_voxel = &voxel_buffer[0][0];
     last_voxel = next_voxel + NUM_VOX_PER_CHUNK * size(3);
-    current_chunk = 0;
   }
 
 protected:
@@ -78,14 +77,10 @@ protected:
   vector<vector<value_type>> voxel_buffer;
   value_type *next_voxel;
   value_type *last_voxel;
-  size_t current_chunk;
 
   value_type *allocate_voxel() {
     if (next_voxel == last_voxel) {
-      ++current_chunk;
-      if (current_chunk >= voxel_buffer.size())
-        voxel_buffer.push_back(vector<value_type>(NUM_VOX_PER_CHUNK * size(3)));
-      assert(current_chunk < voxel_buffer.size());
+      voxel_buffer.push_back(vector<value_type>(NUM_VOX_PER_CHUNK * size(3)));
       next_voxel = &voxel_buffer.back()[0];
       last_voxel = next_voxel + NUM_VOX_PER_CHUNK * size(3);
     }
@@ -95,19 +90,21 @@ protected:
   }
 
   value_type *get_voxel() {
-    value_type *&data(
-        voxels.insert(std::make_pair(Eigen::Vector3i(index(0), index(1), index(2)), nullptr)).first->second);
-    if (!data) {
-      data = allocate_voxel();
-      ssize_t pos = index(3);
-      for (auto l = Loop(3)(*this); l; ++l)
-        data[index(3)] = base_type::value();
-      index(3) = pos;
-      func(data);
-    }
+    const Eigen::Vector3i voxel (index(0), index(1), index(2));
+    const typename std::map<Eigen::Vector3i, value_type *, IndexCompare>::const_iterator existing = voxels.find(voxel);
+    if (existing != voxels.end())
+      return existing->second;
+    value_type* const data = allocate_voxel();
+    ssize_t pos = index(3);
+    for (auto l = Loop(3)(*this); l; ++l)
+      data[index(3)] = base_type::value();
+    index(3) = pos;
+    func(data);
+    voxels.insert (std::make_pair (voxel, data));
     return data;
   }
 };
+
 
 } // namespace DWI
 } // namespace MR


### PR DESCRIPTION
Two components to change:

-   Removal of `current_chunk` should have no effect. It looks to me like vestigial code from trying different approaches to keep track of buffer chunks, but the use of `next_voxel` & `last_voxel` satisfies the requirement.

-   While `get_voxel()` looks like it's doing exactly the same thing, though perhaps less elegantly, it nevertheless resolves a buffer overflow. Though it looks to me like an invalid or overwritten address rather than a conventional "off-by-one"-type overflow.
    On `dev`, within an individual thread, the `value_type*` yielded by the map for a previously sampled voxel is occasionally different to that used when buffer data were allocated for that voxel. Maybe one in every 1000 times that a pointer for a previously sampled voxel is requested.
    I can't report exactly what is wrong with the `dev` code. If it were possible for the `std::map` implementation to perform an internal tree rebalancing after it has done its search as part of `insert()`, but the yielded pointer address pointer were that from before rather than after the rebalancing, that would seem to me like a pretty large STL implementation bug.