### PR TITLE
Fix CI clang-tidy review action 

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -6,13 +6,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: sudo apt install qt6-base-dev libqt6opengl6-dev libglvnd-dev libeigen3-dev zlib1g-dev libfftw3-dev ninja-build
+
+    - name: Run CMake
+      run: cmake . -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
     - uses: ZedThree/clang-tidy-review@v0.17.0
       id: review
       with:
         apt_packages: g++,qt6-base-dev,libqt6opengl6-dev,libglvnd-dev,libeigen3-dev,zlib1g-dev,libfftw3-dev,ninja-build
-        cmake_command: cmake . -DCMAKE_EXPORT_COMPILE_COMMANDS=on
         config_file: .clang-tidy
 
     - uses: ZedThree/clang-tidy-review/upload@v0.17.0


### PR DESCRIPTION
Aims to fix the running of the clang-tidy review action. The issue was encountered in #2865 and #2871.
Error message:
> CMake Warning at core/CMakeLists.txt:79 (message):
libpng not found, disabling PNG support
CMake Warning at core/CMakeLists.txt:86 (message):
libtiff not found, disabling TIFF support
fatal: detected dubious ownership in repository at '/github/workspace'
To add an exception for this directory, call:
git config --global --add safe.directory /github/workspace
fatal: detected dubious ownership in repository at '/github/workspace'
To add an exception for this directory, call:
git config --global --add safe.directory /github/workspace
CMake Error at /github/workspace/cmake/FindVersion.cmake:21 (message):
MRtrix3 base version does not match the git tag!

Instead of generating the compilation database for compiler commands inside the container (as suggested by the documentation of the recipe of the action), we explictly run `cmake . -DCMAKE_EXPORT_COMPILE_COMMANDS=ON` prior to running `ZedThree/clang-tidy-review`. 