### PR TITLE
Update clang-tidy-review action to v0.20.1

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -14,11 +14,12 @@ jobs:
     - name: Run CMake
       run: cmake . -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
-    - uses: ZedThree/clang-tidy-review@v0.17.0
+    - uses: ZedThree/clang-tidy-review@v0.20.1
       id: review
       with:
         apt_packages: g++,qt6-base-dev,libqt6opengl6-dev,libglvnd-dev,zlib1g-dev,libfftw3-dev,ninja-build
         config_file: .clang-tidy
+        clang_tidy_version: 16
 
-    - uses: ZedThree/clang-tidy-review/upload@v0.17.0
+    - uses: ZedThree/clang-tidy-review/upload@v0.20.1
       id: upload-review


### PR DESCRIPTION
We also explicitly specify the clang-tidy version wanted (currently set to 16). This should fix the failing clang-tidy checks noticed in recent PRs.