### PR TITLE
Fix bug in detection of duplicates in user-specified strides

### DIFF
--- a/core/stride.cpp
+++ b/core/stride.cpp
@@ -110,7 +110,7 @@ namespace MR
           throw Exception ("strides specified exceed image dimensions: got " + str(opt[0][0]) + ", but image has " + str(current.size()) + " axes");
 
       for (size_t i = 0; i < strides.size()-1; ++i) {
-        if (!strides[1]) continue;
+        if (!strides[i]) continue;
         for (size_t j = i+1; j < strides.size(); ++j)
           if (abs (strides[i]) == abs (strides[j]))
             throw Exception ("duplicate entries provided to \"-strides\" option: " + str(opt[0][0]));


### PR DESCRIPTION
Currently making an attempt at refactoring the stride handling as per discussion in #3108 and came across this howler. Quite possibly never actually affected anybody given it will pretty much always be the case that all three spatial strides are either zero or non-zero.