### PR TITLE
Fix packaging workflows on master

### DIFF
--- a/.github/workflows/package-linux-anaconda.yml
+++ b/.github/workflows/package-linux-anaconda.yml
@@ -28,6 +28,6 @@ jobs:
     - name: Upload package to GitHub Release
       uses: AButler/upload-release-assets@v2.0
       with:
-        files: '*.tar.bz2'
+        files: '*.conda'
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/package-macos-anaconda.yml
+++ b/.github/workflows/package-macos-anaconda.yml
@@ -6,33 +6,34 @@ on:
 
 jobs:
   package:
-
     runs-on: macos-latest
 
     steps:
+      - name: Set up Miniconda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniconda-version: "latest"
 
-    - name: fetch MacOSX 10.11 SDK
-      run: curl -L https://github.com/phracker/MacOSX-SDKs/releases/download/MacOSX10.11.sdk/MacOSX10.11.sdk.tar.xz | sudo tar xf - -C /opt/
+      - name: Install conda-build
+        run: conda install -y conda-build
 
-    - name: install conda-build # and anaconda-client
-      run: sudo $CONDA/bin/conda install -y conda-build # anaconda-client
+      - name: fetch MacOSX 10.11 SDK
+        run: curl -L https://github.com/phracker/MacOSX-SDKs/releases/download/MacOSX10.11.sdk/MacOSX10.11.sdk.tar.xz | sudo tar xf - -C /opt/
 
