### PR TITLE
Set C++ as the language in main CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
 
-project(mrtrix3 VERSION 3.0.4)
+project(mrtrix3 LANGUAGES CXX VERSION 3.0.4)
+
 include(GNUInstallDirs)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")


### PR DESCRIPTION
As mentioned by @bjeurissen this morning, we should set C++ as the language for our CMake project file since we don't rely only any C code.