### PR TITLE
Update .git-blame-ignore-devs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -124,3 +124,8 @@ cd8a6f1c2d0debcf3a6de185f8b92fc0be3e1401
 #Author: MRtrixBot <gitbot@mrtrix.org>
 #Date:   Sun Jun 9 20:33:33 2024 +1000
 #    population_template: Split source code between files
+
+10c49930a63e6a2b0ce7d25d3f6d8dde290b2719
+#Author: MRtrixBot <gitbot@mrtrix.org>
+#Date:   Mon, 19 Aug 2024 16:18:12 +0100
+#    Remove core/file/json.h and core/half.hpp


### PR DESCRIPTION
This PR updates our `.git-blame-ignore-devs` file with the addition of 10c49930a63e6a2b0ce7d25d3f6d8dde290b2719, authored by @MRtrixBot , to remove third-party headers files from the codebase.