### PR TITLE
New option to build non-core code as a static lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ option(MRTRIX_STL_DEBUGGING "Enable STL debug mode" OFF)
 option(MRTRIX_BUILD_TESTS "Build tests executables" OFF)
 option(MRTRIX_STRIP_CONDA "Strip ananconda/mininconda from PATH to avoid conflicts" ON)
 option(MRTRIX_USE_PCH "Use precompiled headers" ON)
-option(MRTRIX_BUILD_STATIC "Build MRtrix's non-core code as a static library" OFF)
+option(MRTRIX_BUILD_NON_CORE_STATIC "Build MRtrix's non-core code as a static library" OFF)
 
 if(MRTRIX_BUILD_TESTS)
     if(CMAKE_VERSION VERSION_GREATER 3.17)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ option(MRTRIX_STL_DEBUGGING "Enable STL debug mode" OFF)
 option(MRTRIX_BUILD_TESTS "Build tests executables" OFF)
 option(MRTRIX_STRIP_CONDA "Strip ananconda/mininconda from PATH to avoid conflicts" ON)
 option(MRTRIX_USE_PCH "Use precompiled headers" ON)
+option(MRTRIX_BUILD_STATIC "Build MRtrix's non-core code as a static library" OFF)
 
 if(MRTRIX_BUILD_TESTS)
     if(CMAKE_VERSION VERSION_GREATER 3.17)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,7 +40,7 @@ add_library(mrtrix-exec-version-lib STATIC ${EXEC_VERSION_CPP})
 add_library(mrtrix::exec-version-lib ALIAS mrtrix-exec-version-lib)
 add_dependencies(mrtrix-exec-version-lib exec-version-target)
 
-if(MRTRIX_BUILD_STATIC)
+if(MRTRIX_BUILD_NON_CORE_STATIC)
     set(MRTRIX_LIBRARY_TYPE STATIC)
 else()
     set(MRTRIX_LIBRARY_TYPE SHARED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,7 +40,13 @@ add_library(mrtrix-exec-version-lib STATIC ${EXEC_VERSION_CPP})
 add_library(mrtrix::exec-version-lib ALIAS mrtrix-exec-version-lib)
 add_dependencies(mrtrix-exec-version-lib exec-version-target)
 
-add_library(mrtrix-headless SHARED ${HEADLESS_SOURCES})
+if(MRTRIX_BUILD_STATIC)
+    set(MRTRIX_LIBRARY_TYPE STATIC)
+else()
+    set(MRTRIX_LIBRARY_TYPE SHARED)
+endif()
+
+add_library(mrtrix-headless ${MRTRIX_LIBRARY_TYPE} ${HEADLESS_SOURCES})
 add_library(mrtrix::headless ALIAS mrtrix-headless)
 
 
@@ -65,7 +71,7 @@ target_link_libraries(mrtrix-headless PUBLIC
 )
 
 if(MRTRIX_BUILD_GUI)
-    add_library(mrtrix-gui SHARED ${GUI_SOURCES} ${RCC_SOURCES})
+    add_library(mrtrix-gui ${MRTRIX_LIBRARY_TYPE} ${GUI_SOURCES} ${RCC_SOURCES})
     add_library(mrtrix::gui ALIAS mrtrix-gui)
 
     set_target_properties(mrtrix-gui PROPERTIES


### PR DESCRIPTION
As mentioned in the meeting today, it'd make sense for production builds to have the C++ code in `src` built as a static library. This PR adds a new `MRTRIX_BUILD_STATIC` option to allow for this (@MRtrix3/mrtrix3-devs if anyone has a better name please let me know).
The option is disabled by default and is only intended to be enabled in production and external projects. For every day builds, making shared libraries provides a faster incremental build workflow.