### PR TITLE
Allow filename in write_mrtrix.m to be string or char array

### DIFF
--- a/matlab/write_mrtrix.m
+++ b/matlab/write_mrtrix.m
@@ -131,7 +131,8 @@ end
 
 fprintf (fid, '\nfile: ');
 
-if strcmp(filename(end-3:end), '.mif')
+[filepath,basename,ext] = fileparts(filename);
+if strcmp(ext, '.mif')
   dataoffset = ftell (fid) + 18;
   dataoffset = dataoffset + mod((4 - mod(dataoffset, 4)), 4);
   s = sprintf ('. %d\nEND\n              ', dataoffset);
@@ -139,14 +140,14 @@ if strcmp(filename(end-3:end), '.mif')
   fprintf (fid, s);
   fclose (fid);
   fid = fopen (filename, 'a+', byteorder);
-elseif strcmp(filename(end-3:end), '.mih')
-  datafile = [ filename(1:end-4) '.dat' ];
+elseif strcmp(ext, '.mih')
+  datafile = fullfile(filepath, strcat(basename,'.dat'));
   fprintf (fid, '%s 0\nEND\n', datafile);
   fclose(fid);
   fid = fopen (datafile, 'w', byteorder);
 else
   fclose(fid);
-  error('unknown file suffix - aborting');
+  error('unknown file suffix "%s" - aborting', ext);
 end
 
 if isstruct(image)


### PR DESCRIPTION
Currently, `write_mrtrix.m` crashes if the output filename is a `string`:
```matlab
% char array
write_mrtrix(struct('data',rand(3,3,3)), 'test.mif')
% works without problem

% string
write_mrtrix(struct('data',rand(3,3,3)), "test.mif")
% Gives error: 
% > Array indices must be positive integers or logical values.
% >
% > Error in write_mrtrix (line 134)
% > if strcmp(filename(end-3:end), '.mif')
```

As the error message indicates, this is because array indexing does not work for `string`s. This pull request uses the Matlab functions `fileparts` and `fullfile` to avoid explicit indexing. 

I also took the opportunity to make the error message if the extension is not matched a little more informative.