### PR TITLE
Tolerance for dw_scheme differences on header merge

### DIFF
--- a/cmd/dwiextract.cpp
+++ b/cmd/dwiextract.cpp
@@ -19,6 +19,7 @@
 #include "phase_encoding.h"
 #include "progressbar.h"
 #include "dwi/gradient.h"
+#include "dwi/shells.h"
 #include "algo/loop.h"
 #include "adapter/extract.h"
 

--- a/cmd/mrinfo.cpp
+++ b/cmd/mrinfo.cpp
@@ -24,6 +24,7 @@
 #include "file/json.h"
 #include "file/json_utils.h"
 #include "dwi/gradient.h"
+#include "dwi/shells.h"
 #include "image_io/pipe.h"
 
 

--- a/cmd/mrtransform.cpp
+++ b/cmd/mrtransform.cpp
@@ -588,7 +588,7 @@ void run ()
 
     if (interp == 0)
       output_header.datatype() = DataType::from_command_line (input_header.datatype());
-    auto output = Image<float>::create (argument[1], output_header).with_direct_io();
+    auto output = Image<float>::create (argument[1], output_header);
 
     switch (interp) {
       case 0:
@@ -630,7 +630,7 @@ void run ()
       add_line (output_header.keyval()["comments"], std::string ("resliced using warp image \"" + warp.name() + "\""));
     }
 
