### PR TITLE
Windows: Delayed writeback to host

### DIFF
--- a/core/file/mmap.cpp
+++ b/core/file/mmap.cpp
@@ -112,9 +112,10 @@ namespace MR
           delayed_writeback = true;
         }
 
-        if (fsbuf.f_type == 0xff534d42 /* CIFS */|| fsbuf.f_type == 0x6969 /* NFS */ || 
-            fsbuf.f_type == 0x65735546 /* FUSE */ || fsbuf.f_type == 0x517b /* SMB */ || 
-            fsbuf.f_type == 0x47504653 /* GPFS */ || fsbuf.f_type == 0xbd00bd0 /* LUSTRE */
+        if (fsbuf.f_type == 0xff534d42 /* CIFS */ || fsbuf.f_type == 0x6969 /* NFS */ ||
+            fsbuf.f_type == 0x65735546 /* FUSE */ || fsbuf.f_type == 0x517b /* SMB */ ||
+            fsbuf.f_type == 0x47504653 /* GPFS */ || fsbuf.f_type == 0xbd00bd0 /* LUSTRE */ ||
+            fsbuf.f_type == 0x1021997 /* 9P (WSL) */
 
 #ifdef MRTRIX_MACOSX
             || fsbuf.f_type == 0x0017 /* OSXFUSE */


### PR DESCRIPTION
This had been discussed in some detail back when #2554 was first discussed, but AFAICT this change was never explicitly proposed. Makes a measurable difference to command execution times when writing to a host drive.