### PR TITLE
Update testing README

### DIFF
--- a/testing/README.md
+++ b/testing/README.md
@@ -86,6 +86,15 @@ ctest -L dwi2response # Runs all tests of the Python command dwi2response
     ctest -R 5ttgen_hsvs # Run only the tests of specifically the "HSVS" algorithm of the 5ttgen command
     ```
 
+-   Environment variables "`MRTRIX_BINARIES_DATA_DIR`" and "`MRTRIX_SCRIPTS_DATA_DIR`"
+    can be used to specify alternative locations to be used by `cmake`
+    to clone the appropriate versions of those data within the build directory.
+    By setting these to contain local filesystem locations,
+    internet traffic will be reduced if deleting build directories or using multiple build configurations;
+    it additionally enables the execution of `ctest` utilising updated test data
+    prior to pushing the updated test data to GitHub
+    (see "Adding test data" step 7 below).
+
 ## Adding tests
 
 A new text file should be added to one of the following locations,
@@ -192,10 +201,21 @@ depending on the nature of the proposed modification.
     It is highly recommended to give this branch in the data repository
     the same name as the relevant branch in the source code repository.
 
-6.  Create a commit adding or modifying test data,
-    and push the updated branch to GitHub.
+6.  Create a commit adding or modifying test data.
 
-7.  In your clone of the source code repository:
+7.  Push the updated branch to GitHub.
+    Note that if `cmake` is configured to use local clones
+    of the test data repositories rather than GitHub
+    (as explained in "Running tests" -> "Advanced usage" above),
+    then this step will not be necessary for verifying test suite success
+    on your local machine;
+    test data changes will however nevertheless eventually
+    need to be pushed to GitHub
+    in order for other developers,
+    or indeed Continuous Integration (CI) checks,
+    to be able to acquire the updated data.
+
+8.  In your clone of the source code repository:
 
     1.  In file `testing/CMakeLists.txt`,
         find the invocation of the ExternalProject_Add() function
@@ -206,19 +226,19 @@ depending on the nature of the proposed modification.
     2.  Make any other additions or modifications to tests
         that do not involve modification of test *data*.
 
-    3.  Create a commit that includes changes from both steps 7.1 and 7.2
+    3.  Create a commit that includes changes from both steps 8.1 and 8.2,
         and push the updated source code repository branch to GitHub.
 
-8.  Ensure that within the Pull Request,
-    no merge conflict occurs at the location modified by step 7.1.
+9.  Ensure that within the Pull Request,
+    no merge conflict occurs at the location modified by step 8.1.
     A merge conflict here indicates that on the target source branch,
     there has been evolution of the test data accessed by that branch
     in parallel to the test data changes made in step 6.
     Resolving this necessitates explicit merging of changes
     between the corresponding branches in the test data repository,
-    followed by repeating step 7.1 and 7.3 to access the result of this merge.
+    followed by repeating step 8.1 and 8.3 to access the result of this merge.
 
-9.  After the relevant Pull Request on the source code repository is merged:
+10. After the relevant Pull Request on the source code repository is merged:
 
     1.  For the data repository branch that has the same name
         as the target branch of the Pull Request,

--- a/testing/README.md
+++ b/testing/README.md
@@ -5,42 +5,44 @@ with expectation. If you intend to help with development of MRtrix3, it is
 recommended you run the enclosed tests regularly to ensure your changes do not
 introduce regressions. 
 
-Recommended command to fully test everything is working:
+Recommended workflow to fully test everything is working:
 ```ShellSession
-./configure && ./build && ./run_tests 
+cmake -B build -DMRTRIX_BUILD_TESTS=ON
+cmake --build build
+cd build && ctest
 ```
-Look in `testing.log` for details of any failures encountered. 
 
 ## To run the tests
-
-Simply run the `./run_tests` script from within the MRtrix3 toplevel folder:
+To run the tests, you will need to use `ctest` (an executable bundled with CMake)
+as follows:
 ```ShellSession
-./run_tests
-```
-        
-This will fetch the testing data as a submodule from a separate dedicated repo,
-build the testing executables, then run the tests. All activities are logged to
-the `testing.log` file - take a look in there for details of any failures.
-
-Note that the `./run_tests` script will _not_ build the executables to be tested.
-This is to allow developers to build and test individual commands without
-needing to rebuild all other commands. If you want to test all commands, make
-sure you run `./build` first.
-
-### Running tests for a single command
-
-You can run a test for a single command simply by adding the name of the
-command as the argument:
-
-```ShellSession
-./run_tests mrconvert
-
+cd build_directory
+ctest
 ```
 
-This means you don't need to build everything to test one particular command.
-For example, this is a construct I commonly use:
+Note that this requires you to build the project enabling the `MRTRIX_BUILD_TESTS`
+option when configuring CMake. Only once you have sucessfully built the project, you'll be 
+able to run the tests.
+
+### Running tests for specific commands
+
+In order to run a specific set of tests, `ctest` allows you to make use of regex expressions, for example:
+
 ```ShellSession
