### PR TITLE
Add argument to specify environment for bash tests

### DIFF
--- a/cmake/BashTests.cmake
+++ b/cmake/BashTests.cmake
@@ -1,6 +1,6 @@
 # A function that adds a bash test for each line in a given file
 function(add_bash_tests)
-    set(singleValueArgs FILE_PATH PREFIX WORKING_DIRECTORY)
+    set(singleValueArgs FILE_PATH PREFIX WORKING_DIRECTORY ENVIRONMENT)
     set(multiValueArgs EXEC_DIRECTORIES)
     cmake_parse_arguments(
         ARG
@@ -14,6 +14,7 @@ function(add_bash_tests)
     set(prefix ${ARG_PREFIX})
     set(working_directory ${ARG_WORKING_DIRECTORY})
     set(exec_directories ${ARG_EXEC_DIRECTORIES})
+    set(environment ${ARG_ENVIRONMENT})
 
     # Regenerate tests when the test script changes
     set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${file_path})
@@ -67,8 +68,9 @@ function(add_bash_tests)
             COMMAND ${BASH} -c "export PATH=${EXEC_DIR_PATHS}:$PATH;${line}"
             WORKING_DIRECTORY ${working_directory}
         )
-        set_tests_properties(${prefix}_${test_name} 
-            PROPERTIES FIXTURES_REQUIRED ${file_name}_cleanup
+        set_tests_properties(${prefix}_${test_name} PROPERTIES 
+            ENVIRONMENT "${environment}"
+            FIXTURES_REQUIRED ${file_name}_cleanup
         )
         message(VERBOSE "Add bash tests commands for ${file_name}: ${line}")
     endforeach()


### PR DESCRIPTION
This adds a new function argument to add_bash_tests() to specify environment variables that should be defined for running a test.
Usage example:

```cmake
add_bash_tests(
    FILE_PATH file
    PREFIX script
    WORKING_DIRECTORY ${DATA_DIR}
    ENVIRONMENT "PYTHONPATH=${PROJECT_BINARY_DIR}/lib"
)
```

In #2678, the possibility of specifying `PYTHONPATH` for a given test seems to be useful. This PR addresses this need more generally, by allowing the specification of any environment variables when running a collection of tests specified in a text file.

@Lestropie this should be enough to address the issue raised, but let me know if this actually solves the problem.
