### PR TITLE
Final GA workflows changes for 3.0.5

### DIFF
--- a/.github/workflows/package-linux-anaconda.yml
+++ b/.github/workflows/package-linux-anaconda.yml
@@ -28,6 +28,6 @@ jobs:
     - name: Upload package to GitHub Release
       uses: AButler/upload-release-assets@v2.0
       with:
-        files: '*.conda'
+        files: '*.conda*'
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/package-linux-anaconda.yml
+++ b/.github/workflows/package-linux-anaconda.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
     - name: install conda-build # and anaconda-client
-      run: $CONDA/bin/conda install -y conda-build #anaconda-client
+      run: $CONDA/bin/conda install -c conda-forge -y conda-build #anaconda-client
 
     - name: fetch recipe
       run: |

--- a/.github/workflows/package-macos-anaconda.yml
+++ b/.github/workflows/package-macos-anaconda.yml
@@ -35,5 +35,5 @@ jobs:
       - name: Upload package to GitHub Release
         uses: AButler/upload-release-assets@v2.0
         with:
-          files: "*.conda"
+          files: "*.conda*"
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-macos-anaconda.yml
+++ b/.github/workflows/package-macos-anaconda.yml
@@ -15,7 +15,7 @@ jobs:
           miniconda-version: "latest"
 
       - name: Install conda-build
-        run: conda install -y conda-build
+        run: conda install -c conda-forge -y conda-build
 
       - name: fetch MacOSX 10.11 SDK
         run: curl -L https://github.com/phracker/MacOSX-SDKs/releases/download/MacOSX10.11.sdk/MacOSX10.11.sdk.tar.xz | sudo tar xf - -C /opt/


### PR DESCRIPTION
Small fixes for Linux/MacOS conda workflows:
- Change extensions of build artefacts.
- Install conda-build from conda-forge channel.

We still need to update the version in `core/version.h` and then we should be ready for the release.