### PR TITLE
mrregister: Fix -nl_init option

### DIFF
--- a/cmd/mrregister.cpp
+++ b/cmd/mrregister.cpp
@@ -670,7 +670,8 @@ void run() {
     }
   }
 
-  const bool nonlinear_init = !get_options("nl_init").empty();
+  opt = get_options("nl_init");
+  const bool nonlinear_init = !opt.empty();
   if (nonlinear_init) {
 
     if (!do_nonlinear)


### PR DESCRIPTION
Error introduced in d81d0ed101c0005519bf33b567395867fc4ce150 as manual refinement of #2829.

Issue wasn't picked up because of incomplete coverage of `mrregister` tests; but `population_template` tests (not run by CI) fail.