### PR TITLE
Include CMake modules in root CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,12 @@ set(CMAKE_INSTALL_RPATH ${base} ${base}/${relDir})
 
 include(BuildType)
 include(BuildInfo)
+include(LinkerSetup)
+include(FindFFTW)
+include(ECMEnableSanitizers)
+include(Dependencies)
+include(CompilerCache)
+use_compiler_cache()
 
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git AND NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git/hooks/pre-commit)
     message(WARNING

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,10 +1,3 @@
-include(LinkerSetup)
-include(FindFFTW)
-include(ECMEnableSanitizers)
-include(Dependencies)
-include(CompilerCache)
-use_compiler_cache()
-
 add_library(mrtrix-common INTERFACE)
 add_library(mrtrix::common ALIAS mrtrix-common)
 target_compile_definitions(mrtrix-common INTERFACE


### PR DESCRIPTION
After #3012, the CMake modules relevant for C++ commands don't propagate to the testing subdirectory. This broke our sanitisers tests (among other things). 
This PR moves the inclusion of those modules in the root `CMakeLists.txt` to fix that. 