### PR TITLE
Pipe image format: Revise error message

### DIFF
--- a/core/formats/pipe.cpp
+++ b/core/formats/pipe.cpp
@@ -64,7 +64,7 @@ namespace MR
         return false;
 
       if (isatty (STDOUT_FILENO))
-        throw Exception ("attempt to pipe image to standard output (this will leave temporary files behind)");
+        throw Exception ("cannot create output piped image: no command connected at other end of pipe to receive that image");
 
       H.name() = File::create_tempfile (0, "mif");
 


### PR DESCRIPTION
Creating PRs for any branches that I find in the repo that have commits ahead of `dev` or `master`.

For this one I find the current message misleading. It's not that the issue *will* leave temporary files behind; it's that it *would* were the command to not error out at that point.