### PR TITLE
dwi2tensor: fix operation with -iter 1

### DIFF
--- a/cmd/dwi2tensor.cpp
+++ b/cmd/dwi2tensor.cpp
@@ -149,7 +149,7 @@ class Processor { MEMALIGN(Processor)
           work.setZero();
           work.selfadjointView<Eigen::Lower>().rankUpdate (b.transpose()*w.asDiagonal());
           p = llt.compute (work.selfadjointView<Eigen::Lower>()).solve(b.transpose()*w.asDiagonal()*w.asDiagonal()*dwi);
-          if (maxit > 1)
+          if (it < maxit)
             w = (b*p).array().exp();
         }
 


### PR DESCRIPTION
Problem has been present since initial addition of iterative reweighted least squares for tensor fitting in #1542.

Does *not* affect default operation; only affects the specific use case of `-iter 1`.