### PR TITLE
Suppress erroneous warning RE merging of gradient table

### DIFF
--- a/core/dwi/gradient.cpp
+++ b/core/dwi/gradient.cpp
@@ -236,9 +236,13 @@ namespace MR
 
     void clear_DW_scheme (Header& header)
     {
-      auto it = header.keyval().find ("dw_scheme");
-      if (it != header.keyval().end())
-        header.keyval().erase (it);
+      clear_DW_scheme (header.keyval());
+    }
+    void clear_DW_scheme (KeyValues& kv)
+    {
+      auto it = kv.find ("dw_scheme");
+      if (it != kv.end())
+        kv.erase (it);
     }
 
 

--- a/core/dwi/gradient.h
+++ b/core/dwi/gradient.h
@@ -257,6 +257,7 @@ namespace MR
 
     //! clear any DW gradient encoding scheme from the header
     void clear_DW_scheme (Header&);
+    void clear_DW_scheme (KeyValues&);
 
 
 

--- a/core/header.cpp
+++ b/core/header.cpp
@@ -71,7 +71,7 @@ namespace MR
 
 
 
-  void Header::merge_keyval (const KeyValues& in)
+  void Header::merge_keyval (const KeyValues& in, const bool suppress_warnings)
   {
     std::map<std::string, std::string> new_keyval;
     std::set<std::string> unique_comments;
@@ -105,7 +105,9 @@ namespace MR
             auto scheme = DWI::resolve_DW_scheme (parse_matrix (item.second), parse_matrix (it->second));
             DWI::set_DW_scheme (new_keyval, scheme);
           } catch (Exception& e) {
-            WARN("Error merging DW gradient tables between headers");
+            if (!suppress_warnings) {
+              WARN("Error merging DW gradient tables between headers");
+            }
             new_keyval["dw_scheme"] = "variable";
           }
         } else {
@@ -799,7 +801,7 @@ namespace MR
       }
 
       // Resolve key-value pairs
-      result.merge_keyval (H.keyval());
+      result.merge_keyval (H.keyval(), true);
 
       // Resolve discrepancies in datatype;
       //   also throw an exception if such mismatch is not permitted

--- a/core/header.cpp
+++ b/core/header.cpp
@@ -71,7 +71,7 @@ namespace MR
 
 
 
-  void Header::merge_keyval (const KeyValues& in, const bool suppress_warnings)
+  void Header::merge_keyval (const KeyValues& in)
   {
     std::map<std::string, std::string> new_keyval;
     std::set<std::string> unique_comments;
@@ -101,14 +101,16 @@ namespace MR
         } else if (item.first == "SliceTiming") {
           new_keyval["SliceTiming"] = Metadata::SliceEncoding::resolve_slice_timing (item.second, it->second);
         } else if (item.first == "dw_scheme") {
-          try {
-            auto scheme = DWI::resolve_DW_scheme (parse_matrix (item.second), parse_matrix (it->second));
-            DWI::set_DW_scheme (new_keyval, scheme);
-          } catch (Exception& e) {
-            if (!suppress_warnings) {
-              WARN("Error merging DW gradient tables between headers");
-            }
+          if (item.second == "variable" || it->second == "variable") {
             new_keyval["dw_scheme"] = "variable";
+          } else {
+            try {
+              auto scheme = DWI::resolve_DW_scheme (parse_matrix (item.second), parse_matrix (it->second));
+              DWI::set_DW_scheme (new_keyval, scheme);
+            } catch (Exception& e) {
+              WARN("Unable to merge inconsistent DW gradient tables between headers");
+              new_keyval["dw_scheme"] = "variable";
+            }
           }
         } else {
           new_keyval[item.first] = "variable";
@@ -760,14 +762,25 @@ namespace MR
       }
     }
 
+    // Need an enum to track what we're going to do with these fields,
+    //   rather than relying exclusively on Header::merge_keyval()
+    enum class scheme_manip_t { ABSENT, MERGE, CONCAT, ERASE };
     Eigen::MatrixXd dw_scheme, pe_scheme;
