### PR TITLE
Fix ROI edits disappearing on MacOS

### DIFF
--- a/src/gui/mrview/mode/slice.cpp
+++ b/src/gui/mrview/mode/slice.cpp
@@ -15,8 +15,8 @@
  */
 
 #include "gui/mrview/mode/slice.h"
-
 #include "gui/opengl/transformation.h"
+#include "gui/mrview/tool/roi_editor/item.h"
 
 namespace MR
 {
@@ -45,19 +45,21 @@ namespace MR
 
         std::string Slice::Shader::fragment_shader_source (const Displayable& object)
         {
-          std::string source = object.declare_shader_variables () +
-            "uniform sampler3D tex;\n"
-            "in vec3 texcoord;\n"
-            "out vec4 color;\n";
+          const auto *roi_item = dynamic_cast<const Tool::ROI_Item *>(&object);
+          const bool is_roi = roi_item != nullptr;
+          std::string source = object.declare_shader_variables() +
+                               (is_roi ? "uniform usampler3D tex;\n" : "uniform sampler3D tex;\n") +
+                               "in vec3 texcoord;\n"
+                               "out vec4 color;\n";
 
-          source +=
-            "void main() {\n"
-            "  if (texcoord.s < 0.0 || texcoord.s > 1.0 ||\n"
-            "      texcoord.t < 0.0 || texcoord.t > 1.0 ||\n"
-            "      texcoord.p < 0.0 || texcoord.p > 1.0) discard;\n"
-            "  color = texture (tex, texcoord.stp);\n"
-            "  float amplitude = " + std::string (ColourMap::maps[object.colourmap].amplitude) + ";\n"
-            "  if (isnan(amplitude) || isinf(amplitude)) discard;\n";
+          source += "void main() {\n"
+                    "  if (texcoord.s < 0.0 || texcoord.s > 1.0 ||\n"
+                    "      texcoord.t < 0.0 || texcoord.t > 1.0 ||\n"
+                    "      texcoord.p < 0.0 || texcoord.p > 1.0) discard;\n" +
+                    (is_roi ? std::string("  uint ru = texture(tex, texcoord.stp).r;\n  color = vec4(ru > 0u ? 1.0 : 0.0);\n")
+                            : std::string("  color = texture (tex, texcoord.stp);\n")) +
+                    "  float amplitude = " + std::string(ColourMap::maps[object.colourmap].amplitude) + ";\n"
+                    "  if (isnan(amplitude) || isinf(amplitude)) discard;\n";
 
           if (object.use_discard_lower())
             source += "  if (amplitude < lower) discard;\n";

--- a/src/gui/mrview/tool/roi_editor/item.cpp
+++ b/src/gui/mrview/tool/roi_editor/item.cpp
@@ -54,8 +54,8 @@ namespace MR
             current_undo (-1)
         {
           type = gl::UNSIGNED_BYTE;
-          format = gl::RED;
-          internal_format = gl::R8;
+          format = gl::RED_INTEGER;
+          internal_format = gl::R8UI;
           set_allowed_features (false, true, false);
           set_interpolate (false);
           set_use_transparency (true);

--- a/src/gui/mrview/tool/roi_editor/roi.cpp
+++ b/src/gui/mrview/tool/roi_editor/roi.cpp
@@ -347,7 +347,7 @@ namespace MR
             GL::assert_context_is_current();
             roi->texture().bind();
             gl::PixelStorei (gl::PACK_ALIGNMENT, 1);
-            gl::GetTexImage (gl::TEXTURE_3D, 0, gl::RED, gl::UNSIGNED_BYTE, (void*) (&data[0]));
+            gl::GetTexImage (gl::TEXTURE_3D, 0, gl::RED_INTEGER, gl::UNSIGNED_BYTE, (void*) (&data[0]));
             GL::assert_context_is_current();
           }
 

--- a/src/gui/mrview/tool/roi_editor/undoentry.cpp
+++ b/src/gui/mrview/tool/roi_editor/undoentry.cpp
@@ -43,16 +43,17 @@ namespace MR
               "  gl_Position = vec4 (vertpos,1);\n"
               "}\n");
           GL::Shader::Fragment fragment_shader (
-              "uniform isampler3D tex;\n"
-              "uniform ivec3 position;\n"
-              "uniform ivec2 axes;\n"
-              "layout (location = 0) out vec3 color0;\n"
-              "void main() {\n"
-              "  ivec3 pos = position;\n"
-              "  pos[axes.x] = int(gl_FragCoord.x);\n"
-              "  pos[axes.y] = int(gl_FragCoord.y);\n"
-              "  color0.r = texelFetch (tex, pos, 0).r;\n"
-              "}\n");
+            "uniform usampler3D tex;\n"
+            "uniform ivec3 position;\n"
+            "uniform ivec2 axes;\n"
+            "layout (location = 0) out float color0;\n"
+            "void main() {\n"
+            "  ivec3 pos = position;\n"
+            "  pos[axes.x] = int(gl_FragCoord.x);\n"
+            "  pos[axes.y] = int(gl_FragCoord.y);\n"
+            "  uint v = texelFetch(tex, pos, 0).r;\n"
+            "  color0 = (v > 0u) ? 1.0 : 0.0;\n"
+            "}\n");
 
           program.attach (vertex_shader);
           program.attach (fragment_shader);
