### PR TITLE
mrregister: Fix erroneous reporting of default robust estimators

### DIFF
--- a/docs/reference/commands/mrregister.rst
+++ b/docs/reference/commands/mrregister.rst
@@ -63,7 +63,7 @@ Rigid registration options
 
 -  **-rigid_metric type** valid choices are: diff (intensity differences); Default: diff
 
--  **-rigid_metric.diff.estimator type** Valid choices are: l1 (least absolute: \|x\|); l2 (ordinary least squares); lp (least powers: \|x\|^1.2); Default: l2
+-  **-rigid_metric.diff.estimator type** Robust estimator to use during rigid-body registration. Valid choices are: l1 (least absolute: \|x\|); l2 (ordinary least squares); lp (least powers: \|x\|^1.2); none. Default: none.
 
 -  **-rigid_lmax num** explicitly set the lmax to be used per scale factor in rigid FOD registration. By default, FOD registration will use lmax 0,2,4 with default scale factors 0.25,0.5,1.0 respectively. Note that no reorientation will be performed with lmax = 0.
 
@@ -90,7 +90,7 @@ Affine registration options
 
 -  **-affine_metric type** valid choices are: diff (intensity differences); Default: diff
 
--  **-affine_metric.diff.estimator type** Valid choices are: l1 (least absolute: \|x\|); l2 (ordinary least squares); lp (least powers: \|x\|^1.2); Default: l2
+-  **-affine_metric.diff.estimator type** Robust estimator to use durring affine registration. Valid choices are: l1 (least absolute: \|x\|); l2 (ordinary least squares); lp (least powers: \|x\|^1.2); none. Default: none.
 
 -  **-affine_lmax num** explicitly set the lmax to be used per scale factor in affine FOD registration. By default FOD registration will use lmax 0,2,4 with default scale factors 0.25,0.5,1.0 respectively. Note that no reorientation will be performed with lmax = 0.
 

--- a/src/registration/linear.cpp
+++ b/src/registration/linear.cpp
@@ -312,11 +312,13 @@ const OptionGroup rigid_options =
       + Argument("type").type_choice(linear_metric_choices)
 
     + Option("rigid_metric.diff.estimator",
-             "Valid choices are:"
+             "Robust estimator to use during rigid-body registration."
+             " Valid choices are:"
              " l1 (least absolute: |x|);"
              " l2 (ordinary least squares);"
              " lp (least powers: |x|^1.2);"
-             " Default: l2")
+             " none."
+             " Default: none.")
       + Argument("type").type_choice(linear_robust_estimator_choices)
 
     // + Option ("rigid_loop_density", "density of gradient descent 1 (batch) to 0.0 (max stochastic) (Default: 1.0)")
@@ -401,11 +403,13 @@ const OptionGroup affine_options =
       + Argument("type").type_choice(linear_metric_choices)
 
     + Option("affine_metric.diff.estimator",
-             "Valid choices are:"
+             "Robust estimator to use durring affine registration."
+             " Valid choices are:"
              " l1 (least absolute: |x|);"
              " l2 (ordinary least squares);"
              " lp (least powers: |x|^1.2);"
-             " Default: l2")
+             " none."
+             " Default: none.")
       + Argument("type").type_choice(linear_robust_estimator_choices)
 
     // + Option ("affine_loop_density", "density of gradient descent 1 (batch) to 0.0 (max stochastic) (Default: 1.0)")


### PR DESCRIPTION
Second part of #2586.

I am restricting this change to altering the `mrregister` help page to reflect what the code is actually doing. I can confirm that if those `-*_metric.diff.estimator` options are omitted, then the L2 estimator is *not* used.

There is some outside chance that it was intended for the L2 robust estimator to be the default behaviour, and that this was conveyed in the help page but the code failed to achieve this. However I'm a lot more confident in updating the help page given my naivety on the topic than changing the default software behaviour. So unless @maxpietsch interjects I think this is the way to go.

There's also an argument to be made that this should go to `master` rather than `dev`...