### PR TITLE
Fixes to external phase encoding table handling

### DIFF
--- a/bin/dwifslpreproc
+++ b/bin/dwifslpreproc
@@ -805,7 +805,7 @@ def execute(): #pylint: disable=unused-variable
 
 
     # Do the conversion in preparation for topup
-    run.command('mrconvert ' + se_epi_path + ' topup_in.nii' + se_epi_manual_pe_table_option + ' -strides -1,+2,+3,+4 -export_pe_table topup_datain.txt')
+    run.command('mrconvert ' + se_epi_path + ' topup_in.nii' + se_epi_manual_pe_table_option + ' -strides -1,+2,+3,+4 -export_pe_topup topup_datain.txt')
     app.cleanup(se_epi_path)
 
     # Run topup

--- a/cmd/mrconvert.cpp
+++ b/cmd/mrconvert.cpp
@@ -410,7 +410,7 @@ void run ()
   auto opt = get_options("json_import");
   if (!opt.empty())
     File::JSON::load(header_in, opt[0][0]);
-  if (!get_options("import_pe_table").empty() || !get_options("import_pe_eddy").empty())
+  if (!get_options("import_pe_table").empty() || !get_options("import_pe_topup").empty() || !get_options("import_pe_eddy").empty())
     Metadata::PhaseEncoding::set_scheme(header_in.keyval(), Metadata::PhaseEncoding::get_scheme(header_in));
 
   Header header_out (header_in);

--- a/cmd/mrinfo.cpp
+++ b/cmd/mrinfo.cpp
@@ -78,6 +78,13 @@ void usage ()
        "raw gradient table information as stored in the image header, i.e. without "
        "MRtrix3 back-end processing, use \"-property dw_scheme\"."
 
+    + "The -petable option exports the MRtrix3 internal representation of the phase encoding table, "
+      "regardless of whether the relevant metadata are stored in the BIDS fields \"PhaseEncodingDirection\" "
+      "and \"TotalReadoutTime\" or the MRtrix3-specific \"pe_scheme\". The contents of this query "
+      "should however *not* be provided to FSL tools: despite the contents being of the same format, "
+      "the phase encoding directions may be erroneously interpreted. If extracting phase encoding information "
+      "to interface with FSL tools, use the -export_pe_topup or -export_pe_eddy options."
+
     + DWI::bvalue_scaling_description;
 
   ARGUMENTS
@@ -108,7 +115,7 @@ void usage ()
     +   Option ("shell_indices", "list the image volumes attributed to each b-value shell")
 
     + Metadata::PhaseEncoding::ExportOptions
-    +   Option ("petable", "print the phase encoding table")
+    +   Option ("petable", "print the MRtrix internal representation of the phase encoding table (see Description)")
 
     + OptionGroup ("Handling of piped images")
     +   Option ("nodelete", "don't delete temporary images or images passed to mrinfo via Unix pipes");

