### PR TITLE
Use LLVM linker on Linux if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ file(RELATIVE_PATH relDir
 set(CMAKE_INSTALL_RPATH ${base} ${base}/${relDir})
 
 include(BuildType)
+include(LinkerSetup)
 include(FindFFTW)
 include(CompilerCache)
 include(ECMEnableSanitizers)

--- a/cmake/LinkerSetup.cmake
+++ b/cmake/LinkerSetup.cmake
@@ -1,0 +1,18 @@
+# On Linux we want to use the LLVM linker if available as it is faster than the default GNU linker.
+
+if(UNIX AND NOT APPLE)
+  find_program(LLVM_LINKER NAMES "ld.lld")
+
+  if(LLVM_LINKER)
+    message(STATUS "Using LLVM linker: ${LLVM_LINKER}")
+
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.29)
+      set(CMAKE_LINKER_TYPE "LLD" CACHE STRING "Linker type")
+    else()
+      set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld")
+      set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fuse-ld-lld")
+      set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -fuse-ld=lld")
+    endif()
+
+  endif()
+endif()


### PR DESCRIPTION
Enables the use of the LLVM linker by default on Linux platforms. It is much faster than the standard GNU linker and can provide a significant improvement in linking time, especially in incremental builds.