### PR TITLE
New command meshsample

### DIFF
--- a/cmd/meshsample.cpp
+++ b/cmd/meshsample.cpp
@@ -1,0 +1,100 @@
+/* Copyright (c) 2008-2023 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Covered Software is provided under this License on an "as is"
+ * basis, without warranty of any kind, either expressed, implied, or
+ * statutory, including, without limitation, warranties that the
+ * Covered Software is free of defects, merchantable, fit for a
+ * particular purpose or non-infringing.
+ * See the Mozilla Public License v. 2.0 for more details.
+ *
+ * For more details, see http://www.mrtrix.org/.
+ */
+
+#include "command.h"
+#include "image.h"
+#include "interp/cubic.h"
+#include "interp/linear.h"
+#include "interp/nearest.h"
+#include "interp/sinc.h"
+#include "surface/mesh.h"
+
+
+
+using namespace MR;
+using namespace App;
+using namespace MR::Interp;
+using MR::Surface::Mesh;
+
+
+using vector_type = Eigen::Array<float, Eigen::Dynamic, 1>;
+
+
+// TODO This could be centralised and shared across multiple commands
+const char* interp_choices[] = { "nearest", "linear", "cubic", "sinc", nullptr };
+
+
+void usage ()
+{
+
+  AUTHOR = "Robert E. Smith (robert.smith@florey.edu.au)";
+
+  SYNOPSIS = "Sample the values of an image the vertex locations of a surface mesh";
+
+  DESCRIPTION
+  + "This command assumes that the surface is defined in such a way that the "
+    "vertices are defined in real / scanner space. If a surface is defined with respect "
+    "to some other space, it is necessary to first explicitly perform a spatial "
+    "transformation of the surface data prior to running this command.";
+
+  ARGUMENTS
+  + Argument ("input",  "the input mesh file").type_file_in()
+  + Argument ("input",  "the input image").type_image_in()
+  + Argument ("output", "the output sampled values").type_file_out();
+
+  OPTIONS
+  + Option ("interp",
+        "set the interpolation method to use when reslicing (choices: nearest, linear, cubic, sinc. Default: cubic).")
+    + Argument ("method").type_choice (interp_choices);
+
+}
+
+
+
+template <class InterpType>
+vector_type sample (const Mesh& mesh, const Image<float>& image)
+{
+  InterpType interp (image);
+  vector_type result = vector_type::Zero (mesh.num_vertices());
+  for (size_t i = 0; i != mesh.num_vertices(); ++i) {
+    if (interp.scanner (mesh.vert (i)))
+      result[i] = interp.value();
+    else
+      result[i] = std::numeric_limits<float>::quiet_NaN();
+  }
+  return result;
+}
+
+
+
+void run ()
+{
+
+  const Mesh mesh (argument[0]);
+  Image<float> image = Image<float>::open (argument[1]);
+  auto opt = get_options ("interp");
+  const size_t interp_type = opt.size() ? opt[0][0] : 2;
+  vector_type data;
+  switch (interp_type) {
+    case 0: data = sample<Interp::Nearest<Image<float>>> (mesh, image); break;
+    case 1: data = sample<Interp::Linear <Image<float>>> (mesh, image); break;
+    case 2: data = sample<Interp::Cubic  <Image<float>>> (mesh, image); break;
+    case 3: data = sample<Interp::Sinc   <Image<float>>> (mesh, image); break;
+    default: assert (false);
+  }
+  MR::save_vector (data, argument[2]);
+
+}

--- a/cmd/meshsample.cpp
+++ b/cmd/meshsample.cpp
@@ -51,8 +51,8 @@ void usage ()
     "transformation of the surface data prior to running this command.";
 
   ARGUMENTS
-  + Argument ("input",  "the input mesh file").type_file_in()
-  + Argument ("input",  "the input image").type_image_in()
+  + Argument ("mesh_in",  "the input mesh file").type_file_in()
+  + Argument ("image_in",  "the input image").type_image_in()
   + Argument ("output", "the output sampled values").type_file_out();
 
   OPTIONS
@@ -74,6 +74,7 @@ vector_type sample (const Mesh& mesh, const Image<float>& image)
       result[i] = interp.value();
     else
       result[i] = std::numeric_limits<float>::quiet_NaN();
