### PR TITLE
Derive MR::Exception from std::exception

### DIFF
--- a/cpp/core/exception.cpp
+++ b/cpp/core/exception.cpp
@@ -86,6 +86,13 @@ void cmdline_print_func(const std::string &msg) {
 #endif
 }
 
+const char *Exception::what() const noexcept {
+  if (description.empty()) {
+    return "MR::Exception (no specific message)";
+  }
+  return description.back().c_str();
+}
+
 void (*print)(const std::string &msg) = cmdline_print_func;
 void (*report_to_user_func)(const std::string &msg, int type) = cmdline_report_to_user_func;
 void (*Exception::display_func)(const Exception &E, int log_level) = display_exception_cmdline;

--- a/cpp/core/exception.h
+++ b/cpp/core/exception.h
@@ -16,15 +16,16 @@
 
 #pragma once
 
-#include <cerrno>
-#include <iostream>
-#include <string>
-
 #include "types.h"
 
 #ifdef MRTRIX_AS_R_LIBRARY
 #include "wrap_r.h"
 #endif
+
+#include <cerrno>
+#include <exception>
+#include <iostream>
+#include <string>
 
 namespace MR {
 namespace App {
@@ -78,7 +79,7 @@ extern void (*report_to_user_func)(const std::string &msg, int type);
   if (MR::App::log_level >= 3)                                                                                         \
   ::MR::report_to_user_func(msg, 3)
 
-class Exception {
+class Exception : public std::exception {
 public:
   Exception() {}
 
@@ -86,6 +87,8 @@ public:
   Exception(const Exception &previous_exception, const std::string &msg) : description(previous_exception.description) {
     description.push_back(msg);
   }
+
+  const char *what() const noexcept override;
 
   void display(int log_level = 0) const { display_func(*this, log_level); }
 


### PR DESCRIPTION
This improves interoperability with third party libraries so that any code that calls `try ... catch(std::exception& e) {...}` will automatically catch our exceptions.
This is a good [discussion](https://softwareengineering.stackexchange.com/questions/305641/should-one-derive-inherit-from-stdexception) on the idea.
