### PR TITLE
MR::Math::betaincreg(): Use lgamma_r()

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(CheckCXXSourceCompiles)
+
 file(GLOB_RECURSE CORE_SRCS *.cpp *.h)
 
 find_package(Eigen3 REQUIRED NO_MODULE)
@@ -21,6 +23,19 @@ endif()
 add_library(mrtrix-core SHARED ${CORE_SRCS})
 add_library(mrtrix::core ALIAS mrtrix-core)
 
+# Check to see if we can use lgamma_r() function in custom Math::betaincreg()
+check_cxx_source_compiles("
+  extern \"C\" double lgamma_r(double, int *);
+  int main() { int sign; lgamma_r(1.0, &sign); }"
+  MRTRIX_HAVE_LGAMMA_R
+)
+
+if(MRTRIX_HAVE_LGAMMA_R)
+    message(STATUS "Found lgamma_r() function")
+else()
+    message(STATUS "No lgamma_r() function found; statistical inference may have poorer multi-threading performance")
+endif()
+
 # On Windows, the library need to be in the same directory as the executables
 if(WIN32)
     set_target_properties(mrtrix-core PROPERTIES
@@ -31,7 +46,7 @@ endif()
 set(CORE_VERSION_CPP ${CMAKE_CURRENT_BINARY_DIR}/version.cpp)
 
 add_custom_target(core-version-target ALL
-    COMMAND ${CMAKE_COMMAND} 
+    COMMAND ${CMAKE_COMMAND}
         -D GIT_EXECUTABLE=${GIT_EXECUTABLE}
         -D MRTRIX_BASE_VERSION=${MRTRIX_BASE_VERSION}
         -D DST=${CMAKE_CURRENT_BINARY_DIR}/version.cpp
@@ -47,12 +62,13 @@ add_library(mrtrix-core-version-lib STATIC ${CORE_VERSION_CPP})
 add_library(mrtrix::core-version-lib ALIAS mrtrix-core-version-lib)
 add_dependencies(mrtrix-core-version-lib core-version-target)
 
-target_include_directories(mrtrix-core-version-lib PRIVATE 
+target_include_directories(mrtrix-core-version-lib PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-target_compile_definitions(mrtrix-core PUBLIC 
+target_compile_definitions(mrtrix-core PUBLIC
     MRTRIX_BASE_VERSION="${MRTRIX_BASE_VERSION}"
+    MRTRIX_HAVE_LGAMMA_R=$<BOOL:${MRTRIX_HAVE_LGAMMA_R}>
 )
 
 if(PNG_FOUND)
@@ -78,11 +94,11 @@ target_link_libraries(mrtrix-core PUBLIC
     ${FFTW_LIBRARIES}
 )
 
-target_include_directories(mrtrix-core PUBLIC 
+target_include_directories(mrtrix-core PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR} ${FFTW_INCLUDES}
 )
 
-install(TARGETS mrtrix-core 
+install(TARGETS mrtrix-core
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -29,9 +29,7 @@ list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_REENTRANT)
 check_symbol_exists(lgamma_r "math.h" MRTRIX_HAVE_LGAMMA_R)
 list(REMOVE_AT CMAKE_REQUIRED_DEFINITIONS -1)
 
-if(MRTRIX_HAVE_LGAMMA_R)
-    message(STATUS "Found lgamma_r() function")
-else()
+if(NOT MRTRIX_HAVE_LGAMMA_R)
     message(STATUS "No lgamma_r() function found; statistical inference may have poorer multi-threading performance")
 endif()
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(CheckCXXSourceCompiles)
+include(CheckSymbolExists)
 
 file(GLOB_RECURSE CORE_SRCS *.cpp *.h)
 
@@ -24,11 +24,10 @@ add_library(mrtrix-core SHARED ${CORE_SRCS})
 add_library(mrtrix::core ALIAS mrtrix-core)
 
 # Check to see if we can use lgamma_r() function in custom Math::betaincreg()
-check_cxx_source_compiles("
-  extern \"C\" double lgamma_r(double, int *);
-  int main() { int sign; lgamma_r(1.0, &sign); }"
-  MRTRIX_HAVE_LGAMMA_R
-)
+# The function is defined under _REENTRANT on some systems (e.g. MacOS)
+list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_REENTRANT)
+check_symbol_exists(lgamma_r "math.h" MRTRIX_HAVE_LGAMMA_R)
+list(REMOVE_AT CMAKE_REQUIRED_DEFINITIONS -1)
 
 if(MRTRIX_HAVE_LGAMMA_R)
     message(STATUS "Found lgamma_r() function")
@@ -68,8 +67,12 @@ target_include_directories(mrtrix-core-version-lib PRIVATE
 
 target_compile_definitions(mrtrix-core PUBLIC
     MRTRIX_BASE_VERSION="${MRTRIX_BASE_VERSION}"
-    MRTRIX_HAVE_LGAMMA_R=$<BOOL:${MRTRIX_HAVE_LGAMMA_R}>
+    $<$<BOOL:${MRTRIX_HAVE_LGAMMA_R}>:MRTRIX_HAVE_LGAMMA_R>
 )
+
+if(APPLE AND MRTRIX_HAVE_LGAMMA_R)
+    target_compile_definitions(mrtrix-core PRIVATE _REENTRANT)
+endif()
 
 if(PNG_FOUND)
     target_compile_definitions(mrtrix-core PUBLIC MRTRIX_PNG_SUPPORT)

--- a/core/math/betainc.cpp
+++ b/core/math/betainc.cpp
@@ -79,7 +79,7 @@ default_type betaincreg(const default_type a, const default_type b, const defaul
 #else
   default_type lbeta_ab = 0.0;
   {
-    std::lock_guard<std::mutex> lock (mutex_lgamma);
+    std::lock_guard<std::mutex> lock(mutex_lgamma);
     lbeta_ab = std::lgamma(a) + std::lgamma(b) - std::lgamma(a + b);
   }
 #endif
@@ -120,5 +120,9 @@ default_type betaincreg(const default_type a, const default_type b, const defaul
 
   return NaN; // Needed more loops, did not converge
 }
+
+#ifndef MRTRIX_HAVE_LGAMMA_R
+std::mutex mutex_lgamma;
+#endif
 
 } // namespace MR::Math

--- a/core/math/betainc.cpp
+++ b/core/math/betainc.cpp
@@ -79,8 +79,10 @@ default_type betaincreg(const default_type a, const default_type b, const defaul
 #else
   default_type lbeta_ab = 0.0;
   {
-    std::lock_guard<std::mutex> lock(mutex_lgamma);
+    const std::lock_guard<std::mutex> lock(mutex_lgamma);
+    // NOLINTBEGIN(concurrency-mt-unsafe)
     lbeta_ab = std::lgamma(a) + std::lgamma(b) - std::lgamma(a + b);
+    // NOLINTEND(concurrency-mt-unsafe)
   }
 #endif
   const default_type front = std::exp(std::log(x) * a + std::log(1.0 - x) * b - lbeta_ab) / a;

--- a/core/math/betainc.h
+++ b/core/math/betainc.h
@@ -22,7 +22,6 @@
 #endif
 
 #include "types.h"
-#include <math.h>
 
 namespace MR::Math {
 

--- a/core/math/betainc.h
+++ b/core/math/betainc.h
@@ -21,6 +21,10 @@
 #include <unsupported/Eigen/SpecialFunctions>
 #endif
 
+#ifndef MRTRIX_HAVE_LGAMMA_R
+#include <mutex>
+#endif
+
 #include "types.h"
 
 namespace MR::Math {
@@ -42,6 +46,10 @@ betaincreg(const Eigen::ArrayBase<ArgADerived> &a,
 #endif
 
 default_type betaincreg(const default_type a, const default_type b, const default_type x);
+
+#ifndef MRTRIX_HAVE_LGAMMA_R
+static std::mutex mutex_lgamma;
+#endif
 
 } // namespace MR::Math
 

--- a/core/math/betainc.h
+++ b/core/math/betainc.h
@@ -48,7 +48,7 @@ betaincreg(const Eigen::ArrayBase<ArgADerived> &a,
 default_type betaincreg(const default_type a, const default_type b, const default_type x);
 
 #ifndef MRTRIX_HAVE_LGAMMA_R
-static std::mutex mutex_lgamma;
+extern std::mutex mutex_lgamma;
 #endif
 
 } // namespace MR::Math


### PR DESCRIPTION
Partially addresses #2857.

*Hopefully* the concern about `lgamma_r()` only being available on "some" systems should not be of concern for us given the target systems...