### PR TITLE
dwi2mask hdbet: Fix exception handling

### DIFF
--- a/python/mrtrix3/commands/dwi2mask/hdbet.py
+++ b/python/mrtrix3/commands/dwi2mask/hdbet.py
@@ -56,8 +56,9 @@ def execute(): #pylint: disable=unused-variable
     try:
       run.command('hd-bet -i bzero.nii')
       return OUTPUT_IMAGE_PATH
-    except run.MRtrixCmdError as e_gpu: #pylint: disable=unused-variable
+    except run.MRtrixCmdError as exc: #pylint: disable=unused-variable
       app.warn('HD-BET failed when running on GPU; attempting on CPU')
+      e_gpu = exc
   try:
     run.command('hd-bet -i bzero.nii -device cpu -mode fast -tta 0')
     return OUTPUT_IMAGE_PATH


### PR DESCRIPTION
Fixes variable name ghosting bug that arises where first attempt to run third-party command `hd-bet` using the GPU fails.