### PR TITLE
dirmerge: Better selection of first volume

### DIFF
--- a/cmd/dirmerge.cpp
+++ b/cmd/dirmerge.cpp
@@ -111,10 +111,45 @@ void run() {
   }();
   INFO("found total of " + str(total) + " volumes");
 
-  // pick random direction from first direction set:
+  // pick which volume will be first
+  // from within the shell with the largest number of volumes,
+  //   choose the subset with the largest number of volumes,
+  //   then choose a random volume within that subset
+  size_t largest_shell = [&] {
+    value_type largestshell_b = 0.0;
+    size_t largestshell_n = 0;
+    size_t largestshell_index = 0;
+    for (size_t n = 0; n != dirs.size(); ++n) {
+      size_t size = 0;
+      for (auto &m : dirs[n])
+        size += m.size();
+      if (size > largestshell_n || (size == largestshell_n && bvalue[n] > largestshell_b)) {
+        largestshell_b = bvalue[n];
+        largestshell_n = size;
+        largestshell_index = n;
+      }
+    }
+    return largestshell_index;
+  }();
+  INFO("first volume will be from shell b=" + str(bvalue[largest_shell]));
+  size_t largest_subset_within_largest_shell = [&] {
+    size_t largestsubset_index = 0;
+    size_t largestsubset_n = dirs[largest_shell][0].size();
+    for (size_t n = 1; n != dirs[largest_shell].size(); ++n) {
+      const size_t size = dirs[largest_shell][n].size();
+      if (size > largestsubset_n) {
+        largestsubset_n = size;
+        largestsubset_index = n;
+      }
+    }
+    return largestsubset_index;
+  }();
+  if (num_subsets > 1) {
+    INFO("first volume will be from subset " + str(largest_subset_within_largest_shell + 1) + " from largest shell");
+  }
   std::random_device rd;
   std::mt19937 rng(rd());
-  size_t first = std::uniform_int_distribution<size_t>(0, dirs[0][0].size() - 1)(rng);
+  const size_t first = std::uniform_int_distribution<size_t>(0, dirs[largest_shell][largest_subset_within_largest_shell].size() - 1)(rng);
 
   std::vector<OutDir> merged;
 
@@ -161,11 +196,6 @@ void run() {
     fraction.push_back(float(n) / float(total));
   };
 
