### PR TITLE
Add {}-style string formatting for logging macros

### DIFF
--- a/cpp/core/exception.h
+++ b/cpp/core/exception.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "format_string.h"
 #include "types.h"
 
 #ifdef MRTRIX_AS_R_LIBRARY
@@ -63,21 +64,21 @@ inline void __print_stderr(const std::string &text) {
  * debugging information; anything else: none. */
 extern void (*report_to_user_func)(const std::string &msg, int type);
 
-#define CONSOLE(msg)                                                                                                   \
+#define CONSOLE(...)                                                                                                   \
   if (MR::App::log_level >= 1)                                                                                         \
-  ::MR::report_to_user_func(msg, -1)
-#define FAIL(msg)                                                                                                      \
+  ::MR::report_to_user_func(::MR::format_string(__VA_ARGS__), -1)
+#define FAIL(...)                                                                                                      \
   if (MR::App::log_level >= 0)                                                                                         \
-  ::MR::report_to_user_func(msg, 0)
-#define WARN(msg)                                                                                                      \
+  ::MR::report_to_user_func(::MR::format_string(__VA_ARGS__), 0)
+#define WARN(...)                                                                                                      \
   if (MR::App::log_level >= 1)                                                                                         \
-  ::MR::report_to_user_func(msg, 1)
-#define INFO(msg)                                                                                                      \
+  ::MR::report_to_user_func(::MR::format_string(__VA_ARGS__), 1)
+#define INFO(...)                                                                                                      \
   if (MR::App::log_level >= 2)                                                                                         \
-  ::MR::report_to_user_func(msg, 2)
-#define DEBUG(msg)                                                                                                     \
+  ::MR::report_to_user_func(::MR::format_string(__VA_ARGS__), 2)
+#define DEBUG(...)                                                                                                     \
   if (MR::App::log_level >= 3)                                                                                         \
-  ::MR::report_to_user_func(msg, 3)
+  ::MR::report_to_user_func(::MR::format_string(__VA_ARGS__), 3)
 
 class Exception : public std::exception {
 public:

--- a/cpp/core/format_string.h
+++ b/cpp/core/format_string.h
@@ -1,0 +1,46 @@
+/* Copyright (c) 2008-2025 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Covered Software is provided under this License on an "as is"
+ * basis, without warranty of any kind, either expressed, implied, or
+ * statutory, including, without limitation, warranties that the
+ * Covered Software is free of defects, merchantable, fit for a
+ * particular purpose or non-infringing.
+ * See the Mozilla Public License v. 2.0 for more details.
+ *
+ * For more details, see http://www.mrtrix.org/.
+ */
+
+#pragma once
+
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace detail {
+inline void format_impl(std::ostringstream &oss, std::string_view s) { oss << s; }
+
+// recursively replace first "{}" with the first value
+template <typename T, typename... Rest>
+void format_impl(std::ostringstream &oss, std::string_view string, T &&value, Rest &&...rest) {
+  const auto pos = string.find("{}");
+  if (pos == std::string_view::npos) {
+    oss << string;
+    return;
+  }
+  oss << string.substr(0, pos) << std::forward<T>(value);
+  format_impl(oss, string.substr(pos + 2), std::forward<Rest>(rest)...);
+}
+} // namespace detail
+
+namespace MR {
+template <typename... Args> inline std::string format_string(std::string_view fmt, Args &&...args) {
+  std::ostringstream oss;
+  detail::format_impl(oss, fmt, std::forward<Args>(args)...);
+  return oss.str();
+}
+} // namespace MR


### PR DESCRIPTION
This PR introduces a new string formatting utility, `MR::format_string`, and integrates it into the primary logging macros (`CONSOLE`, `FAIL`, `WARN`, `INFO`, `DEBUG`) to provide a more modern and convenient way to format log messages.

Previously, formatting log messages with dynamic values required manual string concatenation or the use of `std::ostringstream`, which can be verbose and less readable.

Now, instead of this:
```cpp
WARN("Failed to open file " + filename + " with error code: " + std::to_string(errno));
```

you can do the following:
```cpp
WARN("Failed to open file {} with error code: {}", filename, errno);
```

Perhaps this could be made more robust to check at compile time whether the number of `{}` parameters match the number of arguments provided (amongst other things), but I think that will make the implementation significantly more complex. This is a good enough solution until we move onto C++20, which introduces `std::format` (an alternative would be to implement #2951).