### PR TITLE
Fix new CI release workflow on Windows

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -128,7 +128,7 @@ jobs:
         run: |
           cd packaging/mingw
           ./run.sh ${{ steps.envs.outputs.commit_sha }} mrtrix3
-          mv mingw*.tar.zst ../../../${{ steps.envs.outputs.output_name }}.tar.zst
+          mv mingw*.tar.zst ../../${{ steps.envs.outputs.output_name }}.tar.zst
 
       - name: Upload release artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This PR fixes a mistake in the logic of uploading artefacts on our new CI workflow. Relevant only to `dev`, but needs to be on `master` (see #2933 for more).