### PR TITLE
New workflow for releases

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,0 +1,137 @@
+name: Releases
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to release from'
+        required: true
+        default: 'dev'
+
+jobs:
+  linux-release:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.branch }}
+      
+      - name: Set env vars
+        id: envs
+        run: |
+          commit_sha=$(git rev-parse HEAD)
+          date=$(date +%Y_%m_%d)
+          echo "commit_sha=$commit_sha" >> $GITHUB_OUTPUT
+          echo "date=$date" >> $GITHUB_OUTPUT
+          echo "output_name=mrtrix3-linux-$commit_sha-$date.tar.gz" >> $GITHUB_OUTPUT
+
+      - name: Install Eigen3
+        run: |
+          git clone https://gitlab.com/libeigen/eigen.git && cd eigen && git checkout 3.4.0
+          cmake -B build && cmake --build build
+          sudo cmake --install build
+
+      - name: Install Qt 6
+        uses: jurplel/install-qt-action@v3
+        with:
+          version: '6.7.0'
+          set-env: true
+
+      - name: Run build
+        run: |
+          ./packaging/package-linux-tarball.sh .
+          mv mrtrix.tar.gz ${{ steps.envs.outputs.output_name }}
+
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.envs.outputs.output_name }}
+          path: ${{ steps.envs.outputs.output_name }}
+
+  macos-release:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: Set env vars
+        id: envs
+        run: |
+          commit_sha=$(git rev-parse HEAD)
+          date=$(date +%Y_%m_%d)
+          echo "commit_sha=$commit_sha" >> $GITHUB_OUTPUT
+          echo "date=$date" >> $GITHUB_OUTPUT
+          echo "output_name=mrtrix3-macos-$commit_sha-$date.tar.xz" >> $GITHUB_OUTPUT
+
+      - name: Install deps
+        run: brew install numpy cmake qt eigen pkg-config fftw libpng ninja
+
+      - name: Run build
+        run: |
+          cd ./packaging/macos
+          ./build ${{ github.event.inputs.branch }}
+          mv ./mrtrix3-macos-${{ github.event.inputs.branch }}.tar.xz ../../${{ steps.envs.outputs.output_name }}
+
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.envs.outputs.output_name }}
+          path: ${{ steps.envs.outputs.output_name }}
+
+  windows-release:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    env:
+      MINGW_PACKAGE_PREFIX: mingw-w64-ucrt-x86_64
+
+    steps:
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          install: |
+            git
+            python
+            ${{env.MINGW_PACKAGE_PREFIX}}-bc
+            ${{env.MINGW_PACKAGE_PREFIX}}-cmake
+            ${{env.MINGW_PACKAGE_PREFIX}}-diffutils
+            ${{env.MINGW_PACKAGE_PREFIX}}-eigen3
+            ${{env.MINGW_PACKAGE_PREFIX}}-fftw
+            ${{env.MINGW_PACKAGE_PREFIX}}-gcc
+            ${{env.MINGW_PACKAGE_PREFIX}}-libtiff
+            ${{env.MINGW_PACKAGE_PREFIX}}-ninja
+            ${{env.MINGW_PACKAGE_PREFIX}}-pkg-config
+            ${{env.MINGW_PACKAGE_PREFIX}}-qt6-base
+            ${{env.MINGW_PACKAGE_PREFIX}}-qt6-svg
+            ${{env.MINGW_PACKAGE_PREFIX}}-zlib
+      
+      - name: Checkout
+        run: git clone https://github.com/mrtrix3/mrtrix3 -b ${{ github.event.inputs.branch }}
+      
+      - name: Set env vars
+        id: envs
+        run: |
+          cd mrtrix3
+          commit_sha=$(git rev-parse HEAD)
+          date=$(date +%Y_%m_%d)
+          echo "commit_sha=$commit_sha" >> $GITHUB_OUTPUT
+          echo "date=$date" >> $GITHUB_OUTPUT
+          echo "output_name=mrtrix3-windows-$commit_sha-$date.tar.zst" >> $GITHUB_OUTPUT
+
+      - name: Run build
+        run: |
+          cd mrtrix3
+          cd packaging/mingw
+          ./run.sh ${{ steps.envs.outputs.commit_sha }} mrtrix3
+          mv mingw*.tar.zst ../../../${{ steps.envs.outputs.output_name }}
+
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.envs.outputs.output_name }}
+          path: ${{ steps.envs.outputs.output_name }}

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -109,14 +109,15 @@ jobs:
             ${{env.MINGW_PACKAGE_PREFIX}}-qt6-base
             ${{env.MINGW_PACKAGE_PREFIX}}-qt6-svg
             ${{env.MINGW_PACKAGE_PREFIX}}-zlib
-      
-      - name: Checkout
-        run: git clone https://github.com/mrtrix3/mrtrix3 -b ${{ github.event.inputs.branch }}
+
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.branch }}
       
       - name: Set env vars
         id: envs
         run: |
