### PR TITLE
5ttgen hsvs: Multiple changes / fixes

### DIFF
--- a/docs/reference/commands/5ttgen.rst
+++ b/docs/reference/commands/5ttgen.rst
@@ -393,6 +393,8 @@ Usage
 Options
 -------
 
+- **-freesurfer_lut file** Manually provide the path to the FreeSurfer lookup table file
+
 - **-template image** Provide an image that will form the template for the generated 5TT image
 
 - **-hippocampi choice** Select method to be used for hippocampi (& amygdalae) segmentation; options are: subfields,first,aseg
@@ -452,6 +454,12 @@ References
 * If -thalami nuclei is used: Iglesias, J.E.; Insausti, R.; Lerma-Usabiaga, G.; Bocchetta, M.; Van Leemput, K.; Greve, D.N.; van der Kouwe, A.; ADNI; Fischl, B.; Caballero-Gaudes, C.; Paz-Alonso, P.M. A probabilistic atlas of the human thalamic nuclei combining ex vivo MRI and histology. NeuroImage, 2018, 183, 314-326
 
 * If ACPCDetect is installed: Ardekani, B.; Bachman, A.H. Model-based automatic detection of the anterior and posterior commissures on MRI scans. NeuroImage, 2009, 46(3), 677-682
+
+* If FSL FIRST is used for subcortical structures: Patenaude, B.; Smith, S. M.; Kennedy, D. N. & Jenkinson, M. A Bayesian model of shape and appearance for subcortical brain segmentation. NeuroImage, 2011, 56, 907-922
+
+* If FSL is installed: Zhang, Y.; Brady, M. & Smith, S. Segmentation of brain MR images through a hidden Markov random field model and the expectation-maximization algorithm. IEEE Transactions on Medical Imaging, 2001, 20, 45-57
+
+* If FSL is installed: Smith, S. M.; Jenkinson, M.; Woolrich, M. W.; Beckmann, C. F.; Behrens, T. E.; Johansen-Berg, H.; Bannister, P. R.; De Luca, M.; Drobnjak, I.; Flitney, D. E.; Niazy, R. K.; Saunders, J.; Vickers, J.; Zhang, Y.; De Stefano, N.; Brady, J. M. & Matthews, P. M. Advances in functional and structural MR image analysis and implementation as FSL. NeuroImage, 2004, 23, S208-S219
 
 Tournier, J.-D.; Smith, R. E.; Raffelt, D.; Tabbara, R.; Dhollander, T.; Pietsch, M.; Christiaens, D.; Jeurissen, B.; Yeh, C.-H. & Connelly, A. MRtrix3: A fast, flexible and open software framework for medical image processing and visualisation. NeuroImage, 2019, 202, 116137
 

--- a/python/mrtrix3/commands/5ttgen/hsvs.py
+++ b/python/mrtrix3/commands/5ttgen/hsvs.py
@@ -41,6 +41,9 @@ def usage(base_parser, subparsers): #pylint: disable=unused-variable
   parser.add_argument('output',
                       type=app.Parser.ImageOut(),
                       help='The output 5TT image')
+  parser.add_argument('-freesurfer_lut',
+                      type=app.Parser.FileIn(),
+                      help='Manually provide the path to the FreeSurfer lookup table file')
   parser.add_argument('-template',
                       type=app.Parser.ImageIn(),
                       help='Provide an image that will form the template for the generated 5TT image')
@@ -84,6 +87,21 @@ def usage(base_parser, subparsers): #pylint: disable=unused-variable
                       'Model-based automatic detection of the anterior and posterior commissures on MRI scans. '
                       'NeuroImage, 2009, 46(3), 677-682',
                       condition='If ACPCDetect is installed',
+                      is_external=True)
+  parser.add_citation('Patenaude, B.; Smith, S. M.; Kennedy, D. N. & Jenkinson, M. '
+                      'A Bayesian model of shape and appearance for subcortical brain segmentation. '
+                      'NeuroImage, 2011, 56, 907-922',
+                      condition='If FSL FIRST is used for subcortical structures',
+                      is_external=True)
+  parser.add_citation('Zhang, Y.; Brady, M. & Smith, S. '
+                      'Segmentation of brain MR images through a hidden Markov random field model and the expectation-maximization algorithm. '
+                      'IEEE Transactions on Medical Imaging, 2001, 20, 45-57',
+                      condition='If FSL is installed',
+                      is_external=True)
+  parser.add_citation('Smith, S. M.; Jenkinson, M.; Woolrich, M. W.; Beckmann, C. F.; Behrens, T. E.; Johansen-Berg, H.; Bannister, P. R.; De Luca, M.; Drobnjak, I.; Flitney, D. E.; Niazy, R. K.; Saunders, J.; Vickers, J.; Zhang, Y.; De Stefano, N.; Brady, J. M. & Matthews, P. M. '
+                      'Advances in functional and structural MR image analysis and implementation as FSL. '
+                      'NeuroImage, 2004, 23, S208-S219',
+                      condition='If FSL is installed',
                       is_external=True)
 
 
@@ -319,11 +337,14 @@ def execute(): #pylint: disable=unused-variable
       app.console('Neither hippocampal subfields module output nor FSL FIRST detected; '
                   'FreeSurfer aseg will be used for hippocampi segmentation')
 
+  freesurfer_lut_file = app.ARGS.freesurfer_lut
   if hippocampi_method == 'subfields':
-    if 'FREESURFER_HOME' not in os.environ:
-      raise MRtrixError('FREESURFER_HOME environment variable not set; '
-                        'required for use of hippocampal subfields module')
-    freesurfer_lut_file = os.path.join(os.environ['FREESURFER_HOME'], 'FreeSurferColorLUT.txt')
+    if not freesurfer_lut_file:
+      if 'FREESURFER_HOME' not in os.environ:
+        raise MRtrixError('If using hippocampal subfields module output,'
+                          'either need to use -freesurfer_lut option to provide path to FreeSurfer lookup table file,'
+                          'or FREESURFER_HOME environment variable needs to be set in order for script to find it')
+      freesurfer_lut_file = os.path.join(os.environ['FREESURFER_HOME'], 'FreeSurferColorLUT.txt')
     check_file(freesurfer_lut_file)
     hipp_lut_file = os.path.join(path.shared_data_path(), '5ttgen', 'hsvs', 'HippSubfields.txt')
     check_file(hipp_lut_file)
@@ -487,6 +508,7 @@ def execute(): #pylint: disable=unused-variable
 
 
   if hippocampi_method == 'subfields':
+    assert freesurfer_lut_file is not None
     progress = app.ProgressBar('Using detected FreeSurfer hippocampal subfields module output',
                                64 if hipp_subfield_has_amyg else 32)
 
@@ -650,7 +672,7 @@ def execute(): #pylint: disable=unused-variable
   #   Generate one 'pial-like' surface containing the GM and WM of the cerebellum,
   #   and another with just the WM
   if not have_fast:
-    progress = app.ProgressBar('Adding FreeSurfer cerebellar segmentations directly', 6)
+    progress = app.ProgressBar('Adding FreeSurfer cerebellar segmentations directly', 12)
     for hemi in [ 'Left-', 'Right-' ]:
       wm_index = [ index for index, tissue, name in CEREBELLUM_ASEG if name.startswith(hemi) and 'White' in name ][0]
       gm_index = [ index for index, tissue, name in CEREBELLUM_ASEG if name.startswith(hemi) and 'Cortex' in name ][0]


### PR DESCRIPTION
- Fix progress bar for when FSL FAST is not used for the cerebellum, and the FreeSurfer segmentations of the cerebellar hemispheres are propagated to the 5TT image.
- New option `-freesurfer_lut`, for manually specifying the location of the FreeSurfer lookup table file; this permits utilisation of the script without environment variable `FREESURFER_HOME` being set, or indeed even the FreeSurfer software being present (related to #3073).
- Add missing citations to help page documentation.
