### PR TITLE
Fix python CLI CI test

### DIFF
--- a/cmake/BashTests.cmake
+++ b/cmake/BashTests.cmake
@@ -1,6 +1,6 @@
 # A function that adds a bash test for each line in a given file
 function(add_bash_tests)
-    set(singleValueArgs FILE_PATH PREFIX WORKING_DIRECTORY)
+    set(singleValueArgs FILE_PATH PREFIX WORKING_DIRECTORY ENVIRONMENT)
     set(multiValueArgs EXEC_DIRECTORIES)
     cmake_parse_arguments(
         ARG
@@ -14,6 +14,7 @@ function(add_bash_tests)
     set(prefix ${ARG_PREFIX})
     set(working_directory ${ARG_WORKING_DIRECTORY})
     set(exec_directories ${ARG_EXEC_DIRECTORIES})
+    set(environment ${ARG_ENVIRONMENT})
 
     # Regenerate tests when the test script changes
     set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${file_path})
@@ -67,8 +68,9 @@ function(add_bash_tests)
             COMMAND ${BASH} -c "export PATH=${EXEC_DIR_PATHS}:$PATH;${line}"
             WORKING_DIRECTORY ${working_directory}
         )
-        set_tests_properties(${prefix}_${test_name} 
-            PROPERTIES FIXTURES_REQUIRED ${file_name}_cleanup
+        set_tests_properties(${prefix}_${test_name} PROPERTIES 
+            ENVIRONMENT "${environment}"
+            FIXTURES_REQUIRED ${file_name}_cleanup
         )
         message(VERBOSE "Add bash tests commands for ${file_name}: ${line}")
     endforeach()

--- a/testing/data/python_cli/help.txt
+++ b/testing/data/python_cli/help.txt
@@ -1,3 +1,4 @@
+
      tteessttiinngg__ppyytthhoonn__ccllii: external MRtrix3 project
 
 SSYYNNOOPPSSIISS

--- a/testing/unit_tests/CMakeLists.txt
+++ b/testing/unit_tests/CMakeLists.txt
@@ -21,6 +21,17 @@ set(DATA_DIR ${SOURCE_PARENT_DIR}/data)
 
 find_program(BASH bash)
 
+set(PYTHON_ENV_PATH "${PROJECT_BINARY_DIR}/lib")
+# On MSYS2 we need to convert Windows paths to Unix paths
+if(MINGW AND WIN32)
+      EXECUTE_PROCESS(
+          COMMAND cygpath -u ${PYTHON_ENV_PATH}
+          OUTPUT_VARIABLE PYTHON_ENV_PATH
+          OUTPUT_STRIP_TRAILING_WHITESPACE
+      )
+endif()
+
+
 function(add_cpp_unit_test FILE_SRC)
     get_filename_component(NAME ${FILE_SRC} NAME_WE)
     add_executable(${NAME} ${FILE_SRC})
@@ -50,7 +61,7 @@ function (add_bash_unit_test FILE_SRC)
         PREFIX "unittest"
         WORKING_DIRECTORY ${DATA_DIR}
         EXEC_DIRECTORIES "${EXEC_DIRS}"
-        ENVIRONMENT "PYTHONPATH=${PROJECT_BINARY_DIR}/lib"
+        ENVIRONMENT "PYTHONPATH=${PYTHON_ENV_PATH}"
     )
 endfunction()
 

--- a/testing/unit_tests/CMakeLists.txt
+++ b/testing/unit_tests/CMakeLists.txt
@@ -50,6 +50,7 @@ function (add_bash_unit_test FILE_SRC)
         PREFIX "unittest"
         WORKING_DIRECTORY ${DATA_DIR}
         EXEC_DIRECTORIES "${EXEC_DIRS}"
+        ENVIRONMENT "PYTHONPATH=${PROJECT_BINARY_DIR}/lib"
     )
 endfunction()
 

--- a/testing/unit_tests/cpp_cli
+++ b/testing/unit_tests/cpp_cli
@@ -1,8 +1,8 @@
 mkdir -p tmp-dirin/ && touch tmp-filein.txt && touch tmp-tracksin.tck && testing_cpp_cli -flag -text my_text -choice One -bool false -int_unbound 0 -int_nonneg 1 -int_bound 50 -float_unbound 0.0 -float_nonneg 1.0 -float_bound 0.5 -int_seq 1,2,3 -float_seq 0.1,0.2,0.3 -dir_in tmp-dirin/ -dir_out tmp-dirout/ -file_in tmp-filein.txt -file_out tmp-fileout.txt -tracks_in tmp-tracksin.tck -tracks_out tmp-tracksout.tck -various my_various && rm -rf tmp-dirin/ && rm -f tmp-filein.txt && rm -f tmp-tracksin.tck