-./build release/bin/mrconvert && ./run_tests mrconvert
+ctest -R unit # Runs all unit tests
+ctest -R bin # Runs all binary tests
+ctest -R bin_5tt2gmwmi # Runs the binary test for the 5tt2gmwmi command
+ctest -E unit # Runs all tests, except unit tests
+```
+
+You can also choose to rerun tests have failed by specifying the `--rerun-failed` option.
+
+You don't need to build every command to test one particular command.
+For example, you can do this:
+```ShellSession
+cmake --build build --target mrconvert 
+cd build
+ctest -R bin_mrconvert
 ```
 
 ## Adding tests
@@ -50,15 +52,15 @@ single test, and will be run as a single unit. Use `&&` and `||` bash
 constructs if needed to create compound commands. Each of these lines should
 return a zero exit code if successful. You can test the output of your commands
 against your expected output using the `testing_diff_image` command (note other
-commands are available to check various types of output - look in `testing/cmd`
+commands are available to check various types of output - look in `testing/tools`
 for the full list). 
 
 
-Note that this script will be invoked directly in the context set up by the
-`run_tests` script, so does not need to be executable, or to set up any
+Note that this script will be invoked directly parsed by the build system, 
+so does not need to be executable, or to set up any
 redirection, or to uses a hash-bang line to specify the interpreter.  Just add
 commands to be run, and if any of them produce a non-zero exit code, this will
-be caught by the `run_tests` script.  All commands will also be logged. 
+be reported when running `ctest`.  All commands will also be logged. 
 
 The testing will consider each line of the test scripts to correspond to an
 individual test, and report as such. If any of your tests need multiple
@@ -69,8 +71,8 @@ examples.
 #### Temporary files 
 
 If your tests need to create temporary files, make sure they are prefixed with
-'tmp' and are not placed in subfolders - the run_tests script will make sure
-these are deleted prior to running the next set of tests. 
+'tmp' and are not placed in subfolders - these will be deleted prior to running the
+next set of tests. 
 
 ## Adding test data
 
@@ -81,20 +83,16 @@ commands. Please keep the size of these data small to ensure this repository
 doesn't grow too large. In general, you really don't need large images to
 verify correct operation.
 
-These data are included as a _submodule_ within the main MRtrix3 repository, as
-a means of ensuring that the version of the data used for the tests is recorded
-within the main repo, while keeping its history separate, and hence on a
-separate repository. This separation helps to keep the size of the main
-repository small, and avoid large downloads for users. The downside is that
-making changes to the test data is more complicated. For [here a full introduction
-into git submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules).
+Data used for testing will be downloaded at build time, ensuring that each test
+has its working directory set to the root path of data in the build directory.
 
 To add data, you will need to:
 
 - add your data to the [test_data repo](https://github.com/MRtrix3/test_data);
 
 - update the main MRtrix3 repo to reflect the new version of the data needed
-  for the tests.
+  for the tests. To do this you will need to update the commit hash in `testing/CMakeLists.txt`
+  to match the latest commit that corresponds to the change in the testing repo.
 
 **Note:** if you need to _modify_ exising data in a way that would break
 existing tests, you will need to be very careful with how you do this - see the
@@ -126,34 +124,6 @@ This can be done using a number of approaches:
   
   You can delete the standalone repo once you have pushed your changes. 
   
-3. Directly within the MRtrix3 installation
-  
-  Adding data can be done by pushing commits on the `master` branch of the
-  submodule within the MRtrix3 folder. Note that you will need to have run
-  `./run_tests` at least once to initialise the submodule. For this to work, you
-  will need to override the default URL for the [test_data
-  submodule](https://github.com/MRtrix3/test_data) in your local
-  installation, since the default URL is the public HTTPS version, which is
-  read-only. This only needs to be done once, using the following instructions: 
-  
-  ```ShellSession
-  $ git config submodule.testing/data.url git@github.com:MRtrix3/test_data.git
-  $ rm -rf testing/data .git/modules/testing/
-  $ ./run_tests
-  ```
-  After this, you should be able to add data by committing directly to the
-  `master` branch. Note that by default, the submodule will be in detached HEAD
-  state, since it is locked to the specific version specified in the main MRtrix3
-  folder. Remember to checkout `master` before committing:
-  
-  ```ShellSession
-  $ cd testing/data
-  $ git checkout master
-  $ git add your_data.mif
-  $ git commit 
-  $ git push
-  ```
-  
 #### Updating the main MRtrix3 repo to make use of the latest commits
 
 Once your new data have been committed to the [test_data
@@ -161,59 +131,8 @@ repo](https://github.com/MRtrix3/test_data), all you need to do is tell the
 main MRtrix3 repository to record the new SHA1 for the latest version of the
 test data.
 
-The first thing to do is ensure your main MRtrix3 repo has already initialised
-the `testing/data` submodule. The simplest way to do this is to just run
-`./run_tests` (you can abort as soon as the 'fetching test data... OK' line has
-completed). Alternatively, you can run the relevant command directly yourself:
-```ShellSession
-$ git submodule update --init
-```
-
-At this point, you can update the submodule with the latest version on the [test_data
-repo](https://github.com/MRtrix3/test_data):
-```ShellSession
-$ git submodule update --remote
-```
-**Note:** this will record the SHA1 of the current `master` branch on the
-[test_data repo](https://github.com/MRtrix3/test_data). See the next section
-if you need to record any other branch or SHA1.
-
-At this point, it's good practice to check your git status, and make sure
-everything makes sense. For example, assuming I'd just added some test data,
-and modified the tests for `mrconvert`:
-```ShellSession
-$ git status
-On branch master
-Your branch is up-to-date with 'github/master'.
-Changes not staged for commit:
-  (use "git add <file>..." to update what will be committed)
-  (use "git checkout -- <file>..." to discard changes in working directory)
-
-        modified:   testing/data (new commits)
-        modified:   testing/tests/mrconvert
-
-no changes added to commit (use "git add" and/or "git commit -a")
-```
-
-If everything looks in order, you can add these to the staging area:
-```ShellSession
-$ git add testing/data 
-$ git add testing/tests/mrconvert
-```
-then commit and push:
-```ShellSession
-$ git commit
-$ git push
-```
-At this point, you can check whether things are working correctly by running
-the `./run_tests` scripts, and checking that the expected checksum shows up
-afterwards when running:
-```ShellSession
-$ git submodule
- b6d0e018d0bad96edec423b81ef1b006a94932fb testing/data (b6d0e01)
-```
-It should show the expected version, _without_ a leading `+` sign.
-
+To do this, navigate to `testing/CMakeLists.txt` and update the commit hash in the 
+`ExternalProject_Add` function for the testing repo.
 
 ## What to do when modifying existing test data  
 
@@ -256,19 +175,19 @@ So this is clearly not the best outcome...
 To avoid these issues, the best thing to do is to push any changes that
 _modify_ existing data to a separate branch on the [test_data
 repo](https://github.com/MRtrix3/test_data), and merge these to `master` when
-the corresponding branch on the main MRtrix3 repo has also been merged. This
-allows other developers to keep pushing additional data to `master` without
+the corresponding commit hash on the main MRtrix3 has correctly been updated. 
+This allows other developers to keep pushing additional data to `master` without
 anything breaking.
 
 > Technically, there is no reason to merge the branch on the [test_data
-> repo](https://github.com/MRtrix3/test_data) to `master` since `run_tests`
+> repo](https://github.com/MRtrix3/test_data) to `master` since CMake
 > will pull in the relevant commit via its SHA1 checksum. However, merging to
 > `master` ensures that the branch can be deleted without risk of losing the
 > relevant commit.
 
 To do this, developers need to push their changes to a different branch than
-`master` on the [test_data repo](https://github.com/MRtrix3/test_data). This
-can be done using for example:
+`master` on the [test_data repo](https://github.com/MRtrix3/test_data). 
+For example, this procedure can be followed:
 ```ShellSession
 $ git clone git@github.com:MRtrix3/test_data.git
 $ cd test_data
