### PR TITLE
SIFT2: Changes to output streamline weights units

### DIFF
--- a/cmd/tcksift2.cpp
+++ b/cmd/tcksift2.cpp
@@ -19,6 +19,7 @@
 #include "header.h"
 #include "image.h"
 
+#include "file/config.h"
 #include "file/path.h"
 
 #include "dwi/directions/set.h"
@@ -29,6 +30,7 @@
 #include "dwi/tractography/SIFT/sift.h"
 
 #include "dwi/tractography/SIFT2/tckfactor.h"
+#include "dwi/tractography/SIFT2/units.h"
 
 using namespace MR;
 using namespace App;
@@ -109,17 +111,75 @@ void usage() {
   SYNOPSIS = "Optimise per-streamline cross-section multipliers"
              " to match a whole-brain tractogram to fixel-wise fibre densities";
 
+  DESCRIPTION
+    + "Interpretation of not just the relative magnitudes of the output weights of different streamlines,"
+      " but their ABSOLUTE magnitude,"
+      " depends on the presence or absence of any modulations applied to those values;"
+      " by the tcksift2 command itself,"
+      " and/or other experimental factors applied,"
+      " whether implicit or explicit."
+      " This has been termed \"inter-subject connection density normalisation\"."
+      " Within the scope of the tcksift2 command,"
+      " some control of this normalisation is available by specifying the units of those output weights."
+      " The options available for these units,"
+      " and their corresponding interpretations,"
+      " are described in further detail in the following paragraphs."
+
+    + "- \"NOS\" (Number Of Streamlines) / \"none\":"
+      " No explicit scaling of the output streamline weights is performed."
+      " A key component of the SIFT model as originally devised"
+      " was to scale the contributions of all streamlines by proportionality coefficient mu,"
+      " to facilitate direct comparison of tractogram and fixel-wise fibre densities."
+      " This is therefore the \"native\" form in which these streamline weights are computed."
+      " In the contex of output of the SIFT2 method,"
+      " this makes the per-streamline weights approximately centred around unity,"
+      " such that the overall magnitude of inter-areal connection weights"
+      " will be comparable to that of the number-of-streamlines metric."
+      " This was the behaviour of the tcksift2 command prior to software version 3.1.0."
+
+    + "- \"AFD/mm\" / \"AFD.mm-1\", \"AFD.mm^-1\":"
+      " The streamline weights in their native representation"
+      " are multiplied by SIFT model proportionality coefficient mu"
+      " as they are exported to file."
+      " These values encode the AFD per millimetre of length"
+      " that is contributed to the model by that streamline."
+      " Only under specific circumstances"
+      " does utilising these units permit direct comparison of Fibre Bundle Capacity (FBC)"
+      " between reconstructions:"
+      " a) Use of common response function(s);"
+      " b) Having used some mechanism for global intensity normalisation"
+      " (as required for any analysis of AFD);"
+      " c) All DWI data have the same spatial resolution."
+
+    + "- \"mm2\" / \"mm^2\":"
+      " The streamline weights in their native representation"
+      " are multiplied both by SIFT model proportionality coefficient mu"
+      " and by the voxel volume in mm^3 as they are exported to file."
+      " These units interpret the fixel-wise AFD values as volume fractions"
+      " (despite the fact that these values do not have an upper bound of 1.0),"
+      " such that the streamline weights may be interpreted"
+      " as a physical fibre cross-sectional area in units of mm^2;"
+      " each streamline therefore contributes some fibre volume per unit length."
+      " Only under specific circumstances"
+      " does utilising these units permit direct comparison of Fibre Bundle Capacity (FBC)"
+      " between reconstructions:"
+      " a) Use of common response function(s);"
+      " b) Having used some mechanism for global intensity normalisation"
+      " (as required for any analysis of AFD)."
+      " Unlike the AFD/mm units however,"
+      " streamline weights exported in these units are invariant"
+      " to the resolution of the FOD voxel grid used in the SIFT2 optimisation.";
+
   REFERENCES
     + "Smith, R. E.; Tournier, J.-D.; Calamante, F. & Connelly, A. " // Internal
     "SIFT2: Enabling dense quantitative assessment of brain white matter connectivity"
     " using streamlines tractography. "
     "NeuroImage, 2015, 119, 338-351"
 
-    + "* If using the -linear option: \n"
-    "Smith, RE; Raffelt, D; Tournier, J-D; Connelly, A. " // Internal
+    + "Smith, RE; Raffelt, D; Tournier, J-D; Connelly, A. " // Internal
     "Quantitative Streamlines Tractography:"
     " Methods and Inter-Subject Normalisation. "
-    "Open Science Framework, https://doi.org/10.31219/osf.io/c67kn.";
+    "OHBM Aperture, doi: 10.52294/ApertureNeuro.2022.2.NEOD9565.";
 
   ARGUMENTS
   + Argument ("in_tracks", "the input track file").type_tracks_in()
@@ -127,6 +187,8 @@ void usage() {
   + Argument ("out_weights", "output text file containing the weighting factor for each streamline").type_file_out();
 
   OPTIONS
+  + Option ("units", "specify the physical units for the output streamline weights (see Description)")
+     + Argument ("choice").type_choice(SIFT2::units_choices)
 
   + SIFT::SIFTModelProcMaskOption
   + SIFT::SIFTModelOption
@@ -141,6 +203,29 @@ void usage() {
 }
 // clang-format on
 
+// CONF option: SIFT2DefaultUnits
+// CONF default: "mm^2"
+// CONF A string indicating the units of the streamline weights
+// CONF yielded by the tcksift2 command.
+SIFT2::units_t get_units() {
+  auto opt = get_options("units");
+  if (!opt.empty()) {
+    try {
+      return SIFT2::str2units(opt[0][0]);
+    } catch (Exception& e) {
+      throw Exception("Incorrectly specified SIFT2 units on command-line");
+    }
+  }
+  const std::string from_config = File::Config::get("SIFT2DefaultUnits");
+  if (from_config.empty())
+    return SIFT2::default_units;
+  try {
+    return SIFT2::str2units(from_config);
+  } catch (Exception& e) {
+    throw Exception(e, "Incorrectly specified SIFT2 units in MRtrix config file");
+  }
+}
+
 void run() {
 
   if (!get_options("min_factor").empty() && !get_options("min_coeff").empty())
@@ -150,6 +235,8 @@ void run() {
 
   if (Path::has_suffix(argument[2], ".tck"))
     throw Exception("Output of tcksift2 command should be a text file, not a tracks file");
+
+  const SIFT2::units_t units = get_units();
 
   auto in_dwi = Image<float>::open(argument[1]);
 
@@ -220,7 +307,7 @@ void run() {
 
   tckfactor.report_entropy();
 
-  tckfactor.output_factors(argument[2]);
+  tckfactor.output_factors(argument[2], units);
 
   auto opt = get_options("out_coeffs");
   if (!opt.empty())

--- a/docs/reference/commands/tcksift2.rst
+++ b/docs/reference/commands/tcksift2.rst
@@ -19,8 +19,21 @@ Usage
 -  *in_fod*: input image containing the spherical harmonics of the fibre orientation distributions
 -  *out_weights*: output text file containing the weighting factor for each streamline
 
+Description
+-----------
+
+Interpretation of not just the relative magnitudes of the output weights of different streamlines, but their ABSOLUTE magnitude, depends on the presence or absence of any modulations applied to those values; by the tcksift2 command itself, and/or other experimental factors applied, whether implicit or explicit. This has been termed "inter-subject connection density normalisation". Within the scope of the tcksift2 command, some control of this normalisation is available by specifying the units of those output weights. The options available for these units, and their corresponding interpretations, are described in further detail in the following paragraphs.
+
+- "NOS" (Number Of Streamlines) / "none": No explicit scaling of the output streamline weights is performed. A key component of the SIFT model as originally devised was to scale the contributions of all streamlines by proportionality coefficient mu, to facilitate direct comparison of tractogram and fixel-wise fibre densities. This is therefore the "native" form in which these streamline weights are computed. In the contex of output of the SIFT2 method, this makes the per-streamline weights approximately centred around unity, such that the overall magnitude of inter-areal connection weights will be comparable to that of the number-of-streamlines metric. This was the behaviour of the tcksift2 command prior to software version 3.1.0.
+
+- "AFD/mm" / "AFD.mm-1", "AFD.mm^-1": The streamline weights in their native representation are multiplied by SIFT model proportionality coefficient mu as they are exported to file. These values encode the AFD per millimetre of length that is contributed to the model by that streamline. Only under specific circumstances does utilising these units permit direct comparison of Fibre Bundle Capacity (FBC) between reconstructions: a) Use of common response function(s); b) Having used some mechanism for global intensity normalisation (as required for any analysis of AFD); c) All DWI data have the same spatial resolution.
+
+- "mm2" / "mm^2": The streamline weights in their native representation are multiplied both by SIFT model proportionality coefficient mu and by the voxel volume in mm^3 as they are exported to file. These units interpret the fixel-wise AFD values as volume fractions (despite the fact that these values do not have an upper bound of 1.0), such that the streamline weights may be interpreted as a physical fibre cross-sectional area in units of mm^2; each streamline therefore contributes some fibre volume per unit length. Only under specific circumstances does utilising these units permit direct comparison of Fibre Bundle Capacity (FBC) between reconstructions: a) Use of common response function(s); b) Having used some mechanism for global intensity normalisation (as required for any analysis of AFD). Unlike the AFD/mm units however, streamline weights exported in these units are invariant to the resolution of the FOD voxel grid used in the SIFT2 optimisation.
+
 Options
 -------
