### PR TITLE
Fix command list generation for Python API

### DIFF
--- a/cmake/GenPythonCommandsLists.cmake
+++ b/cmake/GenPythonCommandsLists.cmake
@@ -1,6 +1,6 @@
 file(
     GLOB CPP_COMMAND_FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/cmd/*.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/cmd/*.cpp
 )
 
 file(


### PR DESCRIPTION
Change absent from #3012 necessary to preserve functionality added in #2920.

Effect was that any Python command invoking an *MRtrix3* C++ command would fail to recognise it as an *MRtrix3* command, and would therefore omit changes that trigger in that instance, such as propagating `-nthreads` or setting `-force` when necessary.