+    DEBUG("Vertex " + str(i) + ": Realspace [" + str(mesh.vert(i).transpose()) + "]; voxelspace [" + str((interp.scanner2voxel * mesh.vert(i)).transpose()) + "]; value = " + str(result[i]));
   }
   return result;
 }

--- a/docs/reference/commands/meshsample.rst
+++ b/docs/reference/commands/meshsample.rst
@@ -1,0 +1,77 @@
+.. _meshsample:
+
+meshsample
+===================
+
+Synopsis
+--------
+
+Sample the values of an image the vertex locations of a surface mesh
+
+Usage
+--------
+
+::
+
+    meshsample [ options ]  input input output
+
+-  *input*: the input mesh file
+-  *input*: the input image
+-  *output*: the output sampled values
+
+Description
+-----------
+
+This command assumes that the surface is defined in such a way that the vertices are defined in real / scanner space. If a surface is defined with respect to some other space, it is necessary to first explicitly perform a spatial transformation of the surface data prior to running this command.
+
+Options
+-------
+
+-  **-interp method** set the interpolation method to use when reslicing (choices: nearest, linear, cubic, sinc. Default: cubic).
+
+Standard options
+^^^^^^^^^^^^^^^^
+
+-  **-info** display information messages.
+
+-  **-quiet** do not display information messages or progress status; alternatively, this can be achieved by setting the MRTRIX_QUIET environment variable to a non-empty string.
+
+-  **-debug** display debugging messages.
+
+-  **-force** force overwrite of output files (caution: using the same file as input and output might cause unexpected behaviour).
+
+-  **-nthreads number** use this number of threads in multi-threaded applications (set to 0 to disable multi-threading).
+
+-  **-config key value** *(multiple uses permitted)* temporarily set the value of an MRtrix config file entry.
+
+-  **-help** display this information page and exit.
+
+-  **-version** display version information and exit.
+
+References
+^^^^^^^^^^
+
+Tournier, J.-D.; Smith, R. E.; Raffelt, D.; Tabbara, R.; Dhollander, T.; Pietsch, M.; Christiaens, D.; Jeurissen, B.; Yeh, C.-H. & Connelly, A. MRtrix3: A fast, flexible and open software framework for medical image processing and visualisation. NeuroImage, 2019, 202, 116137
+
+--------------
+
+
+
+**Author:** Robert E. Smith (robert.smith@florey.edu.au)
+
+**Copyright:** Copyright (c) 2008-2023 the MRtrix3 contributors.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Covered Software is provided under this License on an "as is"
+basis, without warranty of any kind, either expressed, implied, or
+statutory, including, without limitation, warranties that the
+Covered Software is free of defects, merchantable, fit for a
+particular purpose or non-infringing.
+See the Mozilla Public License v. 2.0 for more details.
+
+For more details, see http://www.mrtrix.org/.
+
+

--- a/docs/reference/commands_list.rst
+++ b/docs/reference/commands_list.rst
@@ -68,6 +68,7 @@ List of MRtrix3 commands
     commands/mesh2voxel
     commands/meshconvert
     commands/meshfilter
+    commands/meshsample
     commands/mraverageheader
     commands/mrcalc
     commands/mrcat
@@ -199,6 +200,7 @@ List of MRtrix3 commands
     |cpp.png|, :ref:`mesh2voxel`, "Convert a mesh surface to a partial volume estimation image"
     |cpp.png|, :ref:`meshconvert`, "Convert meshes between different formats, and apply transformations"
     |cpp.png|, :ref:`meshfilter`, "Apply filter operations to meshes"
+    |cpp.png|, :ref:`meshsample`, "Sample the values of an image the vertex locations of a surface mesh"
     |cpp.png|, :ref:`mraverageheader`, "Calculate the average (unbiased) coordinate space of all input images"
     |cpp.png|, :ref:`mrcalc`, "Apply generic voxel-wise mathematical operations to images"
     |cpp.png|, :ref:`mrcat`, "Concatenate several images into one"


### PR DESCRIPTION
Creating draft PR to preclude dangling branches without PRs.

Very simple command. Was I think primarily used for cross-checking the interpretation of surface vertex locations between softwares. 