### PR TITLE
dwishellmath: Enhancements

### DIFF
--- a/docs/reference/commands/dwigradcheck.rst
+++ b/docs/reference/commands/dwigradcheck.rst
@@ -22,7 +22,9 @@ Description
 
 Note that the corrected gradient table can be output using the -export_grad_{mrtrix,fsl} option.
 
-Note that if the -mask command-line option is not specified, the MRtrix3 command dwi2mask will automatically be called to derive a binary mask image to be used for streamline seeding and to constrain streamline propagation. More information on mask derivation from DWI data can be found at the following link: 
+In addition to testing for potential permutations and flips of axes in the gradient table (which may have occurred within either the real / scanner space or bvec representations of such), the command also considers the prospect that the gradient table contents may have been computed / provided in real / scanner space but erroneously interpreted as "bvec" contents or vice-versa. To address this, the command additionally considers possible transpositions between these two representations. Where there is possibly a combination of both transposition and axis shuffles, that transposition will be applied either before or after the axis shuffles as necessary. If it is known that no such transposition has occurred, or if there is very close correspondence between image and real / scanner space axes, the search space of the command can be reduced using the -notranspose option.
+
+Note that if the -mask command-line option is not specified, the MRtrix3 command dwi2mask will automatically be called  to derive a binary mask image to be used for streamline seeding and to constrain streamline propagation. More information on mask derivation from DWI data can be found at the following link: 
 https://mrtrix.readthedocs.io/en/3.0.4/dwi_preprocessing/masking.html
 
 Options
@@ -31,6 +33,16 @@ Options
 - **-mask image** Provide a mask image within which to seed & constrain tracking
 
 - **-number** Set the number of tracks to generate for each test
+
+- **-threshold** Modulate thresold on the ratio of empirical to maximal mean length to issue an error
+
+- **-notranspose** Do not evaluate possible misattribution of gradient directions between image and scanner spaces
+
+- **-shuffle** Restrict the possible search space of axis shuffles; options are: none,real,bvec
+
+- **-all** Print table containing all results to standard output
+
+- **-out** Write text file with table containing all results
 
 Options for importing the diffusion gradient table
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/python/bin/dwigradcheck
+++ b/python/bin/dwigradcheck
@@ -15,7 +15,26 @@
 #
 # For more details, see http://www.mrtrix.org/.
 
-import copy, numbers, os, shutil, sys
+import copy
+import os
+import shutil
+import sys
+
+
+
+FLIPS = (None, 0, 1, 2)
+PERMUTATIONS = ((0,1,2), (0,2,1), (1,0,2), (1,2,0), (2,0,1), (2,1,0))
+SHUFFLING_BASES = ('none', 'real', 'bvec')
+# Names indicate that the gradient table *should have* been stored as the *latter* convention,
+#   but the user has it *erroneously stored* as the *former* convention;
+#   therefore, from a processing perspective,
+#   code must take the data in the former format and manually transpose into the latter
+# Note that this transposition could occur before or after shuffling,
+#   depending on the basis in which the shuffling is performed
+TRANSPOSITIONS = (None, 'real2bvec', 'bvec2real')
+
+DEFAULT_NUMBER = 10000
+DEFAULT_THRESHOLD = 0.95
 
 
 
@@ -24,17 +43,111 @@ def usage(cmdline): #pylint: disable=unused-variable
   cmdline.set_author('Robert E. Smith (robert.smith@florey.edu.au)')
   cmdline.set_synopsis('Check the orientation of the diffusion gradient table')
   cmdline.add_description('Note that the corrected gradient table can be output using the -export_grad_{mrtrix,fsl} option.')
