### PR TITLE
Install MacOS CI packages using brew bundle

### DIFF
--- a/.brewfile
+++ b/.brewfile
@@ -1,0 +1,7 @@
+brew "qt"
+brew "eigen"
+brew "pkg-config"
+brew "fftw"
+brew "libpng"
+brew "ninja"
+brew "cmake"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -113,7 +113,6 @@ jobs:
     runs-on: macos-latest
 
     env:
-      PACKAGES: "qt eigen pkg-config fftw libpng ninja cmake"
       SCCACHE_GHA_ENABLED: "true"
       SCCACHE_CACHE_SIZE: "2G"
 
@@ -124,8 +123,7 @@ jobs:
 
     - name: install dependencies
       run: |
-         brew update || brew update     # https://github.com/Homebrew/brew/issues/2491#issuecomment-294207661
-         brew install $PACKAGES || brew install $PACKAGES
+         brew bundle --file=${{ github.workspace }}/.brewfile
          brew link --force qt
 
     - name: Run sccache-cache


### PR DESCRIPTION
The current method of running `brew update || brew update` works, but leads to unnecessary longer installation times. See https://github.com/Homebrew/brew/issues/2491.
This adds a `.brewfile` that lists the packages needed by the CI checks.
