### PR TITLE
Update check_syntax to work on latest dev

### DIFF
--- a/check_syntax
+++ b/check_syntax
@@ -33,21 +33,7 @@ fi
 
 retval=0
 
-for f in $(find cmd core src -type f -name '*.h' -o -name '*.cpp' | $grep -v '_moc.cpp'); do
-
-# files to ignore:
-  [[ "$f" -ef "src/gui/shview/icons.h" ||
-     "$f" -ef "src/gui/shview/icons.cpp" ||
-     "$f" -ef "src/gui/mrview/icons.h" ||
-     "$f" -ef "src/gui/mrview/icons.cpp" ||
-     "$f" -ef "core/file/mgh.h" ||
-     "$f" -ef "core/file/json.h" ||
-     "$f" -ef "core/file/nifti2.h" ||
-     "$f" -ef "core/signal_handler.h" ||
-     "$f" -ef "core/signal_handler.cpp" ]] && continue
-
-
-
+for f in $(find cpp -type f -name '*.h' -o -name '*.cpp' | $grep -v '_moc.cpp'); do
 
 # process the file to strip comments, macros, etc:
   cat $f | \
@@ -73,7 +59,7 @@ for f in $(find cmd core src -type f -name '*.h' -o -name '*.cpp' | $grep -v '_m
   )
 
 # detect any instances of std::abs (outside of the SFINAE call in core/types.h):
-  if [[ ! "$f" -ef "core/types.h" ]]; then
+  if [[ ! "$f" -ef "cpp/core/types.h" ]]; then
     res="$res"$(
       cat .check_syntax.tmp | \
 # match for the parts we're interested in and output just the bits that match:
@@ -111,9 +97,8 @@ else
 
   echo "" >> $LOG
   echo "Please check the following syntax requirements:
-  - Add MEMALIGN() or NOMEMALIGN macro to any class declarations identified above;
+  - Do not use \"using namespace std\";
   - Replace all instances of std::abs() with MR::abs() (or just abs());
   - Replace all instances of %zu in print() calls with PRI_SIZET." >> $LOG
   exit 1
 fi
-


### PR DESCRIPTION
Decided to have my first look at `check_syntax` in a long time given discussion in #3182.
Turns out it was non-functional on `dev` due to the change in filesystem structure in #3012; it's been passing CI because the number of files it's been checking has been zero.
Further:
-   The log file message was clearly out of date
-   The need to skip certain files has been obviated by those external dependencies now being in the build directory rather than our source code directories as per #2689.

Outstanding question is the use of `std::abs()`; see #1304. This script is currently generating a *massive* number of hits. However this is only problematic in code involving templated data types. So I don't know if we should do a mass refactoring to satisfy this check, or whether the check is too stringent and we just need to be diligent in templated code?