### PR TITLE
Log the location of eigen3, png, tiff and qt during CMake configuration

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -8,6 +8,16 @@ find_package(Threads REQUIRED)
 find_package(PNG QUIET)
 find_package(TIFF QUIET)
 
+# The find modules for Eigen3, PNG and TIFF don't log the location
+# of the libraries, so we do it manually here
+message(STATUS "Found Eigen3: ${EIGEN3_INCLUDE_DIR}")
+if(PNG_FOUND)
+    message(STATUS "Found PNG: ${PNG_LIBRARIES}")
+endif()
+if(TIFF_FOUND)
+    message(STATUS "Found TIFF: ${TIFF_LIBRARIES}")
+endif()
+
 add_library(mrtrix-core SHARED ${CORE_SRCS})
 add_library(mrtrix::core ALIAS mrtrix-core)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,9 @@ if(MRTRIX_BUILD_GUI)
         find_package(Qt6 COMPONENTS Core Gui Widgets OpenGL Network OpenGLWidgets REQUIRED)
         qt6_add_resources(RCC_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../icons/icons.qrc)
     endif()
+    # Explicitly log Qt's location since it's not done automatically by the FindQt module
+    message(STATUS "Qt${QT_MAJOR_VERSION}_DIR is set to: ${Qt${QT_MAJOR_VERSION}_DIR}")
+
     find_package(OpenGL REQUIRED)
     find_package(Threads REQUIRED)
 endif()


### PR DESCRIPTION
It was pointed to me by @bjeurissen that the find modules of `Eigen3`, `libpng`, `libtiff` and `Qt` do not provide a log message for their location when configuring CMake (unlike other modules). This PR addresses that by doing this manually.