### PR TITLE
Print build information at the end of configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ file(RELATIVE_PATH relDir
 set(CMAKE_INSTALL_RPATH ${base} ${base}/${relDir})
 
 include(BuildType)
+include(BuildInfo)
 
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git AND NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git/hooks/pre-commit)
     message(WARNING
@@ -125,3 +126,5 @@ add_custom_target(Github SOURCES
     .github/workflows/package-windows-msys2.yml
     .github/workflows/clang-tidy.yml
 )
+
+mrtrix_print_build_instructions()

--- a/cmake/BuildInfo.cmake
+++ b/cmake/BuildInfo.cmake
@@ -1,7 +1,8 @@
 function(mrtrix_print_build_instructions)
     set(message_list "\n")
+    file(RELATIVE_PATH relative_build_path "${PROJECT_SOURCE_DIR}" "${PROJECT_BINARY_DIR}")
     list(APPEND message_list "MRtrix3 has been successfully configured for compilation.")
-    list(APPEND message_list "To build MRtrix3, run 'cmake --build .' from the build directory.")
+    list(APPEND message_list "To build it, run 'cmake --build ${relative_build_path}'")
 
     list(APPEND message_list "To reconfigure the project, run CMake again with the same arguments.")
     list(APPEND message_list "If reconfiguration fails, remove the CMakeCache.txt file in the build "

--- a/cmake/BuildInfo.cmake
+++ b/cmake/BuildInfo.cmake
@@ -1,0 +1,14 @@
+function(mrtrix_print_build_instructions)
+    set(message_list "\n")
+    list(APPEND message_list "MRtrix3 has been successfully configured for compilation.")
+    list(APPEND message_list "To build MRtrix3, run 'cmake --build .' from the build directory.")
+
+    list(APPEND message_list "To reconfigure the project, run CMake again with the same arguments.")
+    list(APPEND message_list "If reconfiguration fails, remove the CMakeCache.txt file in the build "
+        "directory or run CMake adding the --fresh flag.")
+    list(APPEND message_list "\n")
+
+    # Remove ; from list and add two spaces to the beginning of each line
+    string(REPLACE ";" "\n  " message_list "${message_list}")
+    message(STATUS "${message_list}")
+endfunction()

--- a/cmake/BuildInfo.cmake
+++ b/cmake/BuildInfo.cmake
@@ -2,11 +2,17 @@ function(mrtrix_print_build_instructions)
     set(message_list "\n")
     file(RELATIVE_PATH relative_build_path "${PROJECT_SOURCE_DIR}" "${PROJECT_BINARY_DIR}")
     list(APPEND message_list "MRtrix3 has been successfully configured for compilation.")
-    list(APPEND message_list "To build it, run 'cmake --build ${relative_build_path}'")
+    list(APPEND message_list "To build it, run 'cmake --build ${relative_build_path}'.")
 
     list(APPEND message_list "To reconfigure the project, run CMake again with the same arguments.")
-    list(APPEND message_list "If reconfiguration fails, remove the CMakeCache.txt file in the build "
-        "directory or run CMake adding the --fresh flag.")
+
+    set(RECONFIGURE_ADVICE "If reconfiguration fails, try removing the 'CMakeCache.txt' file in the build directory first.")
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
+        set(RECONFIGURE_ADVICE "${RECONFIGURE_ADVICE} Alternatively, you can reconfigure the project with the '--fresh' flag"
+                               " (e.g. 'cmake -B build --fresh').")
+    endif()
+
+    list(APPEND message_list "${RECONFIGURE_ADVICE}")
     list(APPEND message_list "\n")
 
     # Remove ; from list and add two spaces to the beginning of each line


### PR DESCRIPTION
A small addition that prints build instructions when CMake has finished configuring the project. Also add a suggestion to try to remove `CMakeCache.txt` (or use the `--fresh` flag) if reconfiguration fails (this is a less drastic measure than `rm -rf build`).