+
+-  **-units choice** specify the physical units for the output streamline weights (see Description)
 
 Options for setting the processing mask for the SIFT fixel-streamlines comparison model
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -107,8 +120,7 @@ References
 
 Smith, R. E.; Tournier, J.-D.; Calamante, F. & Connelly, A. SIFT2: Enabling dense quantitative assessment of brain white matter connectivity using streamlines tractography. NeuroImage, 2015, 119, 338-351
 
-* If using the -linear option:  |br|
-  Smith, RE; Raffelt, D; Tournier, J-D; Connelly, A. Quantitative Streamlines Tractography: Methods and Inter-Subject Normalisation. Open Science Framework, https://doi.org/10.31219/osf.io/c67kn.
+Smith, RE; Raffelt, D; Tournier, J-D; Connelly, A. Quantitative Streamlines Tractography: Methods and Inter-Subject Normalisation. OHBM Aperture, doi: 10.52294/ApertureNeuro.2022.2.NEOD9565.
 
 Tournier, J.-D.; Smith, R. E.; Raffelt, D.; Tabbara, R.; Dhollander, T.; Pietsch, M.; Christiaens, D.; Jeurissen, B.; Yeh, C.-H. & Connelly, A. MRtrix3: A fast, flexible and open software framework for medical image processing and visualisation. NeuroImage, 2019, 202, 116137
 

