### PR TITLE
Deprecated distutils module in Python 3.12

### DIFF
--- a/bin/mrtrix3.py
+++ b/bin/mrtrix3.py
@@ -15,7 +15,6 @@
 # For more details, see http://www.mrtrix.org/.
 
 import os, sys
-from distutils.spawn import find_executable
 
 try:
   # since importlib code below only works on Python 3.5+

--- a/lib/mrtrix3/path.py
+++ b/lib/mrtrix3/path.py
@@ -21,13 +21,18 @@
 
 
 import ctypes, errno, inspect, os, random, string, subprocess, time
-from distutils.spawn import find_executable
 # Function can be used in isolation if potentially needing to place quotation marks around a
 #   filesystem path that is to be included as part of a command string
 try:
   from shlex import quote
 except ImportError:
   from pipes import quote
+# Distutils removed in 3.12, but shutil.which not available in 2.7
+try:
+  from shutil import which as find_executable
+except ImportError:
+  from distutils.spawn import find_executable
+
 from mrtrix3 import CONFIG
 from mrtrix3.utils import STRING_TYPES
 

--- a/lib/mrtrix3/run.py
+++ b/lib/mrtrix3/run.py
@@ -17,9 +17,14 @@
 # pylint: disable=unspecified-encoding
 
 import collections, itertools, os, shlex, signal, string, subprocess, sys, tempfile, threading
-from distutils.spawn import find_executable
 from mrtrix3 import ANSI, BIN_PATH, COMMAND_HISTORY_STRING, EXE_LIST, MRtrixBaseError, MRtrixError
 from mrtrix3.utils import STRING_TYPES
+
+# Distutils removed in 3.12, but shutil.which not available in 2.7
+try:
+  from shutil import which as find_executable
+except ImportError:
+  from distutils.spawn import find_executable
 
 IOStream = collections.namedtuple('IOStream', 'handle filename')
 


### PR DESCRIPTION
This fix is exclusively for `master` / 3.0.x, to support Python 3.12 whilst preserving Python2 support. On `dev`, Python2 support has been dropped, and `shutil.which()` is used by name.

`./run_tests scripts` successful.

Can't fully verify via CI as Python2 support is not explicitly tested. No particular interest in doing so either; would prefer to focus on testing the range of Python3 versions supported (#2821) for 3.1. So hopefully this can be reviewed from first principles.