@@ -277,31 +196,6 @@ $ git checkout -b dwi2fod_bug_fix
 $ git commit -a
 $ git push origin dwi2fod_bug_fix
 ```
-At that point, the modifications should be on the `dwi2fod_bug_fix` branch
-only. So far so good.
-
-The next difficulty is updating the main MRtrix3 repo with that particular
-branch. As mentioned above, `git submodule update --remote` will pull in the
-current `master` branch, so we need to do something else. The solution is to
-manually checkout the relevant branch. First, make sure the submodule has been
-initialised (either run `./run_tests` or `git submodule update --init` as per
-instructions above). Then:
-```ShellSession
-$ cd testing/data
-$ git fetch
-$ git checkout dwi2fod_bug_fix
-```
-At which point you can go back to the toplevel folder of the main repo, and
-commit these changes as before:
-```ShellSession
-$ cd ../..
-$ git add testing/data
-$ git commit 
-$ git push
-```
-
-
-
-
-
-
+which should push the modifications on the `dwi2fod_bug_fix` branch only. 
+Then you can update the commit hash in `testing/CMakeLists.txt` to be the latest
+commit hash in `dwi2fod_bug_fix` branch.

--- a/testing/README.md
+++ b/testing/README.md
@@ -40,10 +40,12 @@ You can also choose to rerun tests have failed by specifying the `--rerun-failed
 You don't need to build every command to test one particular command.
 For example, you can do this:
 ```ShellSession
-cmake --build build --target mrconvert 
+cmake --build build --target mrconvert testing_tools
 cd build
 ctest -R bin_mrconvert
 ```
+Note that, in addition to the command you want to test, you also need to build `testing_tools` (an umbrella 
+target that builds the tools needed to run binary tests).
 
 ## Adding tests
  


### PR DESCRIPTION
Addresses #2826.
Testing tips and instructions have been updated to reflect the transition to CMake. Sections on the handling of testing data assume #2848 has been merged. 
Some instructions may not be clear or need removing due to the fact that some of the concerns/workflows no longer apply with the transition to CMake. 

It's still WIP.