### PR TITLE
Minor changes to packaging scripts

### DIFF
--- a/packaging/macos/build
+++ b/packaging/macos/build
@@ -140,7 +140,7 @@ git clone https://github.com/MRtrix3/mrtrix3.git mrtrix3-src -b ${TAGNAME}
 cd ${PREFIX}-src
 sed -i.bak -e '90,101d' cmake/FindFFTW.cmake
 MRTRIX_VERSION=$(git describe --abbrev=8 | tr '-' '_')
-cmake -B build -G Ninja -DCMAKE_PREFIX_PATH=${PREFIX} -DCMAKE_IGNORE_PREFIX_PATH="/opt/homebrew;/usr/X11;/usr/X11R6" -DFFTW_USE_STATIC_LIBS=ON -DCMAKE_OSX_ARCHITECTURES=${CMAKE_ARCHS} -DPNG_PNG_INCLUDE_DIR=${PREFIX}/include/QtPng -DPNG_LIBRARY=${PREFIX}/lib/libQt6BundledLibpng.a -DCMAKE_INSTALL_PREFIX=${PREFIX} -DMRTRIX_USE_PCH=OFF
+cmake -B build -G Ninja -DCMAKE_PREFIX_PATH=${PREFIX} -DCMAKE_IGNORE_PREFIX_PATH="/opt/homebrew;/usr/X11;/usr/X11R6" -DFFTW_USE_STATIC_LIBS=ON -DCMAKE_OSX_ARCHITECTURES=${CMAKE_ARCHS} -DPNG_PNG_INCLUDE_DIR=${PREFIX}/include/QtPng -DPNG_LIBRARY=${PREFIX}/lib/libQt6BundledLibpng.a -DCMAKE_INSTALL_PREFIX=${PREFIX} -DMRTRIX_USE_PCH=OFF -DMRTRIX_BUILD_NON_CORE_STATIC=ON
 cmake --build build
 cd ..
 MRTRIX_SECONDS=${SECONDS}

--- a/packaging/macos/build
+++ b/packaging/macos/build
@@ -140,7 +140,7 @@ git clone https://github.com/MRtrix3/mrtrix3.git mrtrix3-src -b ${TAGNAME}
 cd ${PREFIX}-src
 sed -i.bak -e '90,101d' cmake/FindFFTW.cmake
 MRTRIX_VERSION=$(git describe --abbrev=8 | tr '-' '_')
-cmake -B build -G Ninja -DCMAKE_PREFIX_PATH=${PREFIX} -DCMAKE_IGNORE_PREFIX_PATH="/opt/homebrew;/usr/X11;/usr/X11R6" -DFFTW_USE_STATIC_LIBS=ON -DCMAKE_OSX_ARCHITECTURES=${CMAKE_ARCHS} -DPNG_PNG_INCLUDE_DIR=${PREFIX}/include/QtPng -DPNG_LIBRARY=${PREFIX}/lib/libQt6BundledLibpng.a -DCMAKE_INSTALL_PREFIX=${PREFIX}
+cmake -B build -G Ninja -DCMAKE_PREFIX_PATH=${PREFIX} -DCMAKE_IGNORE_PREFIX_PATH="/opt/homebrew;/usr/X11;/usr/X11R6" -DFFTW_USE_STATIC_LIBS=ON -DCMAKE_OSX_ARCHITECTURES=${CMAKE_ARCHS} -DPNG_PNG_INCLUDE_DIR=${PREFIX}/include/QtPng -DPNG_LIBRARY=${PREFIX}/lib/libQt6BundledLibpng.a -DCMAKE_INSTALL_PREFIX=${PREFIX} -DMRTRIX_USE_PCH=OFF
 cmake --build build
 cd ..
 MRTRIX_SECONDS=${SECONDS}

--- a/packaging/mingw/PKGBUILD
+++ b/packaging/mingw/PKGBUILD
@@ -39,7 +39,7 @@ pkgver() {
 
 build() {
   cd "${_realname}"
-  cmake -B build -G Ninja
+  cmake -B build -G Ninja -DMRTRIX_BUILD_NON_CORE_STATIC=ON
   cmake --build build
   cmake --install build --prefix=./install
 }

--- a/packaging/package-linux-tarball.sh
+++ b/packaging/package-linux-tarball.sh
@@ -66,7 +66,8 @@ cmake -B $build_dir -S $source_dir \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=$install_dir \
     -DCMAKE_EXE_LINKER_FLAGS="-Wl,--as-needed" \
-    -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON
+    -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \
+    -DMRTRIX_BUILD_NON_CORE_STATIC=ON
     
 cmake --build $build_dir
 cmake --install $build_dir


### PR DESCRIPTION
- Build releases by with `-DMRTRIX_BUILD_NON_CORE_STATIC` enabled, to avoid building the code in `src` into a separate shared library.

- Don't use precompiled headers when building macOS releases.