### PR TITLE
Implement MR::apply using std::apply

### DIFF
--- a/cmd/fixel2voxel.cpp
+++ b/cmd/fixel2voxel.cpp
@@ -130,12 +130,12 @@ struct LoopFixelsInVoxelWithMax {
                      const index_type offset,
                      const std::tuple<DataType &...> &data)
         : num_fixels(num_fixels), max_fixels(max_fixels), offset(offset), fixel_index(0), data(data) {
-      MR::apply(set_offset(offset), data);
+      MR::apply_for_each(set_offset(offset), data);
     }
     FORCE_INLINE operator bool() const { return max_fixels ? (fixel_index < max_fixels) : (fixel_index < num_fixels); }
     FORCE_INLINE void operator++() {
       if (!padding())
-        MR::apply(inc_fixel(), data);
+        MR::apply_for_each(inc_fixel(), data);
       ++fixel_index;
     }
     FORCE_INLINE void operator++(int) { operator++(); }

--- a/core/algo/loop.h
+++ b/core/algo/loop.h
@@ -188,10 +188,10 @@ struct LoopAlongSingleAxis {
     const ssize_t size0;
     FORCE_INLINE Run(const size_t axis, const std::tuple<ImageType &...> &vox)
         : axis(axis), vox(vox), size0(std::get<0>(vox).size(axis)) {
-      MR::apply(set_pos(axis, 0), vox);
+      MR::apply_for_each(set_pos(axis, 0), vox);
     }
     FORCE_INLINE operator bool() const { return std::get<0>(vox).index(axis) < size0; }
-    FORCE_INLINE void operator++() const { MR::apply(inc_pos(axis), vox); }
+    FORCE_INLINE void operator++() const { MR::apply_for_each(inc_pos(axis), vox); }
     FORCE_INLINE void operator++(int) const { operator++(); }
   };
 
