### PR TITLE
Fix tractography rendering performance on macOS

### DIFF
--- a/src/gui/mrview/tool/tractography/tractogram.cpp
+++ b/src/gui/mrview/tool/tractography/tractogram.cpp
@@ -24,9 +24,10 @@
 #include "gui/opengl/lighting.h"
 #include "gui/mrview/mode/base.h"
 
-
+#include <cstdint>
 
 const size_t MAX_BUFFER_SIZE = 2796200;  // number of points to fill 32MB
+constexpr uint32_t PRIMITIVE_RESTART_SENTINEL = 0xFFFFFFFFu; // Primitive restart index for UNSIGNED_INT
 
 namespace MR
 {
@@ -399,6 +400,8 @@ namespace MR
             gl::DeleteBuffers (intensity_scalar_buffers.size(), &intensity_scalar_buffers[0]);
           if (threshold_scalar_buffers.size())
             gl::DeleteBuffers (threshold_scalar_buffers.size(), &threshold_scalar_buffers[0]);
+          if (!element_buffers.empty())
+            gl::DeleteBuffers(element_buffers.size(), &element_buffers[0]);
           GL::assert_context_is_current();
         }
 
@@ -566,8 +569,15 @@ namespace MR
 
             auto mode = geometry_type == TrackGeometryType::Points ? gl::POINTS : gl::LINE_STRIP;
 
-            gl::MultiDrawArrays (mode, &track_starts[buf][0], &track_sizes[buf][0], num_tracks_per_buffer[buf]);
-
+            if(mode == gl::POINTS) {
+              gl::MultiDrawArrays(mode, &track_starts[buf][0], &track_sizes[buf][0], num_tracks_per_buffer[buf]);
+            } else if (element_counts[buf] > 0 && element_buffers[buf] != 0) {
+              // Use the EBO stored with this VAO to render all tracks in this chunk
+              gl::Enable(gl::PRIMITIVE_RESTART);
+              gl::PrimitiveRestartIndex(PRIMITIVE_RESTART_SENTINEL);
+              gl::DrawElements(gl::LINE_STRIP, element_counts[buf], gl::UNSIGNED_INT, nullptr);
+              gl::Disable(gl::PRIMITIVE_RESTART);
+            }
           }
 
           vao_dirty = false;
@@ -986,6 +996,32 @@ namespace MR
           original_track_starts.push_back (starts);
           original_track_sizes.push_back (sizes);
           num_tracks_per_buffer.push_back (tck_count);
+
+          // Build an index buffer for this chunk of tracks
+          std::vector<uint32_t> chunk_indices;
+          for (size_t t = 0; t < sizes.size(); ++t) {
+            const GLint start = starts[t];
+            const GLint n     = sizes[t];
+            if (n < 2) continue;
+            for (GLint k = 0; k < n; ++k)
+              chunk_indices.push_back(static_cast<uint32_t>(start + k));
+            chunk_indices.push_back(PRIMITIVE_RESTART_SENTINEL);
+          }
+
+          if (!chunk_indices.empty()) {
+            GLuint ebo = 0;
+            gl::GenBuffers(1, &ebo);
+            // bind to the VAO so that ELEMENT_ARRAY_BUFFER is part of VAO state
+            gl::BindVertexArray(vertex_array_object);
+            gl::BindBuffer(gl::ELEMENT_ARRAY_BUFFER, ebo);
+            gl::BufferData(gl::ELEMENT_ARRAY_BUFFER, chunk_indices.size() * sizeof(uint32_t), chunk_indices.data(), gl::STATIC_DRAW);
+            element_buffers.push_back(ebo);
+            element_counts.push_back(static_cast<GLsizei>(chunk_indices.size()));
+          } else {
+            // keep arrays aligned with other per-chunk vectors
+            element_buffers.push_back(0);
+            element_counts.push_back(0);
+          }
 
           buffer.clear();
           starts.clear();

--- a/src/gui/mrview/tool/tractography/tractogram.h
+++ b/src/gui/mrview/tool/tractography/tractogram.h
@@ -144,6 +144,9 @@ namespace MR
             vector<vector<GLint> > original_track_sizes;
             vector<vector<GLint> > original_track_starts;
             vector<size_t> num_tracks_per_buffer;
+            // EBOs and indices for chunks of tracks
+            std::vector<GLuint> element_buffers;
+            std::vector<GLsizei> element_counts;
             GLint sample_stride;
             bool vao_dirty;
 


