### PR TITLE
Update error message on version mismatch

### DIFF
--- a/core/app.cpp
+++ b/core/app.cpp
@@ -1101,7 +1101,9 @@ void init(int cmdline_argc, const char *const *cmdline_argv) {
     Exception E("executable was compiled for a different version of the MRtrix3 library!");
     E.push_back(std::string("  ") + NAME + " version: " + executable_uses_mrtrix_version);
     E.push_back(std::string("  library version: ") + mrtrix_version);
-    E.push_back("Running ./build again may correct error");
+    E.push_back("You may need to erase files left over from prior MRtrix3 versions;");
+    E.push_back("eg. core/version.cpp; src/exec_version.cpp");
+    E.push_back(", and re-configure cmake");
     throw E;
   }
 


### PR DESCRIPTION
Closes #2822.

I think what's happening is versions of these files generated by the old `build` script are getting grabbed by a `cmake` glob rather than the versions of those files that `cmake` is itself generating in the build directory. Rather than do anything too clever, I propose to just update the error message so that if any fellow dullards manage to run into the same problem, they'll know what to do.

Pretty sure I tried just deleting those files and re-building, and the compiler failed reporting a missing file; so starting with a clean build directory might be required.