### PR TITLE
mrtrix3.path.wait_for(): Fix variable ghosting

### DIFF
--- a/lib/mrtrix3/path.py
+++ b/lib/mrtrix3/path.py
@@ -263,7 +263,7 @@ def wait_for(paths): #pylint: disable=unused-variable
       time.sleep(delay)
       new_num_exist = num_exist(paths)
       if new_num_exist == current_num_exist:
-        delay = max(60.0, delay*2.0)
+        delay = min(60.0, delay*2.0)
       elif new_num_exist > current_num_exist:
         for _ in range(new_num_exist - current_num_exist):
           progress.increment()
@@ -305,7 +305,7 @@ def wait_for(paths): #pylint: disable=unused-variable
     time.sleep(delay)
     new_num_in_use = num_in_use(paths)
     if new_num_in_use == current_num_in_use:
-      delay = max(60.0, delay*2.0)
+      delay = min(60.0, delay*2.0)
     elif new_num_in_use < current_num_in_use:
       for _ in range(current_num_in_use - new_num_in_use):
         progress.increment()


### PR DESCRIPTION
Thought that I had resolved this previously, probably when doing #2609, but in doing some other refactoring discovered that the problematic code was still in place. Maybe I fixed it some time but never pushed.

-   `num_exit()` was a bad name for the function given its operation; it checks for the number of files in a list that *exist*. But there was also an integer variable called `num_exist`.

-   `num_in_use()` function immediately got hidden behind integer variable `num_in_use`.

-   Function was immediately waiting 60s, rather than the intended operation of using a progressively increasing delay time up to a *maximum* of 60s.

The functionality should be reviewable from the code, it's pretty obviously wrong. Verifying within an existing script is hard because I can't replicate the circumstances in which it is required, but I've at least tested in an interactive Python terminal. 