### PR TITLE
mrview: Change interpretation of light position

### DIFF
--- a/src/gui/lighting_dock.cpp
+++ b/src/gui/lighting_dock.cpp
@@ -72,14 +72,14 @@ namespace MR
 
       elevation_slider = new QSlider (Qt::Horizontal);
       elevation_slider->setRange (0,1000);
-      elevation_slider->setSliderPosition (int ( (1000.0/Math::pi) *acos (-info.lightpos[1]/Eigen::Map<Eigen::Matrix<float, 3, 1>>(info.lightpos).norm())));
+      elevation_slider->setSliderPosition (int ( (1000.0/Math::pi) *acos (info.lightpos[2]/Eigen::Map<Eigen::Matrix<float, 3, 1>>(info.lightpos).norm())));
       connect (elevation_slider, SIGNAL (valueChanged (int)), this, SLOT (light_position_slot()));
       grid_layout->addWidget (new QLabel ("Light elevation"), 4, 0);
       grid_layout->addWidget (elevation_slider, 4, 1);
 
       azimuth_slider = new QSlider (Qt::Horizontal);
       azimuth_slider->setRange (-1000,1000);
-      azimuth_slider->setSliderPosition (int ( (1000.0/Math::pi) * atan2 (info.lightpos[0], info.lightpos[2])));
+      azimuth_slider->setSliderPosition (int ( (1000.0/Math::pi) * atan2 (info.lightpos[0], info.lightpos[1])));
       connect (azimuth_slider, SIGNAL (valueChanged (int)), this, SLOT (light_position_slot()));
       grid_layout->addWidget (new QLabel ("Light azimuth"), 5, 0);
       grid_layout->addWidget (azimuth_slider, 5, 1);

--- a/src/gui/lighting_dock.cpp
+++ b/src/gui/lighting_dock.cpp
@@ -118,9 +118,9 @@ namespace MR
     {
       float elevation = elevation_slider->value() * (Math::pi/1000.0);
       float azimuth = azimuth_slider->value() * (Math::pi/1000.0);
-      info.lightpos[2] = sin (elevation) * cos (azimuth);
-      info.lightpos[0] = sin (elevation) * sin (azimuth);
-      info.lightpos[1] = -cos (elevation);
+      info.lightpos[0] = sin (elevation) * cos (azimuth);
+      info.lightpos[1] = sin (elevation) * sin (azimuth);
+      info.lightpos[2] = cos (elevation);
       info.update();
     }
 


### PR DESCRIPTION
Discovered when writing 3ddf1744dd53fdfbda595447ce363c190ddb7079 as part of #2918.

Blame initially reports 4835759438678adbc4237a83a4730c84f6dd4934 addressing #246 & part of tag `0.3.13`, but most recent change is bfa3bd2c1ed061f6b6c4ca06981e499078567b6c as part of `0.3.8`.

Code looks outright incorrect, but don't know if there was some other intent behind it.

It's also entirely possible that downstream GUI lighting calculations may have been bastardised in order to yield the desired behaviour downstream of this code. 

Posting as draft as I'm going to need to dig into the consequences & potential interactions.