### PR TITLE
Update sccache version to 0.0.9

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -32,7 +32,7 @@ jobs:
          sudo apt-get install clang qt6-base-dev libglvnd-dev zlib1g-dev libfftw3-dev ninja-build python3-numpy libpng-dev
 
     - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.4
+      uses: mozilla-actions/sccache-action@v0.0.9
 
     - name: Get CMake
       uses: lukka/get-cmake@latest
@@ -93,7 +93,7 @@ jobs:
          sudo apt-get install g++-9 qt6-base-dev libglvnd-dev zlib1g-dev libfftw3-dev ninja-build python3-numpy libpng-dev
 
     - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.4
+      uses: mozilla-actions/sccache-action@v0.0.9
 
     - name: Get CMake
       uses: lukka/get-cmake@latest
@@ -145,7 +145,7 @@ jobs:
          brew install numpy
 
     - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.4
+      uses: mozilla-actions/sccache-action@v0.0.9
 
     - name: Get CMake
       uses: lukka/get-cmake@latest
@@ -222,7 +222,7 @@ jobs:
             ${{env.MINGW_PACKAGE_PREFIX}}-zlib
 
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.4
+        uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: export sccache to msys2 shell
         run: |

--- a/.github/workflows/weekly_sanitizers.yml
+++ b/.github/workflows/weekly_sanitizers.yml
@@ -31,7 +31,7 @@ jobs:
          sudo apt-get install clang llvm qt6-base-dev libglvnd-dev libeigen3-dev zlib1g-dev libfftw3-dev ninja-build python3-numpy
 
     - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.3
+      uses: mozilla-actions/sccache-action@v0.0.9
 
     - name: Get CMake
       uses: lukka/get-cmake@latest


### PR DESCRIPTION
This PR updates the `mozilla-actions/sccache-action` used in CI workflows to version 0.0.9.
Fixes #3088.