### PR TITLE
ProgressBar: Simple update method where stderr is pipe

### DIFF
--- a/core/progressbar.cpp
+++ b/core/progressbar.cpp
@@ -188,7 +188,7 @@ namespace MR
       // unable to determine nature of stderr; assuming socket
       stderr_to_file = false;
     else
-      stderr_to_file = S_ISREG (buf.st_mode);
+      stderr_to_file = S_ISREG (buf.st_mode) || S_ISFIFO (buf.st_mode);
 
 
 


### PR DESCRIPTION
Likely resolves #1980.

Discovered that `mrinfo`-ing to a file produced the simplified progress bar, whereas using `2>&1 | tee` used the dynamic progress bar, producing a whole lot of junk at the head of the file if opened in a text editor.

This change means that MRtrix3 C++ commands invoked by a MRtrix3 Python command, where the latter is invoked with `-info` or `-debug` (and therefore shows dynamic information about executed processes), will now show the simplified progress bar; this is perfectly fine by me. Similarly if the stdout / stderr contents of a failed command are written to text file in the scratch directory, they will also have the simplified appearance, as they ideally should.

Not 100% happy with the appearance of the simplified progress bar (see eg. #1744), but not the top priority right now.