-          cd mrtrix3
           commit_sha=$(git rev-parse HEAD)
           date=$(date +%Y_%m_%d)
           echo "commit_sha=$commit_sha" >> $GITHUB_OUTPUT
@@ -125,7 +126,6 @@ jobs:
 
       - name: Run build
         run: |
-          cd mrtrix3
           cd packaging/mingw
           ./run.sh ${{ steps.envs.outputs.commit_sha }} mrtrix3
           mv mingw*.tar.zst ../../../${{ steps.envs.outputs.output_name }}

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -24,7 +24,7 @@ jobs:
           date=$(date +%Y_%m_%d)
           echo "commit_sha=$commit_sha" >> $GITHUB_OUTPUT
           echo "date=$date" >> $GITHUB_OUTPUT
-          echo "output_name=mrtrix3-linux-$commit_sha-$date.tar.gz" >> $GITHUB_OUTPUT
+          echo "output_name=mrtrix3-linux-$commit_sha-$date" >> $GITHUB_OUTPUT
 
       - name: Install Eigen3
         run: |
@@ -41,13 +41,13 @@ jobs:
       - name: Run build
         run: |
           ./packaging/package-linux-tarball.sh .
-          mv mrtrix.tar.gz ${{ steps.envs.outputs.output_name }}
+          mv mrtrix.tar.gz ${{ steps.envs.outputs.output_name }}.tar.gz
 
       - name: Upload release artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.envs.outputs.output_name }}
-          path: ${{ steps.envs.outputs.output_name }}
+          path: ${{ steps.envs.outputs.output_name }}.tar.gz
 
   macos-release:
     runs-on: macos-latest
@@ -64,7 +64,7 @@ jobs:
           date=$(date +%Y_%m_%d)
           echo "commit_sha=$commit_sha" >> $GITHUB_OUTPUT
           echo "date=$date" >> $GITHUB_OUTPUT
-          echo "output_name=mrtrix3-macos-$commit_sha-$date.tar.xz" >> $GITHUB_OUTPUT
+          echo "output_name=mrtrix3-macos-$commit_sha-$date" >> $GITHUB_OUTPUT
 
       - name: Install deps
         run: brew install numpy cmake qt eigen pkg-config fftw libpng ninja
@@ -73,13 +73,13 @@ jobs:
         run: |
           cd ./packaging/macos
           ./build ${{ github.event.inputs.branch }}
-          mv ./mrtrix3-macos-${{ github.event.inputs.branch }}.tar.xz ../../${{ steps.envs.outputs.output_name }}
+          mv ./mrtrix3-macos-${{ github.event.inputs.branch }}.tar.xz ../../${{ steps.envs.outputs.output_name }}.tar.xz
 
       - name: Upload release artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.envs.outputs.output_name }}
-          path: ${{ steps.envs.outputs.output_name }}
+          path: ${{ steps.envs.outputs.output_name }}.tar.xz
 
   windows-release:
     runs-on: windows-latest
@@ -122,16 +122,16 @@ jobs:
           date=$(date +%Y_%m_%d)
           echo "commit_sha=$commit_sha" >> $GITHUB_OUTPUT
           echo "date=$date" >> $GITHUB_OUTPUT
-          echo "output_name=mrtrix3-windows-$commit_sha-$date.tar.zst" >> $GITHUB_OUTPUT
+          echo "output_name=mrtrix3-windows-$commit_sha-$date" >> $GITHUB_OUTPUT
 
       - name: Run build
         run: |
           cd packaging/mingw
           ./run.sh ${{ steps.envs.outputs.commit_sha }} mrtrix3
-          mv mingw*.tar.zst ../../../${{ steps.envs.outputs.output_name }}
+          mv mingw*.tar.zst ../../../${{ steps.envs.outputs.output_name }}.tar.zst
 
       - name: Upload release artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.envs.outputs.output_name }}
-          path: ${{ steps.envs.outputs.output_name }}
+          path: ${{ steps.envs.outputs.output_name }}.tar.zst


### PR DESCRIPTION
This PR succeeds the work done in #2835. As mentioned there, instead of having a separate workflow for weekly releases, it's better to have a single CI workflow that manages both tagged and periodic releases. 
As a first step towards that, this PR introduces a new CI workflow which creates artefacts of release builds using GitHub Actions. The artefacts are named as `mrtrix3-{os}-{branch}.{extension}` (@MRtrix3/mrtrix3-devs let me know if we want to add further information like build dates).
The workflow can be triggered manually, and the developer can specify the branch of MRtrix3 they want to build (the branch will need to be based on `cmake`).
This will be useful firstly because it allows a developer to create a release for a particular feature branch of their choice. Secondly, it will allow us to test our build scripts for our upcoming releases without creating a tagged release.

Since GitHub only allows [workflow_dispatch](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch) triggers if the workflow file is on the default branch, the merge needs to be against `master`. This is slightly unfortunate since `master` is still not on `cmake`.
To make sure things behave as expected, I have already tested that the workflow succeeds on a separate fork of MRtrix3.