### PR TITLE
Upgrade CMake version to 3.22 for MacOS CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -150,7 +150,7 @@ jobs:
     - name: Get CMake
       uses: lukka/get-cmake@latest
       with:
-        cmakeVersion: '3.21.0'
+        cmakeVersion: '3.22.0'
 
     - name: Print CMake version
       run: cmake --version


### PR DESCRIPTION
It looks like newer versions of Qt require CMake 3.22 as a minimum to be used. In #3085, this caused a failure of the CI checks on MacOS where Qt is installed through `brew`. This PR upgrades the CMake version used for the MacOS CI from 3.21 to 3.22.