### PR TITLE
dwi2tensor: Fix operation with -iter 1 (re-apply)

### DIFF
--- a/cpp/cmd/dwi2tensor.cpp
+++ b/cpp/cmd/dwi2tensor.cpp
@@ -212,7 +212,7 @@ public:
         x = llt.compute(work.selfadjointView<Eigen::Lower>())
                 .solve(A.transpose() * w.asDiagonal() * w.asDiagonal() * dwi);
       }
-      if (maxit > 1)
+      if (it < maxit)
         w = (A * x).array().exp() * notnan.array();
     }
 

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -16,7 +16,7 @@ include(ExternalProject)
 ExternalProject_Add(BinariesTestData
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/binaries_data
     GIT_REPOSITORY ${mrtrix_binaries_data_url}
-    GIT_TAG 9c5da1483bfb0ec9d592a055e20e4465d828cde9
+    GIT_TAG b4cab4f39e04512d01a70cec8f6ac112b7ab8c99
     GIT_PROGRESS TRUE
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
@@ -35,11 +35,11 @@ ExternalProject_Add(ScriptsTestData
     LOG_DOWNLOAD ON
 )
 
-set(BINARY_DATA_DIR 
+set(BINARY_DATA_DIR
     ${CMAKE_CURRENT_BINARY_DIR}/binaries_data/src/BinariesTestData
 )
 
-set(SCRIPT_DATA_DIR 
+set(SCRIPT_DATA_DIR
     ${CMAKE_CURRENT_BINARY_DIR}/scripts_data/src/ScriptsTestData
 )
 


### PR DESCRIPTION
Restores `dev` to include the fix in #3056 that was seemingly lost during the construction of #3061. 

The mass changes happening on `dev` are going to make us increasingly prone to errors in merge resolution. When we get to the point of merging `3.1.0` we are going to have to do a manual check of all bugfixes in PRs targeting `master` and `dev` and make sure that none of them have slipped away.