### PR TITLE
mrdegibbs: Describe complex-valued capability, update types

### DIFF
--- a/cpp/core/degibbs/degibbs.h
+++ b/cpp/core/degibbs/degibbs.h
@@ -1,0 +1,26 @@
+/* Copyright (c) 2008-2025 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Covered Software is provided under this License on an "as is"
+ * basis, without warranty of any kind, either expressed, implied, or
+ * statutory, including, without limitation, warranties that the
+ * Covered Software is free of defects, merchantable, fit for a
+ * particular purpose or non-infringing.
+ * See the Mozilla Public License v. 2.0 for more details.
+ *
+ * For more details, see http://www.mrtrix.org/.
+ */
+
+#pragma once
+
+#include <complex>
+
+namespace MR::Degibbs {
+
+typedef double real_type;
+typedef std::complex<real_type> complex_type;
+
+} // namespace MR::Degibbs

--- a/cpp/core/degibbs/degibbs.h
+++ b/cpp/core/degibbs/degibbs.h
@@ -20,7 +20,7 @@
 
 namespace MR::Degibbs {
 
-typedef double real_type;
-typedef std::complex<real_type> complex_type;
+using real_type = double;
+using complex_type = std::complex<real_type>;
 
 } // namespace MR::Degibbs

--- a/cpp/core/degibbs/unring1d.h
+++ b/cpp/core/degibbs/unring1d.h
@@ -36,8 +36,8 @@ public:
     assert(data.cols() == 1);
     assert(fft.size() == size_t(data.size()));
 
-    real_type TV1arr[2 * nsh + 1];
-    real_type TV2arr[2 * nsh + 1];
+    VLA(TV1arr, real_type, 2 * nsh + 1);
+    VLA(TV2arr, real_type, 2 * nsh + 1);
 
     const int n = fft.size();
     const int maxn = (n & 1) ? (n - 1) / 2 : n / 2 - 1;

--- a/cpp/core/degibbs/unring1d.h
+++ b/cpp/core/degibbs/unring1d.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "degibbs/degibbs.h"
 #include "math/fft.h"
 
 namespace MR::Degibbs {
@@ -35,8 +36,8 @@ public:
     assert(data.cols() == 1);
     assert(fft.size() == size_t(data.size()));
 
-    double TV1arr[2 * nsh + 1];
-    double TV2arr[2 * nsh + 1];
+    real_type TV1arr[2 * nsh + 1];
+    real_type TV2arr[2 * nsh + 1];
 
     const int n = fft.size();
     const int maxn = (n & 1) ? (n - 1) / 2 : n / 2 - 1;
@@ -50,13 +51,13 @@ public:
 
     // apply shifts and iFFT each line:
     for (int j = 1; j < 2 * nsh + 1; j++) {
-      double phi = Math::pi * double(shifts[j]) / double(n * nsh);
-      cdouble u(std::cos(phi), std::sin(phi));
-      cdouble e(1.0, 0.0);
+      const real_type phi = Math::pi * real_type(shifts[j]) / double(n * nsh);
+      const complex_type u(std::cos(phi), std::sin(phi));
+      complex_type e(1.0, 0.0);
       fft[0] = data[0];
 
       if (!(n & 1))
-        fft[n / 2] = cdouble(0.0, 0.0);
+        fft[n / 2] = complex_type(0.0, 0.0);
 
       for (int l = 0; l < maxn; l++) {
         e = u * e;
@@ -83,7 +84,7 @@ public:
     }
 
     for (int l = 0; l < n; ++l) {
-      double minTV = std::numeric_limits<double>::max();
+      real_type minTV = std::numeric_limits<real_type>::max();
       int minidx = 0;
       for (int j = 0; j < 2 * nsh + 1; ++j) {
 
@@ -107,18 +108,18 @@ public:
         TV2arr[j] -= abs(shifted((l + minW + n) % n, j).imag() - shifted((l + (minW + 1) + n) % n, j).imag());
       }
 
-      double a0r = shifted((l - 1 + n) % n, minidx).real();
-      double a1r = shifted(l, minidx).real();
-      double a2r = shifted((l + 1 + n) % n, minidx).real();
-      double a0i = shifted((l - 1 + n) % n, minidx).imag();
-      double a1i = shifted(l, minidx).imag();
-      double a2i = shifted((l + 1 + n) % n, minidx).imag();
-      double s = double(shifts[minidx]) / (2.0 * nsh);
+      const real_type a0r = shifted((l - 1 + n) % n, minidx).real();
+      const real_type a1r = shifted(l, minidx).real();
+      const real_type a2r = shifted((l + 1 + n) % n, minidx).real();
+      const real_type a0i = shifted((l - 1 + n) % n, minidx).imag();
+      const real_type a1i = shifted(l, minidx).imag();
+      const real_type a2i = shifted((l + 1 + n) % n, minidx).imag();
+      const real_type s = real_type(shifts[minidx]) / (2.0 * nsh);
 
       if (s > 0.0)
-        data(l) = cdouble(a1r * (1.0 - s) + a0r * s, a1i * (1.0 - s) + a0i * s);
+        data(l) = complex_type(a1r * (1.0 - s) + a0r * s, a1i * (1.0 - s) + a0i * s);
       else
-        data(l) = cdouble(a1r * (1.0 + s) - a2r * s, a1i * (1.0 + s) - a2i * s);
+        data(l) = complex_type(a1r * (1.0 + s) - a2r * s, a1i * (1.0 + s) - a2i * s);
     }
   }
 
@@ -128,7 +129,7 @@ public:
 
 private:
   Math::FFT1D &fft;
-  Eigen::MatrixXcd shifted;
+  Eigen::Matrix<complex_type, Eigen::Dynamic, Eigen::Dynamic> shifted;
   std::vector<int> shifts;
 };
 

