### PR TITLE
New commands: peaksconvert, peakscheck

### DIFF
--- a/cmd/peaksconvert.cpp
+++ b/cmd/peaksconvert.cpp
@@ -1,0 +1,569 @@
+/* Copyright (c) 2008-2024 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Covered Software is provided under this License on an "as is"
+ * basis, without warranty of any kind, either expressed, implied, or
+ * statutory, including, without limitation, warranties that the
+ * Covered Software is free of defects, merchantable, fit for a
+ * particular purpose or non-infringing.
+ * See the Mozilla Public License v. 2.0 for more details.
+ *
+ * For more details, see http://www.mrtrix.org/.
+ */
+
+#include <string>
+
+#include "adapter/base.h"
+#include "algo/loop.h"
+#include "command.h"
+#include "header.h"
+#include "image.h"
+#include "math/sphere.h"
+#include "transform.h"
+
+using namespace MR;
+using namespace App;
+
+// TODO Do we need to support both mathematics and physics conventions for spherical coordinates?
+// And if so, where do we do it?
+
+const char *const formats[] = {"unitspherical", "spherical", "unit3vector", "3vector", nullptr};
+enum class format_t { UNITSPHERICAL, SPHERICAL, UNITTHREEVECTOR, THREEVECTOR };
+const char *const references[] = {"xyz", "ijk", "bvec", nullptr};
+enum class reference_t { XYZ, IJK, BVEC };
+
+using transform_linear_type = Eigen::Matrix<default_type, 3, 3>;
+
+// clang-format off
+void usage() {
+
+  AUTHOR = "Robert E. Smith (robert.smith@florey.edu.au)";
+
+  SYNOPSIS = "Convert peak directions images between formats and/or conventions";
+
+  DESCRIPTION
+  + "Under default operation with no command-line options specified, "
+    "the output image will be identical to the input image, "
+    "as the MRtrix convention (3-vectors defined with respect to RAS scanner space axes) "
+    "will be assumed to apply to both cases. "
+    "This behaviour is only modulated by explicitly providing command-line options "
+    "that give additional information about the format or convention of either image.";
+
+  ARGUMENTS
+  + Argument ("input", "the input directions image").type_image_in()
+  + Argument ("output", "the output directions image").type_image_out();
+
+  OPTIONS
+  + OptionGroup ("Options providing information about the input image")
+  + Option ("in_format", "specify the format in which the input directions are specified")
+    + Argument("choice").type_choice(formats)
+  + Option ("in_reference", "specify the reference axes against which the input directions are specified"
+                            " (assumed to be real / scanner space if omitted)")
+    + Argument("choice").type_choice(references)
+  // TODO Add option to import amplitudes to fuse with unit orientations / overwrite existing values
+
+  + OptionGroup ("Options providing information about the output image")
+  + Option ("out_format", "specify the format in which the output directions will be specified"
+                          " (will default to 3-vectors if omitted)")
+    + Argument("choice").type_choice(formats)
+  + Option ("out_reference", "specify the reference axes against which the output directions will be specified"
+                             " (defaults to real / scanner space if omitted)")
+    + Argument("choice").type_choice(references)
+  // TODO Implement -fill
+  //+ Option ("fill", "specify value to be inserted into output image in the absence of valid information")
+  //  + Argument("value").type_float();
+
+  // TODO Any additional options?
+  // - Reduce maximal number of fixels per voxel
+
+}
+// clang-format on
+
+format_t format_from_option(const std::string &option_name) {
+  auto opt = get_options(option_name);
+  if (opt.empty())
+    return format_t::THREEVECTOR;
+  switch (int(opt[0][0])) {
+  case 0:
+    return format_t::UNITSPHERICAL;
+  case 1:
+    return format_t::SPHERICAL;
+  case 2:
+    return format_t::UNITTHREEVECTOR;
+  case 3:
+    return format_t::THREEVECTOR;
+  default:
+    throw Exception("Unsupported input to option -" + option_name);
+  }
+}
+reference_t reference_from_option(const std::string &option_name) {
+  auto opt = get_options(option_name);
+  if (opt.empty())
+    return reference_t::XYZ;
+  switch (int(opt[0][0])) {
+  case 0:
+    return reference_t::XYZ;
+  case 1:
+    return reference_t::IJK;
+  case 2:
+    return reference_t::BVEC;
+  default:
+    throw Exception("Unsupported input to option -" + option_name);
+  }
+}
+size_t volumes_per_fixel(format_t format) { return format == format_t::UNITSPHERICAL ? 2 : 3; }
+
+template <size_t NumElements> class FormatBase {
+public:
+  FormatBase(Eigen::Matrix<default_type, NumElements, 1>) {}
+  virtual Eigen::Matrix<default_type, NumElements, 1> operator()() const = 0;
+  static size_t num_elements() { return NumElements; }
+};
+
+class UnitSpherical : public FormatBase<2> {
+public:
+  UnitSpherical(Eigen::Matrix<default_type, 2, 1> in) : FormatBase(in), azimuth(in[0]), inclination(in[1]) {}
+  Eigen::Matrix<default_type, 2, 1> operator()() const override { return {azimuth, inclination}; }
+  default_type azimuth, inclination;
+  friend std::ostream &operator<<(std::ostream &stream, const UnitSpherical &in) {
+    stream << "UnitSpherical(az=" << in.azimuth << ", in=" << in.inclination << ")";
+    return stream;
+  }
+};
+
+class Spherical : public FormatBase<3> {
+public:
+  Spherical(Eigen::Matrix<default_type, 3, 1> in) : FormatBase(in), radius(in[0]), azimuth(in[1]), inclination(in[2]) {}
+  Eigen::Matrix<default_type, 3, 1> operator()() const override { return {radius, azimuth, inclination}; }
+  default_type radius, azimuth, inclination;
+  friend std::ostream &operator<<(std::ostream &stream, const Spherical &in) {
+    stream << "Spherical(r=" << in.radius << ", az=" << in.azimuth << ", in=" << in.inclination << ")";
+    return stream;
+  }
+};
+
+class UnitThreeVector : public FormatBase<3> {
+public:
+  UnitThreeVector(Eigen::Matrix<default_type, 3, 1> in) : FormatBase(in), unitthreevector(in) {
+    unitthreevector.normalize();
+  }
+  Eigen::Matrix<default_type, 3, 1> operator()() const override { return unitthreevector; }
+  Eigen::Vector3d unitthreevector;
+  friend std::ostream &operator<<(std::ostream &stream, const UnitThreeVector &in) {
+    stream << "UnitThreeVector(" << in.unitthreevector.transpose() << ")";
+    return stream;
+  }
+};
+
+class ThreeVector : public FormatBase<3> {
+public:
+  ThreeVector(Eigen::Matrix<default_type, 3, 1> in) : FormatBase(in), threevector(in) {}
+  Eigen::Matrix<default_type, 3, 1> operator()() const override { return threevector; }
+  Eigen::Matrix<default_type, 3, 1> normalized() const { return threevector.normalized(); }
+  default_type radius() const { return threevector.norm(); }
+  Eigen::Vector3d threevector;
+  friend std::ostream &operator<<(std::ostream &stream, const ThreeVector &in) {
+    stream << "ThreeVector(" << in.threevector.transpose() << ")";
+    return stream;
+  }
+};
+
+// Common intermediary format to be used regardless of input / output image details
+// - ALWAYS in XYZ space
+// - ALWAYS with a unit 3-vector
+// - ALWAYS with a radius term present, even if it might be filled with unity
+class Fixel {
+public:
+  Fixel(const Eigen::Vector3d &unit_threevector_xyz, default_type radius)
+      : unit_threevector_xyz(unit_threevector_xyz), radius(radius) {}
+  Fixel(const Eigen::Vector3d &unit_threevector_xyz)
+      : unit_threevector_xyz(unit_threevector_xyz), radius(default_type(1)) {}
+
+  template <class T, reference_t ref> static Fixel from(const T &);
+  template <class T, reference_t ref> T to() const;
+
+  static void set_input_transforms(const Header &H);
+  static void set_output_transforms(const Header &H);
+
+  friend std::ostream &operator<<(std::ostream &stream, const Fixel &in) {
+    stream << "Fixel([" << in.unit_threevector_xyz.transpose() << "]: " << in.radius << ")";
+    return stream;
+  }
+
+private:
+  Eigen::Vector3d unit_threevector_xyz;
+  default_type radius;
+
+  static transform_linear_type in_ijk2xyz;
+  static bool in_bvec_flipi;
+  static default_type in_bvec_imultiplier;
+  static Eigen::Vector3d in_bvec2ijk;
+
+  static transform_linear_type out_ijk2xyz;
+  static transform_linear_type out_xyz2ijk;
+  static bool out_bvec_flipi;
+  static default_type out_bvec_imultiplier;
+  static Eigen::Vector3d out_ijk2bvec;
+};
+
+transform_linear_type Fixel::in_ijk2xyz = transform_linear_type::Constant(std::numeric_limits<default_type>::signaling_NaN());
+bool Fixel::in_bvec_flipi = false;
+default_type Fixel::in_bvec_imultiplier = std::numeric_limits<default_type>::signaling_NaN();
+Eigen::Vector3d Fixel::in_bvec2ijk = Eigen::Vector3d::Constant(std::numeric_limits<default_type>::signaling_NaN());
+transform_linear_type Fixel::out_ijk2xyz = transform_linear_type::Constant(std::numeric_limits<default_type>::signaling_NaN());
+transform_linear_type Fixel::out_xyz2ijk = transform_linear_type::Constant(std::numeric_limits<default_type>::signaling_NaN());
+bool Fixel::out_bvec_flipi = false;
+default_type Fixel::out_bvec_imultiplier = std::numeric_limits<default_type>::signaling_NaN();
+Eigen::Vector3d Fixel::out_ijk2bvec = Eigen::Vector3d::Constant(std::numeric_limits<default_type>::signaling_NaN());
+
+void Fixel::set_input_transforms(const Header &H) {
+  in_ijk2xyz = H.realignment().orig_transform().linear();
+  in_bvec_flipi = in_ijk2xyz.determinant() > 0.0;
+  in_bvec_imultiplier = in_bvec_flipi ? -1.0 : 1.0;
+  in_bvec2ijk = {in_bvec_imultiplier, 1.0, 1.0};
+  DEBUG("Input transform configured based on image \"" + H.name() + "\":");
+  DEBUG("IJK-to-XYZ transform:\n" + str(in_ijk2xyz));
+  DEBUG("bvec: flip " + str(in_bvec_flipi) + ", i component multiplier " + str(in_bvec_imultiplier) + ", vector multiplier [" + str(in_bvec2ijk.transpose()) + "]");
+}
+
+void Fixel::set_output_transforms(const Header &H) {
+  out_ijk2xyz = H.transform().linear();
+  out_xyz2ijk = H.transform().inverse().linear();
+  out_bvec_flipi = out_ijk2xyz.determinant() > 0.0;
+  out_bvec_imultiplier = out_bvec_flipi ? -1.0 : 1.0;
+  out_ijk2bvec = {out_bvec_imultiplier, 1.0, 1.0};
+  DEBUG("Output transform configured based on image \"" + H.name() + "\":");
+  DEBUG("IJK-to-XYZ transform:\n" + str(out_ijk2xyz));
+  DEBUG("XYZ-to-IJK transform:\n" + str(out_xyz2ijk));
+  DEBUG("bvec: flip " + str(out_bvec_flipi) + ", i component multiplier " + str(out_bvec_imultiplier) + ", vector multiplier [" + str(out_ijk2bvec.transpose()) + "]");
+}
+
+template <> Fixel Fixel::from<UnitSpherical, reference_t::XYZ>(const UnitSpherical &in) {
+  const Eigen::Matrix<default_type, 2, 1> az_in_xyz({in.azimuth, in.inclination});
+  Eigen::Vector3d unit_threevector_xyz;
+  Math::Sphere::spherical2cartesian(az_in_xyz, unit_threevector_xyz);
+  return Fixel(unit_threevector_xyz);
+}
+
+template <> Fixel Fixel::from<UnitSpherical, reference_t::IJK>(const UnitSpherical &in) {
+  const Eigen::Matrix<default_type, 2, 1> az_in_ijk({in.azimuth, in.inclination});
+  Eigen::Vector3d unit_threevector_ijk;
+  Math::Sphere::spherical2cartesian(az_in_ijk, unit_threevector_ijk);
+  return Fixel(in_ijk2xyz * unit_threevector_ijk);
+}
+
+template <> Fixel Fixel::from<UnitSpherical, reference_t::BVEC>(const UnitSpherical &in) {
+  const Eigen::Matrix<default_type, 2, 1> az_in_bvec({in.azimuth, in.inclination});
+  const Eigen::Matrix<default_type, 2, 1> az_in_ijk(
+      {in_bvec_flipi ? Math::pi - az_in_bvec[0] : az_in_bvec[0], az_in_bvec[1]});
+  Eigen::Vector3d unit_threevector_ijk;
+  Math::Sphere::spherical2cartesian(az_in_ijk, unit_threevector_ijk);
+  return Fixel(in_ijk2xyz * unit_threevector_ijk);
+}
+
+template <> Fixel Fixel::from<Spherical, reference_t::XYZ>(const Spherical &in) {
+  const Eigen::Matrix<default_type, 3, 1> r_az_in_xyz({in.radius, in.azimuth, in.inclination});
+  Eigen::Vector3d unit_threevector_xyz;
+  Math::Sphere::spherical2cartesian(r_az_in_xyz.tail<2>(), unit_threevector_xyz);
+  return Fixel(unit_threevector_xyz, r_az_in_xyz[0]);
+}
+
+template <> Fixel Fixel::from<Spherical, reference_t::IJK>(const Spherical &in) {
+  const Eigen::Matrix<default_type, 3, 1> r_az_in_ijk({in.radius, in.azimuth, in.inclination});
+  Eigen::Vector3d unit_threevector_ijk;
+  Math::Sphere::spherical2cartesian(r_az_in_ijk.tail<2>(), unit_threevector_ijk);
+  return Fixel(in_ijk2xyz * unit_threevector_ijk, r_az_in_ijk[0]);
+}
+
+template <> Fixel Fixel::from<Spherical, reference_t::BVEC>(const Spherical &in) {
+  const Eigen::Matrix<default_type, 3, 1> r_az_in_bvec({in.radius, in.azimuth, in.inclination});
+  const Eigen::Matrix<default_type, 3, 1> r_az_in_ijk(
+      {r_az_in_bvec[0], in_bvec_flipi ? Math::pi - r_az_in_bvec[1] : r_az_in_bvec[1], r_az_in_bvec[2]});
+  Eigen::Vector3d unit_threevector_ijk;
+  Math::Sphere::spherical2cartesian(r_az_in_ijk.tail<2>(), unit_threevector_ijk);
+  return Fixel(in_ijk2xyz * unit_threevector_ijk, r_az_in_ijk[0]);
+}
+
+template <> Fixel Fixel::from<UnitThreeVector, reference_t::XYZ>(const UnitThreeVector &in) {
+  return Fixel(in());
+}
+
+template <> Fixel Fixel::from<UnitThreeVector, reference_t::IJK>(const UnitThreeVector &in) {
+  return Fixel(in_ijk2xyz * in());
+}
+template <> Fixel Fixel::from<UnitThreeVector, reference_t::BVEC>(const UnitThreeVector &in) {
+  return Fixel(in_ijk2xyz * (in().cwiseProduct(in_bvec2ijk)));
+}
+
+template <> Fixel Fixel::from<ThreeVector, reference_t::XYZ>(const ThreeVector &in) {
+  return Fixel(in.normalized(), in.radius());
+}
+
+template <> Fixel Fixel::from<ThreeVector, reference_t::IJK>(const ThreeVector &in) {
+  return Fixel(in_ijk2xyz * in.normalized(), in.radius());
+}
+
+template <> Fixel Fixel::from<ThreeVector, reference_t::BVEC>(const ThreeVector &in) {
+  return Fixel(in_ijk2xyz * (in.normalized().cwiseProduct(in_bvec2ijk)), in.radius());
+}
+
+template <> UnitSpherical Fixel::to<UnitSpherical, reference_t::XYZ>() const {
+  Eigen::Matrix<default_type, 2, 1> az_in_xyz;
+  Math::Sphere::cartesian2spherical(unit_threevector_xyz, az_in_xyz);
+  return UnitSpherical(az_in_xyz);
+}
+
+template <> UnitSpherical Fixel::to<UnitSpherical, reference_t::IJK>() const {
+  const default_type azimuth = std::atan2(unit_threevector_xyz.dot(out_ijk2xyz.col(1)),
+                                          unit_threevector_xyz.dot(out_ijk2xyz.col(0)));
+  const default_type inclination = std::acos(unit_threevector_xyz.dot(out_ijk2xyz.col(2)));
+  return UnitSpherical({azimuth, inclination});
+}
+
+template <> UnitSpherical Fixel::to<UnitSpherical, reference_t::BVEC>() const {
+  default_type azimuth = std::atan2(unit_threevector_xyz.dot(out_ijk2xyz.col(1)),
+                                    unit_threevector_xyz.dot(out_ijk2xyz.col(0)));
+  if (out_bvec_flipi)
+    azimuth = Math::pi - azimuth;
+  const default_type inclination = std::acos(unit_threevector_xyz.dot(out_ijk2xyz.col(2)));
+  return UnitSpherical({azimuth, inclination});
+}
+
+template <> Spherical Fixel::to<Spherical, reference_t::XYZ>() const {
+  Eigen::Matrix<default_type, 3, 1> r_az_in_xyz;
+  r_az_in_xyz[0] = radius;
+  Math::Sphere::cartesian2spherical(unit_threevector_xyz, r_az_in_xyz.tail<2>());
+  return Spherical(r_az_in_xyz);
+}
+
+template <> Spherical Fixel::to<Spherical, reference_t::IJK>() const {
+  const default_type azimuth = std::atan2(unit_threevector_xyz.dot(out_ijk2xyz.col(1)),
+                                          unit_threevector_xyz.dot(out_ijk2xyz.col(0)));
+  const default_type inclination = std::acos(unit_threevector_xyz.dot(out_ijk2xyz.col(2)));
+  return Spherical({radius, azimuth, inclination});
+}
+
+template <> Spherical Fixel::to<Spherical, reference_t::BVEC>() const {
+  default_type azimuth = std::atan2(unit_threevector_xyz.dot(out_ijk2xyz.col(1)),
+                                    unit_threevector_xyz.dot(out_ijk2xyz.col(0)));
+  if (out_bvec_flipi)
+    azimuth = Math::pi - azimuth;
+  const default_type inclination = std::acos(unit_threevector_xyz.dot(out_ijk2xyz.col(2)));
+  return Spherical({radius, azimuth, inclination});
+}
+
+template <> UnitThreeVector Fixel::to<UnitThreeVector, reference_t::XYZ>() const {
+  return UnitThreeVector(unit_threevector_xyz);
+}
+
+template <> UnitThreeVector Fixel::to<UnitThreeVector, reference_t::IJK>() const {
+  return UnitThreeVector(out_xyz2ijk * unit_threevector_xyz);
+}
+
+template <> UnitThreeVector Fixel::to<UnitThreeVector, reference_t::BVEC>() const {
+  return UnitThreeVector((out_xyz2ijk * unit_threevector_xyz).cwiseProduct(out_ijk2bvec));
+}
+
+template <> ThreeVector Fixel::to<ThreeVector, reference_t::XYZ>() const {
+  return ThreeVector(unit_threevector_xyz * radius);
+}
+
+template <> ThreeVector Fixel::to<ThreeVector, reference_t::IJK>() const {
+  return ThreeVector(out_xyz2ijk * unit_threevector_xyz * radius);
+}
+
+template <> ThreeVector Fixel::to<ThreeVector, reference_t::BVEC>() const {
+  return ThreeVector((out_xyz2ijk * unit_threevector_xyz).cwiseProduct(out_ijk2bvec) * radius);
+}
+
+template <class FixelType> class FixelImage : public Adapter::Base<FixelImage<FixelType>, Image<float>> {
+public:
+  using ImageType = Image<float>;
+  using BaseType = Adapter::Base<FixelImage<FixelType>, ImageType>;
+  using BaseType::parent;
+  FixelImage(Image<float> &that) : BaseType(that), fixel_index(0) {}
+  void reset() {
+    parent().reset();
+    fixel_index = 0;
+  }
+  ssize_t size(size_t axis) const {
+    return axis == 3 ? (parent().size(3) / FixelType::num_elements()) : parent().size(axis);
+  }
+  ssize_t get_index(size_t axis) const { return (axis == 3) ? fixel_index : parent().get_index(axis); }
+  void move_index(size_t axis, ssize_t increment) {
+    if (axis != 3) {
+      parent().move_index(axis, increment);
+      return;
+    }
+    parent().move_index(3, FixelType::num_elements() * increment);
+    fixel_index += increment;
+  }
+  FixelType get_value() {
+    Eigen::Matrix<default_type, Eigen::Dynamic, 1> data(
+        Eigen::Matrix<default_type, Eigen::Dynamic, 1>::Zero(FixelType::num_elements()));
+    for (size_t index = 0; index != FixelType::num_elements(); ++index) {
+      data[index] = parent().get_value();
+      parent().move_index(3, 1);
+    }
+    parent().move_index(3, -FixelType::num_elements());
+    return FixelType(data);
+  }
+  void set_value(const FixelType &value) {
+    Eigen::Matrix<default_type, Eigen::Dynamic, 1> data(
+        Eigen::Matrix<default_type, Eigen::Dynamic, 1>::Zero(FixelType::num_elements()));
+    data = value();
+    for (size_t index = 0; index != FixelType::num_elements(); ++index) {
+      parent().set_value(data[index]);
+      parent().move_index(3, 1);
+    }
+    parent().move_index(3, -FixelType::num_elements());
+  }
+
+private:
+  ssize_t fixel_index;
+};
+
+template <reference_t in_reference, class InFixelType, reference_t out_reference, class OutFixelType>
+void run(FixelImage<InFixelType> &in_fixel_image, FixelImage<OutFixelType> &out_fixel_image) {
+  // TODO Multi-thread
+  // TODO Test to see if this naturally works across bootstrap realisations
+  for (auto l = Loop("Converting peaks orientations", in_fixel_image)(in_fixel_image, out_fixel_image); l; ++l) {
+    const Fixel fixel(Fixel::from<InFixelType, in_reference>(in_fixel_image.get_value()));
+    out_fixel_image.set_value(fixel.to<OutFixelType, out_reference>());
+  }
+}
+
+template <class InFixelType, reference_t out_reference, class OutFixelType>
+void run(reference_t in_reference, FixelImage<InFixelType> &in_fixel_image, FixelImage<OutFixelType> &out_fixel_image) {
+  switch (in_reference) {
+  case reference_t::XYZ:
+    run<reference_t::XYZ, InFixelType, out_reference, OutFixelType>(in_fixel_image, out_fixel_image);
+    return;
+  case reference_t::IJK:
+    run<reference_t::IJK, InFixelType, out_reference, OutFixelType>(in_fixel_image, out_fixel_image);
+    return;
+  case reference_t::BVEC:
+    run<reference_t::BVEC, InFixelType, out_reference, OutFixelType>(in_fixel_image, out_fixel_image);
+    return;
+  }
+}
+
+template <reference_t out_reference, class OutFixelType>
+void run(format_t in_format,
+         reference_t in_reference,
+         Image<float> &input_image,
+         FixelImage<OutFixelType> &out_fixel_image) {
+  switch (in_format) {
+  case format_t::UNITSPHERICAL: {
+    FixelImage<UnitSpherical> in_fixel_image(input_image);
+    run<UnitSpherical, out_reference, OutFixelType>(in_reference, in_fixel_image, out_fixel_image);
+    return;
+  }
+  case format_t::SPHERICAL: {
+    FixelImage<Spherical> in_fixel_image(input_image);
+    run<Spherical, out_reference, OutFixelType>(in_reference, in_fixel_image, out_fixel_image);
+    return;
+  }
+  case format_t::UNITTHREEVECTOR: {
+    FixelImage<UnitThreeVector> in_fixel_image(input_image);
+    run<UnitThreeVector, out_reference, OutFixelType>(in_reference, in_fixel_image, out_fixel_image);
+    return;
+  }
+  case format_t::THREEVECTOR: {
+    FixelImage<ThreeVector> in_fixel_image(input_image);
+    run<ThreeVector, out_reference, OutFixelType>(in_reference, in_fixel_image, out_fixel_image);
+    return;
+  }
+  default:
+    assert(false);
+  }
+}
+
+template <class OutFixelType>
+void run(format_t in_format,
+         reference_t in_reference,
+         Image<float> &input_image,
+         reference_t out_reference,
+         FixelImage<OutFixelType> &out_fixel_image) {
+  switch (out_reference) {
+  case reference_t::XYZ:
+    run<reference_t::XYZ, OutFixelType>(in_format, in_reference, input_image, out_fixel_image);
+    return;
+  case reference_t::IJK:
+    run<reference_t::IJK, OutFixelType>(in_format, in_reference, input_image, out_fixel_image);
+    return;
+  case reference_t::BVEC:
+    run<reference_t::BVEC, OutFixelType>(in_format, in_reference, input_image, out_fixel_image);
+    return;
+  }
+}
+
+void run(format_t in_format,
+         reference_t in_reference,
+         Image<float> &input_image,
+         format_t out_format,
+         reference_t out_reference,
+         Image<float> &output_image) {
+  switch (out_format) {
+  case format_t::UNITSPHERICAL: {
+    FixelImage<UnitSpherical> out_fixel_image(output_image);
+    run(in_format, in_reference, input_image, out_reference, out_fixel_image);
+    return;
+  }
+  case format_t::SPHERICAL: {
+    FixelImage<Spherical> out_fixel_image(output_image);
+    run(in_format, in_reference, input_image, out_reference, out_fixel_image);
+    return;
+  }
+  case format_t::UNITTHREEVECTOR: {
+    FixelImage<UnitThreeVector> out_fixel_image(output_image);
+    run(in_format, in_reference, input_image, out_reference, out_fixel_image);
+    return;
+  }
+  case format_t::THREEVECTOR: {
+    FixelImage<ThreeVector> out_fixel_image(output_image);
+    run(in_format, in_reference, input_image, out_reference, out_fixel_image);
+    return;
+  }
+  default:
+    assert(false);
+  }
+}
+
+void run() {
+
+  Header H_in = Header::open(argument[0]);
+  if (H_in.ndim() != 4)
+    throw Exception("Input image must be 4D");
+
+  const format_t in_format(format_from_option("in_format"));
+  const size_t in_volumes_per_fixel(volumes_per_fixel(in_format));
+  const size_t num_fixels = H_in.size(3) / in_volumes_per_fixel;
+  if (num_fixels * in_volumes_per_fixel != H_in.size(3))
+    throw Exception("Number of volumes in input image (" + str(H_in.size(3)) + ")"
+                    + " incompatible with "
+                    + str(volumes_per_fixel) + " volumes per orientation");
+  const reference_t in_reference(reference_from_option("in_reference"));
+
+  const format_t out_format(format_from_option("out_format"));
+  if ((in_format == format_t::SPHERICAL || in_format == format_t::THREEVECTOR) &&
+      (out_format == format_t::UNITSPHERICAL || out_format == format_t::UNITTHREEVECTOR)) {
+    WARN("Output image will not include amplitudes that may be present in input image due to chosen format");
+  }
+  const reference_t out_reference(reference_from_option("out_reference"));
+
+  Header H_out(H_in);
+  H_out.name() = std::string(argument[1]);
+  H_out.size(3) = num_fixels * volumes_per_fixel(out_format);
+  Stride::set_from_command_line(H_out);
+
+  Fixel::set_input_transforms(H_in);
+  Fixel::set_output_transforms(H_out);
+
+  auto input = H_in.get_image<float>();
+  auto output = Image<float>::create(argument[1], H_out);
+  run(in_format, in_reference, input, out_format, out_reference, output);
+}

