### PR TITLE
Fix typo in LinkerSetup.cmake

### DIFF
--- a/cmake/LinkerSetup.cmake
+++ b/cmake/LinkerSetup.cmake
@@ -10,7 +10,7 @@ if(UNIX AND NOT APPLE)
       set(CMAKE_LINKER_TYPE "LLD" CACHE STRING "Linker type")
     else()
       set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld")
-      set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fuse-ld-lld")
+      set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fuse-ld=lld")
       set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -fuse-ld=lld")
     endif()
 


### PR DESCRIPTION
Fixes. a typo introduced in #2875 