### PR TITLE
Disable download logs for NIfTI headers to the console

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -76,6 +76,7 @@ else()
         CONFIGURE_COMMAND "" BUILD_COMMAND "" INSTALL_COMMAND ""
         DOWNLOAD_NO_EXTRACT ON
         DOWNLOAD_NO_PROGRESS ON
+        LOG_DOWNLOAD ON
     )
     ExternalProject_Add(
         nifti2
@@ -84,6 +85,7 @@ else()
         CONFIGURE_COMMAND "" BUILD_COMMAND "" INSTALL_COMMAND ""
         DOWNLOAD_NO_EXTRACT ON
         DOWNLOAD_NO_PROGRESS ON
+        LOG_DOWNLOAD ON
     )
     target_include_directories(nifti INTERFACE "${CMAKE_CURRENT_BINARY_DIR}/nifti/src/")
 endif()


### PR DESCRIPTION
Enabling `LOG_DOWNLOAD` the output of the download step for NIfTI headers is logged to CMake log files in the build directory, instead of the console. This reduces the unnecessary verbosity mentioned in #2984.