-    - name: fetch recipe
-      run: |
-        git clone https://github.com/MRtrix3/conda-build.git
-        mv conda-build/* .
-        { echo "CONDA_BUILD_SYSROOT:"; echo "  - /opt/MacOSX10.11.sdk        # [osx]"; } > conda_build_config.yaml
+      - name: fetch recipe
+        run: |
+          git clone https://github.com/MRtrix3/conda-build.git
+          mv conda-build/* .
+          { echo "CONDA_BUILD_SYSROOT:"; echo "  - /opt/MacOSX10.11.sdk        # [osx]"; } > conda_build_config.yaml
 
-    - name: build package
-      run: sudo CONDA="$CONDA" ./run.sh ${GITHUB_REF#refs/*/} ${GITHUB_REPOSITORY%/*} conda-macos
+      - name: build package
+        run: sudo CONDA="$CONDA" ./run.sh ${GITHUB_REF#refs/*/} ${GITHUB_REPOSITORY%/*} conda-macos
 
-#    - name: upload package
-#      run: $CONDA/bin/anaconda -t ${{ secrets.ANACONDA_TOKEN }} upload -u MRtrix3 $(sudo $CONDA/bin/conda build conda-build/ --output)
+      #    - name: upload package
+      #      run: $CONDA/bin/anaconda -t ${{ secrets.ANACONDA_TOKEN }} upload -u MRtrix3 $(sudo $CONDA/bin/conda build conda-build/ --output)
 
-    - name: Upload package to GitHub Release
-      uses: AButler/upload-release-assets@v2.0
-      with:
-        files: '*.tar.bz2'
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-
+      - name: Upload package to GitHub Release
+        uses: AButler/upload-release-assets@v2.0
+        with:
+          files: "*.tar.bz2"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-macos-anaconda.yml
+++ b/.github/workflows/package-macos-anaconda.yml
@@ -35,5 +35,5 @@ jobs:
       - name: Upload package to GitHub Release
         uses: AButler/upload-release-assets@v2.0
         with:
-          files: "*.tar.bz2"
+          files: "*.conda"
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-macos-anaconda.yml
+++ b/.github/workflows/package-macos-anaconda.yml
@@ -27,7 +27,7 @@ jobs:
           { echo "CONDA_BUILD_SYSROOT:"; echo "  - /opt/MacOSX10.11.sdk        # [osx]"; } > conda_build_config.yaml
 
       - name: build package
-        run: sudo CONDA="$CONDA" ./run.sh ${GITHUB_REF#refs/*/} ${GITHUB_REPOSITORY%/*} conda-macos
+        run: CONDA="$CONDA" ./run.sh ${GITHUB_REF#refs/*/} ${GITHUB_REPOSITORY%/*} conda-macos
 
       #    - name: upload package
       #      run: $CONDA/bin/anaconda -t ${{ secrets.ANACONDA_TOKEN }} upload -u MRtrix3 $(sudo $CONDA/bin/conda build conda-build/ --output)

--- a/.github/workflows/package-macos-native.yml
+++ b/.github/workflows/package-macos-native.yml
@@ -15,7 +15,7 @@ jobs:
       run: git clone https://github.com/MRtrix3/macos-installer.git
 
     - name: build packages
-      run: ./build ${GITHUB_REF#refs/*/}
+      run: ./build ${GITHUB_REF#refs/*/} 5.15.2
       working-directory: ./macos-installer
 
     - name: Upload package to GitHub Release

--- a/.github/workflows/package-macos-native.yml
+++ b/.github/workflows/package-macos-native.yml
@@ -11,11 +11,16 @@ jobs:
 
     steps:
 
+    - name: Symlink Python3
+      run: |
+        mkdir -p python_dir
+        ln -s $(which python3) python_dir/python
+
     - name: fetch recipe
       run: git clone https://github.com/MRtrix3/macos-installer.git
 
     - name: build packages
-      run: ./build ${GITHUB_REF#refs/*/} 5.15.2
+      run: ./build ${GITHUB_REF#refs/*/} 5.15.2 ${{ github.workspace }}/python_dir
       working-directory: ./macos-installer
 
     - name: Upload package to GitHub Release

--- a/.github/workflows/package-macos-native.yml
+++ b/.github/workflows/package-macos-native.yml
@@ -20,7 +20,7 @@ jobs:
       run: git clone https://github.com/MRtrix3/macos-installer.git
 
     - name: build packages
-      run: ./build ${GITHUB_REF#refs/*/} 5.15.2 ${{ github.workspace }}/python_dir
+      run: ./build ${GITHUB_REF#refs/*/} 5.15.16 ${{ github.workspace }}/python_dir
       working-directory: ./macos-installer
 
     - name: Upload package to GitHub Release

--- a/.github/workflows/package-windows-msys2.yml
+++ b/.github/workflows/package-windows-msys2.yml
@@ -44,5 +44,5 @@ jobs:
       - name: Upload package to GitHub Release
         uses: AButler/upload-release-assets@v2.0
         with:
-          files: "*.tar.xz"
+          files: "*.tar.zst"
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-windows-msys2.yml
+++ b/.github/workflows/package-windows-msys2.yml
@@ -4,37 +4,45 @@ on:
   release:
     types: [created]
 
-
 jobs:
   package:
-
     runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
 
     env:
-      MSYSTEM: MINGW64
       MSYSCON: defterm
       CHERE_INVOKING: enabled_from_arguments
       MSYS2_NOSTART: yes
+      MINGW_PACKAGE_PREFIX: mingw-w64-x86_64
 
     steps:
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          install: |
+            git
+            pkg-config
+            python
+            ${{env.MINGW_PACKAGE_PREFIX}}-bc
+            ${{env.MINGW_PACKAGE_PREFIX}}-diffutils
+            ${{env.MINGW_PACKAGE_PREFIX}}-eigen3
+            ${{env.MINGW_PACKAGE_PREFIX}}-fftw
+            ${{env.MINGW_PACKAGE_PREFIX}}-gcc
+            ${{env.MINGW_PACKAGE_PREFIX}}-libtiff
+            ${{env.MINGW_PACKAGE_PREFIX}}-qt5-base
+            ${{env.MINGW_PACKAGE_PREFIX}}-qt5-svg
+            ${{env.MINGW_PACKAGE_PREFIX}}-zlib
 
-    - name: fetch and install MSYS2
-      run: bash -c 'curl -sL https://github.com/MRtrix3/MinGW/releases/download/1.0/msys2.tar.{0,1} | tar xf -'
+      - name: fetch PKGBUILD
+        run: git clone https://github.com/MRtrix3/MinGW.git && mv MinGW/* .
 
-    - name: run qtbinpatcher
-      shell: cmd
-      run: msys64\msys2_shell.cmd -c "qtbinpatcher --qt-dir=$(dirname $(which qmake))"
+      - name: run makepkg
+        run: ./run.sh ${GITHUB_REF#refs/*/} ${GITHUB_REPOSITORY%%/*}
 
-    - name: fetch PKGBUILD
-      shell: cmd
-      run: msys64\msys2_shell.cmd -c "git clone https://github.com/MRtrix3/MinGW.git && mv MinGW/* ."
-
-    - name: run makepkg
-      shell: cmd
-      run: msys64\msys2_shell.cmd -c "./run.sh ${GITHUB_REF#refs/*/} ${GITHUB_REPOSITORY%%/*}"
-
-    - name: Upload package to GitHub Release
-      uses: AButler/upload-release-assets@v2.0
-      with:
-        files: '*.tar.xz'
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload package to GitHub Release
+        uses: AButler/upload-release-assets@v2.0
+        with:
+          files: "*.tar.xz"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-windows-msys2.yml
+++ b/.github/workflows/package-windows-msys2.yml
@@ -39,7 +39,7 @@ jobs:
         run: git clone https://github.com/MRtrix3/MinGW.git && mv MinGW/* .
 
       - name: run makepkg
-        run: ./run.sh ${GITHUB_REF#refs/*/} ${GITHUB_REPOSITORY%%/*}
+        run: LINKFLAGS=-lopengl32 ./run.sh ${GITHUB_REF#refs/*/} ${GITHUB_REPOSITORY%%/*}
 
       - name: Upload package to GitHub Release
         uses: AButler/upload-release-assets@v2.0


### PR DESCRIPTION
This PR fixes all of our packaging workflows in preparation for the 3.0.5 release. Main changes:
- Windows workflow now uses the same Github Action used on `dev` to set up an MSYS2 environment (MINGW64 instead of UCRT64 for compatibility reasons). Additionally, an explicit addition of `-lopengl32` linker flag has been made (otherwise the build was failing).
- The MacOS conda workflow now uses the [conda-incubator/setup-miniconda](https://github.com/conda-incubator/setup-miniconda) to set up a `miniconda` environment.
- Qt 5.15.2 is used for the MacOS native build (we may want to discuss this further).
- Extensions of release artefacts have been changed to match the new standards used by package managers (`conda` and `pacman`).

Since GitHub Actions are painful to debug, I tested these on a separate fork of MRtrix3. The workflows seem to produce the expected results with the exception of the MacOS native build script, which is configured to directly clone and build the MRtrix3 repo (the release tag that triggers the workflow must be present in the MRtrix3 official repo). We should probably do a test release to check that all of them work as intended.

Closes #3007.