### PR TITLE
Fix clang-tidy config file path

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         apt_packages: g++,libqt5opengl5-dev,libqt5svg5-dev,libglvnd-dev,libeigen3-dev,zlib1g-dev,libfftw3-dev,ninja-build
         cmake_command: cmake . -DCMAKE_EXPORT_COMPILE_COMMANDS=on
-        config_file: ${{ github.workspace }}/.clang-tidy
+        config_file: .clang-tidy
 
     - uses: ZedThree/clang-tidy-review/upload@v0.17.0
       id: upload-review


### PR DESCRIPTION
Our clang-tidy CI review action appears to be broken after #2782, as inspecting the log of a few workflows shows that the action is unable to find the configuration file. 
 
It seems that using `github.workspace` doesn't work as intended, but just using a relative path from the top level directory seems to do the job.

EDIT: this is because the Github Actions runs inside Docker