### PR TITLE
OpenGL: Minimise what is imported by windows.h

### DIFF
--- a/src/gui/opengl/gl_core_3_3.cpp
+++ b/src/gui/opengl/gl_core_3_3.cpp
@@ -14,6 +14,10 @@
  * For more details, see http://www.mrtrix.org/.
  */
 
+#if defined(_WIN32)
+#include <windows.h>
+#endif
+
 #include "gui/opengl/gl_core_3_3.h"
 #include <algorithm>
 #include <cstddef>

--- a/src/gui/opengl/gl_core_3_3.cpp
+++ b/src/gui/opengl/gl_core_3_3.cpp
@@ -15,6 +15,13 @@
  */
 
 #if defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#define NOSERVICE
+#define NOMCX
+#define NOIME
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
 #endif
 


### PR DESCRIPTION
Extension of #2913.

Tried to quickly read up on the topic. It is considered most severely problematic to not define `NOMINMAX`, but there's strong disdain generally for including `windows.h` rather than sub-components thereof. As stated in #2913 this could be done, but would require more effort. What I thought I'd try here is throw in some #defines that are intended to disable certain components of `windows.h` that are commonly not required. This specific list I pulled from [here](https://belaycpp.com/2021/05/11/windows-h-breaks-the-stl-and-my-will-to-live/#comment-4), but have seen various references to these in different places.