--- a/core/metadata/phase_encoding.cpp
+++ b/core/metadata/phase_encoding.cpp
@@ -29,6 +29,8 @@ namespace MR {
         OptionGroup("Options for importing phase-encode tables")
         + Option("import_pe_table", "import a phase-encoding table from file")
           + Argument("file").type_file_in()
+        + Option("import_pe_topup", "import a phase-encoding table intended for FSL TOPUP from file")
+          + Argument("file").type_file_in()
         + Option("import_pe_eddy", "import phase-encoding information from an EDDY-style config / index file pair")
           + Argument("config").type_file_in()
           + Argument("indices").type_file_in();
@@ -46,9 +48,13 @@ namespace MR {
         OptionGroup("Options for exporting phase-encode tables")
         + Option("export_pe_table", "export phase-encoding table to file")
           + Argument("file").type_file_out()
+        + Option("export_pe_topup", "export phase-encoding table to a file intended for FSL topup")
+          + Argument("file").type_file_out()
         + Option("export_pe_eddy", "export phase-encoding information to an EDDY-style config / index file pair")
           + Argument("config").type_file_out()
           + Argument("indices").type_file_out();
+
+
 
       void check(const scheme_type& PE) {
         if (PE.rows() == 0)
@@ -177,21 +183,23 @@ namespace MR {
       scheme_type get_scheme(const Header& header) {
         DEBUG("searching for suitable phase encoding data...");
         using namespace App;
-        scheme_type result;
 
+        const auto opt_table = get_options("import_pe_table");
+        const auto opt_topup = get_options("import_pe_topup");
+        const auto opt_eddy = get_options("import_pe_eddy");
+        if (opt_table.size() + opt_topup.size() + opt_eddy.size() > 1)
+          throw Exception("Cannot specify more than one command-line option"
+                          " for importing phase encoding information from external file(s)");
+
+        scheme_type result;
         try {
-          const auto opt_table = get_options("import_pe_table");
           if (!opt_table.empty())
-            result = load(opt_table[0][0], header);
-          const auto opt_eddy = get_options("import_pe_eddy");
-          if (!opt_eddy.empty()) {
-            if (!opt_table.empty())
-              throw Exception("Phase encoding table can be provided"
-                              " using either -import_pe_table or -import_pe_eddy option,"
-                              " but NOT both");
+            result = load_table(opt_table[0][0], header);
+          else if (!opt_topup.empty())
+            result = load_topup(opt_topup[0][0], header);
+          else if (!opt_eddy.empty())
             result = load_eddy(opt_eddy[0][0], opt_eddy[0][1], header);
-          }
-          if (opt_table.empty() && opt_eddy.empty())
+          else
             result = parse_scheme(header.keyval(), header);
         } catch (Exception &e) {
           throw Exception(e, "error importing phase encoding table for image \"" + header.name() + "\"");
@@ -207,6 +215,10 @@ namespace MR {
 
         return result;
       }
+
+
+
+
 
 
 
@@ -284,7 +296,7 @@ namespace MR {
 
 
 
-      void scheme2eddy(const scheme_type& PE, Eigen::MatrixXd& config, Eigen::Array<int, Eigen::Dynamic, 1>& indices) {
+      void topup2eddy(const scheme_type& PE, Eigen::MatrixXd& config, Eigen::Array<int, Eigen::Dynamic, 1>& indices) {
         try {
           check(PE);
         } catch (Exception& e) {
@@ -315,7 +327,7 @@ namespace MR {
 
 
 
-      scheme_type eddy2scheme(const Eigen::MatrixXd& config, const Eigen::Array<int, Eigen::Dynamic, 1>& indices) {
+      scheme_type eddy2topup(const Eigen::MatrixXd& config, const Eigen::Array<int, Eigen::Dynamic, 1>& indices) {
         if (config.cols() != 4)
           throw Exception("Expected 4 columns in EDDY-format phase-encoding config file");
         scheme_type result(indices.size(), 4);
@@ -328,6 +340,8 @@ namespace MR {
         return result;
       }
 
+
+
       void export_commandline(const Header& header) {
         auto check = [&](const scheme_type& m) -> const scheme_type & {
           if (m.rows() == 0)
@@ -339,7 +353,11 @@ namespace MR {
 
         auto opt = get_options("export_pe_table");
         if (!opt.empty())
-          save(check(scheme), header, opt[0][0]);
+          save_table(check(scheme), header, opt[0][0]);
+
+        opt = get_options("export_pe_topup");
+        if (!opt.empty())
+          save_topup(check(scheme), header, opt[0][0]);
 
         opt = get_options("export_pe_eddy");
         if (!opt.empty())
@@ -348,7 +366,7 @@ namespace MR {
 
 
 
-      scheme_type load(const std::string& path, const Header& header) {
+      scheme_type load_table(const std::string& path, const Header& header) {
         const scheme_type PE = load_matrix(path);
         check(PE, header);
         // As with JSON import, need to query the header to discover if the
@@ -360,18 +378,35 @@ namespace MR {
 
 
 
-      scheme_type load_eddy(const std::string& config_path, const std::string& index_path, const Header& header) {
-        const Eigen::MatrixXd config = load_matrix(config_path);
-        const Eigen::Array<int, Eigen::Dynamic, 1> indices = load_vector<int>(index_path);
-        const scheme_type PE = eddy2scheme(config, indices);
+      scheme_type load_topup(const std::string& path, const Header& header) {
+        scheme_type PE = load_matrix(path);
         check(PE, header);
+        // Flip of first image axis based on determinant of image transform
+        //   applies to however the image was stored on disk,
+        //   before any interpretation by MRtrix3
+        if (header.realignment().orig_transform().linear().determinant() > 0.0)
+          PE.col(0) *= -1;
         return transform_for_image_load(PE, header);
       }
 
 
 
-      void save(const scheme_type& PE, const std::string& path) {
+      scheme_type load_eddy(const std::string& config_path, const std::string& index_path, const Header& header) {
+        const Eigen::MatrixXd config = load_matrix(config_path);
+        const Eigen::Array<int, Eigen::Dynamic, 1> indices = load_vector<int>(index_path);
+        scheme_type PE = eddy2topup(config, indices);
+        check(PE, header);
+        if (header.realignment().orig_transform().linear().determinant() > 0.0)
+          PE.col(0) *= -1;
+        return transform_for_image_load(PE, header);
+      }
+
+
+
+      void save_table(const scheme_type& PE, const std::string& path, const bool write_command_history) {
         File::OFStream out(path);
+        if (write_command_history)
+          out << "# " << App::command_history_string << "\n";
         for (ssize_t row = 0; row != PE.rows(); ++row) {
           // Write phase-encode direction as integers; other information as floating-point
           out << PE.template block<1, 3>(row, 0).template cast<int>();

--- a/core/metadata/phase_encoding.h
+++ b/core/metadata/phase_encoding.h
@@ -118,7 +118,7 @@ namespace MR {
 
         if (Path::has_suffix(header.name(), {".mgh", ".mgz", ".nii", ".nii.gz", ".img"})) {
           WARN("External phase encoding table \"" + path + "\" for image \"" + header.name() + "\""
-               " may not be suitable for FSL topup; consider use of -eport_pe_topup instead");
+               " may not be suitable for FSL topup; consider use of -export_pe_topup instead");
           save_table(transform_for_nifti_write(PE, header), path, true);
         } else {
           save_table(PE, path, true);

--- a/core/metadata/phase_encoding.h
+++ b/core/metadata/phase_encoding.h
@@ -78,11 +78,11 @@ namespace MR {
        */
       scheme_type get_scheme(const Header&);
 
-      //! Convert a phase-encoding scheme into the EDDY config / indices format
-      void scheme2eddy(const scheme_type& PE, Eigen::MatrixXd& config, Eigen::Array<int, Eigen::Dynamic, 1>& indices);
+      //! Convert a phase-encoding scheme in TOPUP format into the EDDY config / indices format
+      void topup2eddy(const scheme_type& PE, Eigen::MatrixXd& config, Eigen::Array<int, Eigen::Dynamic, 1>& indices);
 
-      //! Convert phase-encoding infor from the EDDY config / indices format into a standard scheme
-      scheme_type eddy2scheme(const Eigen::MatrixXd&, const Eigen::Array<int, Eigen::Dynamic, 1>&);
+      //! Convert phase-encoding infor from the EDDY config / indices format into a TOPUP format scheme
+      scheme_type eddy2topup(const Eigen::MatrixXd&, const Eigen::Array<int, Eigen::Dynamic, 1>&);
 
       //! Modifies a phase encoding scheme if being imported alongside a non-RAS image
       //  and internal header realignment is performed
@@ -93,10 +93,10 @@ namespace MR {
       void transform_for_nifti_write(KeyValues& keyval, const Header& H);
       scheme_type transform_for_nifti_write(const scheme_type& pe_scheme, const Header& H);
 
-      void save(const scheme_type& PE, const std::string& path);
+      void save_table(const scheme_type& PE, const std::string& path, bool write_command_history);
 
       template <class HeaderType>
-      void save(const HeaderType &header, const std::string &path) {
+      void save_table(const HeaderType &header, const std::string &path) {
         const scheme_type scheme = get_scheme(header);
         if (scheme.rows() == 0)
           throw Exception ("No phase encoding scheme in header of image \"" + header.name() + "\" to save");
@@ -105,10 +105,11 @@ namespace MR {
 
       //! Save a phase-encoding scheme associated with an image to file
       // Note that because the output table requires permutation / sign flipping
-      //   only if the output target image is a NIfTI, the output file name must have
-      //   already been set
+      //   only if the output target image is a NIfTI,
+      //   for this function to operate as intended it is necessary for it to be executed
+      //   after having set the output file name in the image header
       template <class HeaderType>
-      void save(const scheme_type &PE, const HeaderType &header, const std::string &path) {
+      void save_table(const scheme_type &PE, const HeaderType &header, const std::string &path) {
         try {
           check(PE, header);
         } catch (Exception &e) {
@@ -116,10 +117,32 @@ namespace MR {
         }
 
         if (Path::has_suffix(header.name(), {".mgh", ".mgz", ".nii", ".nii.gz", ".img"})) {
-          save(transform_for_nifti_write(PE, header), path);
+          save_table(transform_for_nifti_write(PE, header), path, true);
         } else {
-          save(PE, path);
+          save_table(PE, path, true);
         }
+      }
+
+      template <class HeaderType>
+      void save_topup(const scheme_type &PE, const HeaderType &header, const std::string &path) {
+        try {
+          check(PE, header);
+        } catch (Exception &e) {
+          throw Exception(e, "Cannot export phase-encoding table to file \"" + path + "\"");
+        }
+
+        if (!Path::has_suffix(header.name(), {".mgh", ".mgz", ".nii", ".nii.gz", ".img"}))
+          throw Exception("Only export phase encoding table to FSL topup format"
+                          " in conjunction with MGH / NIfTI format images");
+
+        scheme_type table = transform_for_nifti_write(PE, header);
+        // The flipping of first axis based on the determinant of the image header transform
+        //   applies to what is stored on disk
+        Axes::permutations_type order;
+        const auto adjusted_transform = File::NIfTI::adjust_transform(header, order);
+        if (adjusted_transform.linear().determinant() > 0.0)
+          table.col(0) *= -1.0;
+        save_table(table, path, false);
       }
 
       //! Save a phase-encoding scheme to EDDY format config / index files
@@ -128,9 +151,17 @@ namespace MR {
                      const HeaderType& header,
                      const std::string& config_path,
                      const std::string& index_path) {
+        if (!Path::has_suffix(header.name(), {".mgh", ".mgz", ".nii", ".nii.gz", ".img"}))
+          throw Exception("Only export phase encoding table to FSL eddy format"
+                          " in conjunction with MGH / NIfTI format images");
+        scheme_type table = transform_for_nifti_write(PE, header);
+        Axes::permutations_type order;
+        const auto adjusted_transform = File::NIfTI::adjust_transform(header, order);
+        if (adjusted_transform.linear().determinant() > 0.0)
+          table.col(0) *= -1.0;
         Eigen::MatrixXd config;
         Eigen::Array<int, Eigen::Dynamic, 1> indices;
-        scheme2eddy(transform_for_nifti_write(PE, header), config, indices);
+        topup2eddy(table, config, indices);
         save_matrix(config, config_path, KeyValues(), false);
         save_vector(indices, index_path, KeyValues(), false);
       }
@@ -139,7 +170,10 @@ namespace MR {
       void export_commandline(const Header&);
 
       //! Load a phase-encoding scheme from a matrix text file
-      scheme_type load(const std::string& path, const Header& header);
+      scheme_type load_table(const std::string& path, const Header& header);
+
+      //! Load a phase-encoding scheme from a FSL topup format text file
+      scheme_type load_topup(const std::string& path, const Header& header);
 
       //! Load a phase-encoding scheme from an EDDY-format config / indices file pair
       scheme_type load_eddy(const std::string& config_path, const std::string& index_path, const Header& header);

--- a/core/metadata/phase_encoding.h
+++ b/core/metadata/phase_encoding.h
@@ -117,6 +117,8 @@ namespace MR {
         }
 
         if (Path::has_suffix(header.name(), {".mgh", ".mgz", ".nii", ".nii.gz", ".img"})) {
+          WARN("External phase encoding table \"" + path + "\" for image \"" + header.name() + "\""
+               " may not be suitable for FSL topup; consider use of -eport_pe_topup instead");
           save_table(transform_for_nifti_write(PE, header), path, true);
         } else {
           save_table(PE, path, true);
@@ -131,6 +133,7 @@ namespace MR {
           throw Exception(e, "Cannot export phase-encoding table to file \"" + path + "\"");
         }
 
+        // TODO Should this check be in place?
         if (!Path::has_suffix(header.name(), {".mgh", ".mgz", ".nii", ".nii.gz", ".img"}))
           throw Exception("Only export phase encoding table to FSL topup format"
                           " in conjunction with MGH / NIfTI format images");

--- a/docs/concepts/pe_scheme.rst
+++ b/docs/concepts/pe_scheme.rst
@@ -100,7 +100,6 @@ of the last echo, in the train; this is consistent with BIDS, and is sometimes
 referred to as the "FSL definition", since it is consistent with relevant
 calculations performed within FSL tools. It should be defined in seconds.
 
-
 Variable phase encoding
 .......................
 
@@ -118,6 +117,13 @@ number is the total readout time. The direction is specified as a unit direction
 the image coordinate system; for instance, a phase encoding direction of A>>P would
 be encoded as ``[ 0 -1 0 ]``.
 
+Note that while this format closely resembles the interface by which the FSL
+software is provided with phase encoding information, particularly the ``topup``
+command, there is a subtle distinction relating to the way in which the FSL
+software interprets image data. The contents of this field should therefore *not*
+be interfaced with directly if the goal is to pass data to/from the FSL software;
+the ``-import_pe_topup`` and ``-export_pe_topup`` options should instead be used
+(see manipulation_of_phase_encoding_data_ below).
 
 .. _non_axial_acquisitions:
 
@@ -216,6 +222,8 @@ becomes more complex at both read and write stages, each in their own complex wa
    of axes within the file.
 
 
+.. _manipulation_of_phase_encoding_data:
+
 Manipulation of phase encoding data
 -----------------------------------
 
@@ -278,10 +286,24 @@ to manipulate this information:
    if all volumes in the image have the same phase encoding direction and total
    readout time, these options will still import / export these data in table format.
 
+-  The ``-import_pe_topup`` and ``-export_pe_topup`` options can be used to
+   import/export the phase encoding information in the format required by FSL's
+   ``topup`` tool. While this may look identical to the phase encoding table as stored
+   in the ``pe_scheme`` header entry and passed using the ``-import_pe_table`` and
+   ``-export_pe_table``, the two are not always equivalent.
+   Data interfaced using this option considers the possible flipping of the first image
+   axis that occurs when the FSL software interprets image data for images with
+   a transform with a positive determinant, just as occurs in the "``bvecs``" format
+   for handling diffusion gradient tables. These options should therefore be used instead
+   of the ``-import_pe_table`` and ``-export_pe_table`` options if the relevant text
+   file involves interfacing with the FSL software.
+
 -  The ``-import_pe_eddy`` and ``-export_pe_eddy`` options can be used to
    import/export the phase encoding information in the format required by FSL's
    ``eddy`` tool. The `FSL documentation page <https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/eddy/UsersGuide#A--acqp>`_
-   describes this format in more detail.
+   describes this format in more detail. This format takes into account the possible
+   flipping of the first image axis in the same way as do the ``-import_pe_topup`` and
+   ``-export_pe_topup`` options.
 
 -  The ``-json_import`` and ``-json_export`` options can be used to import/export
    *all* header key-value entries from/to an external JSON file. This may be useful

--- a/docs/reference/commands/dwiextract.rst
+++ b/docs/reference/commands/dwiextract.rst
@@ -61,6 +61,8 @@ Options for importing phase-encode tables
 
 -  **-import_pe_table file** import a phase-encoding table from file
 
+-  **-import_pe_topup file** import a phase-encoding table intended for FSL TOPUP from file
+
 -  **-import_pe_eddy config indices** import phase-encoding information from an EDDY-style config / index file pair
 
 Options for selecting volumes based on phase-encoding

--- a/docs/reference/commands/dwiextract.rst
+++ b/docs/reference/commands/dwiextract.rst
@@ -59,8 +59,6 @@ DW gradient table export options
 Options for importing phase-encode tables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
--  **-import_pe_table file** import a phase-encoding table from file
-
 -  **-import_pe_topup file** import a phase-encoding table intended for FSL TOPUP from file
 
 -  **-import_pe_eddy config indices** import phase-encoding information from an EDDY-style config / index file pair

--- a/docs/reference/commands/mrconvert.rst
+++ b/docs/reference/commands/mrconvert.rst
@@ -149,12 +149,16 @@ Options for importing phase-encode tables
 
 -  **-import_pe_table file** import a phase-encoding table from file
 
+-  **-import_pe_topup file** import a phase-encoding table intended for FSL TOPUP from file
+
 -  **-import_pe_eddy config indices** import phase-encoding information from an EDDY-style config / index file pair
 
 Options for exporting phase-encode tables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 -  **-export_pe_table file** export phase-encoding table to file
+
+-  **-export_pe_topup file** export phase-encoding table to a file intended for FSL topup
 
 -  **-export_pe_eddy config indices** export phase-encoding information to an EDDY-style config / index file pair
 

--- a/docs/reference/commands/mrconvert.rst
+++ b/docs/reference/commands/mrconvert.rst
@@ -147,16 +147,12 @@ DW gradient table export options
 Options for importing phase-encode tables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
--  **-import_pe_table file** import a phase-encoding table from file
-
 -  **-import_pe_topup file** import a phase-encoding table intended for FSL TOPUP from file
 
 -  **-import_pe_eddy config indices** import phase-encoding information from an EDDY-style config / index file pair
 
 Options for exporting phase-encode tables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
--  **-export_pe_table file** export phase-encoding table to file
 
 -  **-export_pe_topup file** export phase-encoding table to a file intended for FSL topup
 

--- a/docs/reference/commands/mrinfo.rst
+++ b/docs/reference/commands/mrinfo.rst
@@ -28,6 +28,8 @@ The command can also write the diffusion gradient table from a single input imag
 
 The -dwgrad, -export_* and -shell_* options provide (information about) the diffusion weighting gradient table after it has been processed by the MRtrix3 back-end (vectors normalised, b-values scaled by the square of the vector norm, depending on the -bvalue_scaling option). To see the raw gradient table information as stored in the image header, i.e. without MRtrix3 back-end processing, use "-property dw_scheme".
 
+The -petable option exports the MRtrix3 internal representation of the phase encoding table, regardless of whether the relevant metadata are stored in the BIDS fields "PhaseEncodingDirection" and "TotalReadoutTime" or the MRtrix3-specific "pe_scheme". The contents of this query should however *not* be provided to FSL tools: despite the contents being of the same format, the phase encoding directions may be erroneously interpreted. If extracting phase encoding information to interface with FSL tools, use the -export_pe_topup or -export_pe_eddy options.
+
 The -bvalue_scaling option controls an aspect of the import of diffusion gradient tables. When the input diffusion-weighting direction vectors have norms that differ substantially from unity, the b-values will be scaled by the square of their corresponding vector norm (this is how multi-shell acquisitions are frequently achieved on scanner platforms). However in some rare instances, the b-values may be correct, despite the vectors not being of unit norm (or conversely, the b-values may need to be rescaled even though the vectors are close to unit norm). This option allows the user to control this operation and override MRrtix3's automatic detection.
 
 Options
@@ -91,13 +93,11 @@ DW gradient table export options
 Options for exporting phase-encode tables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
--  **-export_pe_table file** export phase-encoding table to file
-
 -  **-export_pe_topup file** export phase-encoding table to a file intended for FSL topup
 
 -  **-export_pe_eddy config indices** export phase-encoding information to an EDDY-style config / index file pair
 
--  **-petable** print the phase encoding table
+-  **-petable** print the MRtrix internal representation of the phase encoding table (see Description)
 
 Handling of piped images
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/reference/commands/mrinfo.rst
+++ b/docs/reference/commands/mrinfo.rst
@@ -93,6 +93,8 @@ Options for exporting phase-encode tables
 
 -  **-export_pe_table file** export phase-encoding table to file
 
+-  **-export_pe_topup file** export phase-encoding table to a file intended for FSL topup
+
 -  **-export_pe_eddy config indices** export phase-encoding information to an EDDY-style config / index file pair
 
 -  **-petable** print the phase encoding table


### PR DESCRIPTION
As suspected following posting of #3122 and reported in #3127, there are residual issues with the handling of phase encoding data. I am creating this PR so that I can more easily pull the data into https://github.com/Lestropie/DWI_metadata and perform more exhaustive tests.

Certainly as a first pass, with current `master` code, when I combine data with more complex phase encoding contrast than just reversal, results are OK if the NIfTI is left-handed but erroneous if right-handed.

- [x] Confirm that results from `topup` and `applytopup` with > 2 phase encoding directions are correct with the code posted here.

- [x] Confirm that results from `eddy` with > 2 phase encoding directions are correct with the code posted here.
    (currently trying to run `eddy` utilising all of the data for each candidate stride list is prohibitively slow, so I will need to derive some trickery to utilise only a subset of the available data in such a way that `eddy` still works OK and can confirm that interpretation of phase encoding is correct)

- [x] Implement tests to confirm that exporting to any phase encoding text file format, then importing back in, yields the same internal representation
    (If data exported from *MRtrix3* are interpreted correctly by FSL, then making sure that an *MRtrix3* export / import pair yields no change should be adequate validation of the *MRtrix3* imports)