### PR TITLE
Update configure script for Xcode26 compatibility

### DIFF
--- a/configure
+++ b/configure
@@ -1284,6 +1284,7 @@ int main() { Foo f; }
       filetext += 'HEADERS += qt.h\nSOURCES += qt.cpp\n'
       if system == "darwin":
         filetext += 'QMAKE_MACOSX_DEPLOYMENT_TARGET = ' + macosx_version + '\n'
+        filetext += 'QMAKE_LIBS_OPENGL = -framework OpenGL\n'
 
       log ('\nproject file "qt.pro":\n---\n' + filetext + '---\n')
       with open (os.path.join (qt_dir.name, 'qt.pro'), 'w') as f:


### PR DESCRIPTION
Qt5 links to both OpenGL and AGL for OpenGL apps, but AGL is no longer included in MacOS Tahoe/Xcode26 (https://bugreports.qt.io/browse/QTBUG-137687). This will cause our configure script to fail on latest macOS. This issue will not be addressed in future Qt5 versions (only in Qt6), but we can work around it by explicitly linking only to OpenGL.