--- a/cpp/core/degibbs/unring2d.h
+++ b/cpp/core/degibbs/unring2d.h
@@ -18,13 +18,12 @@
 
 #include "algo/threaded_loop.h"
 #include "axes.h"
+#include "degibbs/degibbs.h"
 #include "degibbs/unring1d.h"
 #include "image.h"
 #include "progressbar.h"
 
 namespace MR::Degibbs {
-
-typedef cdouble value_type;
 
 class Unring2D {
 public:
@@ -54,15 +53,15 @@ public:
     col_FFT(slice);
 
     for (int k = 0; k < slice.cols(); k++) {
-      double ck = (1.0 + cos(2.0 * Math::pi * (double(k) / slice.cols()))) * 0.5;
+      const real_type ck = (1.0 + cos(2.0 * Math::pi * (real_type(k) / slice.cols()))) * 0.5;
       for (int j = 0; j < slice.rows(); j++) {
-        double cj = (1.0 + cos(2.0 * Math::pi * (double(j) / slice.rows()))) * 0.5;
+        const real_type cj = (1.0 + cos(2.0 * Math::pi * (real_type(j) / slice.rows()))) * 0.5;
 
         if (ck + cj != 0.0) {
           slice2(j, k) = slice(j, k) * cj / (ck + cj);
           slice(j, k) *= ck / (ck + cj);
         } else
-          slice(j, k) = slice2(j, k) = cdouble(0.0, 0.0);
+          slice(j, k) = slice2(j, k) = complex_type(0.0, 0.0);
       }
     }
 
@@ -80,7 +79,7 @@ public:
 private:
   Math::FFT1D row_fft, col_fft, row_ifft, col_ifft;
   Unring1D unring1d_row, unring1d_col;
-  Eigen::MatrixXcd slice2;
+  Eigen::Matrix<complex_type, Eigen::Dynamic, Eigen::Dynamic> slice2;
 
   template <typename fft_obj, typename Derived> FORCE_INLINE void FFT(fft_obj &fft, Eigen::MatrixBase<Derived> &M) {
     assert(fft.size() == size_t(M.cols()));
@@ -111,8 +110,8 @@ public:
                   const int &nsh,
                   const int &minW,
                   const int &maxW,
-                  Image<value_type> &in,
-                  Image<value_type> &out)
+                  Image<complex_type> &in,
+                  Image<complex_type> &out)
       : outer_axes(outer_axes),
         slice_axes(slice_axes),
         in(in),
@@ -137,8 +136,8 @@ public:
 protected:
   const std::vector<size_t> &outer_axes;
   const std::vector<size_t> &slice_axes;
-  Image<value_type> in, out;
-  Eigen::MatrixXcd slice;
+  Image<complex_type> in, out;
+  Eigen::Matrix<complex_type, Eigen::Dynamic, Eigen::Dynamic> slice;
   Unring2D unring2d;
 };
 

