### PR TITLE
dwifslpreproc: Fix -topup_files option

### DIFF
--- a/python/mrtrix3/commands/dwifslpreproc.py
+++ b/python/mrtrix3/commands/dwifslpreproc.py
@@ -15,7 +15,7 @@
 
 
 
-import glob, itertools, json, math, os, shlex, shutil, sys
+import argparse, glob, itertools, json, math, os, shlex, shutil, sys
 
 
 
@@ -389,19 +389,23 @@ def execute(): #pylint: disable=unused-variable
 
     if os.path.isfile(topup_file_userpath):
       if topup_file_userpath.endswith('_movpar.txt'):
-        topup_input_movpar = app.Parser.FileIn(topup_file_userpath)
-        topup_input_fieldcoef = app.Parser.ImageIn(find_fieldcoef(topup_file_userpath[:-len('_movpar.txt')]))
+        topup_input_movpar = app.Parser.FileIn()(topup_file_userpath)
+        topup_input_fieldcoef = app.Parser.ImageIn()(find_fieldcoef(topup_file_userpath[:-len('_movpar.txt')]))
       elif any(str(topup_file_userpath).endswith(postfix) for postfix in ('_fieldcoef.nii', '_fieldcoef.nii.gz')):
-        topup_input_fieldcoef = app.Parser.ImageIn(topup_file_userpath)
+        topup_input_fieldcoef = app.Parser.ImageIn()(topup_file_userpath)
         topup_input_movpar = topup_file_userpath[:-len('.gz')] if topup_file_userpath.endswith('.gz') else topup_file_userpath
-        topup_input_movpar = app.Parser.FileIn(topup_input_movpar[:-len('_fieldcoef.nii')] + '_movpar.txt')
+        topup_input_movpar = app.Parser.FileIn()(topup_input_movpar[:-len('_fieldcoef.nii')] + '_movpar.txt')
       else:
         raise MRtrixError(f'Unrecognised file "{topup_file_userpath}" specified as pre-calculated topup susceptibility field')
     else:
       if topup_file_userpath[-1] == '_':
         topup_file_userpath = topup_file_userpath[:-1]
-      topup_input_movpar = app.Parser.FileIn(f'{topup_file_userpath}_movpar.txt')
-      topup_input_fieldcoef = app.Parser.ImageIn(find_fieldcoef(topup_file_userpath))
+      try:
+        topup_input_movpar = app.Parser.FileIn()(f'{topup_file_userpath}_movpar.txt')
+        topup_input_fieldcoef = app.Parser.ImageIn()(find_fieldcoef(topup_file_userpath))
+      except argparse.ArgumentTypeError as e:
+        raise argparse.ArgumentTypeError(f'Unable to find topup files from user specification "{topup_file_userpath}"') from e
+
 
 
   # Convert all input images into MRtrix format and store in scratch directory first

--- a/python/mrtrix3/commands/dwifslpreproc.py
+++ b/python/mrtrix3/commands/dwifslpreproc.py
@@ -403,8 +403,8 @@ def execute(): #pylint: disable=unused-variable
       try:
         topup_input_movpar = app.Parser.FileIn()(f'{topup_file_userpath}_movpar.txt')
         topup_input_fieldcoef = app.Parser.ImageIn()(find_fieldcoef(topup_file_userpath))
-      except argparse.ArgumentTypeError as e:
-        raise argparse.ArgumentTypeError(f'Unable to find topup files from user specification "{topup_file_userpath}"') from e
+      except argparse.ArgumentTypeError as exc:
+        raise argparse.ArgumentTypeError(f'Unable to find topup files from user specification "{topup_file_userpath}"') from exc
 
 
 

--- a/testing/scripts/CMakeLists.txt
+++ b/testing/scripts/CMakeLists.txt
@@ -201,6 +201,7 @@ add_bash_script_test(dwifslpreproc/rpeheader_rpepair)
 add_bash_script_test(dwifslpreproc/rpenone_default)
 add_bash_script_test(dwifslpreproc/rpepair_alignseepi)
 add_bash_script_test(dwifslpreproc/rpepair_default)
+add_bash_script_test(dwifslpreproc/topup_files)
 add_bash_script_test(dwifslpreproc/whitespace)
 
 add_bash_script_test(dwigradcheck/default)

--- a/testing/scripts/tests/dwifslpreproc/topup_files
+++ b/testing/scripts/tests/dwifslpreproc/topup_files
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Ensure that the -topup_files for dwifslpreproc works for all intended use cases
+
+mrconvert BIDS/sub-04/dwi/sub-04_dwi.nii.gz tmp-sub-04_dwi.mif -force \
+    -fslgrad BIDS/sub-04/dwi/sub-04_dwi.bvec BIDS/sub-04/dwi/sub-04_dwi.bval \
+    -json_import BIDS/sub-04/dwi/sub-04_dwi.json \
+    -strides 0,0,0,1
+
+mrcat \
+    BIDS/sub-04/fmap/sub-04_dir-1_epi.nii.gz \
+    BIDS/sub-04/fmap/sub-04_dir-2_epi.nii.gz \
+    -axis 3 - | \
+mrconvert - tmp-sub-04_epi.nii \
+    -strides -1,+2,+3,+4 -force
+
+echo $'0 -1 0 0.1\n0 1 0 0.1\n' | \
+tee tmp-sub-04_epi.txt
+
+topupcmd="topup --imain=tmp-sub-04_epi.nii --datain=tmp-sub-04_epi.txt --config=${FSLDIR}/etc/flirtsch/b02b0_2.cnf --out=tmp-out"
+echo $topupcmd
+$topupcmd
+
+#topup \
+#    --imain=tmp-sub-04_epi.nii \
+#    --datain=tmp-sub-04_epi.txt \
+#    --config=${FSLDIR}/etc/flirtsch/b02b0_2.cnf \
+#    --out=tmp-out
+
+# Different strings that could possibly be provided by the user at the command-line
+dwifslpreproc tmp-sub-04_dwi.mif tmp.mif -rpe_header -force \
+    -topup_files tmp-out -debug
+testing_diff_header tmp.mif dwifslpreproc/rpepair_default.mif.gz
+
+dwifslpreproc tmp-sub-04_dwi.mif tmp.mif -rpe_header -force \
+    -topup_files tmp-out_ -debug
+testing_diff_header tmp.mif dwifslpreproc/rpepair_default.mif.gz
+
+dwifslpreproc tmp-sub-04_dwi.mif tmp.mif -rpe_header -force \
+    -topup_files tmp-out_fieldcoef.nii.gz -debug
+testing_diff_header tmp.mif dwifslpreproc/rpepair_default.mif.gz
+
+dwifslpreproc tmp-sub-04_dwi.mif tmp.mif -rpe_header -force \
+    -topup_files tmp-out_movpar.txt -debug
+testing_diff_header tmp.mif dwifslpreproc/rpepair_default.mif.gz
+
+


### PR DESCRIPTION
Errors in completion of Python CLI changes in #2678 to support addition of -topup_files option in #2150. New tests ensure that set of intended possible user-specified paths are supported.
