### PR TITLE
Disable LTO in msys2 packaging script

### DIFF
--- a/packaging/mingw/PKGBUILD
+++ b/packaging/mingw/PKGBUILD
@@ -41,7 +41,7 @@ pkgver() {
 
 build() {
   cd "${_realname}"
-  cmake -B build -G Ninja -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON 
+  cmake -B build -G Ninja
   cmake --build build
   cmake --install build --prefix=./install
 }


### PR DESCRIPTION
It seems that enabling LTO on Windows causes many linker errors. It looks like that this a bug in `gcc`, so we will disable for our packaging script. See https://github.com/msys2/MINGW-packages/issues/11706