### PR TITLE
New utility for pattern-matching style over std::variant

### DIFF
--- a/cpp/core/match_variant.h
+++ b/cpp/core/match_variant.h
@@ -26,7 +26,7 @@
 //   std::variant<int, std::string> v = 42;
 //   auto s = MR::match_v(v,
 //       [](int i) { return std::to_string(i); },
-//       [](const std::string& s) { return s; });
+//       [](const std::string& s) { return s; }); // check_syntax off
 //   // s == "42"
 
 namespace MR {


### PR DESCRIPTION
This adds a new utility for pattern-matching style over `std::variant`, which is a type-safe version of a discriminated union introduced in C++17.

Example:
```
  std::variant<int, std::string> v = 42;
  auto s = MR::match_v(v,
       [](int i) { return std::to_string(i); },
       [](const std::string& s) { return s; });
  // s == "42"
```