### PR TITLE
shconv: Fix duplicate DESCRIPTION

### DIFF
--- a/cmd/shconv.cpp
+++ b/cmd/shconv.cpp
@@ -44,9 +44,6 @@ void usage ()
        "along the 5th dimension."
     + Math::SH::encoding_description;
 
-  DESCRIPTION
-  + Math::SH::encoding_description;
-
   ARGUMENTS
     + Argument ("odf response", "pairs of input ODF image and corresponding responses").allow_multiple()
     + Argument ("SH_out", "the output spherical harmonics coefficients image.").type_image_out ();

--- a/docs/reference/commands/shconv.rst
+++ b/docs/reference/commands/shconv.rst
@@ -30,9 +30,6 @@ If the responses are multi-shell (with one line of coefficients per shell), the 
 The spherical harmonic coefficients are stored according the conventions described the main documentation, which can be found at the following link:  |br|
 https://mrtrix.readthedocs.io/en/3.0.8/concepts/spherical_harmonics.html
 
-The spherical harmonic coefficients are stored according the conventions described the main documentation, which can be found at the following link:  |br|
-https://mrtrix.readthedocs.io/en/3.0.8/concepts/spherical_harmonics.html
-
 Options
 -------
 


### PR DESCRIPTION
Looks like an error in merging between #1617 and #1635.