### PR TITLE
Fsl first precalc

### DIFF
--- a/docs/reference/commands/5ttgen.rst
+++ b/docs/reference/commands/5ttgen.rst
@@ -213,6 +213,10 @@ Options specific to the "fsl" algorithm
 
 - **-premasked** Indicate that brain masking has already been applied to the input image
 
+- **-first_dir /path/to/first/dir** use pre-calculated output of FSL FIRST previously run on input T1-weighted image; data must be defined in the same space as input T1w
+
+- **-fast_dir /path/to/fast/dir** use pre-calculated output of FSL FAST previously run on input T1-weighted image; data must be defined in the same space as input T1w; filename prefix must be "T1_BET"
+
 Options common to all 5ttgen algorithms
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -400,6 +404,8 @@ Options
 - **-thalami choice** Select method to be used for thalamic segmentation; options are: nuclei,first,aseg
 
 - **-white_stem** Classify the brainstem as white matter
+
+- **-first_dir /path/to/first/dir** utilise pre-calculated output of FSL FIRST run on input T1-weighted image; must have been computed in the same space as FreeSurfer T1w
 
 Options common to all 5ttgen algorithms
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/reference/commands/labelsgmfirst.rst
+++ b/docs/reference/commands/labelsgmfirst.rst
@@ -27,6 +27,8 @@ Options
 
 - **-sgm_amyg_hipp** Consider the amygdalae and hippocampi as sub-cortical grey matter structures, and also replace their estimates with those from FIRST
 
+- **-first_dir /path/to/first/dir** use pre-calculated output of FSL FIRST previously run on T1-weighted image; must be defined in the same space as input FreeSurfer parcellation
+
 Additional standard options for Python scripts
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/python/mrtrix3/commands/5ttgen/fsl.py
+++ b/python/mrtrix3/commands/5ttgen/fsl.py
@@ -58,6 +58,14 @@ def usage(base_parser, subparsers): #pylint: disable=unused-variable
                        action='store_true',
                        default=None,
                        help='Indicate that brain masking has already been applied to the input image')
+  options.add_argument('-first_dir',
+                       metavar='/path/to/first/dir',
+                       help='use pre-calculated output of FSL FIRST previously run on input T1-weighted image; '
+                            'data must be defined in the same space as input T1w')
+  options.add_argument('-fast_dir',
+                       metavar='/path/to/fast/dir',
+                       help='use pre-calculated output of FSL FAST previously run on input T1-weighted image; '
+                            'data must be defined in the same space as input T1w')
   parser.flag_mutually_exclusive_options( [ 'mask', 'premasked' ] )
 
 
@@ -190,10 +198,22 @@ def execute(): #pylint: disable=unused-variable
   # Finish branching based on brain masking
 
   # FAST
-  if fast_t2_input:
-    run.command(f'{fast_cmd} -S 2 {fast_t2_input} {fast_t1_input}')
-  else:
-    run.command(f'{fast_cmd} {fast_t1_input}')
+  if not app.args.fast_dir:
+    if fast_t2_input:
+      run.command(f'{fast_cmd} -S 2 {fast_t2_input} {fast_t1_input}')
+    else:
+      run.command(f'{fast_cmd} {fast_t1_input}')
+  if app.args.fast_dir:
+    if not os.path.isdir(os.path.abspath(app.args.fast_dir)):
+      app.error('FAST directory cannot be found, please check path')
+    else:
+      fast_output_prefix = fast_t1_input.split('.')[0]
+      fast_csf_input = fsl.find_image(app.args.fast_dir + '/' + fast_output_prefix + '_pve_0.nii.gz')
+      fast_gm_input = fsl.find_image(app.args.fast_dir + '/' + fast_output_prefix + '_pve_1.nii.gz')
+      fast_wm_input = fsl.find_image(app.args.fast_dir + '/' + fast_output_prefix + '_pve_2.nii.gz')
+      run.command('cp ' + fast_csf_input + ' .' )
+      run.command('cp ' + fast_gm_input + ' .' )
+      run.command('cp ' + fast_wm_input + ' .' )
 
   # FIRST
   first_input = 'T1.nii'
@@ -205,10 +225,19 @@ def execute(): #pylint: disable=unused-variable
   first_brain_extracted_option = ['-b'] if app.ARGS.premasked else []
   first_debug_option = [] if app.DO_CLEANUP else ['-d']
   first_verbosity_option = ['-v'] if app.VERBOSITY == 3 else []
