### PR TITLE
Fixes to containers FSL dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,24 +36,24 @@ RUN git clone -b $MRTRIX3_GIT_COMMITISH --depth 1 https://github.com/MRtrix3/mrt
     && rm -rf tmp
 
 # Download minified ART ACPCdetect (V2.0).
-FROM base-builder as acpcdetect-installer
+FROM base-builder AS acpcdetect-installer
 WORKDIR /opt/art
 RUN curl -fsSL https://osf.io/73h5s/download \
     | tar xz --strip-components 1
 
 # Download minified ANTs (2.3.4-2).
-FROM base-builder as ants-installer
+FROM base-builder AS ants-installer
 WORKDIR /opt/ants
 RUN curl -fsSL https://osf.io/yswa4/download \
     | tar xz --strip-components 1
 
 # Download FreeSurfer files.
-FROM base-builder as freesurfer-installer
+FROM base-builder AS freesurfer-installer
 WORKDIR /opt/freesurfer
 RUN curl -fsSLO https://raw.githubusercontent.com/freesurfer/freesurfer/v7.1.1/distribution/FreeSurferColorLUT.txt
 
 # Download minified FSL (6.0.7.7)
-FROM base-builder as fsl-installer
+FROM base-builder AS fsl-installer
 WORKDIR /opt/fsl
 RUN curl -fsSL https://osf.io/ph9ex/download \
     | tar xz --strip-components 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,6 @@ ENV ANTSPATH="/opt/ants/bin" \
     FSLMULTIFILEQUIT="TRUE" \
     FSLTCLSH="/opt/fsl/bin/fsltclsh" \
     FSLWISH="/opt/fsl/bin/fslwish" \
-    LD_LIBRARY_PATH="/opt/fsl/lib:$LD_LIBRARY_PATH" \
     PATH="/opt/mrtrix3/bin:/opt/ants/bin:/opt/art/bin:/opt/fsl/share/fsl/bin:$PATH"
 
 # Fix "Singularity container cannot load libQt5Core.so.5" on CentOS 7

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG MAKE_JOBS="1"
 ARG DEBIAN_FRONTEND="noninteractive"
 
 FROM python:3.8-slim AS base
-FROM buildpack-deps:buster AS base-builder
+FROM buildpack-deps:bookworm AS base-builder
 
 FROM base-builder AS mrtrix3-builder
 
@@ -22,7 +22,8 @@ RUN apt-get -qq update \
         libqt5opengl5-dev \
         libqt5svg5-dev \
         libtiff5-dev \
-        qt5-default \
+        python3 \
+        qtbase5-dev \
         zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 
@@ -30,8 +31,8 @@ RUN apt-get -qq update \
 ARG MAKE_JOBS
 WORKDIR /opt/mrtrix3
 RUN git clone -b $MRTRIX3_GIT_COMMITISH --depth 1 https://github.com/MRtrix3/mrtrix3.git . \
-    && ./configure $MRTRIX3_CONFIGURE_FLAGS \
-    && NUMBER_OF_PROCESSORS=$MAKE_JOBS ./build $MRTRIX3_BUILD_FLAGS \
+    && python3 ./configure $MRTRIX3_CONFIGURE_FLAGS \
+    && NUMBER_OF_PROCESSORS=$MAKE_JOBS python3 ./build $MRTRIX3_BUILD_FLAGS \
     && rm -rf tmp
 
 # Download minified ART ACPCdetect (V2.0).
@@ -51,10 +52,10 @@ FROM base-builder as freesurfer-installer
 WORKDIR /opt/freesurfer
 RUN curl -fsSLO https://raw.githubusercontent.com/freesurfer/freesurfer/v7.1.1/distribution/FreeSurferColorLUT.txt
 
-# Download minified FSL (6.0.4-2)
+# Download minified FSL (6.0.7.7)
 FROM base-builder as fsl-installer
 WORKDIR /opt/fsl
-RUN curl -fsSL https://osf.io/dtep4/download \
+RUN curl -fsSL https://osf.io/ph9ex/download \
     | tar xz --strip-components 1
 
 # Build final image.
@@ -66,7 +67,8 @@ RUN apt-get -qq update \
         binutils \
         dc \
         less \
-        libfftw3-3 \
+        libfftw3-single3 \
+        libfftw3-double3 \
         libgl1-mesa-glx \
         libgomp1 \
         liblapack3 \
@@ -77,7 +79,8 @@ RUN apt-get -qq update \
         libqt5svg5 \
         libqt5widgets5 \
         libquadmath0 \
-        libtiff5 \
+        libtiff5-dev \
+        python3 \
         python3-distutils \
     && rm -rf /var/lib/apt/lists/*
 
@@ -96,11 +99,13 @@ ENV ANTSPATH="/opt/ants/bin" \
     FSLTCLSH="/opt/fsl/bin/fsltclsh" \
     FSLWISH="/opt/fsl/bin/fslwish" \
     LD_LIBRARY_PATH="/opt/fsl/lib:$LD_LIBRARY_PATH" \
-    PATH="/opt/mrtrix3/bin:/opt/ants/bin:/opt/art/bin:/opt/fsl/bin:$PATH"
+    PATH="/opt/mrtrix3/bin:/opt/ants/bin:/opt/art/bin:/opt/fsl/share/fsl/bin:$PATH"
 
 # Fix "Singularity container cannot load libQt5Core.so.5" on CentOS 7
 RUN strip --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt5Core.so.5 \
     && ldconfig \
     && apt-get purge -yq binutils
+
+RUN ln -s /usr/bin/python3 /usr/bin/python
 
 CMD ["/bin/bash"]

--- a/Singularity
+++ b/Singularity
@@ -27,7 +27,7 @@ Include: apt
 
 # All
     LD_LIBRARY_PATH="/.singularity.d/libs:/usr/lib:/opt/fsl/lib:$LD_LIBRARY_PATH"
-    PATH="/opt/mrtrix3/bin:/opt/ants/bin:/opt/art/bin:/opt/fsl/bin:$PATH"
+    PATH="/opt/mrtrix3/bin:/opt/ants/bin:/opt/art/bin:/opt/fsl/share/fsl/bin:$PATH"
     export LD_LIBRARY_PATH PATH
 
 %post
@@ -51,8 +51,8 @@ Include: apt
     mkdir -p /opt/ants && curl -fsSL https://osf.io/yswa4/download | tar xz -C /opt/ants --strip-components 1
     # Download FreeSurfer lookup table file (v7.1.1).
     mkdir -p /opt/freesurfer && curl -fsSL -o /opt/freesurfer/FreeSurferColorLUT.txt https://raw.githubusercontent.com/freesurfer/freesurfer/v7.1.1/distribution/FreeSurferColorLUT.txt
-    # Download minified FSL (6.0.4-2).
-    mkdir -p /opt/fsl && curl -fsSL https://osf.io/dtep4/download | tar xz -C /opt/fsl --strip-components 1
+    # Download minified FSL (6.0.7.7).
+    mkdir -p /opt/fsl && curl -fsSL https://osf.io/ph9ex/download | tar xz -C /opt/fsl --strip-components 1
 
 # Use Python3 for anything requesting Python, since Python2 is not installed
     ln -s /usr/bin/python3 /usr/bin/python

--- a/Singularity
+++ b/Singularity
@@ -26,7 +26,7 @@ Include: apt
     export FSLDIR FSLOUTPUTTYPE FSLMULTIFILEQUIT FSLTCLSH FSLWISH
 
 # All
-    LD_LIBRARY_PATH="/.singularity.d/libs:/usr/lib:/opt/fsl/lib:$LD_LIBRARY_PATH"
+    LD_LIBRARY_PATH="/.singularity.d/libs:/usr/lib:$LD_LIBRARY_PATH"
     PATH="/opt/mrtrix3/bin:/opt/ants/bin:/opt/art/bin:/opt/fsl/share/fsl/bin:$PATH"
     export LD_LIBRARY_PATH PATH
 


### PR DESCRIPTION
Closes #2921.

See also https://github.com/MRtrix3/containers/pull/26, which includes changes necessary to produce the minified FSL dependency that this change then downloads from OSF.

While the container minification process *intended* to capture EddyQC's `eddy_quad`, the fact that it was not being properly executed was missed because `dwifslpreproc` does not return non-zero if it fails to execute.

Unfortunately I couldn't easily resolve just this one thing. I've ended up having to update the FSL version as well. Which is not fantastic for a patch MRtrix update, since there's some chance of a change in behaviour out of our control.

Regarding #2921, if this change is deemed acceptable I can push it to DockerHub as `latest`, which would make it easy for people to access immediately but without necessitating an MRtrix patch update.