### PR TITLE
Disable the use of LLD by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ option(MRTRIX_STRIP_CONDA "Strip ananconda/mininconda from PATH to avoid conflic
 option(MRTRIX_USE_PCH "Use precompiled headers" ON)
 option(MRTRIX_PYTHON_SOFTLINK "Build directory softlink to Python source code rather than copying" ON)
 option(MRTRIX_BUILD_NON_CORE_STATIC "Build MRtrix's non-core code as a static library" OFF)
+option(MRTRIX_USE_LLD "Use lld as the linker" OFF)
 
 set(MRTRIX_DEPENDENCIES_DIR "" CACHE PATH
     "An optional local directory containing all thirdparty dependencies:\n \

--- a/cmake/LinkerSetup.cmake
+++ b/cmake/LinkerSetup.cmake
@@ -1,25 +1,33 @@
-# On Linux we want to use the LLVM linker if available as it is faster than the default GNU linker.
+# The LLVM linker is faster than the default GNU linker.
 # Unfortunately, lld is not able to perform LTO when compiling with GCC.
+if(MRTRIX_USE_LLD)
+    include(CheckCXXCompilerFlag)
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_INTERPROCEDURAL_OPTIMIZATION)
-    set(GCC_LTO TRUE)
-else()
-    set(GCC_LTO FALSE)
-endif()
-
-if(UNIX AND NOT APPLE AND NOT GCC_LTO)
-  find_program(LLVM_LINKER NAMES "ld.lld")
-
-  if(LLVM_LINKER)
-    message(STATUS "Using LLVM linker: ${LLVM_LINKER}")
-
-    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.29)
-      set(CMAKE_LINKER_TYPE "LLD" CACHE STRING "Linker type")
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+        set(GCC_LTO TRUE)
+        message(WARNING "LLD cannot be used with GCC when LTO is enabled. Please another compiler or disable LTO.")
     else()
-      set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld")
-      set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fuse-ld=lld")
-      set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -fuse-ld=lld")
+        set(GCC_LTO FALSE)
     endif()
 
-  endif()
+    if(NOT GCC_LTO)
+      set(LINKER_FLAG "-fuse-ld=lld")
+      check_cxx_compiler_flag(${LINKER_FLAG} CXX_SUPPORTS_LLVM_LINKER)
+
+      if(CXX_SUPPORTS_LLVM_LINKER)
+        find_program(LLVM_LINKER NAMES lld ld.lld)
+        message(STATUS "Using LLVM linker: ${LLVM_LINKER}")
+
+        if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.29)
+          set(CMAKE_LINKER_TYPE "LLD" CACHE STRING "Linker type")
+        else()
+          set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld")
+          set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fuse-ld=lld")
+          set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -fuse-ld=lld")
+        endif()
+      else()
+        message(WARNING "Compiler does not support LLVM linker. Using default linker.")
+      endif()
+    endif()
 endif()
+


### PR DESCRIPTION
We no longer use LLD by default if it is available for reasons mentioned in #2986. The use of LLD can now be enabled by using `-DMRTRIX_USE_LLD=ON`. This option only exists as a convenience and will be removed once our target CMake version matches 3.19 or higher (as we will be able to leverage CMake presets to achieve the same thing).
Additionally, we use CMake's `check_cxx_compiler_flag` to see if the compiler supports LLD regardless of the platform (instead of simply relying on the presence of `ld.lld`).