+    scheme_manip_t dwscheme_manip = scheme_manip_t::MERGE;
+    scheme_manip_t pescheme_manip = scheme_manip_t::MERGE;
     if (axis_to_concat == 3) {
       try {
         dw_scheme = DWI::get_DW_scheme (result);
-      } catch (Exception&) { }
+        dwscheme_manip = scheme_manip_t::CONCAT;
+      } catch (Exception&) {
+        dwscheme_manip = scheme_manip_t::ABSENT;
+      }
       try {
         pe_scheme = Metadata::PhaseEncoding::get_scheme (result);
-      } catch (Exception&) { }
+        pescheme_manip = pe_scheme.rows() == 0 ? scheme_manip_t::ABSENT : scheme_manip_t::CONCAT;
+      } catch (Exception&) {
+        pescheme_manip = scheme_manip_t::ERASE;
+      }
     }
 
     for (size_t i = 1; i != headers.size(); ++i) {
@@ -784,24 +797,69 @@ namespace MR
       // Expand the image along the axis of concatenation
       result.size (axis_to_concat) += H.ndim() <= axis_to_concat ? 1 : H.size (axis_to_concat);
 
-      // Concatenate 4D schemes if necessary
       if (axis_to_concat == 3) {
-        try {
-          const auto extra_dw = DWI::parse_DW_scheme (H);
-          concat_scheme (dw_scheme, extra_dw);
-        } catch (Exception&) {
-          dw_scheme.resize (0, 0);
-        }
-        try {
-          const auto extra_pe = Metadata::PhaseEncoding::get_scheme (H);
-          concat_scheme (pe_scheme, extra_pe);
-        } catch (Exception&) {
-          pe_scheme.resize (0, 0);
-        }
-      }
 
-      // Resolve key-value pairs
-      result.merge_keyval (H.keyval(), true);
+        // Create a local copy of the key-value data
+        //   in case we need to apply modifications prior to the key-value merge operation
+        KeyValues kv (H.keyval());
+
+        // Generate local copies of any schemes
+        Eigen::MatrixXd extra_dw, extra_pe;
+        try {
+          extra_dw = DWI::parse_DW_scheme (H);
+        } catch (Exception &) {}
+        try {
+          extra_pe = Metadata::PhaseEncoding::get_scheme (H);
+        } catch (Exception &) {}
+
+        switch (dwscheme_manip) {
+          case scheme_manip_t::ABSENT:
+            if (extra_dw.rows() > 0)
+              dwscheme_manip = scheme_manip_t::ERASE;
+            break;
+          case scheme_manip_t::MERGE:
+            assert(false);
+            throw Exception("Logic error in header key-value merge of DW scheme");
+          case scheme_manip_t::CONCAT:
+            if (extra_dw.rows() == 0) {
+              dw_scheme.resize (0, 0);
+              dwscheme_manip = scheme_manip_t::ERASE;
+            } else {
+              concat_scheme (dw_scheme, extra_dw);
+            }
+            break;
+          case scheme_manip_t::ERASE:
+            break;
+        }
+
+        switch (pescheme_manip) {
+          case scheme_manip_t::ABSENT:
+            if (extra_pe.rows() > 0)
+              pescheme_manip = scheme_manip_t::ERASE;
+            break;
+          case scheme_manip_t::MERGE:
+            assert(false);
+            throw Exception("Logic error in header key-value merge of PE scheme");
+          case scheme_manip_t::CONCAT:
+            if (extra_pe.rows() == 0) {
+              pe_scheme.resize (0, 0);
+              pescheme_manip = scheme_manip_t::ERASE;
+            } else {
+              concat_scheme (pe_scheme, extra_pe);
+            }
+            break;
+          case scheme_manip_t::ERASE:
+            break;
+        }
+
+        // Merge with modified key-value contents where these schemes have been removed
+        DWI::clear_DW_scheme(kv);
+        Metadata::PhaseEncoding::clear_scheme(kv);
+        result.merge_keyval(kv);
+
+      } else { // Axis of concatenation is not 3; can do a straight merge
+        result.merge_keyval (H.keyval());
+      }
 
       // Resolve discrepancies in datatype;
       //   also throw an exception if such mismatch is not permitted
@@ -815,10 +873,33 @@ namespace MR
         result.datatype() = (result.datatype()() & DataType::Attributes) + (H.datatype()() & DataType::Type);
     }
 
