### PR TITLE
Fixes for CLI parsing

### DIFF
--- a/cpp/core/app.cpp
+++ b/cpp/core/app.cpp
@@ -900,9 +900,6 @@ void sort_arguments(const std::vector<std::string> &arguments) {
 
       std::vector<std::string> option_args;
       std::copy_n(it + 1, opt->size(), std::back_inserter(option_args));
-      std::transform(option_args.begin(), option_args.end(), option_args.begin(), [](std::string_view arg) {
-        return is_dash(arg) ? arg : without_leading_dash(arg);
-      });
       option.push_back(ParsedOption(opt, option_args, index));
       it += opt->size();
     } else {

--- a/cpp/core/app.cpp
+++ b/cpp/core/app.cpp
@@ -1380,7 +1380,7 @@ ParsedOption::ParsedOption(const Option *option, const std::vector<std::string> 
     : opt(option), args(arguments), index(i) {
   for (size_t i = 0; i != option->size(); ++i) {
     const auto &p = arguments[i];
-    if (!is_dash(p))
+    if (!starts_with_dash(p))
       continue;
     if (((*option)[i].type == ImageIn || (*option)[i].type == ImageOut) && is_dash(arguments[i]))
       continue;

--- a/cpp/core/cmdline_option.h
+++ b/cpp/core/cmdline_option.h
@@ -127,7 +127,7 @@ public:
   using Limits = std::variant<std::vector<std::string>, IntRange, FloatRange>;
   Limits limits;
 
-  operator bool() const { return id.empty(); }
+  operator bool() const { return !id.empty(); }
 
   //! specifies that the argument is optional
   /*! For example:
@@ -334,7 +334,7 @@ public:
     push_back(arg);
     return *this;
   }
-  operator bool() const { return id.empty(); }
+  operator bool() const { return !id.empty(); }
 
   //! the option name
   std::string id;

--- a/cpp/core/mrtrix.cpp
+++ b/cpp/core/mrtrix.cpp
@@ -238,6 +238,8 @@ bool is_dash(std::string_view arg) {
   return nbytes != 0 && nbytes == arg.size();
 }
 
+bool starts_with_dash(std::string_view arg) { return char_is_dash(arg.data()); }
+
 std::string_view without_leading_dash(std::string_view arg) {
   size_t nbytes = char_is_dash(arg.data());
   while (nbytes > 0) {

--- a/cpp/core/mrtrix.cpp
+++ b/cpp/core/mrtrix.cpp
@@ -238,7 +238,7 @@ bool is_dash(std::string_view arg) {
   return nbytes != 0 && nbytes == arg.size();
 }
 
-bool starts_with_dash(std::string_view arg) { return char_is_dash(arg.data()); }
+bool starts_with_dash(std::string_view arg) { return char_is_dash(arg.data()) != 0U; }
 
 std::string_view without_leading_dash(std::string_view arg) {
   size_t nbytes = char_is_dash(arg.data());

--- a/cpp/core/mrtrix.h
+++ b/cpp/core/mrtrix.h
@@ -106,6 +106,9 @@ size_t char_is_dash(const char *arg);
 //! match whole string to a dash or any Unicode character that looks like one
 bool is_dash(std::string_view arg);
 
+//! match a dash or any Unicode character that looks like one at the start of a string
+bool starts_with_dash(std::string_view arg);
+
 //! returns string without leading dashes
 std::string_view without_leading_dash(std::string_view arg);
 

--- a/testing/data/cpp_cli/full_usage.txt
+++ b/testing/data/cpp_cli/full_usage.txt
@@ -6,7 +6,7 @@ a text input
 ARGUMENT spec 0 0 TEXT
 OPTION bool 1 0
 a boolean input
-ARGUMENT value 0 0 
+ARGUMENT value 0 0 BOOL
 OPTION int_unbound 1 0
 an integer input (unbounded)
 ARGUMENT value 0 0 INT -9223372036854775808 9223372036854775807

--- a/testing/data/cpp_cli/help.txt
+++ b/testing/data/cpp_cli/help.txt
@@ -108,7 +108,7 @@ AAUUTTHHOORR
      Robert E. Smith (robert.smith@florey.edu.au)
 
 CCOOPPYYRRIIGGHHTT
-     Copyright (c) 2008-2024 the MRtrix3 contributors.
+     Copyright (c) 2008-2025 the MRtrix3 contributors.
      This Source Code Form is subject to the terms of the Mozilla Public
      License, v. 2.0. If a copy of the MPL was not distributed with this
      file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/testing/data/cpp_cli/markdown.md
+++ b/testing/data/cpp_cli/markdown.md
@@ -75,7 +75,7 @@ Tournier, J.-D.; Smith, R. E.; Raffelt, D.; Tabbara, R.; Dhollander, T.; Pietsch
 
 **Author:** Robert E. Smith (robert.smith@florey.edu.au)
 
-**Copyright:** Copyright (c) 2008-2024 the MRtrix3 contributors.
+**Copyright:** Copyright (c) 2008-2025 the MRtrix3 contributors.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/testing/data/cpp_cli/restructured_text.rst
+++ b/testing/data/cpp_cli/restructured_text.rst
@@ -86,7 +86,7 @@ Tournier, J.-D.; Smith, R. E.; Raffelt, D.; Tabbara, R.; Dhollander, T.; Pietsch
 
 **Author:** Robert E. Smith (robert.smith@florey.edu.au)
 
-**Copyright:** Copyright (c) 2008-2024 the MRtrix3 contributors.
+**Copyright:** Copyright (c) 2008-2025 the MRtrix3 contributors.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/testing/unit_tests/cpp_cli
+++ b/testing/unit_tests/cpp_cli
@@ -40,6 +40,12 @@ testing_cpp_cli -bool 2
 ! testing_cpp_cli -int_seq Not,An,Int,Seq
 ! testing_cpp_cli -float_seq Not,A,Float,Seq
 
+# Verify correct parsing of option arguments that begin with a dash.
+testing_cpp_cli -int_unbound -123 2>&1 | grep "int_unbound: -123"
+testing_cpp_cli -text "-a-b-c" 2>&1 | grep "text: -a-b-c"
+testing_cpp_cli -file_out - 2>&1 | grep "file_out: -"
+testing_cpp_cli -int_seq -1,-1,-1,5 2>&1 | grep "int_seq: \[-1,-1,-1,5\]" # Ensure the brackets are escaped for grep
+
 # Options requiring arguments should fail if no argument is provided
 ! testing_cpp_cli -choice
 ! testing_cpp_cli -text
@@ -88,4 +94,3 @@ rm -f tmp-tracksin.tck && ! testing_cpp_cli -tracks_in tmp-tracksin.tck
 trap "rm -f tmp-filein.txt" EXIT; touch tmp-filein.txt && ! testing_cpp_cli -tracks_in tmp-filein.txt
 trap "rm -f tmp-tracksout.txt" EXIT; touch tmp-tracksout.tck && ! testing_cpp_cli -tracks_out tmp-tracksout.tck
 trap "rm -f tmp-tracksout.txt" EXIT; touch tmp-tracksout.tck && testing_cpp_cli -tracks_out tmp-tracksout.tck -force
-

--- a/testing/unit_tests/cpp_cli
+++ b/testing/unit_tests/cpp_cli
@@ -42,9 +42,15 @@ testing_cpp_cli -bool 2
 
 # Verify correct parsing of option arguments that begin with a dash.
 testing_cpp_cli -int_unbound -123 2>&1 | grep "int_unbound: -123"
+! testing_cpp_cli -int_unbound --1
+testing_cpp_cli -float_unbound -1.5 2>&1 | grep "float_unbound: -1.5"
+! testing_cpp_cli -float_unbound --1.5
 testing_cpp_cli -text "-a-b-c" 2>&1 | grep "text: -a-b-c"
-testing_cpp_cli -file_out - 2>&1 | grep "file_out: -"
+#testing_cpp_cli -file_out - 2>&1 | grep "file_out: -"
 testing_cpp_cli -int_seq -1,-1,-1,5 2>&1 | grep "int_seq: \[-1,-1,-1,5\]" # Ensure the brackets are escaped for grep
+! testing_cpp_cli -int_seq --1,1
+testing_cpp_cli -float_seq -1.5,1.5 2>&1 | grep "float_seq: \[-1.5,1.5\]"
+! testing_cpp_cli -float_seq --1.5,1.5
 
 # Options requiring arguments should fail if no argument is provided
 ! testing_cpp_cli -choice

--- a/testing/unit_tests/python_cli
+++ b/testing/unit_tests/python_cli
@@ -35,6 +35,20 @@ testing_python_cli -bool 2
 ! testing_python_cli -int_seq Not,An,Int,Seq
 ! testing_python_cli -float_seq Not,A,Float,Seq
 
+# Verify correct parsing of option arguments that begin with a dash.
+testing_python_cli -int_unbound -123 2>&1 | grep "int_unbound: -123"
+! testing_python_cli -int_unbound --1
+testing_python_cli -float_unbound -1.5 2>&1 | grep "float_unbound: -1.5"
+! testing_python_cli -float_unbound --1.5
+#testing_python_cli -file_out - 2>&1 | grep "file_out: -"
+! testing_python_cli -int_seq --1,1
+! testing_python_cli -float_seq --1.5,1.5
+# Following tests currently *not* working due to argparse
+#testing_python_cli -float_seq -1.5,1.5 2>&1 | grep "float_seq: \[-1.5,1.5\]"
+#testing_python_cli -string_explicit "-a-b-c" 2>&1 | grep "string: -a-b-c"
+#testing_python_cli -string_implicit "-a-b-c" 2>&1 | grep "string: -a-b-c"
+#testing_python_cli -int_seq -1,-1,-1,5 2>&1 | grep "int_seq: \[-1,-1,-1,5\]"
+
 # Tests relating to filesystem paths:
 # - Ensure that absent inputs result in appropriate error
 # - Ensure that pre-existing output paths are handled accordingly


### PR DESCRIPTION
Fixes some regressions introduced in #2911:
-  Boolean operators for Argument and Option classes returned reversed truth values.
- Leading dashes were mistakenly being removed from arguments provided for an option.

Also added some CLI parsing tests in `cpp_cli` to prevent future regressions.

It should address issue raised #3110.