--- a/docs/reference/config_file_options.rst
+++ b/docs/reference/config_file_options.rst
@@ -675,6 +675,13 @@ List of MRtrix3 configuration file options
      Linear registration: smallest gradient descent step measured in fraction of a voxel at which to stop
      registration.
 
+.. option:: SIFT2DefaultUnits
+
+    *default: "mm^2"*
+
+     A string indicating the units of the streamline weights
+     yielded by the tcksift2 command.
+
 .. option:: ScriptScratchDir
 
     *default: `.`*

--- a/src/dwi/tractography/SIFT/track_index_range.h
+++ b/src/dwi/tractography/SIFT/track_index_range.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "dwi/tractography/SIFT/types.h"
+#include "thread_queue.h"
 #include "progressbar.h"
 
 namespace MR::DWI::Tractography::SIFT {

--- a/src/dwi/tractography/SIFT2/tckfactor.cpp
+++ b/src/dwi/tractography/SIFT2/tckfactor.cpp
@@ -349,7 +349,7 @@ void TckFactor::report_entropy() const {
        str(equiv_N) + " equally-weighted streamlines");
 }
 
-void TckFactor::output_factors(const std::string &path) const {
+void TckFactor::output_factors(const std::string &path, const units_t units) const {
   if (size_t(coefficients.size()) != contributions.size())
     throw Exception("Cannot output weighting factors if they have not first been estimated!");
   decltype(coefficients) weights;
@@ -359,9 +359,18 @@ void TckFactor::output_factors(const std::string &path) const {
     WARN("Unable to assign memory for output factor file: \"" + Path::basename(path) + "\" not created");
     return;
   }
+  default_type units_multiplier = 0.0;
+  switch (units) {
+    case units_t::NOS: units_multiplier = 1.0; break;
+    case units_t::AFDpermm: units_multiplier = mu(); break;
+    case units_t::mm2: units_multiplier = mu() * header().spacing(0) * header().spacing(1) * header().spacing(2); break;
+  }
   for (SIFT::track_t i = 0; i != num_tracks(); ++i)
     weights[i] = (coefficients[i] == min_coeff || !std::isfinite(coefficients[i])) ? 0.0 : std::exp(coefficients[i]);
-  File::Matrix::save_vector(weights, path);
+  KeyValues keyval;
+  keyval["SIFT_mu"] = str(mu());
+  keyval["Units"] = units2str(units);
+  File::Matrix::save_vector(units_multiplier * weights, path, keyval);
 }
 
 void TckFactor::output_coefficients(const std::string &path) const { File::Matrix::save_vector(coefficients, path); }

--- a/src/dwi/tractography/SIFT2/tckfactor.h
+++ b/src/dwi/tractography/SIFT2/tckfactor.h
@@ -29,6 +29,7 @@
 #include "dwi/tractography/SIFT/output.h"
 
 #include "dwi/tractography/SIFT2/fixel.h"
+#include "dwi/tractography/SIFT2/units.h"
 
 #define SIFT2_REGULARISATION_TIKHONOV_DEFAULT 0.0
 #define SIFT2_REGULARISATION_TV_DEFAULT 0.1
@@ -88,7 +89,7 @@ public:
 
   void report_entropy() const;
 
-  void output_factors(const std::string &) const;
+  void output_factors(const std::string &, const units_t) const;
   void output_coefficients(const std::string &) const;
 
   void output_TD_images(const std::string &, const std::string &, const std::string &) const;

--- a/src/dwi/tractography/SIFT2/units.cpp
+++ b/src/dwi/tractography/SIFT2/units.cpp
@@ -1,0 +1,46 @@
+/* Copyright (c) 2008-2024 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Covered Software is provided under this License on an "as is"
+ * basis, without warranty of any kind, either expressed, implied, or
+ * statutory, including, without limitation, warranties that the
+ * Covered Software is free of defects, merchantable, fit for a
+ * particular purpose or non-infringing.
+ * See the Mozilla Public License v. 2.0 for more details.
+ *
+ * For more details, see http://www.mrtrix.org/.
+ */
+
+#include "dwi/tractography/SIFT2/units.h"
+
+#include "exception.h"
+#include "mrtrix.h"
+
+namespace MR::DWI::Tractography::SIFT2 {
+
+extern const char* const units_choices[] = { "NOS", "none", "AFD/mm", "AFD.mm-1", "AFD.mm^-1", "mm2", "mm^2", nullptr };
+
+units_t str2units(const std::string& s) {
+  const std::string slower = lowercase(s);
+  if (slower == "nos" || slower == "none")
+    return units_t::NOS;
+  if (slower == "afd/mm" || slower == "afd.mm-1" || slower == "afd.mm^-1")
+    return units_t::AFDpermm;
+  if (slower == "mm2" || slower == "mm^2")
+    return units_t::mm2;
+  throw Exception("Unable to convert string \"" + s + "\" to SIFT2 streamline weight units");
+}
+
+std::string units2str(units_t units) {
+  switch (units) {
+    case units_t::NOS: return "NOS";
+    case units_t::AFDpermm: return "AFD/mm";
+    case units_t::mm2: return "mm^2";
+  }
+  throw Exception("Unexpected units provided to SIFT2::units2str()");
+}
+
+} // namespace MR::DWI::Tractography::SIFT2

--- a/src/dwi/tractography/SIFT2/units.h
+++ b/src/dwi/tractography/SIFT2/units.h
@@ -16,9 +16,17 @@
 
 #pragma once
 
-namespace MR::DWI::Tractography::SIFT {
+#include <string>
 
-using track_t = unsigned int;
-using voxel_t = unsigned int;
+namespace MR::DWI::Tractography::SIFT2 {
 
-} // namespace MR::DWI::Tractography::SIFT
+extern const char* const units_choices[];
+
+enum class units_t { NOS, AFDpermm, mm2 };
+
+constexpr units_t default_units = units_t::mm2;
+
+units_t str2units(const std::string&);
+std::string units2str(units_t);
+
+} // namespace MR::DWI::Tractography::SIFT2

--- a/testing/binaries/CMakeLists.txt
+++ b/testing/binaries/CMakeLists.txt
@@ -404,6 +404,7 @@ add_bash_binary_test(tcksample/tdifraction)
 add_bash_binary_test(tcksift/default)
 
 add_bash_binary_test(tcksift2/default)
+add_bash_binary_test(tcksift2/units)
 
 add_bash_binary_test(tcktransform/unitwarp)
 

--- a/testing/binaries/tests/tcksift2/units
+++ b/testing/binaries/tests/tcksift2/units
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Verify manipulation of the units of the output SIFT2 weights
+
+# 1. If the streamline weights are of units AFD/mm,
+#   then if one takes for each voxel,
+#   for every streamline the product of the streamline weight and the length of the intersection,
+#   and sum these across all streamlines intersecting that voxel,
+#   then the result should be close to the AFD of that voxel
+
+tcksift2 SIFT_phantom/tracks.tck SIFT_phantom/fods.mif tmp.csv -proc_mask SIFT_phantom/mask.mif -units AFD/mm -force
+# Zero out the streamlines density outside of the bundles; we don't want those to contribute to the difference calculation
+tckmap SIFT_phantom/tracks.tck -template SIFT_phantom/mask.mif -precise -tck_weights_in tmp.csv - | \
+mrcalc - SIFT_phantom/mask.mif -mult tmp_AFD_tractogram.mif -force
+fixel2voxel SIFT_phantom/fixels/fd.mif sum tmp_AFD_fixels.mif -force
+testing_diff_image tmp_AFD_tractogram.mif tmp_AFD_fixels.mif -abs 0.1
+
+# 2. The SIFT phantom has a voxel size of 2mm^3.
+#    If you take the AFD in a fixel and multiply it by the voxel volume,
+#    you get the total fibre volume represented by that fixel in mm^3.
+#    If your streamline weights are in mm^2,
+#    and you sum the products of these weights with the voxel intersection lengths,
+#    you get a tractogram-based reconstructed fibre volume in mm^3.
+tcksift2 SIFT_phantom/tracks.tck SIFT_phantom/fods.mif tmp.csv -proc_mask SIFT_phantom/mask.mif -units mm^2 -force
+tckmap SIFT_phantom/tracks.tck -template SIFT_phantom/mask.mif -precise -tck_weights_in tmp.csv - | \
+mrcalc - SIFT_phantom/mask.mif -mult tmp_mm3_tractogram.mif -force
+fixel2voxel SIFT_phantom/fixels/fd.mif sum - | \
+mrcalc - 8.0 -mult tmp_mm3_fixels.mif -force
+testing_diff_image tmp_mm3_tractogram.mif tmp_mm3_fixels.mif -frac 0.1


### PR DESCRIPTION
Closes #2138.

I've for years questioned myself about exactly how this confound should be treated. But in retrospect it's remained unaddressed for too long, and I regularly find myself having to re-explain what factors to apply when, what is automatically applied vs. what isn't, what the default should be, and what the interface should look like.

(I like having the capability to account for differences in response function magnitudes after the fact rather than require common response functions, but in retrospect it just confuses people).

I think I've landed on the right long-term solution. This *does* result in a difference in command output compared to `3.0.x`, but the prior behaviour can also be achieved if desired. Rather than having the interface relate to "has been scaled by X / has not been scaled by X", I think the right approach is to focus on the *units* in which those streamline weights are provided. That is then easily reportable as metadata in the file header. The new tests hopefully prove the corresponding interpretations.