### PR TITLE
Python executables shebang: use env

### DIFF
--- a/cmake/MakePythonExecutable.cmake
+++ b/cmake/MakePythonExecutable.cmake
@@ -4,7 +4,7 @@
 #   - OUTPUT_DIR: Directory in which to create the executable
 
 set(BINPATH_CONTENTS
-    "#!/usr/bin/python3\n"
+    "#!/usr/bin/env python3\n"
     "# -*- coding: utf-8 -*-\n"
     "\n"
     "import importlib\n"


### PR DESCRIPTION
I keep alluding to it but not actually committing.

Closes #2261.

Based on #2261 and many other conversations (eg. #2215), I think that reverting `dev` to using `env` but specifying `python3` as the interpreter is the right way to go.