### PR TITLE
mrtrix3.run: Improved shebang parsing

### DIFF
--- a/python/mrtrix3/run.py
+++ b/python/mrtrix3/run.py
@@ -682,6 +682,7 @@ def _shebang(item):
     try:
       shebang = parse_shebang(line, utils.is_windows())
       app.debug(f'File "{item}": shebang line "{line}"; utilised shebang {shebang}')
+      return shebang
     except ShebangParseError as exc:
       app.warn(f'Invalid shebang in script file "{item}": {exc}')
       return []


### PR DESCRIPTION
In doing #2957 I noticed an issue whereby whenever I manually invoked my compiled-from-source Python 3.12, any Python scripts that themselves invoke Python scripts would revert to Python 3.10 that was in my `PATH`. This is contrary to previously constructed code whose intent was to ensure that if a Python script invoked another Python script, the same interpreter would be used (#1828). This occurred because on `dev`, in the course of dropping Python2 support on `dev` (#2215), the script shebangs were changed to `/usr/bin/python3` rather than `/usr/bin/env python3`---note that this persists through #2741---but the code for explicit shebang parsing was not tested on such.

I note that a reversion back to using `/usr/bin/env` seems to be the most appropriate course of action from discussion with @daljit46. But this shebang parsing code is not just for *MRtrix3* executables, it tries to choose the most suitable interpreter for any shebang.

This change makes the relevant function more robust to both shebang styles, and enhances the version matching logic. If a script specifies a specific *minor* Python version (or indeed even *patch* version), the current interpreter will only be used if it is directly compatible with such; otherwise the shell will get to choose (including if the shell itself invokes `env`).

Tough to integrate the following as unit tests given that it depends on the contents of `PATH`. So I'm just doing a dump here. For context, the system Python version is 3.10, but I'm explicitly running a 3.12.4 from outside of `PATH`; this best shows the selection of when the current interpreter is run vs. other behaviour. Bold indicates cases where behaviour is different on Windows.

- [x] Test behaviour on Windows.
    In particular, the API supersedes `env`, because this was requisite at some point in the past to allow Python scripts to execute other Python scripts on Windows. But this may have been an MSYS2 problem that has since been rectified.

