### PR TITLE
dirrotate: Test using awk rather than bc

### DIFF
--- a/testing/binaries/tests/dirrotate/default
+++ b/testing/binaries/tests/dirrotate/default
@@ -23,7 +23,6 @@ testing_diff_matrix tmp1_stats.txt tmp2_stats.txt
 cat tmp1.txt | \
 tail -n +2 | \
 tr -d "-" | \
-tr -d "n" | \
 tr " " "\n" | \
 sort -g -r | \
 head -n1 > tmp1_max.txt
@@ -31,11 +30,10 @@ head -n1 > tmp1_max.txt
 cat tmp2.txt | \
 tail -n +2 | \
 tr -d "-" | \
-tr -d "n" | \
 tr " " "\n" | \
 sort -g -r | \
 head -n1 > tmp2_max.txt
 
 a=$(cat tmp1_max.txt)
 b=$(cat tmp2_max.txt)
-[[ $(echo "${b} < ${a}" | bc) -eq 1 ]]
+awk 'BEGIN{if ('$a'<='$b') exit 1}'


### PR DESCRIPTION
Should fix issue [reported](https://github.com/MRtrix3/mrtrix3/pull/3012#issuecomment-2376982389) in #3012. Seems to be some kind of race condition in the BASH `[[ ]]` / `[ ]` implementation, where sometimes the "`1`" yielded by `bc` would be invoked as a command name. But it was inconsistent. And running the script manually rather than via `ctest` would never fault. So kinda weird. I've verified that this is indeed testing for expected behaviour by flipping the inequality test.