-    if (axis_to_concat == 3) {
-      DWI::set_DW_scheme (result, dw_scheme);
-      Metadata::PhaseEncoding::set_scheme (result.keyval(), pe_scheme);
+    // If manually concatenating these data along axis 3,
+    //   need to finalise after the last header has been processed
+    switch (dwscheme_manip) {
+      case scheme_manip_t::ABSENT:
+      case scheme_manip_t::MERGE:
+        break;
+      case scheme_manip_t::CONCAT:
+        DWI::set_DW_scheme(result, dw_scheme);
+        break;
+      case scheme_manip_t::ERASE:
+        WARN("Erasing diffusion gradient table: could not reconstruct across concatenated image headers");
+        DWI::clear_DW_scheme(result);
+        break;
     }
+    switch (pescheme_manip) {
+      case scheme_manip_t::ABSENT:
+      case scheme_manip_t::MERGE:
+        break;
+      case scheme_manip_t::CONCAT:
+        Metadata::PhaseEncoding::set_scheme (result.keyval(), pe_scheme);
+        break;
+      case scheme_manip_t::ERASE:
+        WARN("Erasing phase encoding information: could not reconstruct across concatenated image headers");
+        Metadata::PhaseEncoding::clear_scheme(result.keyval());
+        break;
+    }
+
     return result;
   }
 

--- a/core/header.h
+++ b/core/header.h
@@ -366,7 +366,7 @@ namespace MR
       //! get/set generic key/value text attributes
       KeyValues& keyval () { return keyval_; }
       //! merge key/value entries from another dictionary
-      void merge_keyval (const KeyValues&);
+      void merge_keyval (const KeyValues& in, const bool suppress_warnings = false);
 
       static Header open (const std::string& image_name);
       static Header create (const std::string& image_name, const Header& template_header, bool add_to_command_history = true);

--- a/core/header.h
+++ b/core/header.h
@@ -366,7 +366,7 @@ namespace MR
       //! get/set generic key/value text attributes
       KeyValues& keyval () { return keyval_; }
       //! merge key/value entries from another dictionary
-      void merge_keyval (const KeyValues& in, const bool suppress_warnings = false);
+      void merge_keyval (const KeyValues&);
 
       static Header open (const std::string& image_name);
       static Header create (const std::string& image_name, const Header& template_header, bool add_to_command_history = true);

--- a/testing/binaries/tests/mrcat
+++ b/testing/binaries/tests/mrcat
@@ -9,3 +9,6 @@ mrcat mrcat/voxel*.mih - | testing_diff_header -keyval - mrcat/all_axis3.mif
 mrcat mrcat/voxel*.mih - -axis 0 | testing_diff_header -keyval - mrcat/all_axis0.mif
 mrcat mrcat/voxel1.mih mrcat/voxel1.mih mrcat/voxel1.mih mrcat/voxel1.mih mrcat/voxel1.mih mrcat/voxel1.mih - | testing_diff_header -keyval - mrcat/one_axis3.mif
 mrcat mrcat/voxel1.mih mrcat/voxel1.mih mrcat/voxel1.mih mrcat/voxel1.mih mrcat/voxel1.mih mrcat/voxel1.mih - -axis 0 | testing_diff_header -keyval - mrcat/one_axis0.mif
+! mrcat tmp-[].mif -axis 3 tmp.mif -force 2>&1 | grep "Unable to merge inconsistent DW gradient tables between headers"
+! mrcat rpesplit1.mif rpesplit2.mif -axis 3 tmp.mif -force 2>&1 | grep "Unable to merge inconsistent DW gradient tables between headers"
+mrconvert rpesplit1.mif -coord 3 0:9 - | mrcat - rpesplit2.mif -axis 2 - 2>&1 | grep "Unable to merge inconsistent DW gradient tables between headers"


### PR DESCRIPTION
Initially thought that this was a minor annoyance that only affected specific data, but turns out to have been more widespread. See description in 568b28eece279eae6d5bee05bd5abf9555e82127.

`3.0.5` fails the second of the three new tests. Problem introduced in #3027, so 3.0.4 unaffected.

Even if concatenating two 4D series along the volume axis, where the two gradient tables should be stacked atop one another, `mrcat` produces a warning about an inability to *merge* gradient tables. The appropriately *concatenated* gradient table would still be present in the output image, it would just be an erroneous warning at the terminal.

Involves an addition of test data (in retrospect wasn't strictly necessary, but might be of use elsewhere); so `master` branch on test_data repo should be forwarded upon PR merge.