### PR TITLE
API: Replace .type_various()

### DIFF
--- a/cpp/cmd/fixel2peaks.cpp
+++ b/cpp/cmd/fixel2peaks.cpp
@@ -47,8 +47,8 @@ void usage() {
   + Fixel::format_description;
 
   ARGUMENTS
-  + Argument ("in",  "the input fixel information").type_various ()
-  + Argument ("out", "the output peaks image").type_image_out ();
+  + Argument ("in",  "the input fixel information").type_directory_in().type_image_in()
+  + Argument ("out", "the output peaks image").type_image_out();
 
   OPTIONS
   + Option ("number", "maximum number of fixels in each voxel"

--- a/cpp/cmd/fixelcfestats.cpp
+++ b/cpp/cmd/fixelcfestats.cpp
@@ -119,7 +119,7 @@ void usage() {
 
   // .type_various() rather than .type_directory_in() to catch people trying to
   //   pass a track file, and give a more informative error message
-  + Argument ("connectivity", "the fixel-fixel connectivity matrix").type_various ()
+  + Argument ("connectivity", "the fixel-fixel connectivity matrix").type_directory_in().type_tracks_in()
 
   + Argument ("out_fixel_directory", "the output directory where results will be saved."
                                      " Will be created if it does not exist").type_text();

--- a/cpp/cmd/fixelconvert.cpp
+++ b/cpp/cmd/fixelconvert.cpp
@@ -78,8 +78,8 @@ void usage() {
              " to indicate which fixel data files should be used as the source(s) of this information.");
 
   ARGUMENTS
-  + Argument ("fixel_in",  "the input fixel file / directory.").type_various()
-  + Argument ("fixel_out", "the output fixel file / directory.").type_various();
+  + Argument ("fixel_in",  "the input fixel file / directory.").type_directory_in().type_image_in()
+  + Argument ("fixel_out", "the output fixel file / directory.").type_directory_out().type_image_out();
 
   OPTIONS
   + OptionGroup ("Options for converting from old to new format")

--- a/cpp/cmd/fixelfilter.cpp
+++ b/cpp/cmd/fixelfilter.cpp
@@ -52,10 +52,10 @@ void usage() {
   + Fixel::format_description;
 
   ARGUMENTS
-  + Argument ("input", "the input: either a fixel data file, or a fixel directory (see Description)").type_various()
+  + Argument ("input", "the input: either a fixel data file, or a fixel directory (see Description)").type_image_in().type_directory_in()
   + Argument ("filter", "the filtering operation to perform;"
                         " options are: " + join (filters, ", ")).type_choice (filters)
-  + Argument ("output", "the output: either a fixel data file, or a fixel directory (see Description)").type_various();
+  + Argument ("output", "the output: either a fixel data file, or a fixel directory (see Description)").type_image_out().type_directory_out();
 
   OPTIONS
   + Option ("matrix", "provide a fixel-fixel connectivity matrix"

--- a/cpp/cmd/mrcalc.cpp
+++ b/cpp/cmd/mrcalc.cpp
@@ -403,7 +403,7 @@ ARGUMENTS
   + Argument ("operand", "an input image,"
                          " intensity value,"
                          " or special keyword"
-                         " (see Description)").type_various().allow_multiple();
+                         " (see Description)").type_image_in().type_image_out().type_float().type_text().allow_multiple();
 
 OPTIONS
 

--- a/cpp/cmd/mrconvert.cpp
+++ b/cpp/cmd/mrconvert.cpp
@@ -234,7 +234,7 @@ void usage() {
   + Option ("copy_properties",
             "clear all generic properties"
             " and replace with the properties from the image / file specified.")
-  + Argument ("source").type_various()
+  + Argument ("source").type_image_in().type_file_in()
 
   + Stride::Options
 

--- a/cpp/cmd/mtnormalise.cpp
+++ b/cpp/cmd/mtnormalise.cpp
@@ -72,7 +72,7 @@ void usage() {
 
   ARGUMENTS
   + Argument("input output", "list of all input and output tissue compartment files"
-                             " (see example usage).").type_various().allow_multiple();
+                             " (see example usage).").type_image_in().type_image_out().allow_multiple();
 
   OPTIONS
   + Option("mask", "the mask defines the data used to compute the intensity normalisation."

--- a/cpp/cmd/tckconvert.cpp
+++ b/cpp/cmd/tckconvert.cpp
@@ -60,8 +60,8 @@ void usage() {
               " output-0000.txt, output-0001.txt, output-0002.txt, ...");
 
   ARGUMENTS
-    + Argument ("input", "the input track file.").type_various()
-    + Argument ("output", "the output track file.").type_file_out();
+    + Argument ("input", "the input track file.").type_tracks_in().type_file_in().type_text()
+    + Argument ("output", "the output track file.").type_tracks_out().type_file_out();
 
   OPTIONS
     + Option ("scanner2voxel",

--- a/cpp/cmd/tckmap.cpp
+++ b/cpp/cmd/tckmap.cpp
@@ -64,7 +64,7 @@ const OptionGroup OutputDimOption = OptionGroup ("Options for the dimensionality
       "(references an internal direction set),"
       " or a path to a text file containing a set of directions"
       " stored as azimuth/elevation pairs")
-    + Argument ("path").type_various()
+    + Argument ("path").type_file_in().type_integer()
   + Option ("tod",
       "generate a Track Orientation Distribution (TOD) in each voxel;"
       " need to specify the maximum spherical harmonic degree lmax to use"

--- a/cpp/cmd/transformcompose.cpp
+++ b/cpp/cmd/transformcompose.cpp
@@ -92,7 +92,7 @@ void usage() {
   + Argument ("output", "the output file"
                         " (may be a linear transformation text file,"
                         " or a deformation warp field image,"
-                        " depending on usage)").type_various();
+                        " depending on usage)").type_file_out().type_image_out();
 
   OPTIONS
   + Option ("template", "define the output grid defined by a template image")

--- a/cpp/core/app.h
+++ b/cpp/core/app.h
@@ -51,8 +51,6 @@ extern std::vector<std::string> raw_arguments_list;
 extern const char *project_version;
 extern const char *project_build_date;
 
-const char *argtype_description(ArgType type);
-
 std::string help_head(int format);
 std::string help_synopsis(int format);
 std::string help_tail(int format);
@@ -141,10 +139,16 @@ class ParsedArgument {
 public:
   operator std::string() const { return p; }
 
-  const std::string &as_text() const { return p; }
-  bool as_bool() const { return to<bool>(p); }
+  const std::string &as_text() const {
+    assert(arg->types | Text);
+    return p;
+  }
+  bool as_bool() const {
+    assert(arg->types | Boolean);
+    return to<bool>(p);
+  }
   int64_t as_int() const;
-  uint64_t as_uint() const { return uint64_t(as_int()); }
+  uint64_t as_uint() const;
   default_type as_float() const;
 
   std::vector<int32_t> as_sequence_int() const;

--- a/cpp/core/dwi/tractography/roi.cpp
+++ b/cpp/core/dwi/tractography/roi.cpp
@@ -30,26 +30,26 @@ const OptionGroup ROIOption =
              " as either a binary mask image,"
               " or as a sphere using 4 comma-separared values (x,y,z,radius)."
               " Streamlines must traverse ALL inclusion regions to be accepted.").allow_multiple()
-      + Argument("spec").type_various()
+      + Argument("spec").type_image_in().type_sequence_float()
     + Option("include_ordered",
               "specify an inclusion region of interest,"
               " as either a binary mask image,"
               " or as a sphere using 4 comma-separared values (x,y,z,radius)."
               " Streamlines must traverse ALL inclusion_ordered regions"
               " in the order they are specified in order to be accepted.").allow_multiple()
-      + Argument("image").type_text()
+      + Argument("image").type_image_in().type_sequence_float()
     + Option("exclude",
               "specify an exclusion region of interest,"
               " as either a binary mask image,"
               " or as a sphere using 4 comma-separared values (x,y,z,radius)."
               " Streamlines that enter ANY exclude region will be discarded.").allow_multiple()
-      + Argument("spec").type_various()
+      + Argument("spec").type_image_in().type_sequence_float()
     + Option("mask",
              "specify a masking region of interest,"
              " as either a binary mask image,"
              " or as a sphere using 4 comma-separared values (x,y,z,radius)."
              " If defined, streamlines exiting the mask will be truncated.").allow_multiple()
-      + Argument("spec").type_various();
+      + Argument("spec").type_image_in().type_sequence_float();
 // clang-format on
 
 void load_rois(Properties &properties) {

--- a/cpp/core/stride.cpp
+++ b/cpp/core/stride.cpp
@@ -29,7 +29,7 @@ const OptionGroup Options = OptionGroup("Stride options")
              " or as a template image from which the strides shall be extracted and used."
              " The actual strides produced will depend on whether"
              " the output image format can support it.")
-      + Argument("spec").type_various();
+      + Argument("spec").type_sequence_int().type_image_in();
 // clang-format on
 
 List &sanitise(List &current, const List &desired, const std::vector<ssize_t> &dims) {

--- a/cpp/gui/mrview/window.cpp
+++ b/cpp/gui/mrview/window.cpp
@@ -1955,7 +1955,7 @@ void Window::add_commandline_options(MR::App::OptionList &options) {
                "Either set the position of the crosshairs in scanner coordinates,"
                " with the new position supplied as a comma-separated list of floating-point values,"
                " or show or hide the focus cross hair using a boolean value as argument.").allow_multiple()
-        + Argument("spec").type_various()
+        + Argument("spec").type_bool().type_sequence_float()
 
       + Option("target",
                "Set the target location for the viewing window"

--- a/python/mrtrix3/app.py
+++ b/python/mrtrix3/app.py
@@ -847,16 +847,6 @@ class Parser(argparse.ArgumentParser):
     def _metavar():
       return 'trackfile'
 
-  class Various(CustomTypeBase):
-    def __call__(self, input_value):
-      return input_value
-    @staticmethod
-    def _legacytypestring():
-      return 'VARIOUS'
-    @staticmethod
-    def _metavar():
-      return 'spec'
-
 
 
 
@@ -927,7 +917,6 @@ class Parser(argparse.ArgumentParser):
                                   metavar='/path/to/scratch/',
                                   help='manually specify an existing directory in which to generate the scratch directory.')
       script_options.add_argument('-continue',
-                                  type=Parser.Various(),
                                   nargs=2,
                                   dest='cont',
                                   metavar=('ScratchDir', 'LastFile'),

--- a/python/mrtrix3/commands/population_template/usage.py
+++ b/python/mrtrix3/commands/population_template/usage.py
@@ -13,7 +13,8 @@
 #
 # For more details, see http://www.mrtrix.org/.
 
-from mrtrix3 import app #pylint: disable=no-name-in-module
+import pathlib
+from mrtrix3 import app, utils #pylint: disable=no-name-in-module
 
 from . import AGGREGATION_MODES, \
               DEFAULT_AFFINE_LMAX, \
@@ -44,6 +45,22 @@ class SequenceDirectoryOut(app.Parser.CustomTypeBase):
     return 'directory_list'
 
 
+class DirectoryInOrImageOut(app.Parser.CustomTypeBase):
+  def __call__(self, input_value):
+    if input_value == '-':
+      input_value = utils.name_temporary('mif')
+      abspath = pathlib.Path(input_value)
+      app._STDOUT_IMAGES.append(abspath)
+      return abspath # pylint: disable=protected-access
+    return app.Parser.make_userpath_object(app.Parser._UserPathExtras, input_value) # pylint: disable=protected-access
+  @staticmethod
+  def _legacytypestring():
+    return 'DIRIN IMAGEOUT'
+  @staticmethod
+  def _metavar():
+    return 'directory_in'
+
+
 
 def usage(cmdline): #pylint: disable=unused-variable
   cmdline.set_author('David Raffelt (david.raffelt@florey.edu.au)'
@@ -56,7 +73,7 @@ def usage(cmdline): #pylint: disable=unused-variable
                           ' then non-linear registration is used to optimise the template further.')
   cmdline.add_argument('input_dir',
                        nargs='+',
-                       type=app.Parser.Various(),
+                       type=DirectoryInOrImageOut(),
                        help='Input directory containing all images of a given contrast')
   cmdline.add_argument('template',
                        type=app.Parser.ImageOut(),

--- a/testing/data/cpp_cli/full_usage.txt
+++ b/testing/data/cpp_cli/full_usage.txt
@@ -6,7 +6,7 @@ a text input
 ARGUMENT spec 0 0 TEXT
 OPTION bool 1 0
 a boolean input
-ARGUMENT value 0 0 
+ARGUMENT value 0 0 BOOL
 OPTION int_unbound 1 0
 an integer input (unbounded)
 ARGUMENT value 0 0 INT -9223372036854775808 9223372036854775807
@@ -52,9 +52,9 @@ ARGUMENT input 0 0 TRACKSIN
 OPTION tracks_out 1 0
 an output tractogram
 ARGUMENT output 0 0 TRACKSOUT
-OPTION various 1 0
-an argument that could accept one of various forms
-ARGUMENT spec 0 0 VARIOUS
+OPTION any 1 0
+an argument that could accept any of the various forms
+ARGUMENT spec 0 0 TEXT BOOL INT -9223372036854775808 9223372036854775807 FLOAT -inf inf FILEIN FILEOUT DIRIN DIROUT ISEQ FSEQ TRACKSIN TRACKSOUT CHOICE One Two Three
 OPTION nargs_two 1 0
 A command-line option that accepts two arguments
 ARGUMENT first 0 0 TEXT

--- a/testing/data/cpp_cli/help.txt
+++ b/testing/data/cpp_cli/help.txt
@@ -65,8 +65,8 @@ OOPPTTIIOONNSS
   _-_t_r_a_c_k_s___o_u_t output
      an output tractogram
 
-  _-_v_a_r_i_o_u_s spec
-     an argument that could accept one of various forms
+  _-_a_n_y spec
+     an argument that could accept any of the various forms
 
   _-_n_a_r_g_s___t_w_o first second
      A command-line option that accepts two arguments

--- a/testing/data/cpp_cli/markdown.md
+++ b/testing/data/cpp_cli/markdown.md
@@ -45,7 +45,7 @@ Verify operation of the C++ command-line interface & parser
 
 + **-tracks_out output**<br>an output tractogram
 
-+ **-various spec**<br>an argument that could accept one of various forms
++ **-any spec**<br>an argument that could accept any of the various forms
 
 + **-nargs_two first second**<br>A command-line option that accepts two arguments
 

--- a/testing/data/cpp_cli/restructured_text.rst
+++ b/testing/data/cpp_cli/restructured_text.rst
@@ -50,7 +50,7 @@ Options
 
 -  **-tracks_out output** an output tractogram
 
--  **-various spec** an argument that could accept one of various forms
+-  **-any spec** an argument that could accept any of the various forms
 
 -  **-nargs_two first second** A command-line option that accepts two arguments
 

--- a/testing/data/python_cli/full_usage.txt
+++ b/testing/data/python_cli/full_usage.txt
@@ -50,9 +50,9 @@ ARGUMENT tracks_in 0 0 TRACKSIN
 OPTION -tracks_out 1 0
 An output tractogram
 ARGUMENT tracks_out 0 0 TRACKSOUT
-OPTION -various 1 0
-An option that accepts various types of content
-ARGUMENT various 0 0 VARIOUS
+OPTION -custom 1 0
+An option with custom type
+ARGUMENT custom 0 0 CUSTOM
 OPTION -nargs_plus 1 1
 A command-line option with nargs="+", no metavar
 ARGUMENT nargs_plus 0 1 TEXT
@@ -104,8 +104,8 @@ manually specify an existing directory in which to generate the scratch director
 ARGUMENT /path/to/scratch/ 0 0 DIRIN
 OPTION -continue 1 0
 continue the script from a previous execution; must provide the scratch directory path, and the name of the last successfully-generated file.
-ARGUMENT ScratchDir 0 0 VARIOUS
-ARGUMENT LastFile 0 0 VARIOUS
+ARGUMENT ScratchDir 0 0 TEXT
+ARGUMENT LastFile 0 0 TEXT
 OPTION -info 1 0
 display information messages.
 OPTION -quiet 1 0

--- a/testing/data/python_cli/help.txt
+++ b/testing/data/python_cli/help.txt
@@ -1,5 +1,4 @@
-
-     tteessttiinngg__ppyytthhoonn__ccllii: external MRtrix3 project
+     tteessttiinngg__ppyytthhoonn__ccllii: part of the MRtrix3 package
 
 SSYYNNOOPPSSIISS
 
@@ -62,8 +61,8 @@ CCuussttoomm  ttyyppeess
   _-_t_r_a_c_k_s___o_u_t trackfile
      An output tractogram
 
-  _-_v_a_r_i_o_u_s spec
-     An option that accepts various types of content
+  _-_c_u_s_t_o_m custom
+     An option with custom type
 
 CCoommpplleexx  iinntteerrffaacceess;;  nnaarrggss,,  mmeettaavvaarr,,  eettcc..
 
@@ -160,7 +159,7 @@ AAUUTTHHOORR
      Robert E. Smith (robert.smith@florey.edu.au)
 
 CCOOPPYYRRIIGGHHTT
-     Copyright (c) 2008-2024 the MRtrix3 contributors.  This Source Code Form is
+     Copyright (c) 2008-2025 the MRtrix3 contributors.  This Source Code Form is
      subject to the terms of the Mozilla Public License, v. 2.0. If a copy of
      the MPL was not distributed with this file, You can obtain one at
      http://mozilla.org/MPL/2.0/.  Covered Software is provided under this

--- a/testing/data/python_cli/markdown.md
+++ b/testing/data/python_cli/markdown.md
@@ -44,7 +44,7 @@ Test operation of the Python command-line interface
 
 + **--tracks_out trackfile**<br>An output tractogram
 
-+ **--various spec**<br>An option that accepts various types of content
++ **--custom custom**<br>An option with custom type
 
 #### Complex interfaces; nargs, metavar, etc.
 
@@ -112,7 +112,7 @@ Tournier, J.-D.; Smith, R. E.; Raffelt, D.; Tabbara, R.; Dhollander, T.; Pietsch
 
 **Author:** Robert E. Smith (robert.smith@florey.edu.au)
 
-**Copyright:** Copyright (c) 2008-2024 the MRtrix3 contributors.
+**Copyright:** Copyright (c) 2008-2025 the MRtrix3 contributors.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/testing/data/python_cli/restructured_text.rst
+++ b/testing/data/python_cli/restructured_text.rst
@@ -56,7 +56,7 @@ Custom types
 
 - **-tracks_out trackfile** An output tractogram
 
-- **-various spec** An option that accepts various types of content
+- **-custom custom** An option with custom type
 
 Complex interfaces; nargs, metavar, etc.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -131,7 +131,7 @@ Tournier, J.-D.; Smith, R. E.; Raffelt, D.; Tabbara, R.; Dhollander, T.; Pietsch
 
 **Author:** Robert E. Smith (robert.smith@florey.edu.au)
 
-**Copyright:** Copyright (c) 2008-2024 the MRtrix3 contributors.
+**Copyright:** Copyright (c) 2008-2025 the MRtrix3 contributors.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/testing/tools/testing_cpp_cli.cpp
+++ b/testing/tools/testing_cpp_cli.cpp
@@ -87,8 +87,20 @@ void usage() {
   + Option("tracks_out", "an output tractogram")
     + Argument("output").type_tracks_out()
 
-  + Option("various", "an argument that could accept one of various forms")
-    + Argument("spec").type_various()
+  + Option("any", "an argument that could accept any of the various forms")
+    + Argument("spec").type_text()
+                      .type_bool()
+                      .type_integer()
+                      .type_float()
+                      .type_sequence_int()
+                      .type_sequence_float()
+                      .type_choice(choices)
+                      .type_file_in()
+                      .type_file_out()
+                      .type_directory_in()
+                      .type_directory_out()
+                      .type_tracks_in()
+                      .type_tracks_out()
 
   + Option("nargs_two", "A command-line option that accepts two arguments")
     + Argument("first").type_text()
@@ -157,9 +169,9 @@ void run() {
   if (!opt.empty())
     CONSOLE("-tracks_out: " + str(opt[0][0]));
 
-  opt = get_options("various");
+  opt = get_options("any");
   if (!opt.empty())
-    CONSOLE("-various: " + str(opt[0][0]));
+    CONSOLE("-any: " + str(opt[0][0]));
   opt = get_options("nargs_two");
   if (!opt.empty())
     CONSOLE("-nargs_two: [" + str(opt[0][0]) + " " + str(opt[0][1]) + "]");

--- a/testing/tools/testing_python_cli.py
+++ b/testing/tools/testing_python_cli.py
@@ -15,11 +15,21 @@
 #
 # For more details, see http://www.mrtrix.org/.
 
+from mrtrix3 import app
+
 CHOICES = ('One', 'Two', 'Three')
 
-def usage(cmdline): #pylint: disable=unused-variable
-  from mrtrix3 import app #pylint: disable=no-name-in-module, import-outside-toplevel
+class Custom(app.Parser.CustomTypeBase):
+    def __call__(self, input_value):
+      return input_value
+    @staticmethod
+    def _legacytypestring():
+      return 'CUSTOM'
+    @staticmethod
+    def _metavar():
+      return 'custom'
 
+def usage(cmdline): #pylint: disable=unused-variable
   cmdline.set_author('Robert E. Smith (robert.smith@florey.edu.au)')
   cmdline.set_synopsis('Test operation of the Python command-line interface')
 
@@ -123,15 +133,13 @@ def usage(cmdline): #pylint: disable=unused-variable
   custom.add_argument('-tracks_out',
                       type=app.Parser.TracksOut(),
                       help='An output tractogram')
-  custom.add_argument('-various',
-                      type=app.Parser.Various(),
-                      help='An option that accepts various types of content')
+  custom.add_argument('-custom',
+                      type=Custom(),
+                      help='An option with custom type')
 
 
 
 def execute(): #pylint: disable=unused-variable
-  from mrtrix3 import app #pylint: disable=no-name-in-module, import-outside-toplevel
-
   for key in vars(app.ARGS):
     value = getattr(app.ARGS, key)
     if value is not None:

--- a/testing/unit_tests/cpp_cli
+++ b/testing/unit_tests/cpp_cli
@@ -2,21 +2,117 @@
 # Multiple tests for the C++ binary command-line interface
 
 # Test using all options at once
-mkdir -p tmp-dirin/ && touch tmp-filein.txt && touch tmp-tracksin.tck && testing_cpp_cli -flag -text my_text -choice One -bool false -int_unbound 0 -int_nonneg 1 -int_bound 50 -float_unbound 0.0 -float_nonneg 1.0 -float_bound 0.5 -int_seq 1,2,3 -float_seq 0.1,0.2,0.3 -dir_in tmp-dirin/ -dir_out tmp-dirout/ -file_in tmp-filein.txt -file_out tmp-fileout.txt -tracks_in tmp-tracksin.tck -tracks_out tmp-tracksout.tck -various my_various && rm -rf tmp-dirin/ && rm -f tmp-filein.txt && rm -f tmp-tracksin.tck
+trap "rm -rf tmp-dirin/ tmp-filein.txt tmp-tracksin.tck" EXIT \
+    mkdir -p tmp-dirin/ \
+    && touch tmp-filein.txt \
+    && touch tmp-tracksin.tck \
+    && testing_cpp_cli \
+        -flag \
+        -text my_text \
+        -choice One \
+        -bool false \
+        -int_unbound 0 \
+        -int_nonneg 1 \
+        -int_bound 50 \
+        -float_unbound 0.0 \
+        -float_nonneg 1.0 \
+        -float_bound 0.5 \
+        -int_seq 1,2,3 \
+        -float_seq 0.1,0.2,0.3 \
+        -dir_in tmp-dirin/ \
+        -dir_out tmp-dirout/ \
+        -file_in tmp-filein.txt \
+        -file_out tmp-fileout.txt \
+        -tracks_in tmp-tracksin.tck \
+        -tracks_out tmp-tracksout.tck \
+        -any my_any
 
 # Run previous with different option/argument orders
-mkdir -p tmp-dirin/ && touch tmp-filein.txt && touch tmp-tracksin.tck && testing_cpp_cli -text my_text -choice One -bool false -int_unbound 0 -int_nonneg 1 -int_bound 50 -float_unbound 0.0 -float_nonneg 1.0 -float_bound 0.5 -int_seq 1,2,3 -float_seq 0.1,0.2,0.3 -dir_in tmp-dirin/ -dir_out tmp-dirout/ -file_in tmp-filein.txt -file_out tmp-fileout.txt -tracks_in tmp-tracksin.tck -tracks_out tmp-tracksout.tck -various my_various -flag && rm -rf tmp-dirin/ && rm -f tmp-filein.txt && rm -f tmp-tracksin.tck
-mkdir -p tmp-dirin/ && touch tmp-filein.txt && touch tmp-tracksin.tck && testing_cpp_cli -choice One -bool false -int_unbound 0 -int_nonneg 1 -int_bound 50 -float_unbound 0.0 -float_nonneg 1.0 -float_bound 0.5 -int_seq 1,2,3 -float_seq 0.1,0.2,0.3 -dir_in tmp-dirin/ -dir_out tmp-dirout/ -file_in tmp-filein.txt -file_out tmp-fileout.txt -tracks_in tmp-tracksin.tck -tracks_out tmp-tracksout.tck -various my_various -flag -text my_text && rm -rf tmp-dirin/ && rm -f tmp-filein.txt && rm -f tmp-tracksin.tck
-mkdir -p tmp-dirin/ && touch tmp-filein.txt && touch tmp-tracksin.tck && testing_cpp_cli -bool false -int_unbound 0 -int_nonneg 1 -int_bound 50 -float_unbound 0.0 -float_nonneg 1.0 -float_bound 0.5 -int_seq 1,2,3 -float_seq 0.1,0.2,0.3 -dir_in tmp-dirin/ -dir_out tmp-dirout/ -file_in tmp-filein.txt -file_out tmp-fileout.txt -tracks_in tmp-tracksin.tck -tracks_out tmp-tracksout.tck -various my_various -flag -text my_text -choice One && rm -rf tmp-dirin/ && rm -f tmp-filein.txt && rm -f tmp-tracksin.tck
+trap "rm -rf tmp-dirin/ tmp-filein.txt tmp-tracksin.tck" EXIT \
+    mkdir -p tmp-dirin/ \
+    && touch tmp-filein.txt \
+    && touch tmp-tracksin.tck \
+    && testing_cpp_cli \
+        -text my_text \
+        -choice One \
+        -bool false \
+        -int_unbound 0 \
+        -int_nonneg 1 \
+        -int_bound 50 \
+        -float_unbound 0.0 \
+        -float_nonneg 1.0 \
+        -float_bound 0.5 \
+        -int_seq 1,2,3 \
+        -float_seq 0.1,0.2,0.3 \
+        -dir_in tmp-dirin/ \
+        -dir_out tmp-dirout/ \
+        -file_in tmp-filein.txt \
+        -file_out tmp-fileout.txt \
+        -tracks_in tmp-tracksin.tck \
+        -tracks_out tmp-tracksout.tck \
+        -any my_any \
+        -flag
+trap "rm -rf tmp-dirin/ tmp-filein.txt tmp-tracksin.tck" EXIT \
+    mkdir -p tmp-dirin/ \
+    && touch tmp-filein.txt \
+    && touch tmp-tracksin.tck \
+    && testing_cpp_cli \
+        -choice One \
+        -bool false \
+        -int_unbound 0 \
+        -int_nonneg 1 \
+        -int_bound 50 \
+        -float_unbound 0.0 \
+        -float_nonneg 1.0 \
+        -float_bound 0.5 \
+        -int_seq 1,2,3 \
+        -float_seq 0.1,0.2,0.3 \
+        -dir_in tmp-dirin/ \
+        -dir_out tmp-dirout/ \
+        -file_in tmp-filein.txt \
+        -file_out tmp-fileout.txt \
+        -tracks_in tmp-tracksin.tck \
+        -tracks_out tmp-tracksout.tck \
+        -any my_any \
+        -flag \
+        -text my_text
+trap "rm -rf tmp-dirin/ tmp-filein.txt tmp-tracksin.tck" EXIT \
+    mkdir -p tmp-dirin/ \
+    && touch tmp-filein.txt \
+    && touch tmp-tracksin.tck \
+    && testing_cpp_cli \
+        -bool false \
+        -int_unbound 0 \
+        -int_nonneg 1 \
+        -int_bound 50 \
+        -float_unbound 0.0 \
+        -float_nonneg 1.0 \
+        -float_bound 0.5 \
+        -int_seq 1,2,3 \
+        -float_seq 0.1,0.2,0.3 \
+        -dir_in tmp-dirin/ \
+        -dir_out tmp-dirout/ \
+        -file_in tmp-filein.txt \
+        -file_out tmp-fileout.txt \
+        -tracks_in tmp-tracksin.tck \
+        -tracks_out tmp-tracksout.tck \
+        -any my_any \
+        -flag \
+        -text my_text \
+        -choice One
 
 # No arguments are supported
 ! testing_cpp_cli random_arg
 
 # Test export of interface to various file formats
-testing_cpp_cli -help | tail -n +3 > tmp.txt && diff -a --strip-trailing-cr tmp.txt cpp_cli/help.txt && rm -f tmp.txt
-testing_cpp_cli __print_full_usage__ > tmp.txt && diff -a --strip-trailing-cr tmp.txt cpp_cli/full_usage.txt && rm -f tmp.txt
-testing_cpp_cli __print_usage_markdown__ > tmp.md && diff -a --strip-trailing-cr tmp.md cpp_cli/markdown.md && rm -f tmp.md
-testing_cpp_cli __print_usage_rst__ > tmp.rst && diff -a --strip-trailing-cr tmp.rst cpp_cli/restructured_text.rst && rm -f tmp.rst
+trap "rm -f tmp.txt" EXIT; testing_cpp_cli -help | tail -n +3 > tmp.txt \
+    && diff -a --strip-trailing-cr tmp.txt cpp_cli/help.txt
+trap "rm -f tmp.txt" EXIT; testing_cpp_cli __print_full_usage__ > tmp.txt \
+    && diff -a --strip-trailing-cr tmp.txt cpp_cli/full_usage.txt
+trap "rm -f tmp.md" EXIT; testing_cpp_cli __print_usage_markdown__ > tmp.md \
+    && diff -a --strip-trailing-cr tmp.md cpp_cli/markdown.md
+trap "rm -f tmp.rst" EXIT; testing_cpp_cli __print_usage_rst__ > tmp.rst \
+    && diff -a --strip-trailing-cr tmp.rst cpp_cli/restructured_text.rst
 
 # Test suitable handling of valid and invalid inputs to various argument types
 testing_cpp_cli -bool false
@@ -58,7 +154,7 @@ testing_cpp_cli -bool 2
 ! testing_cpp_cli -dir_out
 ! testing_cpp_cli -tracks_in
 ! testing_cpp_cli -tracks_out
-! testing_cpp_cli -various
+! testing_cpp_cli -any
 ! testing_cpp_cli -nargs_two
 ! testing_cpp_cli -nargs_two first
 

--- a/testing/unit_tests/python_cli
+++ b/testing/unit_tests/python_cli
@@ -2,13 +2,43 @@
 # Various tests of the functionality of the Pyhon command-line interface
 
 # Utilisation of all argument types
-mkdir -p tmp-dirin/ && touch tmp-filein.txt && touch tmp-tracksin.tck && testing_python_cli -flag -string_implicit my_implicit_string -string_explicit my_explicit_string -choice One -bool false -int_builtin 0 -float_builtin 0.0 -int_unbound 0 -int_nonneg 1 -int_bound 50 -float_unbound 0.0 -float_nonneg 1.0 -float_bound 0.5 -int_seq 1,2,3 -float_seq 0.1,0.2,0.3 -dir_in tmp-dirin/ -dir_out tmp-dirout/ -file_in tmp-filein.txt -file_out tmp-fileout.txt -tracks_in tmp-tracksin.tck -tracks_out tmp-tracksout.tck -various my_various && rm -rf tmp-dirin/ && rm -f tmp-filein.txt && rm -f tmp-tracksin.tck
+trap "rm -rf tmp-dirin/ tmp-filein.txt tmp-tracksin.tck" EXIT; \
+mkdir -p tmp-dirin/ \
+    && touch tmp-filein.txt \
+    && touch tmp-tracksin.tck \
+    && testing_python_cli \
+        -flag \
+        -string_implicit my_implicit_string \
+        -string_explicit my_explicit_string \
+        -choice One \
+        -bool false \
+        -int_builtin 0 \
+        -float_builtin 0.0 \
+        -int_unbound 0 \
+        -int_nonneg 1 \
+        -int_bound 50 \
+        -float_unbound 0.0 \
+        -float_nonneg 1.0 \
+        -float_bound 0.5 \
+        -int_seq 1,2,3 \
+        -float_seq 0.1,0.2,0.3 \
+        -dir_in tmp-dirin/ \
+        -dir_out tmp-dirout/ \
+        -file_in tmp-filein.txt \
+        -file_out tmp-fileout.txt \
+        -tracks_in tmp-tracksin.tck \
+        -tracks_out tmp-tracksout.tck \
+        -custom my_custom
 
 # Ensure that export of the command-line interfaces in various file formats obeys expectations
-testing_python_cli -help | tail -n +3 > tmp.txt && diff -a --strip-trailing-cr tmp.txt python_cli/help.txt && rm -f tmp.txt
-testing_python_cli __print_full_usage__ > tmp.txt && diff -a --strip-trailing-cr tmp.txt python_cli/full_usage.txt && rm -f tmp.txt
-testing_python_cli __print_usage_markdown__ > tmp.md && diff -a --strip-trailing-cr tmp.md python_cli/markdown.md && rm -f tmp.md
-testing_python_cli __print_usage_rst__ > tmp.rst && diff -a --strip-trailing-cr tmp.rst python_cli/restructured_text.rst && rm -f tmp.rst
+trap "rm -f tmp.txt" EXIT; testing_python_cli -help | tail -n +3 > tmp.txt \
+    && diff -a --strip-trailing-cr tmp.txt python_cli/help.txt
+trap "rm -f tmp.txt" EXIT; testing_python_cli __print_full_usage__ > tmp.txt \
+    && diff -a --strip-trailing-cr tmp.txt python_cli/full_usage.txt
+trap "rm -f tmp.md" EXIT; testing_python_cli __print_usage_markdown__ > tmp.md \
+    && diff -a --strip-trailing-cr tmp.md python_cli/markdown.md
+trap "rm -f tmp.rst" EXIT; testing_python_cli __print_usage_rst__ > tmp.rst \
+    && diff -a --strip-trailing-cr tmp.rst python_cli/restructured_text.rst
 
 # Test various argument types for both appropriate and inappropriate inputs
 testing_python_cli -bool false


### PR DESCRIPTION
Closes #2580.
Supersedes #3067.
More info via 3ce5b54323136c6720d07c0524d652d77f145c78.

Knew that fixing what I think is the wrong implementation via #3067 was going to irritate me; so went ahead and re-implemented in the way I think is preferable. The changes to the CLI tests should show what's different.

For `__print_full_usage__` (which remains unused elsewhere to the best of my knowledge), I chose to keep all possible types for a given command-line argument on the same line, with `INT` / `FLOAT` always followed by two lower and upper bounds, and `CHOICE` is always the last one in the list given the risk of one of the possible input strings clashing with one of the argument type identifiers.