### PR TITLE
Move share/mrtrix3/labelsgmfix to share/mrtrix3/labelsgmfirst

### DIFF
--- a/share/mrtrix3/labelsgmfirst/FreeSurferSGM.txt
+++ b/share/mrtrix3/labelsgmfirst/FreeSurferSGM.txt
@@ -15,7 +15,8 @@
 
 # This file is used to extract sub-cortical structures from FreeSurfer segmentations
 
-# Previously, the labelsgmfix command was compatible with both FreeSurfer LUT files and connectome config files, as the first two columns were identical. Now, this command ideally needs to be compatible with LUT files in any format.
+# Previously, the labelsgmfirst command was compatible with both FreeSurfer LUT files and connectome config files, as the first two columns were identical.
+# Now, this command ideally needs to be compatible with LUT files in any format.
 
 # This is solved in the following way:
 # * Create a new image for sub-cortical structures using the output of FIRST and these indices.


### PR DESCRIPTION
Change erroneously omitted from 729cba3610d5164bd2c2bc0ebca79c60a9d22f1b / #2839.

Spotted as a consequence of #2849.