### PR TITLE
Testing: Exclude .npy format tests if numpy not available

### DIFF
--- a/testing/unit_tests/CMakeLists.txt
+++ b/testing/unit_tests/CMakeLists.txt
@@ -10,12 +10,24 @@ set(UNIT_TESTS_CPP_SRCS
     to.cpp
 )
 
-set(UNIT_TESTS_BASH_SRCS
+set(UNIT_TESTS_NPY_BASH_SRCS
     npyread
     npywrite
 )
 
 find_program(BASH bash)
+
+find_package(
+        Python3
+        REQUIRED
+        COMPONENTS Interpreter
+)
+
+execute_process(
+    COMMAND Python3::Interpreter -c "import numpy"
+    RESULT_VARIABLE HAVE_NUMPY_EXITCODE
+    OUTPUT_QUIET
+)
 
 function(add_cpp_unit_test FILE_SRC)
     get_filename_component(NAME ${FILE_SRC} NAME_WE)
@@ -55,6 +67,10 @@ foreach(UNIT_TEST ${UNIT_TESTS_CPP_SRCS})
     add_cpp_unit_test(${UNIT_TEST})
 endforeach()
 
-foreach(UNIT_TEST ${UNIT_TESTS_BASH_SRCS})
-    add_bash_unit_test(${UNIT_TEST})
-endforeach()
+if(${HAVE_NUMPY_EXITCODE} EQUAL 0)
+    foreach(UNIT_TEST ${UNIT_TESTS_NPY_BASH_SRCS})
+        add_bash_unit_test(${UNIT_TEST})
+    endforeach()
+else()
+    message(WARNING "Python numpy package not found; omitting .npy format tests\n")
+endif()


### PR DESCRIPTION
Relates to discussion in #2865. Part of posting PRs for any code branches that were either floating on GitHub or have re-appeared as a consequence of a mass force push.

I think this may have been excluded from that PR as it was decided via 73c6e2b to make sure that the CI Action always has NPY installed and can therefore run these tests. However it might nevertheless be useful if, for whatever reason, a developer does not have numpy installed in their native environment, they don't get extensive *MRtrix3* test failures that are not a fault of *MRtrix3*.

Posting as draft; will come back and test after I'm done cleaning up my mess.