-  cmdline.add_description('Note that if the -mask command-line option is not specified, the MRtrix3 command dwi2mask will automatically be called to '
-                          'derive a binary mask image to be used for streamline seeding and to constrain streamline propagation. '
-                          'More information on mask derivation from DWI data can be found at the following link: \n'
+  cmdline.add_description('In addition to testing for potential permutations and flips of axes in the gradient table'
+                          ' (which may have occurred within either the real / scanner space or bvec representations of such),'
+                          ' the command also considers the prospect that the gradient table contents may have been'
+                          ' computed / provided in real / scanner space but erroneously interpreted as "bvec" contents'
+                          ' or vice-versa.'
+                          ' To address this,'
+                          ' the command additionally considers possible transpositions between these two representations.'
+                          ' Where there is possibly a combination of both transposition and axis shuffles,'
+                          ' that transposition will be applied either before or after the axis shuffles as necessary.'
+                          ' If it is known that no such transposition has occurred,'
+                          ' or if there is very close correspondence between image and real / scanner space axes,'
+                          ' the search space of the command can be reduced using the -notranspose option.')
+  cmdline.add_description('Note that if the -mask command-line option is not specified,'
+                          ' the MRtrix3 command dwi2mask will automatically be called '
+                          ' to derive a binary mask image to be used for streamline seeding and to constrain streamline propagation.'
+                          ' More information on mask derivation from DWI data can be found at the following link: \n'
                           'https://mrtrix.readthedocs.io/en/' + _version.__tag__ + '/dwi_preprocessing/masking.html')
-  cmdline.add_citation('Jeurissen, B.; Leemans, A.; Sijbers, J. Automated correction of improperly rotated diffusion gradient orientations in diffusion weighted MRI. Medical Image Analysis, 2014, 18(7), 953-962')
+  cmdline.add_citation('Jeurissen, B.; Leemans, A.; Sijbers, J.'
+                       ' Automated correction of improperly rotated diffusion gradient orientations in diffusion weighted MRI.'
+                       ' Medical Image Analysis, 2014, 18(7), 953-962')
   cmdline.add_argument('input', help='The input DWI series to be checked')
   cmdline.add_argument('-mask', metavar='image', help='Provide a mask image within which to seed & constrain tracking')
-  cmdline.add_argument('-number', type=int, default=10000, help='Set the number of tracks to generate for each test')
-
+  cmdline.add_argument('-number', type=int, default=DEFAULT_NUMBER, help='Set the number of tracks to generate for each test')
+  cmdline.add_argument('-threshold', type=float, default=DEFAULT_THRESHOLD, help='Modulate thresold on the ratio of empirical to maximal mean length to issue an error')
+  cmdline.add_argument('-notranspose', action='store_true', help='Do not evaluate possible misattribution of gradient directions between image and scanner spaces')
+  cmdline.add_argument('-shuffle', choices=SHUFFLING_BASES, help='Restrict the possible search space of axis shuffles; options are: ' + ','.join(SHUFFLING_BASES))
+  cmdline.add_argument('-all', action='store_true', help='Print table containing all results to standard output')
+  cmdline.add_argument('-out', help='Write text file with table containing all results')
   app.add_dwgrad_export_options(cmdline)
   app.add_dwgrad_import_options(cmdline)
+
+
+
+class Variant():
+  def __init__(self, flip, permutations, shuffle_basis, transpose):
+    self.flip = flip
+    self.permutations = permutations
+    self.shuffle_basis = shuffle_basis
+    self.transpose = transpose
+    self.mean_length = None
+  def __format__(self, fmt):
+    if self.is_default():
+      return 'none'
+    if self.transpose == 'bvec2real':
+      if self.no_shuffling():
+        return 'bvec_transB2R'
+      if self.shuffle_basis == 'real':
+        return f'bvec_transB2R_flip{self.flip}_perm{"".join(map(str, self.permutations))}'
+      elif self.shuffle_basis == 'bvec':
+        return f'bvec_flip{self.flip}_perm{"".join(map(str, self.permutations))}_transB2R'
+      else:
+        assert False
+    if self.transpose == 'real2bvec':
+      if self.no_shuffling():
+        return 'real_transR2B'
+      if self.shuffle_basis == 'real':
+        return f'real_flip{self.flip}_perm{"".join(map(str, self.permutations))}_transR2B'
+      elif self.shuffle_basis == 'bvec':
+        return f'real_transR2B_flip{self.flip}_perm{"".join(map(str, self.permutations))}'
+      else:
+        assert False
+    if self.shuffle_basis == 'real':
+      return f'real_flip{self.flip}_perm{"".join(map(str, self.permutations))}'
+    elif self.shuffle_basis == 'bvec':
+      return f'bvec_flip{self.flip}_perm{"".join(map(str, self.permutations))}'
+    else:
+      assert False
+  def is_default(self):
+    return self.flip is None and self.permutations == (0,1,2) and self.shuffle_basis == 'none' and self.transpose is None
+  def no_flip(self):
+    return self.flip is None
+  def no_permutations(self):
+    return self.permutations == (0,1,2)
+  def no_shuffling(self):
+    if self.shuffle_basis == 'none':
+      assert self.no_flip() and self.no_permutations()
+      return True
+    assert not self.no_flip() or not self.no_permutations()
+    return False
+  def str_transpose_preshuffle(self):
+    if self.transpose == 'real2bvec' and self.shuffle_basis != 'real':
+      return 'real2bvec'
+    if self.transpose == 'bvec2real' and self.shuffle_basis != 'bvec':
+      return 'bvec2real'
+    return 'none'
+  def str_transpose_postshuffle(self):
+    if self.transpose == 'real2bvec' and self.shuffle_basis == 'real':
+      return 'real2bvec'
+    if self.transpose == 'bvec2real' and self.shuffle_basis == 'bvec':
+      return 'bvec2real'
+    return 'none'
+  def str_shuffle(self):
+    temp = [1, 2, 3]
+    if self.flip is not None:
+      temp[self.flip] = -temp[self.flip]
+    temp = [temp[self.permutations[0]], temp[self.permutations[1]], temp[self.permutations[2]]]
+    return f'{temp[0]},{temp[1]},{temp[2]}'
+  def str_shuffle_pretty(self):
+    if self.no_shuffling():
+      return '    none     '
+    return f'{self.shuffle_basis}:({self.str_shuffle()}){" " if self.flip is None else ""}'
+
+def sort_key(item):
+  assert item.mean_length is not None
+  return item.mean_length
 
 
 
@@ -42,6 +155,11 @@ def usage(cmdline): #pylint: disable=unused-variable
 def execute(): #pylint: disable=unused-variable
   from mrtrix3 import CONFIG, MRtrixError #pylint: disable=no-name-in-module, import-outside-toplevel
   from mrtrix3 import app, image, matrix, path, run #pylint: disable=no-name-in-module, import-outside-toplevel
+
+  if app.ARGS.notranspose and app.ARGS.shuffle == 'none':
+    raise MRtrixError('No candidate modified gradient tables if both -notranspose and -shuffle none are specified')
+
+  app.check_output_path(app.ARGS.out)
 
   image_dimensions = image.Header(path.from_user(app.ARGS.input, False)).size()
   if len(image_dimensions) != 4:
@@ -80,11 +198,12 @@ def execute(): #pylint: disable=unused-variable
 
   # Import both of these into local memory
   grad_mrtrix = matrix.load_matrix('grad.b')
-  grad_fsl = matrix.load_matrix('bvecs')
+  grad_bvecs = matrix.load_matrix('bvecs')
+  grad_bvals = matrix.load_vector('bvals')
   # Is our gradient table of the correct length?
   if not len(grad_mrtrix) == num_volumes:
     raise MRtrixError('Number of entries in gradient table does not match number of DWI volumes')
-  if not len(grad_fsl) == 3 or not len(grad_fsl[0]) == num_volumes:
+  if not len(grad_bvecs) == 3 or not len(grad_bvecs[0]) == num_volumes or not len(grad_bvals) == len(grad_bvecs[0]):
     raise MRtrixError('Internal error (inconsistent gradient table storage)')
 
 
@@ -95,115 +214,183 @@ def execute(): #pylint: disable=unused-variable
     run.command('dwi2mask ' + CONFIG['Dwi2maskAlgorithm'] + ' data.mif mask.mif -grad grad.b')
 
   # How many tracks are we going to generate?
-  number_option = ' -select ' + str(app.ARGS.number)
+  number_option = ['-select', str(app.ARGS.number)]
+
+  variants = []
+  for f in FLIPS:
+    for p in PERMUTATIONS:
+      for b in SHUFFLING_BASES:
+        # Exclude invalid combinations
+        if b == 'none' and (f is not None or p != (0,1,2)):
+          continue
+        if b != 'none' and (f is None and p == (0,1,2)):
+          continue
+        if app.ARGS.shuffle is not None and b != app.ARGS.shuffle:
+          continue
+        for t in TRANSPOSITIONS:
+          if t is None and b is None:
+            continue
+          if t is not None and app.ARGS.notranspose:
+            continue
+          # Always omit the unmodified data here; add it at the end
+          if f is None and p == (0,1,2) and b == 'none' and t is None:
+            continue
+          variants.append(Variant(f, p, b, t))
+  # Add the "no change" variant only at the very end
+  variants.append(Variant(None, (0,1,2), 'none', None))
+  app.debug('Complete list of variants:')
+  for v in variants:
+    app.debug(f'{v}')
 
 
-  #  What variations of gradient errors can we conceive?
+  progress = app.ProgressBar(f'Testing gradient table alterations (0 of {len(variants)})', len(variants))
+  meanlength_default = None
+  for index, variant in enumerate(variants):
+    # Break processing into four phases:
+    # 1. Do we need to transpose the gradient table from one format to the other?
+    #    (this also flags the basis in which any shuffling may be performed)
+    # 2. Shuffling
+    # 3. Transpose the gradient table from one format to the other
+    #    (this also determines the gradient table format that will be provided to tckgen)
+    # 4. Save the file to provide to tckgen in the appropriate format
 
-  # Done:
-  # * Has an axis been flipped? (none, 0, 1, 2)
-  # * Have axes been swapped? (012 021 102 120 201 210)
-  # * For both flips & swaps, it could occur in either scanner or image space...
+    # 1. Transposition / determination of shuffling basis
+    # If shuffling basis is None, still need to capture and propagate data,
+    #   depending on what transposition might be occurring
+    if variant.transpose == 'real2bvec' and variant.shuffle_basis != 'real':
+      grad = [[row[i] for row in grad_mrtrix] for i in range(0, 3)]
+      shuffling_basis = 'bvec'
+    elif variant.transpose == 'bvec2real' and variant.shuffle_basis != 'bvec':
+      grad = [[row[i] for row in grad_bvecs] + [grad_bvals[i]] for i in range(0, len(grad_bvecs[0]))]
+      shuffling_basis = 'real'
+    else:
+      grad = copy.copy(grad_bvecs) if variant.shuffle_basis == 'bvec' else copy.copy(grad_mrtrix)
+      shuffling_basis = variant.shuffle_basis
 
-  # To do:
-  # * Have the gradients been defined with respect to image space rather than scanner space?
-  # * After conversion to gradients in image space, are they _then_ defined with respect to scanner space?
-  #   (should the above two be tested independently from the axis flips / permutations?)
+    # 2. Shuffling
+    if shuffling_basis == 'real':
+      if variant.flip is not None:
+        multiplier = [ 1.0, 1.0, 1.0, 1.0 ]
+        multiplier[variant.flip] = -1.0
+        grad = [ [ r*m for r,m in zip(row, multiplier) ] for row in grad ]
+      grad = [ [ row[variant.permutations[0]], row[variant.permutations[1]], row[variant.permutations[2]], row[3] ] for row in grad ]
+    elif shuffling_basis == 'bvec':
+      if variant.flip is not None:
+        grad[variant.flip] = [ -v for v in grad[variant.flip] ]
+      grad = [ grad[variant.permutations[0]], grad[variant.permutations[1]], grad[variant.permutations[2]] ]
+    else:
+      assert shuffling_basis == 'none'
 
+    # 3. Post shuffling transposition
+    if variant.transpose == 'real2bvec' and variant.shuffle_basis == 'real':
+      grad = [[row[i] for row in grad] for i in range(0, 3)]
+      save_basis = 'bvec'
+    elif variant.transpose == 'bvec2real' and variant.shuffle_basis == 'bvec':
+      grad = [[row[i] for row in grad_bvecs] + [grad_bvals[i]] for i in range(0, len(grad[0]))]
+      save_basis = 'real'
+    elif shuffling_basis == 'none':
+      save_basis = 'bvec' if variant.transpose == 'real2bvec' else 'real'
+    else:
+      save_basis = shuffling_basis
 
-  axis_flips = [ 'none', 0, 1, 2 ]
-  axis_permutations = [ ( 0, 1, 2 ), (0, 2, 1), (1, 0, 2), (1, 2, 0), (2, 0, 1), (2, 1, 0) ]
-  grad_basis = [ 'scanner', 'image' ]
-  total_tests = len(axis_flips) * len(axis_permutations) * len(grad_basis)
+    # 4. Save to file
+    if save_basis == 'bvec':
+      grad_path = f'bvecs_{variant}'
+      with open(grad_path, 'w', encoding='utf-8') as bvecs_file:
+        for line in grad:
+          bvecs_file.write (' '.join([str(v) for v in line]) + '\n')
+      grad_option = ['-fslgrad', grad_path, 'bvals']
+    elif save_basis == 'real':
+      grad_path = f'grad_{variant}.b'
+      with open(grad_path, 'w', encoding='utf-8') as grad_file:
+        for line in grad:
+          grad_file.write (','.join([str(v) for v in line]) + '\n')
+      grad_option = ['-grad', grad_path]
 
+    # Run the tracking experiment
+    track_file_path = f'tracks_{variant}.tck'
+    run.command(['tckgen', 'data.mif',
+                 '-algorithm', 'tensor_det',
+                 '-seed_image', 'mask.mif',
+                 '-mask', 'mask.mif',
+                 '-minlength', '0',
+                 '-downsample', '5',
+                 track_file_path]
+                + number_option
+                + grad_option)
 
-  # List where the first element is the mean length
-  lengths = [ ]
+    # Get the mean track length & add to the database
+    mean_length = float(run.command(['tckstats', track_file_path, '-output', 'mean', '-ignorezero']).stdout)
+    variants[index].mean_length = mean_length
+    app.cleanup(track_file_path)
 
-  progress = app.ProgressBar('Testing gradient table alterations (0 of ' + str(total_tests) + ')', total_tests)
+    # Save result if this is the unmodified empirical gradient table
+    if variant.is_default():
+      assert meanlength_default is None
+      meanlength_default = mean_length
 
-  for flip in axis_flips:
-    for permutation in axis_permutations:
-      for basis in grad_basis:
-
-        suffix = '_flip' + str(flip) + '_perm' + ''.join(str(item) for item in permutation) + '_' + basis
-
-        if basis == 'scanner':
-
-          grad = copy.copy(grad_mrtrix)
-
-          # Don't do anything if there aren't any axis flips occurring (flip == 'none')
-          if isinstance(flip, numbers.Number):
-            multiplier = [ 1.0, 1.0, 1.0, 1.0 ]
-            multiplier[flip] = -1.0
-            grad = [ [ r*m for r,m in zip(row, multiplier) ] for row in grad ]
-
-          grad = [ [ row[permutation[0]], row[permutation[1]], row[permutation[2]], row[3] ] for row in grad ]
-
-          # Create the gradient table file
-          grad_path = 'grad' + suffix + '.b'
-          with open(grad_path, 'w', encoding='utf-8') as grad_file:
-            for line in grad:
-              grad_file.write (','.join([str(v) for v in line]) + '\n')
-
-          grad_option = ' -grad ' + grad_path
-
-        elif basis == 'image':
-
-          grad = copy.copy(grad_fsl)
-
-          if isinstance(flip, numbers.Number):
-            grad[flip] = [ -v for v in grad[flip] ]
-
-          grad = [ grad[permutation[0]], grad[permutation[1]], grad[permutation[2]] ]
-
-          grad_path = 'bvecs' + suffix
-          with open(grad_path, 'w', encoding='utf-8') as bvecs_file:
-            for line in grad:
-              bvecs_file.write (' '.join([str(v) for v in line]) + '\n')
-
-          grad_option = ' -fslgrad ' + grad_path + ' bvals'
-
-        # Run the tracking experiment
-        run.command('tckgen -algorithm tensor_det data.mif' + grad_option + ' -seed_image mask.mif -mask mask.mif' + number_option + ' -minlength 0 -downsample 5 tracks' + suffix + '.tck')
-
-        # Get the mean track length
-        meanlength=float(run.command('tckstats tracks' + suffix + '.tck -output mean -ignorezero').stdout)
-
-        # Add to the database
-        lengths.append([meanlength,flip,permutation,basis])
-
-        # Increament the progress bar
-        progress.increment('Testing gradient table alterations (' + str(len(lengths)) + ' of ' + str(total_tests) + ')')
+    # Increment the progress bar
+    progress.increment(f'Testing gradient table alterations ({index+1} of {len(variants)})')
 
   progress.done()
 
   # Sort the list to find the best gradient configuration(s)
-  lengths.sort()
-  lengths.reverse()
+  sorted_variants = list(variants)
+  sorted_variants.sort(reverse=True, key=sort_key)
+  meanlength_max = sorted_variants[0].mean_length
 
+  if sorted_variants[0].is_default():
+    meanlength_ratio = 1.0
+    app.console('Absence of manipulation of the gradient table resulted in the maximal mean length')
+  else:
+    meanlength_ratio = meanlength_default / meanlength_max
+    app.console(f'Ratio of mean length of empirical data to mean length of best candidate: {meanlength_ratio:.3f}')
 
   # Provide a printout of the mean streamline length of each gradient table manipulation
-  sys.stderr.write('Mean length     Axis flipped    Axis permutations    Axis basis\n')
-  for line in lengths:
-    if isinstance(line[1], numbers.Number):
-      flip_str = "{:4d}".format(line[1])
+  if app.ARGS.all:
+    def pad_transpose(s):
+      return s.ljust(7, ' ').rjust(9, ' ')
+    if app.ARGS.notranspose:
+      sys.stdout.write('Mean length     Shuffle\n')
+      for variant in sorted_variants:
+        sys.stdout.write(f'  {variant.mean_length:5.2f}      {variant.str_shuffle_pretty()}\n')
+    elif app.ARGS.shuffle == 'none':
+      sys.stdout.write('Mean length   Transform\n')
+      for variant in sorted_variants:
+        sys.stdout.write(f'  {variant.mean_length:5.2f}       {pad_transpose(variant.str_transpose_preshuffle())}\n')
     else:
-      flip_str = line[1]
-    sys.stderr.write("{:5.2f}".format(line[0]) + '         ' + flip_str + '                ' + str(line[2]) + '           ' + line[3] + '\n')
+      sys.stdout.write('Mean length   Transform        Shuffle       Transform\n')
+      for variant in sorted_variants:
+        sys.stdout.write(f'  {variant.mean_length:5.2f}       {pad_transpose(variant.str_transpose_preshuffle())}     {variant.str_shuffle_pretty()}    {pad_transpose(variant.str_transpose_postshuffle())}\n')
+    sys.stdout.flush()
 
+  # Write comprehensive results to a file
+  if app.ARGS.out:
+    if os.path.splitext(app.ARGS.out)[-1].lower() == '.tsv':
+      delimiter = '\t'
+      quote = ''
+    else:
+      delimiter = ','
+      quote = '"'
+    with open(path.from_user(app.ARGS.out, False), 'w') as f:
+      f.write(f'Pre-shuffle transpose{delimiter}Shuffling basis{delimiter}Axis shuffle{delimiter}Post-shuffle transpose{delimiter}Mean length\n')
+      for v in variants:
+        f.write(f'{v.str_transpose_preshuffle()}{delimiter}{v.shuffle_basis}{delimiter}{quote}{v.str_shuffle()}{quote}{delimiter}{v.str_transpose_postshuffle()}{delimiter}{v.mean_length}\n')
 
   # If requested, extract what has been detected as the best gradient table, and
   #   export it in the format requested by the user
   grad_export_option = app.read_dwgrad_export_options()
   if grad_export_option:
-    best = lengths[0]
-    suffix = '_flip' + str(best[1]) + '_perm' + ''.join(str(item) for item in best[2]) + '_' + best[3]
-    if best[3] == 'scanner':
-      grad_import_option = ' -grad grad' + suffix + '.b'
-    elif best[3] == 'image':
-      grad_import_option = ' -fslgrad bvecs' + suffix + ' bvals'
-    run.command('mrinfo data.mif' + grad_import_option + grad_export_option, force=app.FORCE_OVERWRITE)
+    if variant.shuffle_basis == 'real' or (variant.shuffle_basis == 'bvec' and variant.transpose == 'bvec2real'):
+      grad_import_option = ['-grad', 'grad_{sorted_variants[0]}.b']
+    elif variant.shuffle_basis == 'bvec' or (variant.shuffle_basis == 'real' and variant.transpose == 'real2bvec'):
+      grad_import_option = ['-fslgrad', f'bvecs_{variant}', 'bvals']
+    run.command(['mrinfo', 'data.mif'] + grad_import_option + grad_export_option,
+                force=app.FORCE_OVERWRITE)
+
+  if meanlength_ratio < app.ARGS.threshold:
+    raise MRtrixError('Streamline tractography indicates possibly incorrect gradient table')
+
 
 
 # Execute the script

--- a/testing/scripts/CMakeLists.txt
+++ b/testing/scripts/CMakeLists.txt
@@ -149,6 +149,9 @@ add_bash_script_test(dwifslpreproc/rpepair_alignseepi)
 add_bash_script_test(dwifslpreproc/rpepair_default)
 
 add_bash_script_test(dwigradcheck/default)
+add_bash_script_test(dwigradcheck/nobvec)
+add_bash_script_test(dwigradcheck/noshuffle)
+add_bash_script_test(dwigradcheck/notranspose)
 
 add_bash_script_test(dwinormalise/group "pythonci")
 add_bash_script_test(dwinormalise/manual_default "pythonci")

--- a/testing/scripts/tests/dwigradcheck/nobvec
+++ b/testing/scripts/tests/dwigradcheck/nobvec
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Ensure that the dwigradcheck script completes successfully
+#   when testing exclusively shuffling in one basis
+# This means both restricting the basis for shuffling using the -shuffle option,
+#   and excluding any transposition between bases
+# Output should contain 25 lines in this use case:
+#   - Header fields
+#   - 24 possible combinations of axis shuffles and flips
+
+dwigradcheck BIDS/sub-01/dwi/sub-01_dwi.nii.gz -force \
+-fslgrad BIDS/sub-01/dwi/sub-01_dwi.bvec BIDS/sub-01/dwi/sub-01_dwi.bval \
+-shuffle real \
+-notranspose \
+-out tmp.csv
+
+LINECOUNT=$(wc -l tmp.csv)
+if [ "$LINECOUNT" -neq "25" ]]; then
+    exit 1
+fi

