### PR TITLE
run.command(): Do not hide list inputs

### DIFF
--- a/lib/mrtrix3/run.py
+++ b/lib/mrtrix3/run.py
@@ -473,7 +473,7 @@ def command(cmd, **kwargs): #pylint: disable=unused-variable
   if shared.get_scratch_dir():
     with shared.lock:
       with open(os.path.join(shared.get_scratch_dir(), 'log.txt'), 'a') as outfile:
-        outfile.write(cmdstring + '\n')
+        outfile.write(' '.join(cmdsplit) + '\n')
 
   return CommandReturn(return_stdout, return_stderr)
 


### PR DESCRIPTION
Sought confirmation that fix in #2802 is correct, and found that the logs were hiding the full filesystem paths of files being used, which isn't ideal from a diagnostic perspective.