-    auto output = Image<float>::create(argument[1], output_header).with_direct_io();
+    auto output = Image<float>::create(argument[1], output_header);
 
     if (warp.ndim() == 5) {
       Image<default_type> warp_deform;
@@ -684,7 +684,7 @@ void run ()
       output_header.transform() = linear_transform;
     else
       output_header.transform() = linear_transform.inverse() * output_header.transform();
-    auto output = Image<float>::create (argument[1], output_header).with_direct_io();
+    auto output = Image<float>::create (argument[1], output_header);
     copy_with_progress (input, output);
 
     if (fod_reorientation || modulate_jac) {

--- a/core/dwi/gradient.cpp
+++ b/core/dwi/gradient.cpp
@@ -15,8 +15,8 @@
  */
 
 #include "dwi/gradient.h"
+#include "file/config.h"
 #include "file/nifti_utils.h"
-#include "dwi/shells.h"
 
 namespace MR
 {
@@ -82,6 +82,17 @@ namespace MR
       "vectors are close to unit norm). This option allows the user to "
       "control this operation and override MRrtix3's automatic detection."
     );
+
+
+
+//CONF option: BZeroThreshold
+//CONF default: 10.0
+//CONF Specifies the b-value threshold for determining those image
+//CONF volumes that correspond to b=0.
+    default_type bzero_threshold () {
+      static const default_type value = File::Config::get_float ("BZeroThreshold", DWI_BZERO_THREHSOLD_DEFAULT);
+      return value;
+    }
 
 
 

--- a/core/dwi/gradient.h
+++ b/core/dwi/gradient.h
@@ -220,7 +220,7 @@ namespace MR
           }
           if (one_bvalue == two_bvalue) {
             result(rowindex, 3) = one_bvalue;
-          } else if (is_bzero || std::abs(one_bvalue - two_bvalue) <= 1.0) {
+          } else if (is_bzero || abs(one_bvalue - two_bvalue) <= 1.0) {
             result(rowindex, 3) = 0.5 * (one_bvalue + two_bvalue);
           } else {
             throw Exception("Diffusion gradient table b-values not equivalent");

--- a/core/dwi/gradient.h
+++ b/core/dwi/gradient.h
@@ -19,13 +19,15 @@
 
 #include "app.h"
 #include "header.h"
-#include "dwi/shells.h"
+#include "types.h"
 #include "file/config.h"
 #include "file/path.h"
 #include "math/condition_number.h"
 #include "math/sphere.h"
 #include "math/SH.h"
 
+
+#define DWI_BZERO_THREHSOLD_DEFAULT 10.0
 
 namespace MR
 {
@@ -40,6 +42,7 @@ namespace MR
     extern App::Option bvalue_scaling_option;
     extern const char* const bvalue_scaling_description;
 
+    default_type bzero_threshold ();
 
 
     //! check that the DW scheme matches the DWI data in \a header
@@ -166,6 +169,64 @@ namespace MR
         } catch (Exception&) {
           WARN ("attempt to add non-matching DW scheme to header - ignored");
         }
+      }
+
+    //! store the DW gradient encoding matrix in a KeyValues structure
+    /*! this will store the DW gradient encoding matrix under the key 'dw_scheme'.
+     */
+    template <class MatrixType>
+      void set_DW_scheme (KeyValues& keyval, const MatrixType& G)
+      {
+        if (!G.rows()) {
+          auto it = keyval.find ("dw_scheme");
+          if (it != keyval.end())
+            keyval.erase (it);
+          return;
+        }
+        keyval["dw_scheme"] = scheme2str (G);
+      }
+
+    template <class MatrixType1, class MatrixType2>
+      Eigen::MatrixXd resolve_DW_scheme (const MatrixType1& one, const MatrixType2& two)
+      {
+        if (one.rows() != two.rows())
+          throw Exception ("Unequal numbers of rows between gradient tables");
+        if (one.cols() != two.cols())
+          throw Exception ("Unequal numbers of rows between gradient tables");
+        Eigen::MatrixXd result (one.rows(), one.cols());
+        // Don't know how to intellegently combine data beyond four columns;
+        //   therefore don't proceed if such data are present and are not precisely equivalent
+        if (one.cols() > 4) {
+          if (one.rightCols(one.cols()-4) != two.rightCols(two.cols()-4))
+            throw Exception ("Unequal dw_scheme contents beyond standard four columns");
+          result.rightCols(one.cols()-4) = one.rightCols(one.cols()-4);
+        }
+        for (ssize_t rowindex = 0; rowindex != one.rows(); ++rowindex) {
+          auto one_dir = one.template block<1,3>(rowindex, 0);
+          auto two_dir = two.template block<1,3>(rowindex, 0);
+          const default_type one_bvalue = one(rowindex, 3);
+          const default_type two_bvalue = two(rowindex, 3);
+          const bool is_bzero = std::max(one_bvalue, two_bvalue) <= bzero_threshold();
+          if (one_dir == two_dir) {
+            result.block<1,3>(rowindex, 0) = one_dir;
+          } else {
+            const Eigen::Vector3d mean_dir = (one_dir + two_dir).normalized();
+            if (!is_bzero && mean_dir.dot (one_dir) < 1.0 - 1e-3) {
+              throw Exception("Diffusion vector directions not equal within permissible imprecision "
+                              "(row " + str(rowindex) + ": " + str(one_dir.transpose()) + " <--> " + str(two_dir.transpose())
+                              + "; dot product " + str(mean_dir.dot(one_dir)) + ")");
+            }
+            result.block<1,3>(rowindex, 0) = mean_dir;
+          }
+          if (one_bvalue == two_bvalue) {
+            result(rowindex, 3) = one_bvalue;
+          } else if (is_bzero || std::abs(one_bvalue - two_bvalue) <= 1.0) {
+            result(rowindex, 3) = 0.5 * (one_bvalue + two_bvalue);
+          } else {
+            throw Exception("Diffusion gradient table b-values not equivalent");
+          }
+        }
+        return result;
       }
 
 

--- a/core/dwi/shells.h
+++ b/core/dwi/shells.h
@@ -23,7 +23,7 @@
 
 #include "app.h"
 #include "types.h"
-#include "file/config.h"
+#include "dwi/gradient.h"
 #include "misc/bitset.h"
 
 
@@ -37,15 +37,7 @@
 // Default number of volumes necessary for a shell to be retained
 //   (note: only applies if function reject_small_shells() is called explicitly)
 #define DWI_SHELLS_MIN_DIRECTIONS 6
-// Default b-value threshold for a shell to be classified as "b=0"
-#define DWI_SHELLS_BZERO_THREHSOLD 10.0
 
-
-
-//CONF option: BZeroThreshold
-//CONF default: 10.0
-//CONF Specifies the b-value threshold for determining those image
-//CONF volumes that correspond to b=0.
 
 //CONF option: BValueEpsilon
 //CONF default: 80.0
@@ -64,10 +56,6 @@ namespace MR
 
     extern const App::OptionGroup ShellsOption;
 
-    FORCE_INLINE default_type bzero_threshold () {
-      static const default_type value = File::Config::get_float ("BZeroThreshold", DWI_SHELLS_BZERO_THREHSOLD);
-      return value;
-    }
 
 
 
@@ -87,7 +75,7 @@ namespace MR
         default_type get_min()   const { return min; }
         default_type get_max()   const { return max; }
 
-        bool is_bzero()   const { return (mean < bzero_threshold()); }
+        bool is_bzero() const { return (mean <= MR::DWI::bzero_threshold()); }
 
 
         bool operator< (const Shell& rhs) const { return (mean < rhs.mean); }

--- a/core/filter/dwi_brain_mask.h
+++ b/core/filter/dwi_brain_mask.h
@@ -29,6 +29,7 @@
 #include "algo/copy.h"
 #include "algo/loop.h"
 #include "dwi/gradient.h"
+#include "dwi/shells.h"
 
 
 namespace MR

--- a/src/dwi/sdeconv/csd.h
+++ b/src/dwi/sdeconv/csd.h
@@ -20,6 +20,7 @@
 #include "app.h"
 #include "header.h"
 #include "dwi/gradient.h"
+#include "dwi/shells.h"
 #include "math/SH.h"
 #include "math/ZSH.h"
 #include "dwi/directions/predefined.h"

--- a/testing/binaries/tests/mrcalc
+++ b/testing/binaries/tests/mrcalc
@@ -2,3 +2,5 @@ mrcalc mrcalc/in.mif 2 -mult -neg -exp 10 -add - | testing_diff_image - mrcalc/o
 mrcalc mrcalc/in.mif 1.224 -div -cos mrcalc/in.mif -abs -sqrt -log -atanh -sub - | testing_diff_image - mrcalc/out2.mif -frac 1e-5
 mrcalc mrcalc/in.mif 0.2 -gt mrcalc/in.mif mrcalc/in.mif -1.123 -mult 0.9324 -add -exp -neg -if - | testing_diff_image - mrcalc/out3.mif -frac 1e-5
 mrcalc mrcalc/in.mif 0+1j -mult -exp mrcalc/in.mif -mult 1.34+5.12j -mult - | testing_diff_image - mrcalc/out4.mif -frac 1e-5
+mrinfo dwi.mif -dwgrad > tmp.txt && truncate -s-1 tmp.txt && mrconvert dwi.mif -grad tmp.txt - | mrcalc - dwi.mif -add 0.5 -mult - | mrinfo - -dwgrad
+if [ mrtransform dwi.mif -flip 0 - | mrcalc - dwi.mif -add 0.5 -mult - | mrinfo - -property dw_scheme ]; then exit 1; else exit 0; fi


### PR DESCRIPTION
Closes #3015.

As part of this change, I decided that the "*b*=0 threshold" is more appropriate in `dwi/gradient.h` rather than `dwi/shells.h`, since it may be applied to individual volumes rather than shells. Here it's used to say "if two images both have a *b*=0 volume here, then their diffusion gradient tables are compatible; I don't care if their unit directions are different".

Also fixed some transitive includes in the process.

The new tests should hopefully demonstrate the fix:
-   Without this PR, the two "`dw_scheme`" entries only have to differ by one least significant digit to result in the whole diffusion gradient table being discarded.
-   But conversely, if two images undergo an operation and their diffusion gradient tables are totally incompatible, it'll still be dropped.

(They also neatly demonstrate why having just a list of tests per command is restrictive;
with `ctest` I'll be able to name these tests according to what they are actually evaluating,
which isn't specific to any one command)