### PR TITLE
Fix OpenGL context creation on macOS

### DIFF
--- a/cpp/gui/opengl/gl_core_3_3.cpp
+++ b/cpp/gui/opengl/gl_core_3_3.cpp
@@ -37,7 +37,7 @@ namespace gl {
 
 static void *AppleGLGetProcAddress(const char *name) {
   static void *image = nullptr;
-  if (image = nullptr)
+  if (image == nullptr)
     image = dlopen("/System/Library/Frameworks/OpenGL.framework/Versions/Current/OpenGL", RTLD_LAZY);
 
   return (image ? dlsym(image, (const char *)name) : nullptr);


### PR DESCRIPTION
This was a bug due to a typo introduced in #3212.