### PR TITLE
mesh2voxel: Accept >3D image as template voxel grid

### DIFF
--- a/cmd/mesh2voxel.cpp
+++ b/cmd/mesh2voxel.cpp
@@ -62,6 +62,7 @@ void run ()
   // Get the template image
   Header template_header = Header::open (argument[1]);
   check_3D_nonunity (template_header);
+  template_header.ndim() = 3;
 
   // Ensure that a floating-point representation is used for the output image,
   //   as is required for representing partial volumes

--- a/src/surface/algo/mesh2image.cpp
+++ b/src/surface/algo/mesh2image.cpp
@@ -42,6 +42,9 @@ namespace MR
       void mesh2image (const Mesh& mesh_realspace, Image<float>& image)
       {
 
+        if (image.ndim() < 3)
+          throw Exception ("Template voxel grid for mesh2image operation must be at least 3D");
+
         // For initial segmentation of mesh - identify voxels on the mesh, inside & outside
         enum vox_mesh_t { UNDEFINED, ON_MESH, PRELIM_OUTSIDE, PRELIM_INSIDE, FILL_TEMP, OUTSIDE, INSIDE };
 
@@ -83,6 +86,7 @@ namespace MR
           // Create some memory to work with:
           // Stores a flag for each voxel as encoded in enum vox_mesh_t
           Header H (image);
+          H.ndim() = 3;
           H.datatype() = DataType::UInt8;
           auto init_seg = Image<uint8_t>::scratch (H);
           for (auto l = Loop(init_seg) (init_seg); l; ++l)
@@ -227,7 +231,7 @@ namespace MR
             for (adj_voxel[2] = centre_voxel[2]-1; adj_voxel[2] <= centre_voxel[2]+1; ++adj_voxel[2]) {
               for (adj_voxel[1] = centre_voxel[1]-1; adj_voxel[1] <= centre_voxel[1]+1; ++adj_voxel[1]) {
                 for (adj_voxel[0] = centre_voxel[0]-1; adj_voxel[0] <= centre_voxel[0]+1; ++adj_voxel[0]) {
-                  if (!is_out_of_bounds (H, adj_voxel) && (adj_voxel - centre_voxel).any()) {
+                  if (!is_out_of_bounds (H, adj_voxel, 0, 3) && (adj_voxel - centre_voxel).any()) {
                     const Eigen::Vector3d offset (adj_voxel.cast<default_type>().matrix() - mesh.vert(i));
                     const default_type dp_normal = offset.dot (mesh.norm(i));
                     const default_type offset_on_plane = (offset - (mesh.norm(i) * dp_normal)).norm();

--- a/testing/binaries/tests/mesh2voxel
+++ b/testing/binaries/tests/mesh2voxel
@@ -1,1 +1,2 @@
 mesh2voxel meshconvert/in_ascii.vtk meshconvert/image.mif.gz - | testing_diff_image - mesh2voxel/out.mif.gz -abs 1.5e-3
+mrcat meshconvert/image.mif.gz meshconvert/image.mif.gz -axis 3 - | mesh2voxel meshconvert/in_ascii.vtk - - | testing_diff_image - mesh2voxel/out.mif.gz -abs 1.5e-3


### PR DESCRIPTION
Simple change to reduce the template voxel grid image to 3D if the image provided by the user is > 3D.

Given it is not an enhancement of features, but rather precludes the throwing of an unhandled exception, I suggest that it belongs on `master`.