-testing_cpp_cli -help > tmp.txt && sed -i '1,2d' tmp.txt && diff tmp.txt cpp_cli/help.txt && rm -f tmp.txt
-testing_cpp_cli __print_full_usage__ > tmp.txt && diff tmp.txt cpp_cli/full_usage.txt && rm -f tmp.txt
-testing_cpp_cli __print_usage_markdown__ > tmp.md && diff tmp.md cpp_cli/markdown.md && rm -f tmp.md
-testing_cpp_cli __print_usage_rst__ > tmp.rst && diff tmp.rst cpp_cli/restructured_text.rst && rm -f tmp.rst
+testing_cpp_cli -help | tail -n +2 > tmp.txt && diff -a --strip-trailing-cr tmp.txt cpp_cli/help.txt && rm -f tmp.txt
+testing_cpp_cli __print_full_usage__ > tmp.txt && diff -a --strip-trailing-cr tmp.txt cpp_cli/full_usage.txt && rm -f tmp.txt
+testing_cpp_cli __print_usage_markdown__ > tmp.md && diff -a --strip-trailing-cr tmp.md cpp_cli/markdown.md && rm -f tmp.md
+testing_cpp_cli __print_usage_rst__ > tmp.rst && diff -a --strip-trailing-cr tmp.rst cpp_cli/restructured_text.rst && rm -f tmp.rst
 testing_cpp_cli -bool false
 testing_cpp_cli -bool False
 testing_cpp_cli -bool FALSE

--- a/testing/unit_tests/python_cli
+++ b/testing/unit_tests/python_cli
@@ -1,8 +1,8 @@
 mkdir -p tmp-dirin/ && touch tmp-filein.txt && touch tmp-tracksin.tck && testing_python_cli -string_implicit my_implicit_string -string_explicit my_explicit_string -choice One -bool false -int_builtin 0 -float_builtin 0.0 -int_unbound 0 -int_nonneg 1 -int_bound 50 -float_unbound 0.0 -float_nonneg 1.0 -float_bound 0.5 -int_seq 1,2,3 -float_seq 0.1,0.2,0.3 -dir_in tmp-dirin/ -dir_out tmp-dirout/ -file_in tmp-filein.txt -file_out tmp-fileout.txt -tracks_in tmp-tracksin.tck -tracks_out tmp-tracksout.tck -various my_various && rm -rf tmp-dirin/ && rm -f tmp-filein.txt && rm -f tmp-tracksin.tck
-testing_python_cli -help | tail -n +3 > tmp.txt && diff tmp.txt python_cli/help.txt && rm -f tmp.txt
-testing_python_cli __print_full_usage__ > tmp.txt && diff tmp.txt python_cli/full_usage.txt && rm -f tmp.txt
-testing_python_cli __print_usage_markdown__ > tmp.md && diff tmp.md python_cli/markdown.md && rm -f tmp.md
-testing_python_cli __print_usage_rst__ > tmp.rst && diff tmp.rst python_cli/restructured_text.rst && rm -f tmp.rst
+testing_python_cli -help | tail -n +3 > tmp.txt && diff -a --strip-trailing-cr tmp.txt python_cli/help.txt && rm -f tmp.txt
+testing_python_cli __print_full_usage__ > tmp.txt && diff -a --strip-trailing-cr tmp.txt python_cli/full_usage.txt && rm -f tmp.txt
+testing_python_cli __print_usage_markdown__ > tmp.md && diff -a --strip-trailing-cr tmp.md python_cli/markdown.md && rm -f tmp.md
+testing_python_cli __print_usage_rst__ > tmp.rst && diff -a --strip-trailing-cr tmp.rst python_cli/restructured_text.rst && rm -f tmp.rst
 testing_python_cli -bool false
 testing_python_cli -bool False
 testing_python_cli -bool FALSE

--- a/testing/unit_tests/python_cli
+++ b/testing/unit_tests/python_cli
@@ -1,5 +1,5 @@
 mkdir -p tmp-dirin/ && touch tmp-filein.txt && touch tmp-tracksin.tck && testing_python_cli -string_implicit my_implicit_string -string_explicit my_explicit_string -choice One -bool false -int_builtin 0 -float_builtin 0.0 -int_unbound 0 -int_nonneg 1 -int_bound 50 -float_unbound 0.0 -float_nonneg 1.0 -float_bound 0.5 -int_seq 1,2,3 -float_seq 0.1,0.2,0.3 -dir_in tmp-dirin/ -dir_out tmp-dirout/ -file_in tmp-filein.txt -file_out tmp-fileout.txt -tracks_in tmp-tracksin.tck -tracks_out tmp-tracksout.tck -various my_various && rm -rf tmp-dirin/ && rm -f tmp-filein.txt && rm -f tmp-tracksin.tck
-testing_python_cli -help > tmp.txt && sed -i '1,3d' tmp.txt && diff tmp.txt python_cli/help.txt && rm -f tmp.txt
+testing_python_cli -help | tail -n +3 > tmp.txt && diff tmp.txt python_cli/help.txt && rm -f tmp.txt
 testing_python_cli __print_full_usage__ > tmp.txt && diff tmp.txt python_cli/full_usage.txt && rm -f tmp.txt
 testing_python_cli __print_usage_markdown__ > tmp.md && diff tmp.md python_cli/markdown.md && rm -f tmp.md
 testing_python_cli __print_usage_rst__ > tmp.rst && diff tmp.rst python_cli/restructured_text.rst && rm -f tmp.rst


### PR DESCRIPTION
Testing whether the proposed change in #2845 facilitates executing the Python CLI unit tests in CI for #2678.

I do realise in retrospect that this solution might not actually live that long (even if it's a useful capability to leave in place): with #2741, the Python CLI test would need to have the same mechanism of executable binary generation.