### PR TITLE
dwifslpreproc: Fix -rpe_header with no phase encoding contrast

### DIFF
--- a/python/bin/dwifslpreproc
+++ b/python/bin/dwifslpreproc
@@ -773,6 +773,7 @@ def execute(): #pylint: disable=unused-variable
         raise MRtrixError('DWI header indicates no phase encoding contrast between b=0 images; cannot proceed with volume recombination-based pre-processing')
       app.warn('DWI header indicates no phase encoding contrast between b=0 images; proceeding without inhomogeneity field estimation')
       execute_topup = False
+      execute_applytopup = False
       run.function(os.remove, se_epi_path)
       se_epi_path = None
       se_epi_header = None


### PR DESCRIPTION
In this use case, script would erroneously attempt to execute applytopup in the calculation of a processing mask for eddy. Fix to #2266.