### PR TITLE
Regenerate CMake tests when test file is modified

### DIFF
--- a/cmake/BashTests.cmake
+++ b/cmake/BashTests.cmake
@@ -15,6 +15,9 @@ function(add_bash_tests)
     set(working_directory ${ARG_WORKING_DIRECTORY})
     set(exec_directories ${ARG_EXEC_DIRECTORIES})
 
+    # Regenerate tests when the test script changes
+    set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${file_path})
+
     # In MINGW, we need to replace paths starting with drive:/ with /drive/
     # when invoking a bash command (e.g. using bash -c "command")
     if(MINGW AND WIN32)


### PR DESCRIPTION
Fixes #2832. Test files are parsed by CMake at configure time and added using `add_test`. This PR ensures that when a bash test file is modified CMake automatically reconfigures to ensure that the latest version of the tests are deployed.
@Lestropie let me know if this addresses the problem.