### PR TITLE
DICOM: Performance fix to wildcard matching

### DIFF
--- a/core/mrtrix.cpp
+++ b/core/mrtrix.cpp
@@ -118,13 +118,13 @@ namespace MR
       // If the first string contains '?', or current characters
       // of both strings match
       if (*first == '?' || *first == *second)
-        return match(first+1, second+1);
+        return __match(first+1, second+1);
 
       // If there is *, then there are two possibilities
       // a) We consider current character of second string
       // b) We ignore current character of second string.
       if (*first == '*')
-        return match(first+1, second) || match(first, second+1);
+        return __match(first+1, second) || __match(first, second+1);
 
       return false;
     }


### PR DESCRIPTION
Error in 8e3612aebac43ccd56c014d0c2ee87035f55e6c6 as part of #1929.

I expect this to be of no consequence to behaviour, so not even applying the `bug` tag; it's just preventing unnecessary recursive construction of `std::string`'s.

(This will be better addressed using `std::string_view` on dev; that's how I found it)