### PR TITLE
FIX: don't build gui subdirectory with BUILD_GUI=OFF

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -38,4 +38,7 @@ endif()
 
 add_subdirectory(cmd)
 add_subdirectory(core)
-add_subdirectory(gui)
+
+if(MRTRIX_BUILD_GUI)
+    add_subdirectory(gui)
+endif()


### PR DESCRIPTION
This PR fixes #3063.