### PR TITLE
clang-format-all: Fix shebang

### DIFF
--- a/clang-format-all
+++ b/clang-format-all
@@ -1,4 +1,4 @@
-#!/usr/env/python3
+#!/usr/bin/env python3
 
 # Copyright (c) 2008-2024 the MRtrix3 contributors.
 #


### PR DESCRIPTION
Repost of #2973, for which I hastily hit the merge button after resolving #2859 only to realise the next second that it had been based off the original #2859 branch and therefore re-applied the unwanted commits. Just cherry-picked the single commit onto latest `dev`.