### PR TITLE
Fix ICLS performance regression

### DIFF
--- a/cpp/core/math/constrained_least_squares.h
+++ b/cpp/core/math/constrained_least_squares.h
@@ -237,7 +237,9 @@ public:
     lambda_prev.setZero();
     // set active set empty:
     active.setZero();
-    active.tail(num_ineq).setOnes();
+    if (num_eq > 0) {
+      active.tail(num_eq).setOnes();
+    }
 
     // initial estimate of constraint values:
     c = c_u;


### PR DESCRIPTION
Fixes #3260. 
The following change was introduced in #3182:

```cpp
-    std::fill(active.begin(), active.end(), false);
-    if (num_eq > 0)
-      std::fill(active.begin() + num_ineq, active.end(), true);
+    active.setZero();
+    active.tail(num_ineq).setOnes();
```

We were mistakenly setting the last `num_ineq` entries active, while we should be doing the opposite: set the last `num_eq` entries active. This caused a large set of inequality constraints to be active in the solver, leading to performance issues. This PR restores the behaviour prior to #3182.