### PR TITLE
dwi2tensor: Preserve dw_scheme for -predicted_signal

### DIFF
--- a/cmd/dwi2tensor.cpp
+++ b/cmd/dwi2tensor.cpp
@@ -220,7 +220,6 @@ void run ()
   Header header (dwi);
   header.datatype() = DataType::Float32;
   header.ndim() = 4;
-  DWI::stash_DW_scheme (header, grad);
   PhaseEncoding::clear_scheme (header);
 
   Image<value_type> predict;
@@ -228,6 +227,7 @@ void run ()
   if (opt.size())
     predict = Image<value_type>::create (opt[0][0], header);
 
+  DWI::stash_DW_scheme (header, grad);
   header.size(3) = 6;
   auto dt = Image<value_type>::create (argument[1], header);
 


### PR DESCRIPTION
Currently, the output of `dwi2tensor -predicted_signal` can't be loaded in the `mrview` ODF tool, as `dw_scheme` is shashed to `prior_dw_scheme`. This change ensures that `dw_scheme` remains present in the output of the `-predicted_signal` option, but is stashed for all other outputs.