### PR TITLE
Update CMake version for sanitizers workflow

### DIFF
--- a/.github/workflows/weekly_sanitizers.yml
+++ b/.github/workflows/weekly_sanitizers.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Get CMake
       uses: lukka/get-cmake@latest
       with:
-        cmakeVersion: '3.16.3'
+        cmakeVersion: '3.22.3'
 
     - name: Print CMake version
       run: cmake --version


### PR DESCRIPTION
On `dev`, since #3239, we require CMake >= 3.22. This change needs to be propagated to our sanitisers weekly workflows, which are currently failing.