### PR TITLE
mrgrid, mrtransform -template: warn if stride mismatch

### DIFF
--- a/cpp/cmd/mrgrid.cpp
+++ b/cpp/cmd/mrgrid.cpp
@@ -110,7 +110,10 @@ void usage() {
                             " (voxel spacing, image size, header transformation)"
                             " to that of a reference image. "
                  "The image resolution relative to the template image can be changed"
-                 " with one of -size, -voxel, -scale." )
+                 " with one of -size, -voxel, -scale."
+                 "This option will not influence the axis data strides of the output image;"
+                 " these are determined based on the input image, "
+                 "or the input to the -strides option.")
     + Argument ("image").type_image_in ()
 
     + Option   ("size", "define the size (number of voxels) in each spatial dimension for the output image."
@@ -277,6 +280,12 @@ void run() {
 
     Header output_header(regrid_filter);
     Stride::set_from_command_line(output_header);
+    if (get_options("template").size() && !get_options("strides").size()) {
+      if (!Stride::spatial_stride_order_matches(template_header, output_header))
+        WARN("image stride order of the spatial dimensions do not match between template and output image."
+             " Provide the -stride option with the template image as argument"
+             " for compatibility with other software.");
+    }
     if (interp == 0)
       output_header.datatype() = DataType::from_command_line(input_header.datatype());
     else

--- a/cpp/cmd/mrtransform.cpp
+++ b/cpp/cmd/mrtransform.cpp
@@ -331,6 +331,13 @@ void run() {
     output_header.transform() = template_header.transform();
   }
 
+  if (!get_options("strides").size()) {
+    if (!Stride::spatial_stride_order_matches(template_header, output_header))
+      WARN("image stride order of the spatial dimensions do not match between template and output image."
+           " Provide the -stride option with the template image as argument"
+           " for compatibility with other software.");
+  }
+
   // Warp 5D warp
   // TODO add reference to warp format documentation
   opt = get_options("warp_full");

--- a/cpp/core/stride.h
+++ b/cpp/core/stride.h
@@ -334,6 +334,18 @@ template <class HeaderType> inline List contiguous_along_spatial_axes(const Head
   return strides;
 }
 
+//! check that the stride order of the first common spatial dimensions of two headers matches
+template <class HeaderType1, class HeaderType2>
+inline bool spatial_stride_order_matches(const HeaderType1 &header1, const HeaderType2 &header2) {
+  Stride::List stride1 = Stride::get_symbolic(header1);
+  Stride::List stride2 = Stride::get_symbolic(header2);
+  const signed long int offset = (signed long int)stride2[0] - (signed long int)stride1[0];
+  for (size_t i = 1; i < std::min<unsigned long>(3, std::min(stride1.size(), stride2.size())); i++)
+    if ((signed long int)stride2[i] - (signed long int)stride1[i] - offset != 0)
+      return false;
+  return true;
+}
+
 List __from_command_line(const List &current);
 
 template <class HeaderType>

--- a/docs/reference/commands/mrgrid.rst
+++ b/docs/reference/commands/mrgrid.rst
@@ -57,7 +57,7 @@ Options
 Regridding options (involves image interpolation, applied to spatial axes only)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
--  **-template image** match the input image grid (voxel spacing, image size, header transformation) to that of a reference image. The image resolution relative to the template image can be changed with one of -size, -voxel, -scale.
+-  **-template image** match the input image grid (voxel spacing, image size, header transformation) to that of a reference image. The image resolution relative to the template image can be changed with one of -size, -voxel, -scale.This option will not influence the axis data strides of the output image; these are determined based on the input image, or the input to the -strides option.
 
 -  **-size dims** define the size (number of voxels) in each spatial dimension for the output image. This should be specified as a comma-separated list.
 


### PR DESCRIPTION
Replacement of #2460. The merge conflicts claimed there were larger in magnitude than the change itself---how much of that was due to #3167 I'm not sure---so I instead re-applied these changes manually.

Would benefit from tests exemplifying the use cases involved to make sure that the warning appears when it should and doesn't when it shouldn't.