### PR TITLE
More extensive use of std::ostringstream

### DIFF
--- a/cpp/core/dwi/gradient.h
+++ b/cpp/core/dwi/gradient.h
@@ -109,14 +109,16 @@ void save_bvecs_bvals(const Header &, const std::string &, const std::string &);
 
 namespace {
 template <class MatrixType> std::string scheme2str(const MatrixType &G) {
-  std::string dw_scheme;
+  std::ostringstream dw_scheme;
+  dw_scheme.precision(10);
   for (ssize_t row = 0; row < G.rows(); ++row) {
-    std::string line = str(G(row, 0), 10);
+    if (row > 0)
+      dw_scheme << "\n";
+    dw_scheme << G(row, 0);
     for (ssize_t col = 1; col < G.cols(); ++col)
-      line += "," + str(G(row, col), 10);
-    add_line(dw_scheme, line);
+      dw_scheme << "," << G(row, col);
   }
-  return dw_scheme;
+  return dw_scheme.str();
 }
 } // namespace
 

--- a/cpp/core/file/mgh.h
+++ b/cpp/core/file/mgh.h
@@ -313,7 +313,7 @@ template <class Input> void read_other(Header &H, Input &in) {
   auto read_mri_frame = [&](Input &in, const int64_t len) {
     const int64_t fstart = in.tellg();
     const size_t nframes = H.ndim() == 4 ? H.size(3) : 1;
-    std::string table;
+    std::ostringstream table;
     Eigen::IOFormat format(Eigen::StreamPrecision, Eigen::DontAlignCols, " ", " ", "", "", "", "");
     for (size_t frame_index = 0; frame_index != nframes; ++frame_index) {
       mri_frame frame;
@@ -345,14 +345,14 @@ template <class Input> void read_other(Header &H, Input &in) {
       frame.thresh = fetch<float32>(in);
       frame.units = fetch<int32_t>(in);
 
-      std::string line = str(frame.type) + "," + str(frame.TE) + "," + str(frame.TR) + "," + str(frame.flip) + "," +
-                         str(frame.TI) + "," + str(frame.TD) + "," + str(frame.sequence_type) + "," +
-                         str(frame.echo_spacing) + "," + str(frame.echo_train_len) + "," + str(frame.read_dir[0]) +
-                         "," + str(frame.read_dir[1]) + "," + str(frame.read_dir[2]) + "," + str(frame.pe_dir[0]) +
-                         "," + str(frame.pe_dir[1]) + "," + str(frame.pe_dir[2]) + "," + str(frame.slice_dir[0]) + "," +
-                         str(frame.slice_dir[1]) + "," + str(frame.slice_dir[2]) + "," + str(frame.label) + "," +
-                         frame.name + "," + str(frame.dof) + "," + str(frame.m_ras2vox->format(format)) + "," +
-                         str(frame.thresh) + "," + str(frame.units);
+      if (frame_index > 0)
+        table << "\n";
+      table << frame.type << "," << frame.TE << "," << frame.TR << "," << frame.flip << "," << frame.TI << ","
+            << frame.TD << "," << frame.sequence_type << "," << frame.echo_spacing << "," << frame.echo_train_len << ","
+            << frame.read_dir[0] << "," << frame.read_dir[1] << "," << frame.read_dir[2] << "," << frame.pe_dir[0]
+            << "," << frame.pe_dir[1] << "," << frame.pe_dir[2] << "," << frame.slice_dir[0] << ","
+            << frame.slice_dir[1] << "," << frame.slice_dir[2] << "," << frame.label << "," << frame.name << ","
+            << frame.dof << "," << frame.m_ras2vox->format(format) << "," << frame.thresh << "," << frame.units;
 
       delete frame.m_ras2vox;
       frame.m_ras2vox = nullptr;
@@ -383,15 +383,12 @@ template <class Input> void read_other(Header &H, Input &in) {
         frame.D4_flat = fetch<int64_t>(in);
         frame.D4_amp = fetch<float64>(in);
 
-        line += "," + str(frame.DX) + "," + str(frame.DY) + "," + str(frame.DZ) + "," + str(frame.DR) + "," +
-                str(frame.DP) + "," + str(frame.DS) + "," + str(frame.bvalue) + "," + str(frame.TM) + "," +
-                str(frame.D1_ramp) + "," + str(frame.D1_flat) + "," + str(frame.D1_amp) + "," + str(frame.D2_ramp) +
-                "," + str(frame.D2_flat) + "," + str(frame.D2_amp) + "," + str(frame.D3_ramp) + "," +
-                str(frame.D3_flat) + "," + str(frame.D3_amp) + "," + str(frame.D4_ramp) + "," + str(frame.D4_flat) +
-                "," + str(frame.D4_amp);
+        table << "," << frame.DX << "," << frame.DY << "," << frame.DZ << "," << frame.DR << "," << frame.DP << ","
+              << frame.DS << "," << frame.bvalue << "," << frame.TM << "," << frame.D1_ramp << "," << frame.D1_flat
+              << "," << frame.D1_amp << "," << frame.D2_ramp << "," << frame.D2_flat << "," << frame.D2_amp << ","
+              << frame.D3_ramp << "," << frame.D3_flat << "," << frame.D3_amp << "," << frame.D4_ramp << ","
+              << frame.D4_flat << "," << frame.D4_amp;
       }
-
-      add_line(table, line);
     }
 
     // Test to see if the correct amount of data has been read
@@ -403,13 +400,13 @@ template <class Input> void read_other(Header &H, Input &in) {
       in.read(buffer, empty_space_len);
     }
 
-    return table;
+    return table.str();
   };
 
   auto read_colourtable_V1 = [&](Input &in, const int32_t nentries) {
     if (!nentries)
       throw Exception("Error reading colour table from file \"" + H.name() + "\": No entries");
-    std::string table;
+    std::ostringstream table;
     const int32_t filename_length = fetch<int32_t>(in);
     std::string filename(filename_length, '\0');
     in.read(const_cast<char *>(filename.data()), filename_length);
@@ -419,16 +416,18 @@ template <class Input> void read_other(Header &H, Input &in) {
         throw Exception("Error reading colour table from file \"" + H.name() + "\": Negative structure name length");
       std::string structurename(structurename_length, '\0');
       in.read(const_cast<char *>(structurename.data()), structurename_length);
-      while (!structurename.empty() && !structurename.back())
+      while (!structurename.empty() && structurename.back() == '\0')
         structurename.pop_back();
       const int32_t r = fetch<int32_t>(in);
       const int32_t g = fetch<int32_t>(in);
       const int32_t b = fetch<int32_t>(in);
       const int32_t t = fetch<int32_t>(in);
       const int32_t a = 255 - t; // Alpha = 255 - transparency
-      add_line(table, structurename + "," + str(r) + "," + str(g) + "," + str(b) + "," + str(a));
+      if (structure > 0)
+        table << "\n";
+      table << structurename << "," << r << "," << g << "," << b << "," << a;
     }
-    return table;
+    return table.str();
   };
 
   auto read_colourtable_V2 = [&](Input &in) {
@@ -456,7 +455,7 @@ template <class Input> void read_other(Header &H, Input &in) {
                         " Negative structure name length");                            //
       std::string structurename(structurename_length, '\0');
       in.read(const_cast<char *>(structurename.data()), structurename_length);
-      while (!structurename.empty() && !structurename.back())
+      while (!structurename.empty() && structurename.back() == '\0')
         structurename.pop_back();
       const int32_t r = fetch<int32_t>(in);
       const int32_t g = fetch<int32_t>(in);
@@ -465,12 +464,15 @@ template <class Input> void read_other(Header &H, Input &in) {
       const int32_t a = 255 - t; // Alpha = 255 - transparency
       table[structure] = structurename + "," + str(r) + "," + str(g) + "," + str(b) + "," + str(a);
     }
-    std::string result;
+    std::ostringstream result;
     for (size_t index = 0; index != table.size(); ++index) {
-      if (!table[index].empty())
-        add_line(result, str(index) + "," + table[index]);
+      if (!table[index].empty()) {
+        if (!result.str().empty())
+          result << "\n";
+        result << index << "," << table[index];
+      }
     }
-    return result;
+    return result.str();
   };
 
   // Start the function read_other() proper

--- a/cpp/core/metadata/phase_encoding.cpp
+++ b/cpp/core/metadata/phase_encoding.cpp
@@ -91,21 +91,29 @@ void set_scheme(KeyValues &keyval, const scheme_type &PE) {
     erase(keyval, "TotalReadoutTime");
     return;
   }
-  std::string pe_scheme;
+  std::ostringstream pe_scheme;
   std::string first_line;
   bool variation = false;
   for (ssize_t row = 0; row < PE.rows(); ++row) {
-    std::string line = str(PE(row, 0));
-    for (ssize_t col = 1; col < PE.cols(); ++col)
-      line += "," + str(PE(row, col), 3);
-    add_line(pe_scheme, line);
-    if (first_line.empty())
-      first_line = line;
-    else if (line != first_line)
-      variation = true;
+    std::ostringstream line;
+    line.precision(0);
+    line << static_cast<int>(PE(row, 0));
+    for (ssize_t col = 1; col < 3; ++col)
+      line << "," << static_cast<int>(PE(row, col));
+    line.precision(3);
+    for (ssize_t col = 3; col < PE.cols(); ++col)
+      line << "," << PE(row, col);
+    if (row == 0) {
+      first_line = line.str();
+    } else {
+      pe_scheme << "\n";
+      if (line.str() != first_line)
+        variation = true;
+    }
+    pe_scheme << line.str();
   }
   if (variation) {
-    keyval["pe_scheme"] = pe_scheme;
+    keyval["pe_scheme"] = pe_scheme.str();
     erase(keyval, "PhaseEncodingDirection");
     erase(keyval, "TotalReadoutTime");
   } else {


### PR DESCRIPTION
Addresses a compilation issue that arose when attempting to compile a container for an external project using the `ci-release-checks` preset. Looks like a FP to me, but regardless, `std::ostringstream` is more suitable than `MR::add_line()` where all content for a single string is created sequentially.

```text
25.46 FAILED: cpp/core/CMakeFiles/mrtrix-core.dir/dwi/gradient.cpp.o 
25.46 /usr/bin/c++ -DMRTRIX_BASE_VERSION=\"3.0.7\" -DMRTRIX_BUILD_TYPE=\"Release\" -DMRTRIX_HAVE_LGAMMA_R -DMRTRIX_PNG_SUPPORT -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC -Dmrtrix_core_EXPORTS -I/src/mrtrix3/cpp/core -I/src/mrtrix3/build/_deps/eigen3-src -I/src/mrtrix3/build/_deps/json-src/include -I/src/mrtrix3/build/_deps/nifti1-src -I/src/mrtrix3/build/_deps/nifti2-src -I/src/mrtrix3/build/_deps/half-src/include -O3 -DNDEBUG -fPIC -Werror -std=gnu++17 -Winvalid-pch -include /src/mrtrix3/build/cpp/core/CMakeFiles/mrtrix-core.dir/cmake_pch.hxx -MD -MT cpp/core/CMakeFiles/mrtrix-core.dir/dwi/gradient.cpp.o -MF cpp/core/CMakeFiles/mrtrix-core.dir/dwi/gradient.cpp.o.d -o cpp/core/CMakeFiles/mrtrix-core.dir/dwi/gradient.cpp.o -c /src/mrtrix3/cpp/core/dwi/gradient.cpp
25.47 In file included from /usr/include/c++/12/ios:40,
25.47                  from /usr/include/c++/12/istream:38,
25.47                  from /usr/include/c++/12/sstream:38,
25.47                  from /usr/include/c++/12/complex:45,
25.47                  from /src/mrtrix3/cpp/core/types.h:20,
25.47                  from /src/mrtrix3/cpp/core/exception.h:19,
25.47                  from /src/mrtrix3/build/cpp/core/CMakeFiles/mrtrix-core.dir/cmake_pch.hxx:5,
25.47                  from <command-line>:
25.47 In static member function 'static std::char_traits<char>::char_type* std::char_traits<char>::copy(char_type*, const char_type*, std::size_t)',
25.47     inlined from 'static void std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::_S_copy(_CharT*, const _CharT*, size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]' at /usr/include/c++/12/bits/basic_string.h:423:21,
25.47     inlined from 'std::__cxx11::basic_string<_CharT, _Traits, _Allocator>& std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::_M_replace(size_type, size_type, const _CharT*, size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]' at /usr/include/c++/12/bits/basic_string.tcc:532:22,
25.47     inlined from 'std::__cxx11::basic_string<_CharT, _Traits, _Alloc>& std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::replace(size_type, size_type, const _CharT*, size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]' at /usr/include/c++/12/bits/basic_string.h:2171:19,
25.47     inlined from 'std::__cxx11::basic_string<_CharT, _Traits, _Alloc>& std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::insert(size_type, const _CharT*) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]' at /usr/include/c++/12/bits/basic_string.h:1928:22,
25.47     inlined from 'std::__cxx11::basic_string<_CharT, _Traits, _Allocator> std::operator+(const _CharT*, __cxx11::basic_string<_CharT, _Traits, _Allocator>&&) [with _CharT = char; _Traits = char_traits<char>; _Alloc = allocator<char>]' at /usr/include/c++/12/bits/basic_string.h:3541:36,
25.47     inlined from 'std::string MR::DWI::{anonymous}::scheme2str(const MatrixType&) [with MatrixType = Eigen::Matrix<double, -1, -1>]' at /src/mrtrix3/cpp/core/dwi/gradient.h:116:12,
25.47     inlined from 'void MR::DWI::set_DW_scheme(MR::Header&, const MatrixType&) [with MatrixType = Eigen::Matrix<double, -1, -1>]' at /src/mrtrix3/cpp/core/dwi/gradient.h:136:34:
25.47 /usr/include/c++/12/bits/char_traits.h:431:56: error: 'void* __builtin_memcpy(void*, const void*, long unsigned int)' specified bound between 9223372036854775810 and 18446744073709551615 exceeds maximum object size 9223372036854775807 [-Werror=stringop-overflow=]
25.47   431 |         return static_cast<char_type*>(__builtin_memcpy(__s1, __s2, __n));
25.47       |                                        ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
25.47 cc1plus: all warnings being treated as errors
```