### PR TITLE
Add missing windows.h include header

### DIFF
--- a/src/gui/opengl/gl_core_3_3.cpp
+++ b/src/gui/opengl/gl_core_3_3.cpp
@@ -14,6 +14,10 @@
  * For more details, see http://www.mrtrix.org/.
  */
 
+#if defined(_WIN32)
+#include <windows.h>
+#endif
+
 #include "gui/opengl/gl_core_3_3.h"
 #include <algorithm>
 #include <cstddef>


### PR DESCRIPTION
Including `src/gui/opengl/gl_core_3_3.h` should automatically include `windows.h` if `APIENTRY` is not defined. Still, some libraries (e.g., the latest versions of Qt) define this macro without including `windows.h` in their public headers (to avoid polluting the global namespace).
Since this issue is currently preventing the merging of PRs on `dev`, a quick solution that explicitly includes `<windows.h>` is added to deal with this.
Ideally, no public header should automatically include `windows.h`, so a more robust approach is warranted here. We could either wrap the header to prevent the propagation of `windows.h` or replace it with something else. Will try to address this in a future PR.