### PR TITLE
Disable LLD when using GCC with LTO enabled

### DIFF
--- a/cmake/LinkerSetup.cmake
+++ b/cmake/LinkerSetup.cmake
@@ -1,6 +1,13 @@
 # On Linux we want to use the LLVM linker if available as it is faster than the default GNU linker.
+# Unfortunately, lld is not able to perform LTO when compiling with GCC.
 
-if(UNIX AND NOT APPLE)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+    set(GCC_LTO TRUE)
+else()
+    set(GCC_LTO FALSE)
+endif()
+
+if(UNIX AND NOT APPLE AND NOT GCC_LTO)
   find_program(LLVM_LINKER NAMES "ld.lld")
 
   if(LLVM_LINKER)


### PR DESCRIPTION
I made the unfortunate discovery that the LLVM linker cannot perform Link Time Optimisation when compiling with GCC. See [here](https://stackoverflow.com/questions/58084395/does-lto-works-when-compiling-with-gcc-but-linking-with-llvm-lld). In fact, the compilation is broken if lld is used with GCC with LTO on.

So we simply don't use lld if we detect that GCC and LTO are used together.