### PR TITLE
Fix warnings from new pylint version

### DIFF
--- a/python/mrtrix3/commands/dwi2mask/hdbet.py
+++ b/python/mrtrix3/commands/dwi2mask/hdbet.py
@@ -64,8 +64,8 @@ def execute(): #pylint: disable=unused-variable
   except run.MRtrixCmdError as e_cpu:
     if app.ARGS.nogpu:
       raise
-    gpu_header = ('===\nGPU\n===\n')
-    cpu_header = ('===\nCPU\n===\n')
+    gpu_header = '===\nGPU\n===\n'
+    cpu_header = '===\nCPU\n===\n'
     exception_stdout = f'{gpu_header}{e_gpu.stdout}\n\n{cpu_header}{e_cpu.stdout}\n\n'
     exception_stderr = f'{gpu_header}{e_gpu.stderr}\n\n{cpu_header}{e_cpu.stderr}\n\n'
     raise run.MRtrixCmdError('hd-bet', 1, exception_stdout, exception_stderr)

--- a/python/mrtrix3/commands/dwi2mask/mtnorm.py
+++ b/python/mrtrix3/commands/dwi2mask/mtnorm.py
@@ -97,7 +97,7 @@ def execute(): #pylint: disable=unused-variable
       int(round(float(value)))
       for value in image.mrinfo('input.mif', 'shell_bvalues') \
                                .strip().split()]
-  multishell = (len(bvalues) > 2)
+  multishell = len(bvalues) > 2
   if lmax is None:
     lmax = LMAXES_MULTI if multishell else LMAXES_SINGLE
   elif len(lmax) == 3 and not multishell:

--- a/python/mrtrix3/commands/dwibiascorrect/mtnorm.py
+++ b/python/mrtrix3/commands/dwibiascorrect/mtnorm.py
@@ -79,7 +79,7 @@ def execute(): #pylint: disable=unused-variable
       int(round(float(value)))
       for value in image.mrinfo('in.mif', 'shell_bvalues') \
                                .strip().split()]
-  multishell = (len(bvalues) > 2)
+  multishell = len(bvalues) > 2
   if lmax is None:
     lmax = LMAXES_MULTI if multishell else LMAXES_SINGLE
   elif len(lmax) == 3 and not multishell:

--- a/python/mrtrix3/commands/dwibiasnormmask.py
+++ b/python/mrtrix3/commands/dwibiasnormmask.py
@@ -219,7 +219,7 @@ def execute(): #pylint: disable=unused-variable
       int(round(float(value)))
       for value in image.mrinfo('input.mif', 'shell_bvalues') \
                                 .strip().split()]
-  multishell = (len(bvalues) > 2)
+  multishell = len(bvalues) > 2
   if lmax is None:
     lmax = LMAXES_MULTI if multishell else LMAXES_SINGLE
   elif len(lmax) == 3 and not multishell:

--- a/python/mrtrix3/commands/dwigradcheck.py
+++ b/python/mrtrix3/commands/dwigradcheck.py
@@ -157,7 +157,7 @@ def execute(): #pylint: disable=unused-variable
 
           grad_option = f' -grad {grad_path}'
 
-        elif basis == 'image':
+        else:
 
           grad = copy.copy(grad_fsl)
 

--- a/python/mrtrix3/commands/dwinormalise/mtnorm.py
+++ b/python/mrtrix3/commands/dwinormalise/mtnorm.py
@@ -113,7 +113,7 @@ def execute(): #pylint: disable=unused-variable
       int(round(float(value)))
       for value in image.mrinfo('input.mif', 'shell_bvalues') \
                                .strip().split()]
-  multishell = (len(bvalues) > 2)
+  multishell = len(bvalues) > 2
   if lmax is None:
     lmax = LMAXES_MULTI if multishell else LMAXES_SINGLE
   elif len(lmax) == 3 and not multishell:

--- a/testing/pylint.rc
+++ b/testing/pylint.rc
@@ -384,4 +384,4 @@ known-third-party=enchant
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception


### PR DESCRIPTION
These were throwing warnings on my Windows machine with Python 3.11.9, pylint 3.2.5.

If the GitHub CI runners get upgraded to this level, some of this may need to be back-propagated to `master`; for now I'm just getting warnings out of my way while I fix other things.