@@ -211,11 +211,11 @@ struct LoopAlongSingleAxisProgress {
     const ssize_t size0;
     FORCE_INLINE Run(const std::string &text, const size_t axis, const std::tuple<ImageType &...> &vox)
         : progress(text, std::get<0>(vox).size(axis)), axis(axis), vox(vox), size0(std::get<0>(vox).size(axis)) {
-      MR::apply(set_pos(axis, 0), vox);
+      MR::apply_for_each(set_pos(axis, 0), vox);
     }
     FORCE_INLINE operator bool() const { return std::get<0>(vox).index(axis) < size0; }
     FORCE_INLINE void operator++() {
-      MR::apply(inc_pos(axis), vox);
+      MR::apply_for_each(inc_pos(axis), vox);
       ++progress;
     }
     FORCE_INLINE void operator++(int) { operator++(); }
@@ -241,21 +241,21 @@ struct LoopAlongAxisRange {
           size0(std::get<0>(vox).size(from)),
           ok(true) {
       for (size_t n = from; n < to; ++n)
-        MR::apply(set_pos(n, 0), vox);
+        MR::apply_for_each(set_pos(n, 0), vox);
     }
     FORCE_INLINE operator bool() const { return ok; }
     FORCE_INLINE void operator++() {
-      MR::apply(inc_pos(from), vox);
+      MR::apply_for_each(inc_pos(from), vox);
       if (std::get<0>(vox).index(from) < size0)
         return;
 
-      MR::apply(set_pos(from, 0), vox);
+      MR::apply_for_each(set_pos(from, 0), vox);
       size_t axis = from + 1;
       while (axis < to) {
-        MR::apply(inc_pos(axis), vox);
+        MR::apply_for_each(inc_pos(axis), vox);
         if (std::get<0>(vox).index(axis) < std::get<0>(vox).size(axis))
           return;
-        MR::apply(set_pos(axis, 0), vox);
+        MR::apply_for_each(set_pos(axis, 0), vox);
         ++axis;
       }
       ok = false;
@@ -317,18 +317,18 @@ struct LoopAlongDynamicAxes {
     FORCE_INLINE Run(const std::vector<size_t> &axes, const std::tuple<ImageType &...> &vox)
         : axes(axes), vox(vox), from(axes[0]), size0(std::get<0>(vox).size(from)), ok(true) {
       for (auto axis : axes)
-        MR::apply(set_pos(axis, 0), vox);
+        MR::apply_for_each(set_pos(axis, 0), vox);
     }
     FORCE_INLINE operator bool() const { return ok; }
     FORCE_INLINE void operator++() {
-      MR::apply(inc_pos(from), vox);
+      MR::apply_for_each(inc_pos(from), vox);
       if (std::get<0>(vox).index(from) < size0)
         return;
 
       auto axis = axes.cbegin() + 1;
       while (axis != axes.cend()) {
-        MR::apply(set_pos(*(axis - 1), 0), vox);
-        MR::apply(inc_pos(*axis), vox);
+        MR::apply_for_each(set_pos(*(axis - 1), 0), vox);
+        MR::apply_for_each(inc_pos(*axis), vox);
         if (std::get<0>(vox).index(*axis) < std::get<0>(vox).size(*axis))
           return;
         ++axis;

--- a/core/algo/random_threaded_loop.h
+++ b/core/algo/random_threaded_loop.h
@@ -25,6 +25,7 @@
 #include "thread.h"
 #include <algorithm> // std::shuffle
 #include <random>
+#include <tuple>
 // #include "algo/random_loop.h"
 
 namespace MR {
@@ -55,13 +56,13 @@ template <int N, class Functor, class... ImageType> struct RandomThreadedLoopRun
 
   void operator()(const Iterator &pos) {
     assign_pos_of(pos, outer_axes).to(vox);
-    for (auto i = unpack(loop, vox); i; ++i) {
+    for (auto i = std::apply(loop, vox); i; ++i) {
       // if (rng() >= density){
       //   DEBUG (str(pos) + " ...skipped inner");
       //   continue;
       // }
       // DEBUG (str(pos) + " ...used inner");
-      unpack(func, vox);
+      std::apply(func, vox);
     }
   }
 };

--- a/core/algo/stochastic_threaded_loop.h
+++ b/core/algo/stochastic_threaded_loop.h
@@ -22,6 +22,7 @@
 #include "debug.h"
 #include "math/rng.h"
 #include "thread.h"
+#include <tuple>
 
 namespace MR {
 
@@ -51,13 +52,13 @@ template <int N, class Functor, class... ImageType> struct StochasticThreadedLoo
 
   void operator()(const Iterator &pos) {
     assign_pos_of(pos, outer_axes).to(vox);
-    for (auto i = unpack(loop, vox); i; ++i) {
+    for (auto i = std::apply(loop, vox); i; ++i) {
       if (rng() >= density) {
         // DEBUG (str(pos) + " ...skipped inner");
         continue;
       }
       // DEBUG (str(pos) + " ...used inner");
-      unpack(func, vox);
+      std::apply(func, vox);
     }
   }
 };

--- a/core/algo/threaded_loop.h
+++ b/core/algo/threaded_loop.h
@@ -21,6 +21,7 @@
 #include "algo/loop.h"
 #include "debug.h"
 #include "thread.h"
+#include <tuple>
 
 namespace MR {
 
@@ -273,8 +274,8 @@ template <int N, class Functor, class... ImageType> struct ThreadedLoopRunInner 
 
   void operator()(const Iterator &pos) {
     assign_pos_of(pos, outer_axes).to(vox);
-    for (auto i = unpack(loop, vox); i; ++i)
-      unpack(func, vox);
+    for (auto i = std::apply(loop, vox); i; ++i)
+      std::apply(func, vox);
   }
 };
 

--- a/core/apply.h
+++ b/core/apply.h
@@ -22,7 +22,7 @@
 
 namespace MR {
 //! invoke \c Function f for each entry in \c Tuple t
-template <typename Function, typename Tuple> constexpr void apply(Function &&f, Tuple &&t) {
+template <typename Function, typename Tuple> constexpr void apply_for_each(Function &&f, Tuple &&t) {
   std::apply([&f](auto &&...x) { (f(x), ...); }, std::forward<Tuple>(t));
 }
 

--- a/core/apply.h
+++ b/core/apply.h
@@ -20,30 +20,10 @@
 #include <tuple>
 #include <type_traits>
 
-#include "types.h" // For FORCE_INLINE
-
 namespace MR {
-namespace {
-
-template <size_t N> struct Apply {
-  template <typename F, typename T> static FORCE_INLINE void apply(F &&f, T &&t) {
-    Apply<N - 1>::apply(::std::forward<F>(f), ::std::forward<T>(t));
-    ::std::forward<F>(f)(::std::get<N>(::std::forward<T>(t)));
-  }
-};
-
-template <> struct Apply<0> {
-  template <typename F, typename T> static FORCE_INLINE void apply(F &&f, T &&t) {
-    ::std::forward<F>(f)(::std::get<0>(::std::forward<T>(t)));
-  }
-};
-
-} // namespace
-
-//! invoke \c f(x) for each entry in \c t
-template <class F, class T> FORCE_INLINE void apply(F &&f, T &&t) {
-  Apply<::std::tuple_size<typename ::std::decay<T>::type>::value - 1>::apply(::std::forward<F>(f),
-                                                                             ::std::forward<T>(t));
+//! invoke \c Function f for each entry in \c Tuple t
+template <typename Function, typename Tuple> constexpr void apply(Function &&f, Tuple &&t) {
+  std::apply([&f](auto &&...x) { (f(x), ...); }, std::forward<Tuple>(t));
 }
 
 } // namespace MR

--- a/core/apply.h
+++ b/core/apply.h
@@ -38,22 +38,6 @@ template <> struct Apply<0> {
   }
 };
 
-template <size_t N> struct Unpack {
-  template <typename F, typename T, typename... A>
-  static FORCE_INLINE auto unpack(F &&f, T &&t, A &&...a) -> decltype(Unpack<N - 1>::unpack(
-      ::std::forward<F>(f), ::std::forward<T>(t), ::std::get<N - 1>(::std::forward<T>(t)), ::std::forward<A>(a)...)) {
-    return Unpack<N - 1>::unpack(
-        ::std::forward<F>(f), ::std::forward<T>(t), ::std::get<N - 1>(::std::forward<T>(t)), ::std::forward<A>(a)...);
-  }
-};
-
-template <> struct Unpack<0> {
-  template <typename F, typename T, typename... A>
-  static FORCE_INLINE auto unpack(F &&f, T &&, A &&...a) -> decltype(::std::forward<F>(f)(::std::forward<A>(a)...)) {
-    return ::std::forward<F>(f)(::std::forward<A>(a)...);
-  }
-};
-
 } // namespace
 
 //! invoke \c f(x) for each entry in \c t
@@ -62,14 +46,6 @@ template <class F, class T> FORCE_INLINE void apply(F &&f, T &&t) {
                                                                              ::std::forward<T>(t));
 }
 
-//! if \c t is a tuple of elements \c a..., invoke \c f(a...)
-template <typename F, typename T>
-FORCE_INLINE auto unpack(F &&f, T &&t)
-    -> decltype(Unpack<::std::tuple_size<typename ::std::decay<T>::type>::value>::unpack(::std::forward<F>(f),
-                                                                                         ::std::forward<T>(t))) {
-  return Unpack<::std::tuple_size<typename ::std::decay<T>::type>::value>::unpack(::std::forward<F>(f),
-                                                                                  ::std::forward<T>(t));
-}
 } // namespace MR
 
 #endif

--- a/core/fixel/loop.h
+++ b/core/fixel/loop.h
@@ -46,11 +46,11 @@ struct LoopFixelsInVoxel {
     const std::tuple<DataType &...> data;
     FORCE_INLINE Run(const index_type num_fixels, const index_type offset, const std::tuple<DataType &...> &data)
         : num_fixels(num_fixels), offset(offset), fixel_index(0), data(data) {
-      MR::apply(set_offset(offset), data);
+      MR::apply_for_each(set_offset(offset), data);
     }
     FORCE_INLINE operator bool() const { return fixel_index < num_fixels; }
     FORCE_INLINE void operator++() {
-      MR::apply(inc_fixel(), data);
+      MR::apply_for_each(inc_fixel(), data);
       fixel_index++;
     }
     FORCE_INLINE void operator++(int) const { operator++(); }

--- a/core/image_helpers.h
+++ b/core/image_helpers.h
@@ -66,7 +66,7 @@ template <class... DestImageType> struct __assign<std::tuple<DestImageType...>> 
   const size_t axis;
   const ssize_t index;
   template <class ImageType> FORCE_INLINE void operator()(ImageType &x) {
-    MR::apply(__assign<DestImageType...>(axis, index), x);
+    MR::apply_for_each(__assign<DestImageType...>(axis, index), x);
   }
 };
 
@@ -83,16 +83,16 @@ template <class... DestImageType> struct __max_axis<std::tuple<DestImageType...>
   __max_axis(size_t &axis) : axis(axis) {}
   size_t &axis;
   template <class ImageType> FORCE_INLINE void operator()(ImageType &x) {
-    MR::apply(__max_axis<DestImageType...>(axis), x);
+    MR::apply_for_each(__max_axis<DestImageType...>(axis), x);
   }
 };
 
 template <class ImageType> struct __assign_pos_axis_range {
   template <class... DestImageType> FORCE_INLINE void to(DestImageType &...dest) const {
     size_t last_axis = to_axis;
-    MR::apply(__max_axis<DestImageType...>(last_axis), std::tie(ref, dest...));
+    MR::apply_for_each(__max_axis<DestImageType...>(last_axis), std::tie(ref, dest...));
     for (size_t n = from_axis; n < last_axis; ++n)
-      MR::apply(__assign<DestImageType...>(n, __get_index(ref, n)), std::tie(dest...));
+      MR::apply_for_each(__assign<DestImageType...>(n, __get_index(ref, n)), std::tie(dest...));
   }
   const ImageType &ref;
   const size_t from_axis, to_axis;
@@ -101,7 +101,7 @@ template <class ImageType> struct __assign_pos_axis_range {
 template <class ImageType, typename IntType> struct __assign_pos_axes {
   template <class... DestImageType> FORCE_INLINE void to(DestImageType &...dest) const {
     for (auto a : axes)
-      MR::apply(__assign<DestImageType...>(a, __get_index(ref, a)), std::tie(dest...));
+      MR::apply_for_each(__assign<DestImageType...>(a, __get_index(ref, a)), std::tie(dest...));
   }
   const ImageType &ref;
   const std::vector<IntType> axes;


### PR DESCRIPTION
I noticed some potential use after move in `core/apply.h`. I think this code can be fully replaced by [std::apply](https://en.cppreference.com/w/cpp/utility/apply) introduced in C++17. This PR replaces `MR::unpack` by directly calling `std::apply` instead. `MR::apply` doesn't have a strict equivalent in the STL, but can be easily emulated using fold expressions and lambdas as below:

```cpp
namespace MR {
//! invoke \c Function f for each entry in \c Tuple t
template <typename Function, typename Tuple> constexpr void apply(Function &&f, Tuple &&t) {
  std::apply([&f](auto &&...x) { (f(x), ...); }, std::forward<Tuple>(t));
}

} // namespace MR
```
We could of course replace every instance of `MR::apply` with the definition of the function above, but that would be verbose and tedious. So I think we should still keep the `core/apply.h` header with this wrapper function, however perhaps we should rename `MR::apply` to something else?
