### PR TITLE
mrgrid: Fix help for -as option

### DIFF
--- a/cmd/mrgrid.cpp
+++ b/cmd/mrgrid.cpp
@@ -107,7 +107,7 @@ void usage ()
   + OptionGroup ("Pad and crop options (no image interpolation is performed, header transformation is adjusted)")
     + Option   ("as", "pad or crop the input image on the upper bound to match the specified reference image grid. "
                 "This operation ignores differences in image transformation between input and reference image.")
-    + Argument ("reference image").type_image_in ()
+    + Argument ("reference_image").type_image_in ()
 
     + Option   ("uniform", "pad or crop the input image by a uniform number of voxels on all sides")
     + Argument ("number").type_integer ()

--- a/docs/reference/commands/mrgrid.rst
+++ b/docs/reference/commands/mrgrid.rst
@@ -72,7 +72,7 @@ Regridding options (involves image interpolation, applied to spatial axes only)
 Pad and crop options (no image interpolation is performed, header transformation is adjusted)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
--  **-as reference image** pad or crop the input image on the upper bound to match the specified reference image grid. This operation ignores differences in image transformation between input and reference image.
+-  **-as reference_image** pad or crop the input image on the upper bound to match the specified reference image grid. This operation ignores differences in image transformation between input and reference image.
 
 -  **-uniform number** pad or crop the input image by a uniform number of voxels on all sides
 


### PR DESCRIPTION
Whitespace present in name of associated compulsory argument erroneously implies that there are two input arguments expected.