### PR TITLE
DICOM: ignore image positioning tags if nested within Philips private sequence

### DIFF
--- a/core/file/dicom/image.cpp
+++ b/core/file/dicom/image.cpp
@@ -158,6 +158,10 @@ namespace MR {
             }
             return;
           case 0x0020U:
+            for (const auto& p : item.parents)
+              if (p.group == 0x2005)
+                return; // ignore if nested within Philips private sequence
+
             switch (item.element) {
               case 0x000EU:
                 ignore_series_num = item.is_in_series_ref_sequence();


### PR DESCRIPTION
See discussion in #2977

Full testing underway...