### PR TITLE
Fix erroneous clamping of FSL bvals

### DIFF
--- a/core/dwi/gradient.cpp
+++ b/core/dwi/gradient.cpp
@@ -211,7 +211,7 @@ namespace MR
       Eigen::VectorXd bvals = grad.col(3);
       size_t bval_zeroed_count = 0;
       for (ssize_t n = 0; n < bvals.size(); ++n) {
-        if (bvecs.row(n).squaredNorm() > 0.0 && bvals[n] && bvals[n] <= MR::DWI::bzero_threshold()) {
+        if (bvecs.col(n).squaredNorm() > 0.0 && bvals[n] && bvals[n] <= MR::DWI::bzero_threshold()) {
           ++bval_zeroed_count;
           bvals[n] = 0.0;
         }

--- a/testing/binaries/tests/mrinfo
+++ b/testing/binaries/tests/mrinfo
@@ -1,0 +1,5 @@
+mrinfo dwi.mif -export_grad_fsl tmp.bvec tmp.bval -force && sed -i"" "s/^0/NaN/" tmp.bval && mrinfo dwi.mif -fslgrad tmp.bvec tmp.bval
+mrinfo dwi.mif -export_grad_fsl tmp.bvec tmp.bval -force && sed -i"" "s/^0/NaN/" tmp.bvec && mrinfo dwi.mif -fslgrad tmp.bvec tmp.bval
+mrinfo dwi.mif -export_grad_fsl tmp.bvec tmp.bval -force && sed -i"" "3 s/^0/1/" tmp.bvec && sed -i"" "s/^0/NaN/" tmp.bval && if [[ $(mrinfo dwi.mif -fslgrad tmp.bvec tmp.bval) ]]; then exit 1; else exit 0; fi
+mrinfo dwi.mif -export_grad_fsl tmp.bvec tmp.bval -force && sed -i"" "s/^0/NaN/" tmp.bvec && sed -i"" "s/^0/3000/" tmp.bval && if [[ $(mrinfo dwi.mif -fslgrad tmp.bvec tmp.bval) ]]; then exit 1; else exit 0; fi
+


### PR DESCRIPTION
Code error introduced in cf7e6371eff25ae2c76e10db849f15edad229208 as part of #2602.

-----

Commit cf7e6371eff25ae2c76e10db849f15edad229208 [replaces](https://github.com/MRtrix3/mrtrix3/pull/2602/commits/cf7e6371eff25ae2c76e10db849f15edad229208#diff-fb7ac61fa2ac9443e9c3ab3ccfa2459bcbb3b6338a2af81e19a591286fbfaabfL226):

> `if (!G.row(n).squaredNorm() && grad(n, 3) && grad(n, 3) <= MR::DWI::bzero_threshold()) {`

[with](https://github.com/MRtrix3/mrtrix3/pull/2602/commits/cf7e6371eff25ae2c76e10db849f15edad229208#diff-fb7ac61fa2ac9443e9c3ab3ccfa2459bcbb3b6338a2af81e19a591286fbfaabfR214):

> `if (bvecs.row(n).squaredNorm() > 0.0 && bvals[n] && bvals[n] <= MR::DWI::bzero_threshold()) {`

However with the updated code, variable `bvecs` has already undergone the requisite transposition. `bvecs.row(n)` therefore should raise an assertion as soon as you do `-export_grad_fsl` on any DWI with more than 3 volumes. 

The issue is two-fold. Firstly, there are no existing tests within CI that actually execute `-export_grad_fsl`. Secondly, #2602 was supposed to contain new tests that verified the operation of those changes; but this file appears to have been omitted from the relevant commits.

Pretty sure this one will require a hasty 3.0.6.