-  push(0, 0, first);
-
-  std::vector<size_t> counts(bvalue.size(), 0);
-  ++counts[0];
-
   auto num_for_b = [&](size_t b) {
     size_t n = 0;
     for (auto &d : merged)
@@ -173,6 +203,11 @@ void run() {
         ++n;
     return n;
   };
+
+  // write the volume that was chosen to be first
+  push(largest_shell, largest_subset_within_largest_shell, first);
+  std::vector<size_t> counts(bvalue.size(), 0);
+  ++counts[largest_shell];
 
   size_t nPE = num_subsets > 1 ? 1 : 0;
   while (merged.size() < total) {

--- a/cmd/dirmerge.cpp
+++ b/cmd/dirmerge.cpp
@@ -132,7 +132,7 @@ void run() {
     return largestshell_index;
   }();
   INFO("first volume will be from shell b=" + str(bvalue[largest_shell]));
-  size_t largest_subset_within_largest_shell = [&] {
+  const size_t largest_subset_within_largest_shell = [&] {
     size_t largestsubset_index = 0;
     size_t largestsubset_n = dirs[largest_shell][0].size();
     for (size_t n = 1; n != dirs[largest_shell].size(); ++n) {
@@ -149,7 +149,8 @@ void run() {
   }
   std::random_device rd;
   std::mt19937 rng(rd());
-  const size_t first = std::uniform_int_distribution<size_t>(0, dirs[largest_shell][largest_subset_within_largest_shell].size() - 1)(rng);
+  const size_t first = std::uniform_int_distribution<size_t>(
+      0, dirs[largest_shell][largest_subset_within_largest_shell].size() - 1)(rng);
 
   std::vector<OutDir> merged;
 

--- a/docs/reference/commands/dirmerge.rst
+++ b/docs/reference/commands/dirmerge.rst
@@ -24,6 +24,8 @@ Options
 
 -  **-unipolar_weight value** set the weight given to the unipolar electrostatic repulsion model compared to the bipolar model (default: 0.2).
 
+-  **-firstisfirst** choose the first volume in the list from the first shell, rather than choosing such from the shell with the most volumes (replicates behaviour prior to version 3.1.0)
+
 Standard options
 ^^^^^^^^^^^^^^^^
 

--- a/testing/binaries/CMakeLists.txt
+++ b/testing/binaries/CMakeLists.txt
@@ -57,6 +57,13 @@ add_bash_binary_test(dirgen/default)
 add_bash_binary_test(dirgen/power)
 add_bash_binary_test(dirgen/unipolar)
 
+add_bash_binary_test(dirmerge/onesubset)
+add_bash_binary_test(dirmerge/twosubsets)
+add_bash_binary_test(dirmerge/foursubsets)
+add_bash_binary_test(dirmerge/onesubset_firstisfirst)
+add_bash_binary_test(dirmerge/twosubsets_firstisfirst)
+add_bash_binary_test(dirmerge/foursubsets_firstisfirst)
+
 add_bash_binary_test(dwi2adc/default)
 
 add_bash_binary_test(dwi2fod/csd_default)

--- a/testing/binaries/tests/dirmerge/foursubsets
+++ b/testing/binaries/tests/dirmerge/foursubsets
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Test successful execution for four subsets and no other options
+# Cannot compare directly to a pre-generated output due to stochasticity of command
+
+dirmerge 4 \
+0 dirmerge/bzero_2.txt dirmerge/bzero_2.txt dirmerge/bzero_2.txt dirmerge/bzero_2.txt \
+300 dirmerge/12_1of4.txt dirmerge/12_2of4.txt dirmerge/12_3of4.txt dirmerge/12_4of4.txt \
+1000 dirmerge/24_1of4.txt dirmerge/24_2of4.txt dirmerge/24_3of4.txt dirmerge/24_4of4.txt \
+3000 dirmerge/60_1of4.txt dirmerge/60_2of4.txt dirmerge/60_3of4.txt dirmerge/60_4of4.txt \
+tmp.txt -force

--- a/testing/binaries/tests/dirmerge/foursubsets_firstisfirst
+++ b/testing/binaries/tests/dirmerge/foursubsets_firstisfirst
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Test successful execution for four subsets
+#   where the -firstisfirst option is specified
+# Cannot compare directly to a pre-generated output due to stochasticity of command
+
+dirmerge 4 \
+0 dirmerge/bzero_2.txt dirmerge/bzero_2.txt dirmerge/bzero_2.txt dirmerge/bzero_2.txt \
+300 dirmerge/12_1of4.txt dirmerge/12_2of4.txt dirmerge/12_3of4.txt dirmerge/12_4of4.txt \
+1000 dirmerge/24_1of4.txt dirmerge/24_2of4.txt dirmerge/24_3of4.txt dirmerge/24_4of4.txt \
+3000 dirmerge/60_1of4.txt dirmerge/60_2of4.txt dirmerge/60_3of4.txt dirmerge/60_4of4.txt \
+tmp.txt -force -firstisfirst

--- a/testing/binaries/tests/dirmerge/onesubset
+++ b/testing/binaries/tests/dirmerge/onesubset
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Test successful execution for a single subset and no other options
+# Cannot compare directly to a pre-generated output due to stochasticity of command
+
+dirmerge 1 \
+0 dirmerge/bzero_8.txt \
+300 dirmerge/12.txt \
+1000 dirmerge/24.txt \
+3000 dirmerge/60.txt \
+tmp.txt -force

--- a/testing/binaries/tests/dirmerge/onesubset_firstisfirst
+++ b/testing/binaries/tests/dirmerge/onesubset_firstisfirst
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Test successful execution for a single subset
+#   where the -firstisfirst option is specified
+# Cannot compare directly to a pre-generated output due to stochasticity of command
+
+dirmerge 1 \
+0 dirmerge/bzero_8.txt \
+300 dirmerge/12.txt \
+1000 dirmerge/24.txt \
+3000 dirmerge/60.txt \
+tmp.txt -force -firstisfirst

--- a/testing/binaries/tests/dirmerge/twosubsets
+++ b/testing/binaries/tests/dirmerge/twosubsets
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Test successful execution for two subsets and no other options
+# Cannot compare directly to a pre-generated output due to stochasticity of command
+
+dirmerge 2 \
+0 dirmerge/bzero_4.txt dirmerge/bzero_4.txt \
+300 dirmerge/12_1of2.txt dirmerge/12_2of2.txt \
+1000 dirmerge/24_1of2.txt dirmerge/24_2of2.txt \
+3000 dirmerge/60_1of2.txt dirmerge/60_2of2.txt \
+tmp.txt -force

--- a/testing/binaries/tests/dirmerge/twosubsets_firstisfirst
+++ b/testing/binaries/tests/dirmerge/twosubsets_firstisfirst
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Test successful execution for two subsets
+#   where the -firstisfirst option is specified
+# Cannot compare directly to a pre-generated output due to stochasticity of command
+
+dirmerge 2 \
+0 dirmerge/bzero_4.txt dirmerge/bzero_4.txt \
+300 dirmerge/12_1of2.txt dirmerge/12_2of2.txt \
+1000 dirmerge/24_1of2.txt dirmerge/24_2of2.txt \
+3000 dirmerge/60_1of2.txt dirmerge/60_2of2.txt \
+tmp.txt -force -firstisfirst


### PR DESCRIPTION
Did this in addition to #2749 as I needed to modify the gradient table for the local primary project and therefore figured I'd address this annoyance as well.

Previously, the first volume in the output scheme was chosen as a random volume from the first subset of the first shell. Here, this is modified to instead be a random volume from the largest subset of the largest shell. This should slightly improve the quality of distribution of bmax volumes across the acquisition time.

Closes #2677.

@jdtournier: I've only tested this with my own usage of `dirmerge`, which doesn't involve multiple subsets as input (since Siemens can't interleave phase encoding directions). Do you have data lying around that you can feed into this modified version? Otherwise I'll have to synthesize something, as there's no committed test data for this command.