@@ -238,7 +239,7 @@ namespace MR
           GL::Context::Grab context;
           GL::assert_context_is_current();
           roi.texture().bind();
-          gl::TexSubImage3D (gl::TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], gl::RED, gl::UNSIGNED_BYTE, (void*) (&after[0]));
+          gl::TexSubImage3D (gl::TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], gl::RED_INTEGER, gl::UNSIGNED_BYTE, (void*) (&after[0]));
           GL::assert_context_is_current();
         }
 
@@ -284,7 +285,7 @@ namespace MR
           GL::Context::Grab context;
           GL::assert_context_is_current();
           roi.texture().bind();
-          gl::TexSubImage3D (gl::TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], gl::RED, gl::UNSIGNED_BYTE, (void*) (&after[0]));
+          gl::TexSubImage3D (gl::TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], gl::RED_INTEGER, gl::UNSIGNED_BYTE, (void*) (&after[0]));
           GL::assert_context_is_current();
         }
 
@@ -319,7 +320,7 @@ namespace MR
           GL::Context::Grab context;
           GL::assert_context_is_current();
           roi.texture().bind();
-          gl::TexSubImage3D (gl::TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], gl::RED, gl::UNSIGNED_BYTE, (void*) (&after[0]));
+          gl::TexSubImage3D (gl::TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], gl::RED_INTEGER, gl::UNSIGNED_BYTE, (void*) (&after[0]));
           GL::assert_context_is_current();
         }
 
@@ -352,7 +353,7 @@ namespace MR
           GL::Context::Grab context;
           GL::assert_context_is_current();
           roi.texture().bind();
-          gl::TexSubImage3D (gl::TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], gl::RED, gl::UNSIGNED_BYTE, (void*) (&after[0]));
+          gl::TexSubImage3D (gl::TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], gl::RED_INTEGER, gl::UNSIGNED_BYTE, (void*) (&after[0]));
           GL::assert_context_is_current();
         }
 
@@ -409,7 +410,7 @@ namespace MR
           GL::Context::Grab context;
           GL::assert_context_is_current();
           roi.texture().bind();
-          gl::TexSubImage3D (gl::TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], gl::RED, gl::UNSIGNED_BYTE, (void*) (&before[0]));
+          gl::TexSubImage3D (gl::TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], gl::RED_INTEGER, gl::UNSIGNED_BYTE, (void*) (&before[0]));
           GL::assert_context_is_current();
         }
 
@@ -418,7 +419,7 @@ namespace MR
           GL::Context::Grab context;
           GL::assert_context_is_current();
           roi.texture().bind();
-          gl::TexSubImage3D (gl::TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], gl::RED, gl::UNSIGNED_BYTE, (void*) (&after[0]));
+          gl::TexSubImage3D (gl::TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], gl::RED_INTEGER, gl::UNSIGNED_BYTE, (void*) (&after[0]));
           GL::assert_context_is_current();
         }
 
@@ -428,7 +429,7 @@ namespace MR
           GL::assert_context_is_current();
           after = source.before;
           roi.texture().bind();
-          gl::TexSubImage3D (gl::TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], gl::RED, gl::UNSIGNED_BYTE, (void*) (&after[0]));
+          gl::TexSubImage3D (gl::TEXTURE_3D, 0, from[0], from[1], from[2], size[0], size[1], size[2], gl::RED_INTEGER, gl::UNSIGNED_BYTE, (void*) (&after[0]));
           GL::assert_context_is_current();
         }
 


### PR DESCRIPTION
This small change fixes #2319.
After the discussion this morning with @bjeurissen, I decided to investigate this long-standing issue in the viewer. So this wasn't really a driver issue as discussed in the relevant issue, but an error in our code.
After tinkering with OpenGL code a bit, I noticed that the undo/redo shader in [`undoentry.cpp`](https://github.com/MRtrix3/mrtrix3/blob/56fa0604486cb1dbca1c36d8526a5eddc5bc405d/cpp/gui/mrview/tool/roi_editor/undoentry.cpp#L33) was using an integer sampler to read the values from the texture.
Our texture data type is `GL_R8`, which is an 8-bit normalised fixed-point format. It needs a float sampler, because integer samplers are for *integer* formats like `GL_R8I`. 

@MRtrix3/mrtrix3-devs should we include this fix in 3.0.8?