### PR TITLE
Remove readability-function-cognitive-complexity clang-tidy check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,5 +13,6 @@ Checks: >
   -cppcoreguidelines-avoid-magic-numbers,
   -readability-braces-around-statements,
   -readability-identifier-length,
+  -readability-function-cognitive-complexity,
   -readability-magic-numbers,
 HeaderFilterRegex: '*.(h|hpp)'


### PR DESCRIPTION
Removes the [readability-function-cognitive-complexity](https://clang.llvm.org/extra/clang-tidy/checks/readability/function-cognitive-complexity.html).
Long functions can sometimes hurt readability, but each function needs to be assessed on a case by case basis,. I think this generic check is not so useful.