### PR TITLE
Add support for nightly builds for `dev` branch

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -170,15 +170,15 @@ jobs:
       - name: Run Linux build
         if: matrix.platform == 'linux'
         run: |
-          ./packaging/package-linux-tarball.sh .
+          ./packaging/package-linux-tarball.sh . "${{ steps.out.outputs.output_name }}"
           mv mrtrix.tar.gz ${{ steps.out.outputs.output_name }}.${{ matrix.artifact_ext }}
 
       - name: Run macOS build
         if: matrix.platform == 'macos'
         run: |
           cd ./packaging/macos
-          ./build ${{ needs.prepare.outputs.branch }}
-          mv ./mrtrix3-macos-${{ needs.prepare.outputs.branch }}.${{ matrix.artifact_ext }} ../../${{ steps.out.outputs.output_name }}.${{ matrix.artifact_ext }}
+          ./build "${{ needs.prepare.outputs.branch }}" "${{ steps.out.outputs.output_name }}"
+          mv "./${{ steps.out.outputs.output_name }}.${{ matrix.artifact_ext }}" "../../${{ steps.out.outputs.output_name }}.${{ matrix.artifact_ext }}"
 
       - name: Run Windows build
         if: matrix.platform == 'windows'


### PR DESCRIPTION
This PR refactors the `releases.yml` workflow to add support for nightly builds for the `dev` branch. The workflow is scheduled to run every day at `00:00` and will update the release tagged with the `nightly` tag (which I have already created) with the artefacts for each platform. The release will show the latest 15 commits on `dev`. If there have been no changes on `dev` since the last run, the workflow is cancelled.
Additionally, the workflow file has been refactored for improved code reuse and a simplified YAML file that utilises the GitHub Actions matrix strategy to build artefacts for each platform.