### PR TITLE
fsl.check_first(): Handle run_first_all providing no HOLDID

### DIFF
--- a/lib/mrtrix3/fsl.py
+++ b/lib/mrtrix3/fsl.py
@@ -47,7 +47,7 @@ def check_first(prefix, structures=None, first_stdout=None): #pylint: disable=un
   if first_stdout:
     try:
       job_id = int(first_stdout.rstrip().splitlines()[-1])
-    except ValueError:
+    except (IndexError, ValueError):
       app.debug('Unable to convert FIRST stdout contents to integer job ID')
   execution_verified = False
   if job_id:


### PR DESCRIPTION
Follows #2609.

Hopefully addresses [issue reported on forum](https://community.mrtrix.org/t/5ttgen-fsl-error-for-run-first/8527).