### PR TITLE
Registration: Fix local cross-correlation metric

### DIFF
--- a/src/registration/metric/local_cross_correlation.h
+++ b/src/registration/metric/local_cross_correlation.h
@@ -237,7 +237,9 @@ namespace MR
                   return 0.0;
                 }
 
-                const Eigen::Vector3d pos = Eigen::Vector3d(default_type(iter.index(0)), default_type(iter.index(0)), default_type(iter.index(0)));
+                const Eigen::Vector3d pos = Eigen::Vector3d(default_type(iter.index(0)),
+                                                            default_type(iter.index(1)),
+                                                            default_type(iter.index(2)));
                 params.processed_image_interp->voxel(pos);
                 typename Params::Im1ValueType val1;
                 typename Params::Im2ValueType val2;


### PR DESCRIPTION
No idea if this is even accessible from the command-line, but worth fixing nevertheless in case anyone out there is trying to do anything with it.