### PR TITLE
mrcalc: Support -config option

### DIFF
--- a/cmd/mrcalc.cpp
+++ b/cmd/mrcalc.cpp
@@ -911,6 +911,7 @@ void run () {
       else if (opt->is ("nthreads")) ++n;
       else if (opt->is ("force") || opt->is ("info") || opt->is ("debug") || opt->is ("quiet"))
         continue;
+      else if (opt->is ("config")) n+=2;
 
 #define SECTION 3
 #include "mrcalc.cpp"


### PR DESCRIPTION
Attempting to use the `-config` option with the `mrcalc` command would result in the message "`operation "-config" not yet implemented!`".