### PR TITLE
-json_export: Fix slice encoding direction sign

### DIFF
--- a/core/file/json_utils.cpp
+++ b/core/file/json_utils.cpp
@@ -296,7 +296,7 @@ namespace MR
           const Eigen::Vector3d orig_dir (Axes::id2dir (slice_encoding_it->second));
           Eigen::Vector3d new_dir;
           for (size_t axis = 0; axis != 3; ++axis)
-            new_dir[axis] = flip[axis] ? orig_dir[order[axis]] : -orig_dir[order[axis]];
+            new_dir[axis] = flip[axis] ? -orig_dir[order[axis]] : orig_dir[order[axis]];
           slice_encoding_it->second = Axes::dir2id (new_dir);
           INFO ("Slice encoding direction written to JSON file modified according to expected output NIfTI header transform realignment");
         }


### PR DESCRIPTION
Erroneous sign flip appears to trace all the way back to 909ccab81b659cfb42eac08e1bf1cd814836f98c [here](https://github.com/MRtrix3/mrtrix3/commit/909ccab81b659cfb42eac08e1bf1cd814836f98c#diff-28c39dcc38552f088b660208a74d701b1ed457b641e5fb9b136aa0c073aec063R131), which came in #1175, so it appears to have been there ever since capturing of slice encoding information was added.

I discovered this during a larger experiment verifying the handling of DWI metadata, which involves processing data from 24 DWI acquisitions, with every possible combination of slice orientation, slice order ("ascending" vs. "descending"), and phase encoding direction. This changes makes the output of `mrconvert` from an input DICOM series commensurate with both the outputs from `dcm2niix` and the orientations indicated in the `SeriesDescription`s.

In terms of consequences:
-   Anything that involves detection of the slice encoding *axis* (ie. sign of the direction is ignored) should not be affected; eg. `mrdegibbs`.
-   For `dwifslpreproc`, I *think* the effect should be nil.
    The effect of the slice encoding *direction* (not axis) being negative is that the order of slices / slice groups within the `slspec` file gets reversed.
    To my knowledge, `eddy` models within-volume subject motion separately per volume. Therefore if the order of slices / slice groups within each volume is exactly reversed, the fit of the relevant basis functions within each group should be reversed in time. There may be greater discrepancies in the derivatives of those functions between volumes, but `eddy` does not take such into consideration.
-   Other pipelines may need to be checked.
    @dchristiaens: I recommend checking the dHCP pipeline regarding whether slice encoding information was extracted using `mrconvert` or `dcm2niix`. If the former, then the imposition of smoothness of motion parameters between slice groups across different volumes may result in this bug detrimentally affecting pre-processing.