### PR TITLE
Modified FindFFTW to only look for double precision version of fftw3

### DIFF
--- a/cmake/FindFFTW.cmake
+++ b/cmake/FindFFTW.cmake
@@ -54,22 +54,6 @@ if( FFTW_ROOT )
     NO_DEFAULT_PATH
   )
 
-  find_library(
-    FFTWF_LIB
-    NAMES "fftw3f"
-    PATHS ${FFTW_ROOT}
-    PATH_SUFFIXES "lib" "lib64"
-    NO_DEFAULT_PATH
-  )
-
-  find_library(
-    FFTWL_LIB
-    NAMES "fftw3l"
-    PATHS ${FFTW_ROOT}
-    PATH_SUFFIXES "lib" "lib64"
-    NO_DEFAULT_PATH
-  )
-
   #find includes
   find_path(
     FFTW_INCLUDES
@@ -87,19 +71,6 @@ else()
     PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
   )
 
-  find_library(
-    FFTWF_LIB
-    NAMES "fftw3f"
-    PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
-  )
-
-
-  find_library(
-    FFTWL_LIB
-    NAMES "fftw3l"
-    PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
-  )
-
   find_path(
     FFTW_INCLUDES
     NAMES "fftw3.h"
@@ -108,11 +79,7 @@ else()
 
 endif()
 
-set(FFTW_LIBRARIES ${FFTW_LIB} ${FFTWF_LIB})
-
-if(FFTWL_LIB)
-  set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTWL_LIB})
-endif()
+set(FFTW_LIBRARIES ${FFTW_LIB})
 
 set( CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES_SAV} )
 
@@ -120,5 +87,5 @@ include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(FFTW DEFAULT_MSG
                                   FFTW_INCLUDES FFTW_LIBRARIES)
 
-mark_as_advanced(FFTW_INCLUDES FFTW_LIBRARIES FFTW_LIB FFTWF_LIB FFTWL_LIB)
+mark_as_advanced(FFTW_INCLUDES FFTW_LIBRARIES FFTW_LIB)
 

--- a/packaging/macos/build
+++ b/packaging/macos/build
@@ -138,7 +138,6 @@ export PATH
 SECONDS=0
 git clone https://github.com/MRtrix3/mrtrix3.git mrtrix3-src -b ${TAGNAME}
 cd ${PREFIX}-src
-sed -i.bak -e '90,101d' cmake/FindFFTW.cmake
 MRTRIX_VERSION=$(git describe --abbrev=8 | tr '-' '_')
 cmake -B build -G Ninja -DCMAKE_PREFIX_PATH=${PREFIX} -DCMAKE_IGNORE_PREFIX_PATH="/opt/homebrew;/usr/X11;/usr/X11R6" -DFFTW_USE_STATIC_LIBS=ON -DCMAKE_OSX_ARCHITECTURES=${CMAKE_ARCHS} -DPNG_PNG_INCLUDE_DIR=${PREFIX}/include/QtPng -DPNG_LIBRARY=${PREFIX}/lib/libQt6BundledLibpng.a -DCMAKE_INSTALL_PREFIX=${PREFIX} -DMRTRIX_USE_PCH=OFF -DMRTRIX_BUILD_NON_CORE_STATIC=ON
 cmake --build build


### PR DESCRIPTION
Prevents failure when unused single and quad precision are not available