### PR TITLE
Fix tck writer when a single streamline exceed the buffer size

### DIFF
--- a/src/dwi/tractography/file.h
+++ b/src/dwi/tractography/file.h
@@ -389,6 +389,11 @@ namespace MR
             if (buffer_size + tck.size() + 2 > buffer_capacity)
               commit ();
 
+            if (tck.size()+1 >= buffer_capacity) {
+              buffer_capacity = tck.size()+1;
+              buffer.reset (new vector_type [buffer_capacity]);
+            }
+
             for (const auto& i : tck) {
               assert (i.allFinite());
               add_point (i);
@@ -405,7 +410,7 @@ namespace MR
 
 
         protected:
-          const size_t buffer_capacity;
+          size_t buffer_capacity;
           std::unique_ptr<vector_type[]> buffer;
           size_t buffer_size;
           std::string weights_buffer;


### PR DESCRIPTION
This addresses an issue raised on the forum, and is due to our use of a write-back buffer (to prevent file segmentation) with a default size of 16MB. This is ample for regular streamlines, but clearly not enough in all cases...

Original issue:
https://community.mrtrix.org/t/tckgen-seed-point-visualization/8271/2
