### PR TITLE
Add interface library for project-wide compile options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,35 +81,35 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git AND NOT EXISTS ${CMAKE_CURRENT_SOURCE
         "and then run `pre-commit install` from the ${CMAKE_CURRENT_SOURCE_DIR} directory.")
 endif()
 
-
-# Allow compilation of big object of files in debug mode on MINGW
-if(MINGW AND CMAKE_BUILD_TYPE MATCHES "Debug")
-    add_compile_options(-Wa,-mbig-obj)
-endif()
-
-add_compile_definitions(
+add_library(mrtrix-common INTERFACE)
+add_library(mrtrix::common ALIAS mrtrix-common)
+target_compile_definitions(mrtrix-common INTERFACE
     MRTRIX_BUILD_TYPE="${CMAKE_BUILD_TYPE}"
     $<$<PLATFORM_ID:Windows>:MRTRIX_WINDOWS>
     $<$<PLATFORM_ID:Darwin>:MRTRIX_MACOSX>
     $<$<PLATFORM_ID:FreeBSD>:MRTRIX_FREEBSD>
 )
 
-if(MRTRIX_STL_DEBUGGING AND $<NOT:$<CONFIG:Debug>>)
-    if(MSVC)
-        add_compile_definitions(_ITERATOR_DEBUG_LEVEL=1)
-    elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        add_compile_options(_LIBCPP_DEBUG)
-    elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-        add_compile_options(_GLIBCXX_DEBUG _GLIBCXX_DEBUG_PEDANTIC)
-    endif()
+if(MRTRIX_STL_DEBUGGING AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+    message(STATUS "Enabling STL debug mode")
+    target_compile_definitions(mrtrix-common INTERFACE
+        $<$<CXX_COMPILER_ID:MSVC>:_ITERATOR_DEBUG_LEVEL=1>
+        $<$<CXX_COMPILER_ID:GNU>:_GLIBCXX_DEBUG _GLIBCXX_DEBUG_PEDANTIC>
+        $<$<CXX_COMPILER_ID:Clang>:_LIBCPP_DEBUG=1>
+    )
 endif()
 
 if(MRTRIX_WARNINGS_AS_ERRORS)
-    if (MSVC)
-        add_compile_options(/WX)
-    else()
-        add_compile_options(-Werror)
-    endif()
+    message(STATUS "Enabling warnings as errors")
+    target_compile_options(mrtrix-common INTERFACE
+        $<$<CXX_COMPILER_ID:MSVC>:/WX>
+        $<$<CXX_COMPILER_ID:GNU,Clang>:-Werror>
+    )
+endif()
+
+# Allow compilation of big object of files in debug mode on MINGW
+if(MINGW AND CMAKE_BUILD_TYPE MATCHES "Debug")
+    target_compile_options(mrtrix-common INTERFACE -Wa,-mbig-obj)
 endif()
 
 

--- a/cmd/CMakeLists.txt
+++ b/cmd/CMakeLists.txt
@@ -10,7 +10,7 @@ if(MRTRIX_USE_PCH)
     add_executable(pch_cmd ${CMAKE_CURRENT_BINARY_DIR}/pch_cmd.cpp)
     target_include_directories(pch_cmd PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../core)
     find_package(Eigen3 REQUIRED)
-    target_link_libraries(pch_cmd PRIVATE Eigen3::Eigen)
+    target_link_libraries(pch_cmd PRIVATE Eigen3::Eigen mrtrix::common)
     target_precompile_headers(pch_cmd PRIVATE
         [["app.h"]]
         [["image.h"]]

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -87,6 +87,7 @@ target_link_libraries(mrtrix-core PUBLIC
     ZLIB::ZLIB
     ${FFTW_LIBRARIES}
     mrtrix::core-version-lib
+    mrtrix::common
     Threads::Threads
     ${FFTW_LIBRARIES}
 )

--- a/core/file/npy.cpp
+++ b/core/file/npy.cpp
@@ -134,9 +134,10 @@ DataType descr2datatype(const std::string &s) {
   if (bytes > 1) {
     data_type = data_type() | (is_little_endian ? DataType::LittleEndian : DataType::BigEndian);
     if (issue_endianness_warning) {
-      WARN(std::string("NumPy file does not indicate data endianness;") +         //
-           " assuming " + (MRTRIX_IS_BIG_ENDIAN ? "big" : "little") + "-endian" + //
-           " (same as system)");
+      using namespace std::string_literals;
+      const std::string message = "NumPy file does not indicate data endianness; assuming "s +
+                                  (MRTRIX_IS_BIG_ENDIAN ? "big"s : "little"s) + "-endian"s + " (same as system)"s;
+      WARN(message);
     }
   }
   return data_type;


### PR DESCRIPTION
Previously we relied on `add_compile_options` and `add_compile_definitions` for defining compiler definitions and options for the entire project. This commit replaces that behaviour by defining a new `mrtrix::common` INTERFACE library that links to all targets in the project (the library is linked to `mrtrix::core`). This is more CMake-idiomatic and prevents the propagation of compiler definitions to targets that do not link to `mrtrix::core` (useful when compiling MRtrix3 as a subproject of another project). Ideally, we should be using CMake presets for this kind of stuff, but we need to support CMake 3.16.