### PR TITLE
dirrotate: Fix default test

### DIFF
--- a/testing/binaries/tests/dirrotate/default
+++ b/testing/binaries/tests/dirrotate/default
@@ -25,7 +25,7 @@ tail -n +2 | \
 tr -d "-" | \
 tr -d "n" | \
 tr " " "\n" | \
-sort -r | \
+sort -g -r | \
 head -n1 > tmp1_max.txt
 
 cat tmp2.txt | \
@@ -33,7 +33,7 @@ tail -n +2 | \
 tr -d "-" | \
 tr -d "n" | \
 tr " " "\n" | \
-sort -r | \
+sort -g -r | \
 head -n1 > tmp2_max.txt
 
 a=$(cat tmp1_max.txt)


### PR DESCRIPTION
Prevents array values close to zero printed in scientific notation from appearing at the top of the reverse-sorted list.

Resolves issue [reported](https://github.com/MRtrix3/mrtrix3/pull/3006#issuecomment-2357862279) in #3006.