### PR TITLE
Testing: Fix dirrotate default test

### DIFF
--- a/testing/binaries/tests/dirrotate/default
+++ b/testing/binaries/tests/dirrotate/default
@@ -8,29 +8,33 @@
 
 dirgen 30 tmp1.txt -force -cartesian -restarts 1
 
+rm -f tmp1_stats.txt
 dirstat tmp1.txt | \
 grep 'condition numbers for lmax' | \
 awk '{ print $10,$11,$12 }' > tmp1_stats.txt
 
 dirrotate tmp1.txt tmp2.txt -force -cartesian -number 1M
 
+rm -f tmp2_stats.txt
 dirstat tmp2.txt | \
 grep 'condition numbers for lmax' | \
 awk '{ print $10,$11,$12 }' > tmp2_stats.txt
 
 testing_diff_matrix tmp1_stats.txt tmp2_stats.txt
 
+rm -f tmp1_max.txt
 cat tmp1.txt | \
 tail -n +2 | \
-tr -d "-" | \
 tr " " "\n" | \
+sed 's/^-//' | \
 sort -g -r | \
 head -n1 > tmp1_max.txt
 
+rm -f tmp2_max.txt
 cat tmp2.txt | \
 tail -n +2 | \
-tr -d "-" | \
 tr " " "\n" | \
+sed 's/^-//' | \
 sort -g -r | \
 head -n1 > tmp2_max.txt
 


### PR DESCRIPTION
#3014 didn't fully fix the sporadic `dirrotate` test failures.
This one will hopefully get it.
Wasn't an inadequate number of spins tested as I had hypothesized; just me not using the right Unix text manipulations.
