### PR TITLE
Don't use std::move for return values

### DIFF
--- a/core/file/nifti_utils.cpp
+++ b/core/file/nifti_utils.cpp
@@ -648,7 +648,7 @@ template <int VERSION> std::unique_ptr<ImageIO::Base> read(Header &H) {
     const size_t data_offset = fetch(H, *((const nifti_header *)fmap.address()));
     std::unique_ptr<ImageIO::Default> handler(new ImageIO::Default(H));
     handler->files.push_back(File::Entry(H.name(), (single_file ? data_offset : 0)));
-    return std::move(handler);
+    return handler;
   } catch (Exception &e) {
     e.display();
     return std::unique_ptr<ImageIO::Base>();
@@ -672,7 +672,7 @@ template <int VERSION> std::unique_ptr<ImageIO::Base> read_gz(Header &H) {
     memcpy(io_handler.get()->header(), &NH, sizeof(NH));
     memset(io_handler.get()->header() + sizeof(NH), 0, sizeof(nifti1_extender));
     io_handler->files.push_back(File::Entry(H.name(), data_offset));
-    return std::move(io_handler);
+    return io_handler;
   } catch (...) {
     return std::unique_ptr<ImageIO::Base>();
   }
@@ -707,7 +707,7 @@ template <int VERSION> std::unique_ptr<ImageIO::Base> create(Header &H) {
   std::unique_ptr<ImageIO::Default> handler(new ImageIO::Default(H));
   handler->files.push_back(File::Entry(H.name(), data_offset));
 
-  return std::move(handler);
+  return handler;
 }
 
 template <int VERSION> std::unique_ptr<ImageIO::Base> create_gz(Header &H) {
@@ -726,7 +726,7 @@ template <int VERSION> std::unique_ptr<ImageIO::Base> create_gz(Header &H) {
   File::create(H.name());
   io_handler->files.push_back(File::Entry(H.name(), sizeof(nifti_header) + 4));
 
-  return std::move(io_handler);
+  return io_handler;
 }
 
 // force explicit instantiation:

--- a/core/formats/mrtrix_gz.cpp
+++ b/core/formats/mrtrix_gz.cpp
@@ -56,7 +56,7 @@ std::unique_ptr<ImageIO::Base> MRtrix_GZ::read(Header &H) const {
   memset(io_handler.get()->header() + header.str().size(), 0, write_offset - header.str().size());
   io_handler->files.push_back(File::Entry(H.name(), offset));
 
-  return std::move(io_handler);
+  return io_handler;
 }
 
 bool MRtrix_GZ::check(Header &H, size_t num_axes) const {
@@ -88,7 +88,7 @@ std::unique_ptr<ImageIO::Base> MRtrix_GZ::create(Header &H) const {
   File::create(H.name());
   io_handler->files.push_back(File::Entry(H.name(), offset));
 
-  return std::move(io_handler);
+  return io_handler;
 }
 
 } // namespace MR::Formats

--- a/core/formats/mrtrix_sparse_legacy.cpp
+++ b/core/formats/mrtrix_sparse_legacy.cpp
@@ -80,7 +80,7 @@ std::unique_ptr<ImageIO::Base> MRtrix_sparse::read(Header &H) const {
   for (size_t n = 0; n < image_list.size(); ++n)
     io_handler->files.push_back(File::Entry(image_list[n].name(), image_offset));
 
-  return std::move(io_handler);
+  return io_handler;
 }
 
 bool MRtrix_sparse::check(Header &H, size_t num_axes) const {
@@ -149,7 +149,7 @@ std::unique_ptr<ImageIO::Base> MRtrix_sparse::create(Header &H) const {
       H, name_it->second, to<size_t>(size_it->second), File::Entry(sparse_path, sparse_offset)));
   io_handler->files.push_back(File::Entry(image_path, image_offset));
 
-  return std::move(io_handler);
+  return io_handler;
 }
 
 } // namespace MR::Formats

--- a/core/formats/pipe.cpp
+++ b/core/formats/pipe.cpp
@@ -46,7 +46,7 @@ std::unique_ptr<ImageIO::Base> Pipe::read(Header &H) const {
 
   std::unique_ptr<ImageIO::Base> original_handler(mrtrix_handler.read(H));
   std::unique_ptr<ImageIO::Pipe> io_handler(new ImageIO::Pipe(std::move(*original_handler)));
-  return std::move(io_handler);
+  return io_handler;
 }
 
 bool Pipe::check(Header &H, size_t num_axes) const {
@@ -66,7 +66,7 @@ bool Pipe::check(Header &H, size_t num_axes) const {
 std::unique_ptr<ImageIO::Base> Pipe::create(Header &H) const {
   std::unique_ptr<ImageIO::Base> original_handler(mrtrix_handler.create(H));
   std::unique_ptr<ImageIO::Pipe> io_handler(new ImageIO::Pipe(std::move(*original_handler)));
-  return std::move(io_handler);
+  return io_handler;
 }
 
 } // namespace MR::Formats

--- a/core/formats/ram.cpp
+++ b/core/formats/ram.cpp
@@ -45,7 +45,7 @@ bool RAM::check(Header &H, size_t num_axes) const {
 std::unique_ptr<ImageIO::Base> RAM::create(Header &H) const {
   if (H.name() == "NULL") {
     std::unique_ptr<ImageIO::RAM> io_handler(new ImageIO::RAM(H));
-    return std::move(io_handler);
+    return io_handler;
   }
 
 #ifdef MRTRIX_AS_R_LIBRARY

--- a/core/formats/xds.cpp
+++ b/core/formats/xds.cpp
@@ -65,7 +65,7 @@ std::unique_ptr<ImageIO::Base> XDS::read(Header &H) const {
   std::unique_ptr<ImageIO::Default> io_handler(new ImageIO::Default(H));
   io_handler->files.push_back(File::Entry(H.name()));
 
-  return std::move(io_handler);
+  return io_handler;
 }
 
 bool XDS::check(Header &H, size_t num_axes) const {
@@ -120,7 +120,7 @@ std::unique_ptr<ImageIO::Base> XDS::create(Header &H) const {
   File::create(H.name(), footprint(H, "11 1"));
   io_handler->files.push_back(File::Entry(H.name()));
 
-  return std::move(io_handler);
+  return io_handler;
 }
 
 } // namespace MR::Formats

--- a/core/image.h
+++ b/core/image.h
@@ -371,7 +371,7 @@ template <typename ValueType> Image<ValueType> Image<ValueType>::with_direct_io(
     with_strides = Stride::get(*this);
 
   if (!preload)
-    return std::move(*this);
+    return *this;
 
   // do the preload:
 


### PR DESCRIPTION
It prevents NRVO (Named Return Value Optimisation) and in fact can be a pessimisation. See [here](https://devblogs.microsoft.com/oldnewthing/20231124-00/?p=109059).