### PR TITLE
Update clang-tidy-review action to 0.21.0

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -14,12 +14,12 @@ jobs:
     - name: Run CMake
       run: cmake . -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
-    - uses: ZedThree/clang-tidy-review@v0.20.1
+    - uses: ZedThree/clang-tidy-review@v0.21.0
       id: review
       with:
         apt_packages: g++,qt6-base-dev,libqt6opengl6-dev,libglvnd-dev,zlib1g-dev,libfftw3-dev,ninja-build
         config_file: .clang-tidy
         clang_tidy_version: 16
 
-    - uses: ZedThree/clang-tidy-review/upload@v0.20.1
+    - uses: ZedThree/clang-tidy-review/upload@v0.21.0
       id: upload-review


### PR DESCRIPTION
See changelog [here](https://github.com/ZedThree/clang-tidy-review/releases/tag/v0.21.0).