### PR TITLE
Remove misc-non-private-member-variables-in-classes check clang-tidy check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,6 +5,7 @@ Checks: >
   concurrency-*,
   cppcoreguidelines-*,
   misc-*,
+  -misc-non-private-member-variables-in-classes,
   performance-*,
   portability-*,
   readability-*,


### PR DESCRIPTION
See [misc-non-private-member-variables-in-classes](https://clang.llvm.org/extra/clang-tidy/checks/misc/non-private-member-variables-in-classes.html). 
While I understand the reasoning behind this check, I believe that in the overwhelming majority of cases the check doesn't really provide any concrete benefits and it boils down to preference. Encapsulating everything via getters and setters, while useful in some scenarios, hurts readability.
I'm proposing to remove it.