### PR TITLE
Add microstructure-informed weighting prior to tcksift2

### DIFF
--- a/cmd/tcksift2.cpp
+++ b/cmd/tcksift2.cpp
@@ -50,6 +50,16 @@ const OptionGroup SIFT2RegularisationOption = OptionGroup ("Regularisation optio
     + Argument ("value").type_float (0.0)
 
   + Option ("reg_tv", "provide coefficient for regularising variance of streamline weighting coefficient to fixels along its length (Total Variation regularisation) (default: " + str(SIFT2_REGULARISATION_TV_DEFAULT, 2) + ")")
+    + Argument ("value").type_float (0.0)
+
+  + Option ("microstructure_weighting", "provide a text file containing per-streamline microstructure weighting values (MicroAF); "
+                                        "when provided, adds a prior term to the objective that penalises high weights on streamlines "
+                                        "with low microstructure values. The file should contain one value per streamline, in the same "
+                                        "order as the input tractogram.")
+    + Argument ("file").type_file_in()
+
+  + Option ("microstructure_lambda", "strength of the microstructure prior term; only has effect when -microstructure_weighting is provided "
+                                     "(default: " + str(SIFT2_REGULARISATION_MICRO_DEFAULT, 2) + ")")
     + Argument ("value").type_float (0.0);
 
 
@@ -194,7 +204,17 @@ void run ()
 
     const float reg_tikhonov = get_option_value ("reg_tikhonov", SIFT2_REGULARISATION_TIKHONOV_DEFAULT);
     const float reg_tv = get_option_value ("reg_tv", SIFT2_REGULARISATION_TV_DEFAULT);
-    tckfactor.set_reg_lambdas (reg_tikhonov, reg_tv);
+
+    auto opt_micro = get_options ("microstructure_weighting");
+    double reg_micro = 0.0;
+    if (opt_micro.size()) {
+      tckfactor.load_microstructure_weights (opt_micro[0][0]);
+      reg_micro = get_option_value ("microstructure_lambda", SIFT2_REGULARISATION_MICRO_DEFAULT);
+    } else if (get_options ("microstructure_lambda").size()) {
+      WARN ("-microstructure_lambda specified without -microstructure_weighting; the lambda value will be ignored");
+    }
+
+    tckfactor.set_reg_lambdas (reg_tikhonov, reg_tv, reg_micro);
 
     opt = get_options ("min_iters");
     if (opt.size())

--- a/scripts/validate_microstructure_sift2.py
+++ b/scripts/validate_microstructure_sift2.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""
+Validation script for microstructure-weighted SIFT2.
+
+Runs the original and modified SIFT2 on the same data and compares:
+1. That lambda=0 produces identical weights to the original
+2. That low-MicroAF streamlines get lower weights with the prior enabled
+3. Summary statistics of weight distributions
+
+Usage:
+    python validate_microstructure_sift2.py <tracks.tck> <fod.mif> <microaf.txt> [tcksift2_binary]
+
+Arguments:
+    tracks.tck   - input tractogram
+    fod.mif      - FOD image
+    microaf.txt  - per-streamline MicroAF values (one per line)
+    tcksift2     - path to tcksift2 binary (default: tcksift2)
+"""
+
+import sys
+import os
+import subprocess
+import tempfile
+import numpy as np
+
+
+def run_tcksift2(binary, tracks, fod, output, extra_args=None):
+    cmd = [binary, tracks, fod, output]
+    if extra_args:
+        cmd.extend(extra_args)
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"ERROR running: {' '.join(cmd)}")
+        print(result.stderr)
+        sys.exit(1)
+    return result
+
+
+def load_weights(path):
+    return np.loadtxt(path)
+
+
+def weight_stats(weights, label):
+    print(f"\n  {label}:")
+    print(f"    N          = {len(weights)}")
+    print(f"    Mean       = {np.mean(weights):.6f}")
+    print(f"    Std        = {np.std(weights):.6f}")
+    print(f"    Min        = {np.min(weights):.6f}")
+    print(f"    Max        = {np.max(weights):.6f}")
+    print(f"    Median     = {np.median(weights):.6f}")
+    nonzero = np.sum(weights > 0)
+    print(f"    Non-zero   = {nonzero} ({100*nonzero/len(weights):.1f}%)")
+
+
+def main():
+    if len(sys.argv) < 4:
+        print(__doc__)
+        sys.exit(1)
+
+    tracks = sys.argv[1]
+    fod = sys.argv[2]
+    microaf_file = sys.argv[3]
+    tcksift2 = sys.argv[4] if len(sys.argv) > 4 else "tcksift2"
+
+    for f in [tracks, fod, microaf_file]:
+        if not os.path.exists(f):
+            print(f"ERROR: File not found: {f}")
+            sys.exit(1)
+
+    microaf = load_weights(microaf_file)
+    print(f"Loaded {len(microaf)} MicroAF values "
+          f"(range: {np.min(microaf):.4f} - {np.max(microaf):.4f}, "
+          f"mean: {np.mean(microaf):.4f})")
+
+    tmpdir = tempfile.mkdtemp(prefix="sift2_validate_")
+    w_original = os.path.join(tmpdir, "weights_original.txt")
+    w_lambda0 = os.path.join(tmpdir, "weights_lambda0.txt")
+    w_modified = os.path.join(tmpdir, "weights_modified.txt")
+
+    # --- Test 1: Original SIFT2 (no microstructure flags) ---
+    print("\n=== Running original SIFT2 (no microstructure flags) ===")
+    run_tcksift2(tcksift2, tracks, fod, w_original)
+
+    # --- Test 2: Modified SIFT2 with lambda=0 ---
+    print("\n=== Running SIFT2 with -microstructure_weighting and -microstructure_lambda 0 ===")
+    run_tcksift2(tcksift2, tracks, fod, w_lambda0,
+                 ["-microstructure_weighting", microaf_file,
+                  "-microstructure_lambda", "0"])
+
+    # --- Test 3: Modified SIFT2 with default lambda ---
+    print("\n=== Running SIFT2 with -microstructure_weighting (default lambda) ===")
+    run_tcksift2(tcksift2, tracks, fod, w_modified,
+                 ["-microstructure_weighting", microaf_file])
+
+    # Load all weights
+    weights_orig = load_weights(w_original)
+    weights_l0 = load_weights(w_lambda0)
+    weights_mod = load_weights(w_modified)
+
+    # --- Report weight distributions ---
+    print("\n" + "=" * 60)
+    print("WEIGHT DISTRIBUTION COMPARISON")
+    print("=" * 60)
+    weight_stats(weights_orig, "Original SIFT2")
+    weight_stats(weights_l0, "Lambda=0 (should match original)")
+    weight_stats(weights_mod, "Microstructure-weighted")
+
+    # --- Check 1: lambda=0 should produce identical weights ---
+    print("\n" + "=" * 60)
+    print("CHECK 1: Lambda=0 vs Original (identity check)")
+    print("=" * 60)
+    max_diff = np.max(np.abs(weights_orig - weights_l0))
+    mean_diff = np.mean(np.abs(weights_orig - weights_l0))
+    print(f"  Max absolute difference:  {max_diff:.2e}")
+    print(f"  Mean absolute difference: {mean_diff:.2e}")
+    if max_diff < 1e-10:
+        print("  PASS: Weights are numerically identical")
+    elif max_diff < 1e-6:
+        print("  PASS: Weights match within floating-point tolerance")
+    else:
+        print("  FAIL: Weights differ significantly!")
+
+    # --- Check 2: Low-MicroAF streamlines should get lower weights ---
+    print("\n" + "=" * 60)
+    print("CHECK 2: Microstructure prior effect")
+    print("=" * 60)
+
+    # Split streamlines into low and high MicroAF groups
+    median_microaf = np.median(microaf)
+    low_mask = microaf < median_microaf
+    high_mask = microaf >= median_microaf
+
+    # Weight ratios: modified / original
+    valid = (weights_orig > 0) & (weights_mod > 0)
+    ratio = np.where(valid, weights_mod / weights_orig, np.nan)
+
+    low_ratio = np.nanmean(ratio[low_mask & valid])
+    high_ratio = np.nanmean(ratio[high_mask & valid])
+
+    print(f"  Median MicroAF threshold: {median_microaf:.4f}")
+    print(f"  Low-MicroAF group  (n={np.sum(low_mask)}):  mean weight ratio (mod/orig) = {low_ratio:.4f}")
+    print(f"  High-MicroAF group (n={np.sum(high_mask)}): mean weight ratio (mod/orig) = {high_ratio:.4f}")
+
+    if low_ratio < high_ratio:
+        print("  PASS: Low-MicroAF streamlines receive systematically lower weights")
+    else:
+        print("  FAIL: Expected low-MicroAF streamlines to get lower relative weights")
+
+    # Correlation between MicroAF and weight change
+    valid_both = valid & np.isfinite(ratio)
+    if np.sum(valid_both) > 10:
+        corr = np.corrcoef(microaf[valid_both], ratio[valid_both])[0, 1]
+        print(f"  Correlation(MicroAF, weight_ratio): {corr:.4f}")
+        if corr > 0:
+            print("  PASS: Positive correlation confirms prior is working as intended")
+        else:
+            print("  WARNING: Expected positive correlation between MicroAF and weight ratio")
+
+    # --- Histogram comparison ---
+    print("\n" + "=" * 60)
+    print("WEIGHT HISTOGRAM (log-scale bins)")
+    print("=" * 60)
+    bins = np.logspace(-3, 2, 21)
+    hist_orig, _ = np.histogram(weights_orig[weights_orig > 0], bins=bins)
+    hist_mod, _ = np.histogram(weights_mod[weights_mod > 0], bins=bins)
+    print(f"  {'Bin range':>20s}  {'Original':>10s}  {'Modified':>10s}  {'Diff':>10s}")
+    for i in range(len(bins) - 1):
+        print(f"  {bins[i]:9.4f}-{bins[i+1]:9.4f}  {hist_orig[i]:10d}  {hist_mod[i]:10d}  {hist_mod[i]-hist_orig[i]:+10d}")
+
+    # --- Summary ---
+    print("\n" + "=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    print(f"  Output directory: {tmpdir}")
+    print(f"  Files: weights_original.txt, weights_lambda0.txt, weights_modified.txt")
+
+    print("\nValidation complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/dwi/tractography/SIFT2/line_search.cpp
+++ b/src/dwi/tractography/SIFT2/line_search.cpp
@@ -35,7 +35,9 @@ namespace MR {
         reg_tik (tckfactor.reg_multiplier_tikhonov),
         // Pre-scale reg_tv by total streamline contribution; each fixel then contributes (PM * length),
         //   and the whole thing is appropriately normalised
-        reg_tv  (tckfactor.reg_multiplier_tv / tckfactor.contributions[track_index]->get_total_contribution())
+        reg_tv  (tckfactor.reg_multiplier_tv / tckfactor.contributions[track_index]->get_total_contribution()),
+        reg_micro (tckfactor.reg_multiplier_micro),
+        micro_af (tckfactor.has_microstructure_weights() ? tckfactor.microstructure_weights[track_index] : 1.0)
       {
         const SIFT::TrackContribution& track_contribution = *tckfactor.contributions[track_index];
         for (size_t i = 0; i != track_contribution.dim(); ++i) {
@@ -82,6 +84,19 @@ namespace MR {
 
         data_result += tik_result;
         data_result += tv_result;
+
+        // Microstructure prior term: reg_micro * exp(coefficient) / MicroAF
+        // All derivatives of exp(c)/MicroAF w.r.t. c are identical: exp(c)/MicroAF
+        if (reg_micro > 0.0) {
+          const double micro_term = reg_micro * factor / micro_af;
+          Result micro_result;
+          micro_result.cost         = micro_term;
+          micro_result.first_deriv  = micro_term;
+          micro_result.second_deriv = micro_term;
+          micro_result.third_deriv  = micro_term;
+          data_result += micro_result;
+        }
+
         return data_result;
       }
 
@@ -96,7 +111,8 @@ namespace MR {
           cf_reg_tv += i->SL_eff * SIFT2::tvreg (Fs+dFs, i->meanFs);
         }
         const double cf_reg_tik = Math::pow2 (Fs+dFs);
-        return (cf_data + (reg_tik * cf_reg_tik) + (reg_tv * cf_reg_tv));
+        const double cf_reg_micro = (reg_micro > 0.0) ? (reg_micro * std::exp (Fs+dFs) / micro_af) : 0.0;
+        return (cf_data + (reg_tik * cf_reg_tik) + (reg_tv * cf_reg_tv) + cf_reg_micro);
       }
 
 

--- a/src/dwi/tractography/SIFT2/line_search.h
+++ b/src/dwi/tractography/SIFT2/line_search.h
@@ -77,7 +77,8 @@ namespace MR {
           const SIFT::track_t track_index;
           const double mu;
           const double Fs;
-          const double reg_tik, reg_tv;
+          const double reg_tik, reg_tv, reg_micro;
+          const double micro_af;
 
           vector<Fixel> fixels;
 

--- a/src/dwi/tractography/SIFT2/reg_calculator.cpp
+++ b/src/dwi/tractography/SIFT2/reg_calculator.cpp
@@ -31,29 +31,35 @@ namespace MR {
 
 
 
-      RegularisationCalculator::RegularisationCalculator (TckFactor& tckfactor, double& cf_reg_tik, double& cf_reg_tv) :
+      RegularisationCalculator::RegularisationCalculator (TckFactor& tckfactor, double& cf_reg_tik, double& cf_reg_tv, double& cf_reg_micro) :
         master (tckfactor),
         cf_reg_tik (cf_reg_tik),
         cf_reg_tv (cf_reg_tv),
+        cf_reg_micro (cf_reg_micro),
         tikhonov_sum (0.0),
-        tv_sum (0.0) { }
+        tv_sum (0.0),
+        micro_sum (0.0) { }
 
 
 
       RegularisationCalculator::~RegularisationCalculator()
       {
         std::lock_guard<std::mutex> lock (master.mutex);
-        cf_reg_tik += tikhonov_sum;
-        cf_reg_tv  += tv_sum;
+        cf_reg_tik   += tikhonov_sum;
+        cf_reg_tv    += tv_sum;
+        cf_reg_micro += micro_sum;
       }
 
 
 
       bool RegularisationCalculator::operator() (const SIFT::TrackIndexRange& range)
       {
+        const bool has_micro = master.has_microstructure_weights();
         for (SIFT::track_t track_index = range.first; track_index != range.second; ++track_index) {
           const double coefficient = master.coefficients[track_index];
           tikhonov_sum += Math::pow2 (coefficient);
+          if (has_micro)
+            micro_sum += std::exp (coefficient) / master.microstructure_weights[track_index];
           const SIFT::TrackContribution& this_contribution (*(master.contributions[track_index]));
           const double contribution_multiplier = 1.0 / this_contribution.get_total_contribution();
           double this_tv_sum = 0.0;

--- a/src/dwi/tractography/SIFT2/reg_calculator.h
+++ b/src/dwi/tractography/SIFT2/reg_calculator.h
@@ -37,7 +37,7 @@ namespace MR {
       { NOMEMALIGN
 
         public:
-          RegularisationCalculator (TckFactor&, double&, double&);
+          RegularisationCalculator (TckFactor&, double&, double&, double&);
           ~RegularisationCalculator();
 
           bool operator() (const SIFT::TrackIndexRange& range);
@@ -47,9 +47,10 @@ namespace MR {
           TckFactor& master;
           double& cf_reg_tik;
           double& cf_reg_tv;
+          double& cf_reg_micro;
 
           // Each thread needs a local copy of these
-          double tikhonov_sum, tv_sum;
+          double tikhonov_sum, tv_sum, micro_sum;
 
       };
 

--- a/src/dwi/tractography/SIFT2/tckfactor.cpp
+++ b/src/dwi/tractography/SIFT2/tckfactor.cpp
@@ -45,7 +45,7 @@ namespace MR {
 
 
 
-      void TckFactor::set_reg_lambdas (const double lambda_tikhonov, const double lambda_tv)
+      void TckFactor::set_reg_lambdas (const double lambda_tikhonov, const double lambda_tv, const double lambda_micro)
       {
         assert (num_tracks());
         double A = 0.0;
@@ -56,6 +56,32 @@ namespace MR {
         INFO ("Constant A scaling regularisation terms to match data term is " + str(A));
         reg_multiplier_tikhonov = lambda_tikhonov * A;
         reg_multiplier_tv       = lambda_tv * A;
+        reg_multiplier_micro    = lambda_micro * A;
+      }
+
+
+
+      void TckFactor::load_microstructure_weights (const std::string& path)
+      {
+        microstructure_weights = load_vector<default_type> (path);
+        if (size_t(microstructure_weights.size()) != num_tracks())
+          throw Exception ("Microstructure weighting file contains " + str(microstructure_weights.size()) +
+                           " values, but tractogram contains " + str(num_tracks()) + " streamlines");
+
+        size_t clamped_count = 0;
+        for (Eigen::Index i = 0; i != microstructure_weights.size(); ++i) {
+          if (microstructure_weights[i] < SIFT2_MICRO_AF_EPSILON) {
+            microstructure_weights[i] = SIFT2_MICRO_AF_EPSILON;
+            ++clamped_count;
+          }
+        }
+        if (clamped_count)
+          WARN (str(clamped_count) + " streamlines had MicroAF values below epsilon (" +
+                str(SIFT2_MICRO_AF_EPSILON) + ") and were clamped");
+
+        INFO ("Loaded microstructure weighting values for " + str(microstructure_weights.size()) + " streamlines"
+              " (range: " + str(microstructure_weights.minCoeff()) + " - " + str(microstructure_weights.maxCoeff()) +
+              ", mean: " + str(microstructure_weights.mean()) + ")");
       }
 
 
@@ -310,16 +336,17 @@ namespace MR {
           // Calculate the cost of regularisation, given the updates to both the
           //   streamline weighting coefficients and the new fixel mean coefficients
           // Log different regularisation costs separately
-          double cf_reg_tik = 0.0, cf_reg_tv = 0.0;
+          double cf_reg_tik = 0.0, cf_reg_tv = 0.0, cf_reg_micro = 0.0;
           {
             SIFT::TrackIndexRangeWriter writer (SIFT_TRACK_INDEX_BUFFER_SIZE, num_tracks());
-            RegularisationCalculator worker (*this, cf_reg_tik, cf_reg_tv);
+            RegularisationCalculator worker (*this, cf_reg_tik, cf_reg_tv, cf_reg_micro);
             Thread::run_queue (writer, SIFT::TrackIndexRange(), Thread::multi (worker));
           }
-          cf_reg_tik *= reg_multiplier_tikhonov;
-          cf_reg_tv  *= reg_multiplier_tv;
+          cf_reg_tik   *= reg_multiplier_tikhonov;
+          cf_reg_tv    *= reg_multiplier_tv;
+          cf_reg_micro *= reg_multiplier_micro;
 
-          cf_reg = cf_reg_tik + cf_reg_tv;
+          cf_reg = cf_reg_tik + cf_reg_tv + cf_reg_micro;
 
           new_cf = cf_data + cf_reg;
 

--- a/src/dwi/tractography/SIFT2/tckfactor.h
+++ b/src/dwi/tractography/SIFT2/tckfactor.h
@@ -36,6 +36,8 @@
 
 #define SIFT2_REGULARISATION_TIKHONOV_DEFAULT 0.0
 #define SIFT2_REGULARISATION_TV_DEFAULT 0.1
+#define SIFT2_REGULARISATION_MICRO_DEFAULT 0.05
+#define SIFT2_MICRO_AF_EPSILON 1e-6
 
 #define SIFT2_MIN_TD_FRAC_DEFAULT 0.10
 
@@ -65,6 +67,7 @@ namespace MR {
               SIFT::Model<Fixel> (fod_image, dirs),
               reg_multiplier_tikhonov (0.0),
               reg_multiplier_tv (0.0),
+              reg_multiplier_micro (0.0),
               min_iters (SIFT2_MIN_ITERS_DEFAULT),
               max_iters (SIFT2_MAX_ITERS_DEFAULT),
               min_coeff (SIFT2_MIN_COEFF_DEFAULT),
@@ -74,7 +77,9 @@ namespace MR {
               data_scale_term (0.0) { }
 
 
-          void set_reg_lambdas     (const double, const double);
+          void set_reg_lambdas     (const double, const double, const double = 0.0);
+          void load_microstructure_weights (const std::string&);
+          bool has_microstructure_weights() const { return microstructure_weights.size() > 0; }
           void set_min_iters       (const int    i) { min_iters = i; }
           void set_max_iters       (const int    i) { max_iters = i; }
           void set_min_factor      (const double i) { min_coeff = i ? std::log(i) : -std::numeric_limits<double>::infinity(); }
@@ -110,8 +115,9 @@ namespace MR {
 
         private:
           Eigen::Array<default_type, Eigen::Dynamic, 1> coefficients;
+          Eigen::Array<default_type, Eigen::Dynamic, 1> microstructure_weights;
 
-          double reg_multiplier_tikhonov, reg_multiplier_tv;
+          double reg_multiplier_tikhonov, reg_multiplier_tv, reg_multiplier_micro;
           size_t min_iters, max_iters;
           double min_coeff, max_coeff, max_coeff_step, min_cf_decrease_percentage;
           std::string csv_path;


### PR DESCRIPTION
Add an optional microstructure prior term to the SIFT2 objective function: λ₂ · Σ_i (w_i / MicroAF_i), which penalises high weights on streamlines with low microstructure values (MicroAF). Setting λ₂=0 recovers exactly the original SIFT2 behaviour.

New CLI flags:
- -microstructure_weighting <file>: per-streamline MicroAF values
- -microstructure_lambda <float>: prior strength (default: 0.05)

Includes epsilon clamping (1e-6) for near-zero MicroAF values and a Python validation script to verify correctness.

https://claude.ai/code/session_01E5zTwkVYQBPzdmWW5rjLPe

Please enter a concise description of the changes proposed in the pull request,
along with any relevant links to external discussions.

-  If your pull request involves fixing a bug, then the relevant code
   should be in a branch that is a derivative of `master`, and you should
   select `master` as the target branch in the pull request; for all other
   pull requests, the relevant code should be in a branch that is a
   derivative of `dev`, and you should select `dev` as the target branch
   of the pull request (assuming no other more appropriate branch exists).

-  If your proposed changes address an [existing Issue](https://github.com/MRtrix3/mrtrix3/issues)
   listed on GitHub, please add a reference to that Issue (a "`#`"
   character followed by the issue number).

-  If your proposed changes are not yet ready to be merged, but you are
   creating a pull request in order to initiate communications on such,
   please flag it as a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

-  You may optionally add `@mentions` of a person or team appropriate
   for reviewing proposed changes.