### PR DESCRIPTION
This PR fixes the longstanding performance issues in the viewer on macOS when visualising tractography streamlines (using pseudotubes). 
The root cause turned out not to be geometry-shader emulation per se, but the cost of submitting many draws via `glMultiDrawArrays<. On Apple’s stack, glMultiDraw* does not seem to guarantee hardware batching, and it can result in significant CPU/driver overhead. Details below.

After working on #3095, I decided to investigate the performance issues raised in #2247. As discussed there, the culprit seemed to be the use of geometry shaders in our OpenGL code. This was a reasonable suspicion that their emulation performance could be the culprit (since the OpenGL drivers on macOS are built upon Metal, which doesn't support geometry shaders).  I spent a significant amount of time tinkering with the code, but it was unreasonable to assume that emulation of geometry shaders (via compute shaders) could be so slow that the app would either completely freeze or even crash.

Investigating with the Xcode profiler, I noticed that the application essentially just hung when calling `glMultiDrawArrays`:

```
1.54 s 40.0% 400.00 µs GLDContextRec::flushContext(bool) 
1.47 s 38.3% 600.00 µs -[_MTLCommandQueue submitCommandBuffer:] 
1.47 s 38.3% 400.00 µs _dispatch_lane_barrier_sync_invoke_and_complete 
1.47 s 38.3% 300.00 µs _dispatch_client_callout 
1.47 s 38.3% 400.00 µs __40-[_MTLCommandQueue submitCommandBuffer:]_block_invoke 
1.47 s 38.3% 400.00 µs -[_MTLCommandQueue _submitAvailableCommandBuffers] 
1.46 s 38.0% 264.54 µs -[IOGPUMetalCommandQueue submitCommandBuffers:count:] 
1.46 s 38.0% 700.00 µs -[IOGPUMetalCommandQueue _submitCommandBuffers:count:] 
1.40 s 36.5% 700.00 µs IOGPUCommandQueueSubmitCommandBuffers 
1.40 s 36.5% 0 s IOConnectCallMethod 
1.40 s 36.5% 3.20 ms io_connect_method 
1.40 s 36.4% 300.00 µs mach_msg2_internal 
1.40 s 36.3% 
1.40 s mach_msg2_trap
```

which made me realise that most likely we are CPU-bound on command submission. The OpenGL on Metal implementation
seems to be submitting too many draw calls, which results in a hang.
Looking around, I found this great [article](https://programming4.us/multimedia/8302.aspx) which mentions:

> Even functions like glMultiDrawArrays and glMultiDrawElements don’t always help because the graphics hardware may not implement these functions directly, and so OpenGL essentially has to convert them to multiple calls to glDrawArrays internally anyway.

`glMultiDrawsArrays` is the command that we use in [tracogram.cpp](https://github.com/MRtrix3/mrtrix3/blob/3bcf5c10f457afea505180eeb27d577d126cbd81/src/gui/mrview/tool/tractography/tractogram.cpp#L569) to instruct the GPU to draw a chunk of streamlines. In theory, the command should be hardware-batched, but as the article mentioned, this is upon the GPU driver's implementation, and it's not guaranteed (as it seems to be the case on OpenGL on Metal).

The article also offers a better alternative to ensure the commands are batched. The idea is to supply an index buffer that is one long sequence of vertex indices, with a special sentinel value between line strips (a "primitive-restart index") that tells the GPU where each track starts or terminates. Once the index buffer is built, we can submit everything in one go via `glDrawElements(GL_LINE_STRIP, num_elements, GL_UNSIGNED_INT, nullptr)`.

Suppose we have 3 tracks with 4 elements each: [0 1 2 3] [4 5 6 7] [8 9 10 11]. With `glMultiDrawArrays` we do:

```
starting_indices = {0, 4, 8};
element_counts = {4, 4, 4};
glMultiDrawArrays(GL_LINE_STRIP, firsts, counts, 3);
```

while with the indexed approach:

```
// Use 0xFFFFFFFF as sentinel values
indices = [0,1,2,3, 0xFFFFFFFF, 4,5,6,7, 0xFFFFFFFF, 8,9,10,11, 0xFFFFFFFF]
glEnable(GL_PRIMITIVE_RESTART);
glPrimitiveRestartIndex(0xFFFFFFFFu);
glDrawElements(GL_LINE_STRIP, indices.size(), GL_UNSIGNED_INT, nullptr);
```

I implemented this idea in the code, and it fixed the performance issues while visualising tractograms on macOS!  On my MacBook M2, I now see framerates between 100 - 150 (dropping to 60-90 with volume rendering) when displaying a track file with 200k streamlines. Previously, `mrview` would even struggle to load the file.
As a bonus on Linux, with my modest laptop with Intel 11th i5-1135G7, I'm also seeing up to 25% improvements in framerates. 

Notes:
- There is a slight disadvantage in using the new approach, as the index buffer consumes some additional memory.
- I have only enabled the index buffer code path for pseudotubes. I preferred to keep the code changes to a minimum, as this PR is targeting `master` and its primary aim is to fix the performance issues on macOS. But we can enable this for points too if we want that (either in this PR or a separate one, perhaps targeting `dev`).

@MRtrix3/mrtrix3-devs  I believe this change is correct and safe, but I'd appreciate it if you could test this on your own machines to see if you encounter any issues and maybe compare with `mrview` built from `master` to see if you notice any performance improvements. Also, this PR is *strictly* not a correctness fix, so I'd be happy if we want to target `dev` instead (I think other easy opportunities may potentially improve performance further).