--- a/cpp/core/degibbs/unring3d.h
+++ b/cpp/core/degibbs/unring3d.h
@@ -18,6 +18,7 @@
 
 #include "algo/threaded_loop.h"
 #include "axes.h"
+#include "degibbs/degibbs.h"
 #include "degibbs/unring1d.h"
 #include "image.h"
 #include "progressbar.h"
@@ -29,7 +30,7 @@ using ImageType = Image<cdouble>;
 namespace {
 
 // gives proper index according to fourier indices
-inline double indexshift(ssize_t n, ssize_t size) {
+inline real_type indexshift(ssize_t n, ssize_t size) {
   if (n > size / 2)
     n -= size;
   return n;
@@ -47,13 +48,13 @@ public:
   Filter(size_t axis) : axis(axis) {}
   void operator()(ImageType &in, ImageType &out) {
     // apply filter
-    const double x[3] = {1.0 + std::cos(2.0 * Math::pi * indexshift(in.index(0), in.size(0)) / in.size(0)),
-                         1.0 + std::cos(2.0 * Math::pi * indexshift(in.index(1), in.size(1)) / in.size(1)),
-                         1.0 + std::cos(2.0 * Math::pi * indexshift(in.index(2), in.size(2)) / in.size(2))};
-    const double w[3] = {x[1] * x[2], x[0] * x[2], x[0] * x[1]};
-    const double denom = w[0] + w[1] + w[2];
+    const real_type x[3] = {1.0 + std::cos(2.0 * Math::pi * indexshift(in.index(0), in.size(0)) / in.size(0)),
+                            1.0 + std::cos(2.0 * Math::pi * indexshift(in.index(1), in.size(1)) / in.size(1)),
+                            1.0 + std::cos(2.0 * Math::pi * indexshift(in.index(2), in.size(2)) / in.size(2))};
+    const real_type w[3] = {x[1] * x[2], x[0] * x[2], x[0] * x[1]};
+    const real_type denom = w[0] + w[1] + w[2];
 
-    out.value() = cdouble(in.value()) * (denom ? w[axis] / denom : 0.0);
+    out.value() = complex_type(in.value()) * (denom ? w[axis] / denom : real_type(0));
   }
 
 protected:
@@ -83,7 +84,7 @@ public:
     const int lsize = input.size(axis);
 
     // creating zero-centred shift array
-    double shift_ind[2 * num_shifts + 1];
+    real_type shift_ind[2 * num_shifts + 1];
     shift_ind[0] = 0;
     for (int j = 0; j < num_shifts; j++) {
       shift_ind[j + 1] = (j + 1) / (2.0 * num_shifts + 1.0);
@@ -91,12 +92,12 @@ public:
     }
 
     // applying shift and inverse fourier transform back line-by-line
-    const std::complex<double> j(0.0, 1.0);
+    const complex_type j(0.0, 1.0);
     for (int f = 0; f < 2 * num_shifts + 1; f++) {
       for (int n = 0; n < lsize; ++n)
-        ifft[f][n] = fft[n] * exp(j * 2.0 * indexshift(n, lsize) * Math::pi * shift_ind[f] / double(lsize));
+        ifft[f][n] = fft[n] * exp(j * 2.0 * indexshift(n, lsize) * Math::pi * shift_ind[f] / real_type(lsize));
       if (!(lsize & 1))
-        ifft[f][lsize / 2] = 0.0;
+        ifft[f][lsize / 2] = real_type(0);
       ifft[f].run();
     }
 
@@ -108,11 +109,11 @@ public:
       const double shift = shift_ind[optshift_ind];
 
       // calculating current, previous and next (real and imaginary) values
-      cdouble a0r = ifft[optshift_ind][wraparound(n - 1, lsize)];
-      cdouble a1r = ifft[optshift_ind][n];
-      cdouble a2r = ifft[optshift_ind][wraparound(n + 1, lsize)];
+      const complex_type a0r = ifft[optshift_ind][wraparound(n - 1, lsize)];
+      const complex_type a1r = ifft[optshift_ind][n];
+      const complex_type a2r = ifft[optshift_ind][wraparound(n + 1, lsize)];
 
-      const double scale = input.size(0) * input.size(1) * input.size(2) * lsize;
+      const real_type scale = input.size(0) * input.size(1) * input.size(2) * lsize;
 
       // interpolate particular ifft back to right place
       if (shift > 0.0)
@@ -132,11 +133,11 @@ protected:
 
   int optimumshift(int n, int lsize) {
     int ind = 0;
-    double opt_var = std::numeric_limits<double>::max();
+    real_type opt_var = std::numeric_limits<real_type>::max();
 
     // calculating oscillation measure for subsequent shifts
     for (int f = 0; f < 2 * num_shifts + 1; f++) {
-      double sum_left = 0.0, sum_right = 0.0;
+      real_type sum_left = 0.0, sum_right = 0.0;
 
       // calculating oscillation measure within given window
       for (int k = minW; k <= maxW; ++k) {
@@ -147,7 +148,7 @@ protected:
         sum_right += abs(ifft[f][wraparound(n + k, lsize)].imag() - ifft[f][wraparound(n + k + 1, lsize)].imag());
       }
 
-      double tot_var = std::min(sum_left, sum_right);
+      const real_type tot_var = std::min(sum_left, sum_right);
 
       if (tot_var < opt_var) {
         opt_var = tot_var;

--- a/docs/reference/commands/mrdegibbs.rst
+++ b/docs/reference/commands/mrdegibbs.rst
@@ -25,11 +25,13 @@ This application attempts to remove Gibbs ringing artefacts from MRI images usin
 
 By default, the original 2D slice-wise version is used. If the -mode 3d option is provided, the program will run the 3D version as proposed by Bautista et al. (also in the reference list below).
 
-This command is designed to run on data directly after it has been reconstructed by the scanner, before any interpolation of any kind has taken place. You should not run this command after any form of motion correction (e.g. not after dwifslpreproc). Similarly, if you intend running dwidenoise, you should run denoising before this command to not alter the noise structure, which would impact on dwidenoise's performance.
+This command is designed to run on data directly after it has been reconstructed by the scanner, before any interpolation of any kind has taken place. You should not run this command after any form of motion correction (e.g. not after dwifslpreproc). If however you intend to run a thermal denoising step (eg. dwidenoise), you should do so before this command to not alter the noise structure, which would impact on denoising performance.
 
 For best results, any form of filtering performed by the scanner should be disabled, whether performed in the image domain or k-space. This includes elliptic filtering and other filters  that are often applied to reduce Gibbs ringing artifacts. While this method can still safely be applied to such data, some residual ringing artefacts may still be present in the output.
 
 Note that this method is designed to work on images acquired with full k-space coverage. If this method is executed on data acquired with partial Fourier (eg. "half-scan") acceleration, it may not fully remove all ringing artifacts, and you may observe residuals of the original artifact in the partial Fourier direction. Nonetheless, application of the method is still considered safe and worthwhile. Users are however encouraged to acquired full-Fourier data where possible.
+
+As this method is based on utilisation of the Fourier shift theorem, it operates best if it can be provided with complex-valued image data; in this use case the output image will also be complex-valued.
 
 Options
 -------


### PR DESCRIPTION
In confirming whether I needed to put `mrcalc -abs` upstream or downstream of `mrdegibbs`, it looks like `3.0.x` reads the input image as real-valued, whereas `dev` permits complex-valued data for both 2D and 3D variants. This capability was however not mentioned at all in the description section of the command help page.

While resolving that I decided that the type definitions in this context were ambiguous (is "`value_type`" real or complex?).