--- a/testing/scripts/tests/dwigradcheck/noshuffle
+++ b/testing/scripts/tests/dwigradcheck/noshuffle
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Ensure that the dwigradcheck script completes successfully
+#   when -shuffle none is specified
+# Output should contain 4 lines in this use case:
+#   - Header fields
+#   - No transpose
+#   - Transpose from bvec to real / scanner space
+#   - transpose from real / scanner space to bvec
+
+dwigradcheck BIDS/sub-01/dwi/sub-01_dwi.nii.gz -force \
+-fslgrad BIDS/sub-01/dwi/sub-01_dwi.bvec BIDS/sub-01/dwi/sub-01_dwi.bval \
+-shuffle none \
+-out tmp.csv
+
+LINECOUNT=$(wc -l tmp.csv)
+if [ "$LINECOUNT" -neq "4" ]; then
+    exit 1
+fi

--- a/testing/scripts/tests/dwigradcheck/notranspose
+++ b/testing/scripts/tests/dwigradcheck/notranspose
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Ensure that the dwigradcheck script completes successfully
+#   when the -notranspose option is specified
+# Output should contain 48 lines in this use case:
+#   - 24 possible combinations of axis permutations and flips
+#     when permuting the real / scanner space gradient table
+#   - 24 possible combinations of axis permutations and flips
+#     when permuting the bvecs representation
+#   - Minus one because the no-shuffling variant is redundant between the two
+#   - Plus one for the header fields
+
+dwigradcheck BIDS/sub-01/dwi/sub-01_dwi.nii.gz -force \
+-fslgrad BIDS/sub-01/dwi/sub-01_dwi.bvec BIDS/sub-01/dwi/sub-01_dwi.bval \
+-notranspose \
+-out tmp.csv
+
+LINECOUNT=$(wc -l tmp.csv)
+if [ "$LINECOUNT" -neq "48" ]]; then
+    exit 1
+fi


### PR DESCRIPTION
Am currently in the process of generating data & analyses for verifying the handling of DWI metadata, both raw and derivative, both slice / phase encoding and gradient table (especially with the pesky `bvec` esoterics). Am aiming particularly for resolution of #2477 and for verifying correct interpretation of subsequently derived diffusion model fibre orientations in https://github.com/bids-standard/bids-bep016.

A known limitation of the original implementation of `dwigradcheck` is that it considered exclusively axis permutations and flips. It failed to consider the prospect of a historically common misunderstanding where a user believed `dw_scheme` and `bvec`/`bvals` to be merely transposes of one another, and would therefore apply that operation erroneously. Here I've finally gotten around to addressing this. In retrospect it was not the most crucial of enhancements for me to put effort into, given that the dataset I'm working with always has image axes aligned with the scanner axes, but it was nevertheless annoying that the command was doing twice as much work as it needed to in that case. Plus I wanted to have the command emit a  non-zero return code if it considers the input gradient table to be incorrect, as this allows me to use it for automated verification of metadata handling.