### PR TITLE
Python API: External software usage warning includes licenses

### DIFF
--- a/python/mrtrix3/app.py
+++ b/python/mrtrix3/app.py
@@ -1024,7 +1024,8 @@ class Parser(argparse.ArgumentParser):
             ' from neuroimaging software other than MRtrix3.')
     console('PLEASE ENSURE that any non-MRtrix3 software,'
             ' as well as any research methods they provide,'
-            ' are recognised and cited appropriately.')
+            ' are recognised and cited appropriately,'
+            ' and that any relevant software usage licenses are not violated.')
     console('Consult the help page (-help option) for more information.')
     console('')
 


### PR DESCRIPTION
Extension to #2840, in light of ongoing exploration of software licensing. If an *MRtrix3* Python command invokes a command from some other neuroimaging command, it's not just citation that's required, it's also making sure that the user is not in violation of the licensing requirements of that third party software just because it's being invokved through an *MRtrix3* interface.