### PR TITLE
Add new CMake target to build testing tools

### DIFF
--- a/testing/tools/CMakeLists.txt
+++ b/testing/tools/CMakeLists.txt
@@ -19,6 +19,8 @@ set(PYTHON_TOOLS_SRCS
     testing_gen_npy
 )
 
+add_custom_target(testing_tools)
+
 function(add_testing_cmd CMD_SRC)
     # Extract the filename without an extension (NAME_WE)
     get_filename_component(CMD_NAME ${CMD} NAME_WE)
@@ -29,6 +31,7 @@ function(add_testing_cmd CMD_SRC)
         mrtrix::tests-lib
     )
     set_target_properties(${CMD_NAME} PROPERTIES LINK_DEPENDS_NO_SHARED true)
+    add_dependencies(testing_tools ${CMD_NAME})
 endfunction()
 
 


### PR DESCRIPTION
Useful when you want to run tests for a single command. Currently, tests require the binaries built by `testing/tools` before they can run. However, if you build a specific target `cmake --build build --target tckgen` and then run the tests via `ctest -R bin_tckgen`, it won't work because testing tools are missing.
This PR mitigates this by allowing you to run `cmake --build build --target tckgen testing_tools` and then run `ctest -R bin_tckgen`. 