### PR TITLE
tck2connectome: Fix erroneous assertion with -vector

### DIFF
--- a/src/dwi/tractography/connectome/matrix.cpp
+++ b/src/dwi/tractography/connectome/matrix.cpp
@@ -43,8 +43,6 @@ const App::Option EdgeStatisticOption
 template <typename T>
 bool Matrix<T>::operator() (const Mapped_track_nodepair& in)
 {
-  assert (in.get_first_node()  < mat2vec->mat_size());
-  assert (in.get_second_node() < mat2vec->mat_size());
   assert (assignments_lists.empty());
   if (is_vector()) {
     assert (assignments_pairs.empty());
@@ -61,6 +59,8 @@ bool Matrix<T>::operator() (const Mapped_track_nodepair& in)
       }
     }
   } else {
+    assert (in.get_first_node()  < mat2vec->mat_size());
+    assert (in.get_second_node() < mat2vec->mat_size());
     assert (assignments_single.empty());
     apply_data (in.get_first_node(), in.get_second_node(), in.get_factor(), in.get_weight());
     inc_count (in.get_first_node(), in.get_second_node(), in.get_weight());


### PR DESCRIPTION
Only prevents erroneous assertion failure; no effect to processing results in release mode.

(`mat2vec` is `nullptr` if the command is run with the `-vector` command-line option as it is not needed)