-  run.command([first_cmd, '-m', 'none', '-s', ','.join(sgm_structures), '-i', first_input, '-o', 'first']
-              + first_brain_extracted_option
-              + first_debug_option
-              + first_verbosity_option)
+  if not app.args.first_dir:
+    run.command([first_cmd, '-m', 'none', '-s', ','.join(sgm_structures), '-i', first_input, '-o', 'first']
+                + first_brain_extracted_option
+                + first_debug_option
+                + first_verbosity_option)
+  elif app.args.first_dir:
+    if not os.path.isdir(os.path.abspath(app.args.first_dir)):
+      app.error('FIRST directory cannot be found, please check path')
+    else:
+      for struct in sgm_structures:
+        vtk_in_path = 'first-' + struct + '_first.vtk'
+        run.command('cp ' + app.args.first_dir + '/' + vtk_in_path + ' .')
+      run.command('cp -r ' + app.args.first_dir + '/first.logs' + ' .')
   fsl.check_first('first', sgm_structures)
 
   # Convert FIRST meshes to partial volume images

--- a/python/mrtrix3/commands/5ttgen/hsvs.py
+++ b/python/mrtrix3/commands/5ttgen/hsvs.py
@@ -13,8 +13,6 @@
 #
 # For more details, see http://www.mrtrix.org/.
 
-
-
 import glob, os, re, shutil
 from mrtrix3 import MRtrixError
 from mrtrix3 import app, fsl, image, path, run
@@ -566,11 +564,10 @@ def execute(): #pylint: disable=unused-variable
     elif app.ARGS.first_dir:
       if not os.path.isdir(os.path.abspath(app.ARGS.first_dir)):
         app.error('FIRST directory cannot be found, please check path')
-      else:
-        for key, value in from_first.items():
-          vtk_in_path = 'first-' + key + '_first.vtk'
-          run.command('cp ' + app.ARGS.first_dir + '/' + vtk_in_path + ' .')
-          run.command('cp -r ' + app.ARGS.first_dir + '/first.logs' + ' .')
+      for key, value in from_first.items():
+        vtk_in_path = 'first-' + key + '_first.vtk'
+        run.command('cp ' + app.ARGS.first_dir + '/' + vtk_in_path + ' .')
+        run.command('cp -r ' + app.ARGS.first_dir + '/first.logs' + ' .')
     fsl.check_first('first', from_first.keys())
     app.cleanup(glob.glob('T1_to_std_sub.*'))
     progress = app.ProgressBar('Mapping FIRST segmentations to image', 2*len(from_first))

--- a/python/mrtrix3/commands/labelsgmfirst.py
+++ b/python/mrtrix3/commands/labelsgmfirst.py
@@ -68,8 +68,8 @@ def execute(): #pylint: disable=unused-variable
   from mrtrix3 import MRtrixError #pylint: disable=no-name-in-module, import-outside-toplevel
   from mrtrix3 import app, fsl, image, path, run, utils #pylint: disable=no-name-in-module, import-outside-toplevel
   if not app.ARGS.first_dir:
-  	if utils.is_windows():
-    	  raise MRtrixError('Script cannot run on Windows due to FSL dependency')
+    if utils.is_windows():
+      raise MRtrixError('Script cannot run on Windows due to FSL dependency')
 
   image.check_3d_nonunity(app.ARGS.t1)
 
@@ -79,7 +79,7 @@ def execute(): #pylint: disable=unused-variable
       raise MRtrixError('Environment variable FSLDIR is not set; '
                         'please run appropriate FSL configuration script')
 
-  	first_cmd = fsl.exe_name('run_first_all')
+    first_cmd = fsl.exe_name('run_first_all')
 
     first_atlas_path = os.path.join(fsl_path, 'data', 'first', 'models_336_bin')
     if not os.path.isdir(first_atlas_path):
@@ -124,7 +124,7 @@ def execute(): #pylint: disable=unused-variable
   if app.ARGS.premasked:
     first_input_is_brain_extracted = ' -b'
   if not app.ARGS.first_dir:
-	  structures_string = ','.join(structure_map.keys())
+    structures_string = ','.join(structure_map.keys())
     run.command(f'{first_cmd} -m none -s {structures_string} -i T1.nii {first_input_is_brain_extracted} -o first')
   elif app.ARGS.first_dir:
     if not os.path.isdir(os.path.abspath(app.ARGS.first_dir)):


### PR DESCRIPTION
Work In Progress.

Final relevant changeset being extracted from #2330 to allow its closure. I have extracted the code changes relating to addition of the `-first_dir` option to `labelsgmfirst` / `5ttgen fsl` / `5ttgen hsvs` and applied them to `dev` with authorship to @nicdc. From here I will need to:

- [ ] Resolve against various changes made to `dev` since #2330 was listed. This will include use of f-strings, typed command-line argument variables, ...
- [ ] Re-arrange some code; eg. checking validity of user input before any processing commences
- [ ] Make code more robust to user input; eg. ideally not requiring specific filename prefixes to be used
- [ ] Add tests that manually run FIRST, then run these scripts providing those data as input