- [ ] Discuss any contentious scenarios.
    Possible that @daljit46 may disagree with some of these, preferring to allow the system to decide what to use in all scenarios. However the case that made me pursue this (#2957) was specifically about my using a non-system version of Python yet having subsequent scripts then executing on the system Python. So my current intuition is to preserve this behaviour. The other one that might be contentious is what to do if just "`python`" is specified as the destination interpreter. Here I'm invoking the current interpreter in that case.

| Shebang contents                         | POSIX parsed / error                                                                   | Windows Parsed / error                                                                 |
| ------------------                       | -------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| `b'Not a shebang'`                       | No shebang found                                                                       | No shebang found                                                                       |
| `b'\n#!/newline/before shebang'`         | ['/newline/before', 'shebang']                                                         | ['/newline/before', 'shebang']                                                         |
| `b'#!/usr/bin/env'`                      | Invalid shebang: missing interpreter after "env"                                       | Invalid shebang: missing interpreter after "env"                                       |
| `b'#!/usr/bin/env python'`               | ['/home/unimelb.edu.au/robertes/src/Python3.12/bin/python3']                           | ['/home/unimelb.edu.au/robertes/src/Python3.12/bin/python3']                           |
| **`b'#!/usr/bin/env python2'`**          | ['/usr/bin/env', 'python2']                                                            | ['/usr/bin/python2']                                                                   |
| `b'#!/usr/bin/env python3'`              | ['/home/unimelb.edu.au/robertes/src/Python3.12/bin/python3']                           | ['/home/unimelb.edu.au/robertes/src/Python3.12/bin/python3']                           |
| **`b'#!/usr/bin/env python3.10'`**       | ['/usr/bin/env', 'python3.10']                                                         | ['/usr/bin/python3.10']                                                                |
| **`b'#!/usr/bin/env python3.10 extra'`** | ['/usr/bin/env', 'python3.10', 'extra']                                                | ['/usr/bin/python3.10', 'extra']                                                       |
| **`b'#!/usr/bin/env python3.11'`**       | ['/usr/bin/env', 'python3.11']                                                         | Invalid shebang: "env" executing on Windows, but unable to find command "python3.11"   |
| `b'#!/usr/bin/env python3.12'`           | ['/home/unimelb.edu.au/robertes/src/Python3.12/bin/python3']                           | ['/home/unimelb.edu.au/robertes/src/Python3.12/bin/python3']                           |
| `b'#!/usr/bin/env python3.12 extra'`     | ['/home/unimelb.edu.au/robertes/src/Python3.12/bin/python3', 'extra']                  | ['/home/unimelb.edu.au/robertes/src/Python3.12/bin/python3', 'extra']                  |
| **`b'#!/usr/bin/env python3.10.1'`**     | ['/usr/bin/env', 'python3.10.1']                                                       | Invalid shebang: "env" executing on Windows, but unable to find command "python3.10.1" |
| **`b'#!/usr/bin/env python3.12.3'`**     | ['/usr/bin/env', 'python3.12.3']                                                       | Invalid shebang: "env" executing on Windows, but unable to find command "python3.12.3" |
| `b'#!/usr/bin/env python3.12.4'`         | ['/home/unimelb.edu.au/robertes/src/Python3.12/bin/python3']                           | ['/home/unimelb.edu.au/robertes/src/Python3.12/bin/python3']                           |
| **`b'#!/usr/bin/env python3.12.5'`**     | ['/usr/bin/env', 'python3.12.5']                                                       | Invalid shebang: "env" executing on Windows, but unable to find command "python3.12.5" |
| `b'#!/usr/bin/env python3.x`'            | Invalid shebang: unable to extract Python version from text "#!/usr/bin/env python3.x" | Invalid shebang: unable to extract Python version from text "#!/usr/bin/env python3.x" |
| `b'#!/usr/bin/python'`                   | ['/home/unimelb.edu.au/robertes/src/Python3.12/bin/python3']                           | ['/home/unimelb.edu.au/robertes/src/Python3.12/bin/python3']                           |
| `b'#!/usr/bin/python2'`                  | ['/usr/bin/python2']                                                                   | ['/usr/bin/python2']                                                                   |
| `b'#!/usr/bin/python3'`                  | ['/home/unimelb.edu.au/robertes/src/Python3.12/bin/python3']                           | ['/home/unimelb.edu.au/robertes/src/Python3.12/bin/python3']                           |
| `b'#!/usr/bin/python3.10'`               | ['/usr/bin/python3.10']                                                                | ['/usr/bin/python3.10']                                                                |
| `b'#!/usr/bin/python3.10 extra'`         | ['/usr/bin/python3.10', 'extra']                                                       | ['/usr/bin/python3.10', 'extra']                                                       |
| `b'#!/usr/bin/python3.11'`               | []                                                                                     | []                                                                                     |
| `b'#!/usr/bin/python3.12'`               | ['/home/unimelb.edu.au/robertes/src/Python3.12/bin/python3']                           | ['/home/unimelb.edu.au/robertes/src/Python3.12/bin/python3']                           |
| `b'#!/usr/bin/python3.12 extra'`         | ['/home/unimelb.edu.au/robertes/src/Python3.12/bin/python3', 'extra']                  | ['/home/unimelb.edu.au/robertes/src/Python3.12/bin/python3', 'extra']                  |
| `b'#!/usr/bin/python3.10.1'`             | []                                                                                     | []                                                                                     |
| `b'#!/usr/bin/python3.12.3'`             | []                                                                                     | []                                                                                     |
| `b'#!/usr/bin/python3.12.4'`             | ['/home/unimelb.edu.au/robertes/src/Python3.12/bin/python3']                           | ['/home/unimelb.edu.au/robertes/src/Python3.12/bin/python3']                           |
| `b'#!/usr/bin/python3.12.5'\             | []                                                                                     | []                                                                                     |
| `b'#!/usr/bin/blah'`                     | ['/usr/bin/blah']                                                                      | ['/usr/bin/blah']                                                                      |
| `b'#!/usr/bin/foo bar'`                  | ['/usr/bin/foo', 'bar']                                                                | ['/usr/bin/foo', 'bar']                                                                |
| `b'#!'`                                  | No shebang found                                                                       | No shebang found                                                                       |
| `b'#! /gap/in/shebang'`                  | ['/gap/in/shebang']                                                                    | ['/gap/in/shebang']                                                                    |








