### PR TITLE
MR::Axes::permutations_type: Fix is_identity()

### DIFF
--- a/core/axes.h
+++ b/core/axes.h
@@ -38,7 +38,7 @@ namespace MR
     public:
       Shuffle() : permutations ({-1, -1, -1}), flips ({false, false, false}) {}
       bool is_identity() const {
-        return (permutations[0] == 0 && permutations[1] == 1 && permutations[2] != 2 && //
+        return (permutations[0] == 0 && permutations[1] == 1 && permutations[2] == 2 && //
                 !flips[0] && !flips[1] && !flips[2]);
       }
       bool is_set() const {


### PR DESCRIPTION
Oversight in #3011. Believe that at some point I changed the function from checking for a non-identity transform to checking for an identity transform, and one of the operators didn't get changed.

This should affect any NIfTI export. My best guess right now regarding how this could have survived my barrage of tests is that the metadata checks had no issue in terms of concordance with the image data, but the image data themselves were not conforming to the axis strides that were being requested, and the metadata tests in github.com/Lestropie/DWI_metadata were not doing any check for that and the CI tests in MRtrix3 don't have adequate coverage.