### PR TITLE
Add warning if cmake generator is not Ninja

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,12 @@ cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
 
 project(mrtrix3 LANGUAGES CXX VERSION 3.0.4)
 
+if(NOT CMAKE_GENERATOR STREQUAL "Ninja")
+    message(WARNING "It is recommended to use the Ninja generator to build MRtrix3. "
+                    "To use it, run cmake with -G Ninja or set the CMAKE_GENERATOR"
+                    "environment variable to Ninja.")
+endif()
+
 include(GNUInstallDirs)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")


### PR DESCRIPTION
We primarily test our builds with Ninja, which is not the default on most platforms. This PR adds a warning if other generators are used to build MRtrix3 to recommend using Ninja instead.