### PR TITLE
Fixes for new GA releases workflow

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -67,7 +67,7 @@ jobs:
           echo "output_name=mrtrix3-macos-$commit_sha-$date" >> $GITHUB_OUTPUT
 
       - name: Install deps
-        run: brew install numpy cmake qt eigen pkg-config fftw libpng ninja
+        run: brew install numpy cmake qt pkg-config libpng ninja
 
       - name: Run build
         run: |

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -128,7 +128,7 @@ jobs:
         run: |
           cd packaging/mingw
           ./run.sh ${{ steps.envs.outputs.commit_sha }} mrtrix3
-          mv mingw*.tar.zst ../../../${{ steps.envs.outputs.output_name }}.tar.zst
+          mv mingw*.tar.zst ../../${{ steps.envs.outputs.output_name }}.tar.zst
 
       - name: Upload release artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This PR fixes a mistake in the logic of uploading artefacts on our new CI workflow. Relevant only to dev, but needs to be on master (see https://github.com/MRtrix3/mrtrix3/pull/2933 for more details). Additionally, since for MacOS packaging we build eigen and fftw from source, their installation through brew is omitted.