### PR TITLE
DICOM command-line selection: abort on error reading from std::cin

### DIFF
--- a/core/file/dicom/select_cmdline.cpp
+++ b/core/file/dicom/select_cmdline.cpp
@@ -105,7 +105,7 @@ namespace MR {
             }
             std::cerr << "? ";
             std::cin >> buf;
-            if (buf[0] == 'q' || buf[0] == 'Q')
+            if (!std::cin || buf[0] == 'q' || buf[0] == 'Q')
               throw CancelException();
             if (isdigit (buf[0])) {
               int n = to<int>(buf) - 1;
@@ -145,7 +145,7 @@ namespace MR {
             }
             std::cerr << "? ";
             std::cin >> buf;
-            if (buf[0] == 'q' || buf[0] == 'Q')
+            if (!std::cin || buf[0] == 'q' || buf[0] == 'Q')
               throw CancelException();
             if (isdigit (buf[0])) {
               int n = to<int>(buf) - 1;
@@ -188,7 +188,7 @@ namespace MR {
             }
             std::cerr << "? ";
             std::cin >> buf;
-            if (buf[0] == 'q' || buf[0] == 'Q')
+            if (!std::cin || buf[0] == 'q' || buf[0] == 'Q')
               throw CancelException();
             if (isdigit (buf[0])) {
               vector<uint32_t> seq;


### PR DESCRIPTION
Manually rewrote #2905 for `master` given that it is a problem that presumably manifests there also.