### PR TITLE
Add method for canonical direct I/O layout

### DIFF
--- a/cpp/core/image.h
+++ b/cpp/core/image.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <numeric>
+#include <utility>
 #define IMAGE_H
 
 #include <functional>
@@ -181,6 +183,17 @@ public:
     return with_direct_io(axis < 0 ? Stride::contiguous_along_spatial_axes(*buffer)
                                    : Stride::contiguous_along_axis(axis, *buffer));
   }
+
+  //! return new Image with data preloaded into RAM using a canonical axes order layout.
+  /*!
+   * This layout ensures that axis 0 is the most contiguous (fastest varying),
+   * followed by axis 1, then axis 2, and so on, up to the highest dimension.
+   * All axes involved in this ordering will have positive effective strides.
+   * This is a common packed layout suitable for interoperability with GPU APIs
+   * (where axis 0 often maps to width, axis 1 to height, axis
+   * 2 to depth).
+   */
+  Image with_canonical_axes_order_layout() const;
 
   //! return RAM address of current voxel
   /*! \note this will only work if image access is direct (i.e. for a
@@ -394,6 +407,12 @@ template <typename ValueType> Image<ValueType> Image<ValueType>::with_direct_io(
   }
 
   return Image(buffer, with_strides);
+}
+
+template <typename ValueType> Image<ValueType> Image<ValueType>::with_canonical_axes_order_layout() const {
+  std::vector<ssize_t> strides(ndim());
+  std::iota(strides.begin(), strides.end(), static_cast<ssize_t>(1));
+  return with_direct_io(strides);
 }
 
 template <typename ValueType> std::string Image<ValueType>::dump_to_mrtrix_file(std::string filename, bool) const {


### PR DESCRIPTION
This PR introduces a new `Image::with_canonical_axes_order_layout()`, a utility method to obtain an `Image` with its data preloaded into RAM in a standardized, contiguous layout. This layout ensures that axis 0 is the most contiguous (fastest varying), followed by axis 1, then axis 2, and so on, up to the highest dimension. All axes involved in this ordering will have positive effective strides. This is a common packed layout suitable for interoperability with GPU APIs (where axis 0 often maps to width, axis 1 to height, axis 2 to depth) and possibly other external libraries. 

Checking the implementation of `Image::with_direct_io`, I believe that the implementation of the function should also ensure that the resulting stride should have all positive directions.

I'm slightly unsure about the naming though. I called the function `canonical` but I admit that may be confusing (the other one I was debating was `standard`).