### PR TITLE
Python API: Support Python 3.12

### DIFF
--- a/python/mrtrix3/app.py
+++ b/python/mrtrix3/app.py
@@ -583,7 +583,7 @@ class Parser(argparse.ArgumentParser):
   #   which will derive from both pathlib.Path (which itself through __new__() could be Posix or Windows)
   #   and a desired augmentation that provides additional functions
   @staticmethod
-  def make_userpath_object(base_class, *args, **kwargs):
+  def make_userpath_object(base_class, *args):
     abspath = os.path.normpath(os.path.join(WORKING_DIR, *args))
     super_class = pathlib.WindowsPath if os.name == 'nt' else pathlib.PosixPath
     new_class = type(f'{base_class.__name__.lstrip("_").rstrip("Extras")}',
@@ -593,7 +593,7 @@ class Parser(argparse.ArgumentParser):
       instance = new_class.__new__(new_class, abspath)
     else:
       instance = new_class.__new__(new_class)
-      super(super_class, instance).__init__(abspath)
+      super(super_class, instance).__init__(abspath) # pylint: disable=bad-super-call
     return instance
 
   # Classes that extend the functionality of pathlib.Path


### PR DESCRIPTION
This should unblock CI tests on `dev`.

The newly-used "pathlib" module prior to Python 3.12 utilises the `__new__()` function to initialise member variables; Python 3.12 more suitably uses `__init__()`.

I wasn't able to figure out a cleaner syntax that would work with both versions.

While we had some prior discussion about the use of composition rather than inheritance, here that composition would consist almost exclusively of pass-throughs. So I'm going to stick with the multi-inheritance strategy, at least for now. I might do some re-arrangement to allow developers to construct fstring-quote-escaped filesystem paths outside of the CLI, but I'll defer that until after CI on `dev` is unblocked.