### PR TITLE
Cancel previous Github Action runs in PRs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,6 +8,10 @@ on:
       types: [checks_requested]
       branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   linux-clang-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
When making a PR pushing additional commits triggers the launch of our CI checks without cancelling the previous runs. This can be quite wasteful and unnecessary. This PR fixes that. Explanation of the code change [here](https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre).