### PR TITLE
Adapter::Reslice: Alternative resolution of complex summation

### DIFF
--- a/core/adapter/reslice.h
+++ b/core/adapter/reslice.h
@@ -51,12 +51,23 @@ namespace MR
         return value_type(std::round (sum*norm));
       }
 
+      // Standard implementation for floating point (either real or complex)
       template <typename value_type, typename summing_type>
       typename std::enable_if<!std::is_same<value_type, bool>::value && !std::is_integral<value_type>::value, value_type>::type
       inline normalise (const summing_type sum, const default_type norm)
       {
         return value_type (sum * norm);
       }
+
+      // If summing complex numbers, use double precision complex;
+      //   otherwise, use double precision real
+      template <typename value_type> struct summing_type { NOMEMALIGN
+        using type = double;
+      };
+      template <typename value_type> struct summing_type<is_complex<value_type>> { NOMEMALIGN
+        using type = std::complex<double>;
+      };
+
     }
 
 
@@ -113,7 +124,6 @@ namespace MR
       public:
 
         using value_type = typename ImageType::value_type;
-        using summing_type = typename std::conditional<std::is_arithmetic<value_type>::value, double, cdouble>::type;
 
         template <class HeaderType>
           Reslice (const ImageType& original,
@@ -195,7 +205,7 @@ namespace MR
           using namespace Eigen;
           if (oversampling) {
             Vector3d d (x[0]+from[0], x[1]+from[1], x[2]+from[2]);
-            summing_type sum (0.0);
+            typename summing_type<value_type>::type sum (0);
             Vector3d s;
             for (uint32_t z = 0; z < OS[2]; ++z) {
               s[2] = d[2] + z*inc[2];


### PR DESCRIPTION
@jdtournier: This part of #2768 struck me as odd:
```
using summing_type = typename std::conditional<std::is_arithmetic<value_type>::value, double, cdouble>::type;
```

While it might result in appropriate resolution for template types currently compiled, it would attempt to use `cdouble` for any unexpected type. There's already a `struct MR::is_complex<>`, which makes more sense to me; its use makes the code intention far more clear IMO.