--- a/docs/reference/commands/peakscheck.rst
+++ b/docs/reference/commands/peakscheck.rst
@@ -1,0 +1,97 @@
+.. _peakscheck:
+
+peakscheck
+==========
+
+Synopsis
+--------
+
+Check the orientations of an image containing discrete fibre orientations
+
+Usage
+-----
+
+::
+
+    peakscheck input [ options ]
+
+-  *input*: The input fibre orientations image to be checked
+
+Description
+-----------
+
+MRtrix3 expects "peaks" images to be stored using the real / scanner space axes as reference. There are three possible sources of error in this interpretation: 1. There may be erroneous axis flips and/or permutations, but within the real / scanner space reference. 2. The image data may provide fibre orientations with reference to the image axes rather than real / scanner space. Here there are two additional possibilities: 2a. There may be requisite axis permutations / flips to be applied to the image data *before* transforming them to real / scanner space. 2b. There may be requisite axis permutations / flips to be applied to the image data *after* transforming them to real / scanner space.
+
+Options
+-------
+
+- **-mask image** Provide a mask image within which to seed & constrain tracking
+
+- **-number** Set the number of tracks to generate for each test
+
+- **-threshold** Modulate thresold on the ratio of empirical to maximal mean length to issue an error
+
+- **-in_format** The format in which peak orientations are specified; one of: spherical,unitspherical,3vector,unit3vector
+
+- **-noshuffle** Do not evaluate possibility of requiring shuffles of axes or angles; only consider prospective transforms from alternative reference frames to real / scanner space
+
+- **-notransform** Do not evaluate possibility of requiring transform of peak orientations from image to real / scanner space; only consider prospective shuffles of axes or angles
+
+- **-all** Print table containing all results to standard output
+
+- **-out_table** Write text file with table containing all results
+
+Additional standard options for Python scripts
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- **-nocleanup** do not delete intermediate files during script execution, and do not delete scratch directory at script completion.
+
+- **-scratch /path/to/scratch/** manually specify the path in which to generate the scratch directory.
+
+- **-continue <ScratchDir> <LastFile>** continue the script from a previous execution; must provide the scratch directory path, and the name of the last successfully-generated file.
+
+Standard options
+^^^^^^^^^^^^^^^^
+
+- **-info** display information messages.
+
+- **-quiet** do not display information messages or progress status. Alternatively, this can be achieved by setting the MRTRIX_QUIET environment variable to a non-empty string.
+
+- **-debug** display debugging messages.
+
+- **-force** force overwrite of output files.
+
+- **-nthreads number** use this number of threads in multi-threaded applications (set to 0 to disable multi-threading).
+
+- **-config key value**  *(multiple uses permitted)* temporarily set the value of an MRtrix config file entry.
+
+- **-help** display this information page and exit.
+
+- **-version** display version information and exit.
+
+References
+^^^^^^^^^^
+
+Tournier, J.-D.; Smith, R. E.; Raffelt, D.; Tabbara, R.; Dhollander, T.; Pietsch, M.; Christiaens, D.; Jeurissen, B.; Yeh, C.-H. & Connelly, A. MRtrix3: A fast, flexible and open software framework for medical image processing and visualisation. NeuroImage, 2019, 202, 116137
+
+--------------
+
+
+
+**Author:** Robert E. Smith (robert.smith@florey.edu.au)
+
+**Copyright:** Copyright (c) 2008-2024 the MRtrix3 contributors.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Covered Software is provided under this License on an "as is"
+basis, without warranty of any kind, either expressed, implied, or
+statutory, including, without limitation, warranties that the
+Covered Software is free of defects, merchantable, fit for a
+particular purpose or non-infringing.
+See the Mozilla Public License v. 2.0 for more details.
+
+For more details, see http://www.mrtrix.org/.
+

--- a/docs/reference/commands/peaksconvert.rst
+++ b/docs/reference/commands/peaksconvert.rst
@@ -1,0 +1,90 @@
+.. _peaksconvert:
+
+peaksconvert
+===================
+
+Synopsis
+--------
+
+Convert peak directions images between formats and/or conventions
+
+Usage
+--------
+
+::
+
+    peaksconvert [ options ]  input output
+
+-  *input*: the input directions image
+-  *output*: the output directions image
+
+Description
+-----------
+
+Under default operation with no command-line options specified, the output image will be identical to the input image, as the MRtrix convention (3-vectors defined with respect to RAS scanner space axes) will be assumed to apply to both cases. This behaviour is only modulated by explicitly providing command-line options that give additional information about the format or convention of either image.
+
+Options
+-------
+
+Options providing information about the input image
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  **-in_format choice** specify the format in which the input directions are specified
+
+-  **-in_reference choice** specify the reference axes against which the input directions are specified (assumed to be real / scanner space if omitted)
+
+Options providing information about the output image
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  **-out_format choice** specify the format in which the output directions will be specified (will default to 3-vectors if omitted)
+
+-  **-out_reference choice** specify the reference axes against which the output directions will be specified (defaults to real / scanner space if omitted)
+
+-  **-fill value** specify value to be inserted into output image in the absence of valid information
+
+Standard options
+^^^^^^^^^^^^^^^^
+
+-  **-info** display information messages.
+
+-  **-quiet** do not display information messages or progress status; alternatively, this can be achieved by setting the MRTRIX_QUIET environment variable to a non-empty string.
+
+-  **-debug** display debugging messages.
+
+-  **-force** force overwrite of output files (caution: using the same file as input and output might cause unexpected behaviour).
+
+-  **-nthreads number** use this number of threads in multi-threaded applications (set to 0 to disable multi-threading).
+
+-  **-config key value** *(multiple uses permitted)* temporarily set the value of an MRtrix config file entry.
+
+-  **-help** display this information page and exit.
+
+-  **-version** display version information and exit.
+
+References
+^^^^^^^^^^
+
+Tournier, J.-D.; Smith, R. E.; Raffelt, D.; Tabbara, R.; Dhollander, T.; Pietsch, M.; Christiaens, D.; Jeurissen, B.; Yeh, C.-H. & Connelly, A. MRtrix3: A fast, flexible and open software framework for medical image processing and visualisation. NeuroImage, 2019, 202, 116137
+
+--------------
+
+
+
+**Author:** Robert E. Smith (robert.smith@florey.edu.au)
+
+**Copyright:** Copyright (c) 2008-2024 the MRtrix3 contributors.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Covered Software is provided under this License on an "as is"
+basis, without warranty of any kind, either expressed, implied, or
+statutory, including, without limitation, warranties that the
+Covered Software is free of defects, merchantable, fit for a
+particular purpose or non-infringing.
+See the Mozilla Public License v. 2.0 for more details.
+
+For more details, see http://www.mrtrix.org/.
+
+

--- a/docs/reference/commands_list.rst
+++ b/docs/reference/commands_list.rst
@@ -96,6 +96,8 @@ List of MRtrix3 commands
     commands/mtnormalise
     commands/peaks2amp
     commands/peaks2fixel
+    commands/peakscheck
+    commands/peaksconvert
     commands/population_template
     commands/responsemean
     commands/sh2amp
@@ -228,6 +230,8 @@ List of MRtrix3 commands
     |cpp.png|, :ref:`mtnormalise`, "Multi-tissue informed log-domain intensity normalisation"
     |cpp.png|, :ref:`peaks2amp`, "Extract amplitudes from a peak directions image"
     |cpp.png|, :ref:`peaks2fixel`, "Convert peak directions image to a fixel directory"
+    |python.png|, :ref:`peakscheck`, "Check the orientations of an image containing discrete fibre orientations"
+    |cpp.png|, :ref:`peaksconvert`, "Convert peak directions images between formats and/or conventions"
     |python.png|, :ref:`population_template`, "Generates an unbiased group-average template from a series of images"
     |python.png|, :ref:`responsemean`, "Calculate the mean response function from a set of text files"
     |cpp.png|, :ref:`sh2amp`, "Evaluate the amplitude of an image of spherical harmonic functions along specified directions"

--- a/python/bin/peakscheck
+++ b/python/bin/peakscheck
@@ -1,0 +1,512 @@
+#!/usr/bin/python3
+
+# Copyright (c) 2008-2024 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
+import itertools
+import os
+import sys
+
+from mrtrix3 import MRtrixError #pylint: disable=no-name-in-module
+from mrtrix3 import app, image, path, run #pylint: disable=no-name-in-module
+
+
+
+EUCLIDEAN_FLIPS = (None, 0, 1, 2)
+EUCLIDEAN_PERMUTATIONS = ((0,1,2), (0,2,1), (1,0,2), (1,2,0), (2,0,1), (2,1,0))
+
+THREEVECTOR_OPERATION_SETS = ([],
+                              ['euclidean_shuffle'],
+                              ['euclidean_transform'],
+                              ['euclidean_shuffle', 'euclidean_transform'],
+                              ['euclidean_transform', 'euclidean_shuffle'])
+
+# - 'convert' here refers specifically to a spherical to cartesian conversion
+# - TODO For now, going to have all possible combinations of "transform" and "convert";
+#   while these could ideally be combined in a single step in many instances,
+#   as a first pass it may be preferable to just evaluate all possibilities with individualised operations
+SPHERICAL_OPERATION_SETS = (['convert'],
+                            ['convert', 'euclidean_shuffle'],
+                            ['convert', 'euclidean_transform'],
+                            ['spherical_shuffle', 'convert'],
+                            ['spherical_transform', 'convert'],
+                            ['convert', 'euclidean_shuffle', 'euclidean_transform'],
+                            ['convert', 'euclidean_transform', 'euclidean_shuffle'],
+                            ['spherical_shuffle', 'convert', 'euclidean_transform'],
+                            ['spherical_shuffle', 'spherical_transform', 'convert'],
+                            ['spherical_transform', 'convert', 'euclidean_shuffle'],
+                            ['spherical_transform', 'spherical_shuffle', 'convert'])
+
+# TODO Current framework may omit situation where an XYZ2<something> transform has been erroneously applied,
+#   which would therefore necessitate *two* <something>2XYZ transforms to be applied to get into XYZ reference space
+
+SPHERICAL_SWAPS = (False, True)
+SPHERICAL_EL2INC = (False, True)
+
+# TODO Ideally, rather than considering these two as independent,
+#   only do one;
+#   but if bvec and ijk are equivalent,
+#   or if a combination of ijk transform and flipping first element is performed,
+#   then variant names should reflect this
+INPUT_REFERENCES = ('bvec', 'ijk')
+
+DEFAULT_NUMBER = 10000
+DEFAULT_THRESHOLD = 0.95
+
+FORMATS = ('spherical', 'unitspherical', '3vector', 'unit3vector')
+DEFAULT_FORMAT = '3vector'
+
+
+
+def usage(cmdline): #pylint: disable=unused-variable
+  cmdline.set_author('Robert E. Smith (robert.smith@florey.edu.au)')
+  cmdline.set_synopsis('Check the orientations of an image containing discrete fibre orientations')
+  cmdline.add_description('MRtrix3 expects "peaks" images to be stored'
+                          ' using the real / scanner space axes as reference.'
+                          ' There are three possible sources of error in this interpretation:'
+                          ' 1. There may be erroneous axis flips and/or permutations,'
+                          ' but within the real / scanner space reference.'
+                          ' 2. The image data may provide fibre orientations'
+                          ' with reference to the image axes rather than real / scanner space.'
+                          ' Here there are two additional possibilities:'
+                          ' 2a. There may be requisite axis permutations / flips'
+                          ' to be applied to the image data *before* transforming them to real / scanner space.'
+                          ' 2b. There may be requisite axis permutations / flips'
+                          ' to be applied to the image data *after* transforming them to real / scanner space.')
+  cmdline.add_argument('input', help='The input fibre orientations image to be checked')
+  cmdline.add_argument('-mask', metavar='image', help='Provide a mask image within which to seed & constrain tracking')
+  cmdline.add_argument('-number', type=int, default=DEFAULT_NUMBER, help='Set the number of tracks to generate for each test')
+  cmdline.add_argument('-threshold', type=float, default=DEFAULT_THRESHOLD, help='Modulate thresold on the ratio of empirical to maximal mean length to issue an error')
+  cmdline.add_argument('-in_format', choices=FORMATS, default=DEFAULT_FORMAT, help='The format in which peak orientations are specified; one of: ' + ','.join(FORMATS))
+  # TODO Add -in_reference option, which would control which variant is considered the default for the purpose of command return code
+  cmdline.add_argument('-noshuffle',
+                       action='store_true',
+                       help='Do not evaluate possibility of requiring shuffles of axes or angles;'
+                            ' only consider prospective transforms from alternative reference frames to real / scanner space')
+  cmdline.add_argument('-notransform',
+                       action='store_true',
+                       help='Do not evaluate possibility of requiring transform of peak orientations from image to real / scanner space;'
+                            ' only consider prospective shuffles of axes or angles')
+  cmdline.flag_mutually_exclusive_options(['noshuffle', 'notransform'])
+  cmdline.add_argument('-all', action='store_true', help='Print table containing all results to standard output')
+  cmdline.add_argument('-out_table', help='Write text file with table containing all results')
+
+
+
+class Operation:
+  @staticmethod
+  def prettytype():
+    assert False
+  def prettyparams(self):
+    assert False
+  def cmd(self, nfixels, in_path, out_path):
+    assert False
+
+class EuclideanShuffle(Operation):
+  @staticmethod
+  def prettytype():
+    return 'Euclidean axis shuffle'
+  def __init__(self, flip, permutations):
+    self.flip = flip
+    self.permutations = permutations
+  def __format__(self, fmt):
+    if self.no_flip():
+      assert not self.no_permutations()
+      return f'perm{"".join(map(str, self.permutations))}'
+    if self.no_permutations():
+      return f'flip{self.flip}'
+    return f'flip{self.flip}perm{"".join(map(str, self.permutations))}'
+  def prettyparams(self):
+    result = ''
+    if self.flip is not None:
+      result = f'Flip axis {self.flip}'
+      if not self.no_permutations():
+        result += '; '
+    if not self.no_permutations():
+      result += f'Permute axes: ({",".join(map(str, self.permutations))})'
+    return result
+  def no_flip(self):
+    return self.flip is None
+  def no_permutations(self):
+    return self.permutations == (0,1,2)
+  def cmd(self, nfixels, in_path, out_path):
+    # Below is modified copy-paste from code prior to "new variants"
+    volume_list = [ None ] * (3 * nfixels)
+    for in_volume_index in range(0, 3*nfixels):
+      fixel_index = in_volume_index // 3
+      in_component = in_volume_index - 3*fixel_index
+      # Do we need to invert this item prior to permutation?
+      flip = self.flip == in_component
+      flip_string = 'flip' if flip else ''
+      # What should be the index of this image after permutation has taken place?
+      out_component = self.permutations[in_component]
+      # Where will this volume reside in the output image series?
+      out_volume_index = 3*fixel_index + out_component
+      assert volume_list[out_volume_index] is None
+      # Create the image
+      temppath = f'{os.path.splitext(in_path)[0]}_{flip_string}{in_volume_index}_{out_volume_index}.mif'
+      cmd = ['mrconvert', in_path,
+             '-coord', '3', f'{in_volume_index}',
+             '-axes', '0,1,2',
+             '-config', 'RealignTransform', 'false']
+      if flip:
+        cmd.extend(['-', '|', 'mrcalc', '-', '-1.0', '-mult',
+                    '-config', 'RealignTransform', 'false'])
+      cmd.append(temppath)
+      run.command(cmd)
+      volume_list[out_volume_index] = temppath
+    assert all(item is not None for item in volume_list)
+    run.command(['mrcat', volume_list, out_path,
+                 '-axis', '3',
+                 '-config', 'RealignTransform', 'false'])
+    for item in volume_list:
+      os.remove(item)
+
+class EuclideanTransform(Operation):
+  @staticmethod
+  def prettytype():
+    return 'Euclidean reference axis change'
+  def __init__(self, reference):
+    self.reference = reference
+  def __format__(self, fmt):
+    return f'euctrans{self.reference}2xyz'
+  def prettyparams(self):
+    return f'{self.reference} to xyz'
+  def cmd(self, nfixels, in_path, out_path):
+    run.command(['peaksconvert', in_path, out_path,
+                 '-in_reference', self.reference,
+                 '-in_format', '3vector',
+                 '-out_reference', 'xyz',
+                 '-out_format', '3vector',
+                 '-config', 'RealignTransform', 'false'])
+
+class SphericalShuffle(Operation):
+  @staticmethod
+  def prettytype():
+    return 'Spherical angle shuffle'
+  def __init__(self, is_unit, swap, el2in):
+    self.is_unit = is_unit
+    self.swap = swap
+    self.el2in = el2in
+  def __format__(self, fmt):
+    if self.swap:
+      if self.el2in:
+        return 'swapandel2in'
+      return 'swap'
+    return 'el2in'
+  def prettyparams(self):
+    result = ''
+    if self.swap:
+      result = 'Swap angles'
+      if self.el2in:
+        result += '; '
+    if self.el2in:
+      result += ' Transform elevation to inclination'
+    return result
+  def volsperfixel(self):
+    return 2 if self.is_unit else 3
+  def cmd(self, nfixels, in_path, out_path):
+    # Below is modified copy-paste from code prior to "new variants"
+    num_volumes = self.volsperfixel() * nfixels
+    volume_list = [ None ] * num_volumes
+    for in_volume_index in range(0, num_volumes):
+      fixel_index = in_volume_index // self.volsperfixel()
+      in_component = in_volume_index - (self.volsperfixel() * fixel_index)
+      # Is this a spherical angle that needs to be permuted?
+      if self.swap and not (not self.is_unit and in_component == 0):
+        # If unit, 0->1 and 1->0
+        # If not unit, 1->2 and 2->1
+        out_component = (1 if self.is_unit else 3) - in_component
+      else:
+        out_component = in_component
+      # Where will this volume reside in the output image series?
+      out_volume_index = 3*fixel_index + out_component
+      assert volume_list[out_volume_index] is None
+      # Create the image
+      temppath = f'{os.path.splitext(in_path)[0]}_{in_volume_index}{"el2in" if self.el2in else ""}_{out_volume_index}.mif'
+      cmd = ['mrconvert', in_path,
+             '-coord', '3', f'{in_volume_index}',
+             '-axes', '0,1,2',
+             '-config', 'RealignTransform', 'false']
+      # Do we need to apply the elevation->inclination transform?
+      if self.el2in and out_component == self.volsperfixel() - 1:
+        cmd.extend(['-', '|', 'mrcalc', '0.5', 'pi', '-mult', '-', '-sub',
+                    '-config', 'RealignTransform', 'false'])
+      cmd.append(temppath)
+      run.command(cmd)
+      volume_list[out_volume_index] = temppath
+    assert all(item is not None for item in volume_list)
+    run.command(['mrcat', volume_list, out_path,
+                 '-axis', '3',
+                 '-config', 'RealignTransform', 'false'])
+    for item in volume_list:
+      os.remove(item)
+
+class SphericalTransform(Operation):
+  @staticmethod
+  def prettytype():
+    return 'Spherical reference axis change'
+  def __init__(self, is_unit, reference):
+    self.is_unit = is_unit
+    self.reference = reference
+  def __format__(self, fmt):
+    return f'sphtrans{self.reference}2xyz'
+  def prettyparams(self):
+    return f'{self.reference} to xyz'
+  def cmd(self, nfixels, in_path, out_path):
+    run.command(['peaksconvert', in_path, out_path,
+                 '-in_reference', self.reference,
+                 '-in_format', 'unitspherical' if self.is_unit else 'spherical',
+                 '-out_reference', 'xyz',
+                 '-out_format', 'unitspherical' if self.is_unit else 'spherical',
+                 '-config', 'RealignTransform', 'false'])
+
+class Spherical2Cartesian(Operation):
+  @staticmethod
+  def prettytype():
+    return 'Spherical-to-cartesian transformation'
+  def __init__(self, is_unit):
+    self.is_unit = is_unit
+  def __format__(self, fmt):
+    return 'sph2cart'
+  def prettyparams(self):
+    return 'N/A'
+  def cmd(self, nfixels, in_path, out_path):
+    run.command(['peaksconvert', in_path, out_path,
+                 '-in_format', 'unitspherical' if self.is_unit else 'spherical',
+                 '-out_format', 'unit3vector' if self.is_unit else '3vector',
+                 '-config', 'RealignTransform', 'false'])
+
+
+
+class Variant():
+  def __init__(self, operations):
+    assert isinstance(operations, list)
+    assert all(isinstance(item, Operation) for item in operations)
+    self.operations = operations
+  def __format__(self, fmt):
+    if not self.operations:
+      return 'none'
+    return '_'.join(f'{item}' for item in self.operations)
+  def is_default(self):
+    if not self.operations:
+      return True
+    return len(self.operations) == 1 and isinstance(self.operations[0], Spherical2Cartesian)
+
+def sort_key(item):
+  assert item.mean_length is not None
+  return item.mean_length
+
+
+
+def execute(): #pylint: disable=unused-variable
+
+  app.check_output_path(app.ARGS.out_table)
+
+  image_dimensions = image.Header(path.from_user(app.ARGS.input, False)).size()
+  if len(image_dimensions) != 4:
+    raise MRtrixError('Input image must be a 4D image')
+  if min(image_dimensions) == 1:
+    raise MRtrixError('Cannot perform tractography on an image with a unity dimension')
+  num_volumes = image_dimensions[3]
+  if app.ARGS.in_format in ('unit3vector', '3vector'):
+    num_fixels = num_volumes // 3
+    if 3 * num_fixels != num_volumes:
+      raise MRtrixError(f'Number of input volumes ({num_volumes}) not a valid peaks image:'
+                        ' must be a multiple of 3')
+  elif app.ARGS.in_format == 'spherical':
+    num_fixels = num_volumes // 3
+    if 3 * num_fixels != num_volumes:
+      raise MRtrixError(f'Number of input volumes ({num_volumes}) not a valid spherical coordinates image:'
+                        ' must be a multiple of 3')
+  elif app.ARGS.in_format == 'unitspherical':
+    num_fixels = num_volumes // 2
+    if 2 * num_fixels != num_volumes:
+      raise MRtrixError(f'Number of input volumes ({num_volumes}) not a valid unit spherical coordinates image:'
+                        ' must be a multiple of 2')
+  else:
+    assert False
+
+  is_unit = app.ARGS.in_format in ('unitspherical', 'unit3vector')
+
+  app.make_scratch_dir()
+
+  # Unlike dwigradcheck, here we're going to be performing manual permutation & flipping of volumes
+  # Therefore, we'd actually prefer to *not* have contiguous memory across volumes
+  # Also, in order for subsequent reference transforms to be valid,
+  #   we need for the strides to not be modified by MRtrix3 at the load stage
+  run.command('mrconvert ' + path.from_user(app.ARGS.input) + ' ' + path.to_scratch('data.mif')
+              + ' -datatype float32'
+              + ' -config RealignTransform false')
+
+  if app.ARGS.mask:
+    run.command('mrconvert ' + path.from_user(app.ARGS.mask) + ' ' + path.to_scratch('mask.mif')
+                + ' -datatype bit'
+                + ' -config RealignTransform false')
+
+  app.goto_scratch_dir()
+
+  # Generate a brain mask if we weren't provided with one
+  if not os.path.exists('mask.mif'):
+    run.command('mrcalc data.mif -abs - -config RealignTransform false | '
+                'mrmath - max -axis 3 - -config RealignTransform false | '
+                'mrthreshold - mask.mif -abs 0.0 -comparison gt -config RealignTransform false')
+
+  # How many tracks are we going to generate?
+  number_option = ['-select', str(app.ARGS.number)]
+
+  operation_sets = THREEVECTOR_OPERATION_SETS \
+                   if app.ARGS.in_format in ('unit3vector', '3vector') \
+                   else SPHERICAL_OPERATION_SETS
+
+  # To facilitate looping in order to generate all possible variants,
+  #   pre-prepare lists of all possible configurations of each operation
+  all_euclidean_shuffles = []
+  for flip in EUCLIDEAN_FLIPS:
+    for permutation in EUCLIDEAN_PERMUTATIONS:
+      if flip is None and permutation == (0,1,2):
+        continue
+      all_euclidean_shuffles.append(EuclideanShuffle(flip, permutation))
+  all_euclidean_transforms = [EuclideanTransform('ijk'),
+                              EuclideanTransform('bvec')]
+  all_spherical_shuffles = [SphericalShuffle(is_unit, True, False),
+                            SphericalShuffle(is_unit, False, True),
+                            SphericalShuffle(is_unit, True, True)]
+  all_spherical_transforms = [SphericalTransform(is_unit, 'ijk'),
+                              SphericalTransform(is_unit, 'bvec')]
+  all_spherical2cartesian = [Spherical2Cartesian(is_unit),]
+
+  # TODO Add capabilities to restrict set of variants to be evaluated
+  variants = []
+  for operation_set in operation_sets:
+    if app.ARGS.noshuffle and any('shuffle' in item for item in operation_set):
+      continue
+    if app.ARGS.notransform and any('transform' in item for item in operation_set):
+      continue
+    operations_list = []
+    for operation in operation_set:
+      if operation == 'convert':
+        operations_list.append(all_spherical2cartesian)
+      elif operation == 'euclidean_shuffle':
+        operations_list.append(all_euclidean_shuffles)
+      elif operation == 'euclidean_transform':
+        operations_list.append(all_euclidean_transforms)
+      elif operation == 'spherical_shuffle':
+        operations_list.append(all_spherical_shuffles)
+      elif operation == 'spherical_transform':
+        operations_list.append(all_spherical_transforms)
+      else:
+        assert False
+    for variant in itertools.product(*operations_list):
+      variants.append(Variant(list(variant)))
+  app.debug(f'Complete list of variants for {app.ARGS.in_format} input format:')
+  for v in variants:
+    app.debug(f'{v}')
+
+  progress = app.ProgressBar(f'Testing peaks orientation alterations (0 of {len(variants)})', len(variants))
+  meanlength_default = None
+  for variant_index, variant in enumerate(variants):
+
+    # For each variant, we now have to construct and execute the sequential set of commands necessary
+    tmppath = None
+    imagepath = 'data.mif'
+    for operation_index, operation in enumerate(variant.operations):
+      in_path = 'data.mif' if operation_index == 0 else tmppath
+      imagepath = f'{os.path.splitext(in_path)[0]}_{operation}.mif'
+      # Ensure that an intermediate output of one variant doesn't clash
+      #   with the final output of another variant
+      if operation_index == len(variant.operations) - 1:
+        imagepath = imagepath[len('data_'):]
+      operation.cmd(num_fixels, in_path, imagepath)
+      if tmppath:
+        run.function(os.remove, tmppath)
+      tmppath = imagepath
+
+    # Run the tracking experiment
+    track_file_path = f'tracks_{variant}.tck'
+    run.command(['tckgen', imagepath,
+                 '-algorithm', 'fact',
+                 '-seed_image', 'mask.mif',
+                 '-mask', 'mask.mif',
+                 '-minlength', '0',
+                 '-downsample', '5',
+                 '-config', 'RealignTransform', 'false',
+                 track_file_path]
+                + number_option)
+    # TODO Would prefer nicer logic
+    if imagepath != 'data.mif':
+      app.cleanup(imagepath)
+
+    # Get the mean track length & add to the database
+    mean_length = float(run.command(['tckstats', track_file_path, '-output', 'mean', '-ignorezero']).stdout)
+    variants[variant_index].mean_length = mean_length
+    app.cleanup(track_file_path)
+
+    # Save result if this is the unmodified empirical gradient table
+    if variant.is_default():
+      assert meanlength_default is None
+      meanlength_default = mean_length
+
+    # Increment the progress bar
+    progress.increment(f'Testing peaks orientation alterations ({variant_index+1} of {len(variants)})')
+
+  progress.done()
+
+  # Sort the list to find the best gradient configuration(s)
+  sorted_variants = list(variants)
+  sorted_variants.sort(reverse=True, key=sort_key)
+  meanlength_max = sorted_variants[0].mean_length
+
+  if sorted_variants[0].is_default():
+    meanlength_ratio = 1.0
+    app.console('Absence of manipulation of peaks orientations resulted in the maximal mean length')
+  else:
+    meanlength_ratio = meanlength_default / meanlength_max
+    app.console(f'Ratio of mean length of empirical data to mean length of best candidate: {meanlength_ratio:.3f}')
+
+  # Provide a printout of the mean streamline length of each orientation manipulation
+  if app.ARGS.all:
+    sys.stdout.write('Mean length     Variant\n')
+    for variant in sorted_variants:
+      sys.stdout.write(f'  {variant.mean_length:5.2f}      {variant}\n')
+    sys.stdout.flush()
+
+  # Write comprehensive results to a file
+  if app.ARGS.out_table:
+    if os.path.splitext(app.ARGS.out_table)[-1].lower() == '.tsv':
+      delimiter = '\t'
+      quote = ''
+    else:
+      delimiter = ','
+      quote = '"'
+    with open(path.from_user(app.ARGS.out_table, False), 'w') as f:
+      f.write(f'{quote}Mean length{quote}{delimiter}'
+              f'{quote}Operation 1 type{quote}{delimiter}{quote}Operation 1 parameters{quote}{delimiter}'
+              f'{quote}Operation 2 type{quote}{delimiter}{quote}Operation 2 parameters{quote}{delimiter}'
+              f'{quote}Operation 3 type{quote}{delimiter}{quote}Operation 3 parameters{quote}{delimiter}\n')
+      for v in variants:
+        f.write(f'{v.mean_length}')
+        for operation in v.operations:
+          f.write(f'{delimiter}{quote}{operation.prettytype()}{quote}{delimiter}{quote}{operation.prettyparams()}{quote}')
+        f.write('\n')
+
+  if meanlength_ratio < app.ARGS.threshold:
+    raise MRtrixError('Streamline tractography indicates possibly incorrect gradient table')
+
+
+
+# Execute the script
+import mrtrix3 #pylint: disable=wrong-import-position
+mrtrix3.execute() #pylint: disable=no-member


### PR DESCRIPTION
Draft PR.

Depends on #2917 (uses that as base branch).

This is work that I deemed necessary for BIDS BEP016 DWI models (https://github.com/bids-standard/bids-bep016/pull/24).

To have any kind of confidence around robust encoding of the outcomes of diffusion model fits on the filesystem, in my mind there are two requirements:

-   Prove that the purported coordinate system is correct.
    This necessitates a broader set of data. Showing that for one data instance, the purported coordinate system seems reasonable, is not evidence that in some other use case the interpretation will be incorrect.
-   Have the capability to convert data between different encodings or reference frames.

Here I've created two new commands, that are requisite for later parts of [this validation tool](https://github.com/Lestropie/DWI_metadata).

-   `peaksconvert` converts both between different reference frames, and between 3-vector versus spherical coordinate encodings. This for instance should allow loading the outcomes of diffusion model fits from FSL and MRtrix in the converse software.

-   `peakscheck` does something similar to `dwigradcheck`, just using `peaks` images and `tckgen -algorithm fact`. Similar to #2902 (which happened during the course of generating this changeset) the set of possible errors in encoding that are evaluated can be more complex than just axis permutations and flips.

-----

Outstanding TODOs, many of which are plucked from code comments:

- [ ] Deep in the spherical coordinates handling, the prospect of a triplet of spherical coefficients appears, where the third element is inferred to be a radius. This is however contrary to ISO convention, where the first element should be the radius. Would need to audit what code uses it, but I would like to consider changing that behaviour. Potentially to avoid unexpected errors, revert those functions to only consider unit spherical coordinates, and have newly named functions that deal with the prospect of triplets?

- [ ] For spherical coordinates, should support for both physics and mathematics conventions be implemented?
    `peakscheck` tests for the prospect of swapping the order of the two angles; but permitting explicit specification of which of the two is in use may be preferable (relates to https://github.com/bids-standard/bids-bep016/issues/96).

- [ ] Give `peaksconvert` ability to change fill value of absent fixels

- [ ] Give `peaksconvert` ability to reduce maximal number of fixels
    Hypothetically, this could be done either by culling volumes, or by first sorting by the value per fixel (as 3-vector norm or spherical radius) and then removing

- [ ] Multi-thread `peaksconvert`

- [ ] Check whether `peaksconvert` works across bootstrap realisations, if those realisations appear along the fifth image axis
    (In BEP016 I want to define explicitly if an image axis is used to encode orientation information vs. if an image axis is used to encode bootstrap realisations; see https://github.com/bids-standard/bids-bep016/issues/38. But that may not necessarily propagate to MRtrix)

- [ ] `peakscheck`: Try to catch case where upstream there has been an erroneous transformation; eg. someone has orientations in IJK, they erroneously applied an XYZ2IJK transformation, and so now they need to apply the IJK2XYZ transformation twice to get their orientations in MRtrix's expected XYZ

- [ ] `peakscheck`: Reduce doubling-up between ijk and bvec reference frames.
    Ideally evaluate each *unique* transformation only once; there may however be multiple interpretations to a unique transformation.

- [ ] `peakscheck`: Add `-in_reference` option; the variant that includes the corresponding transformation to XYZ should then be considered the "expected" interpretation of the input data, used to determine whether the return code should be non-zero.

- [ ] Add ability to disable internal transform realignment on image load via environment variable; make use of this in `peakscheck`
