### PR TITLE
mrregister: fix race condition in displacement update

### DIFF
--- a/src/registration/warp/compose.h
+++ b/src/registration/warp/compose.h
@@ -36,7 +36,7 @@ namespace MR
         class MaxNormSquaredFunctor { MEMALIGN(MaxNormSquaredFunctor)
           public:
             explicit MaxNormSquaredFunctor (default_type& overall_max_norm_squared) :
-                                            overall_max_norm_squared (overall_max_norm_squared),
+                                            overall_max_norm_squared (&overall_max_norm_squared),
                                             local_max_norm_squared (0.0) { }
 
             MaxNormSquaredFunctor (const MaxNormSquaredFunctor&) = default;
@@ -45,8 +45,8 @@ namespace MR
             MaxNormSquaredFunctor& operator= (MaxNormSquaredFunctor&&) = delete;
 
             ~MaxNormSquaredFunctor () {
-              std::lock_guard<std::mutex> lock (mutex());
-              overall_max_norm_squared = std::max (overall_max_norm_squared, local_max_norm_squared);
+              const std::lock_guard<std::mutex> lock (mutex());
+              *overall_max_norm_squared = std::max (*overall_max_norm_squared, local_max_norm_squared);
             }
 
             void operator() (Image<default_type>& update) {
@@ -63,7 +63,7 @@ namespace MR
               return max_norm_mutex;
             }
 
-            default_type& overall_max_norm_squared;
+            default_type* const overall_max_norm_squared;
             default_type local_max_norm_squared;
         };
 

--- a/src/registration/warp/compose.h
+++ b/src/registration/warp/compose.h
@@ -24,6 +24,7 @@
 #include "adapter/jacobian.h" //TODO remove after debug
 #include "registration/warp/helpers.h"
 #include "adapter/extract.h"
+#include <mutex>
 
 namespace MR
 {
@@ -31,6 +32,40 @@ namespace MR
   {
     namespace Warp
     {
+
+        class MaxNormSquaredFunctor { MEMALIGN(MaxNormSquaredFunctor)
+          public:
+            explicit MaxNormSquaredFunctor (default_type& overall_max_norm_squared) :
+                                            overall_max_norm_squared (overall_max_norm_squared),
+                                            local_max_norm_squared (0.0) { }
+
+            MaxNormSquaredFunctor (const MaxNormSquaredFunctor&) = default;
+            MaxNormSquaredFunctor (MaxNormSquaredFunctor&&) = default;
+            MaxNormSquaredFunctor& operator= (const MaxNormSquaredFunctor&) = delete;
+            MaxNormSquaredFunctor& operator= (MaxNormSquaredFunctor&&) = delete;
+
+            ~MaxNormSquaredFunctor () {
+              std::lock_guard<std::mutex> lock (mutex());
+              overall_max_norm_squared = std::max (overall_max_norm_squared, local_max_norm_squared);
+            }
+
+            void operator() (Image<default_type>& update) {
+              const default_type norm_squared = Eigen::Vector3d (update.row(3)).squaredNorm();
+              if (norm_squared > local_max_norm_squared)
+                local_max_norm_squared = norm_squared;
+            }
+
+          private:
+            // One shared mutex per translation unit that instantiates this function
+            // When we upgrade to C++17, we should just use `inline static max_norm_mutex`.
+            static std::mutex& mutex() {
+              static std::mutex max_norm_mutex;
+              return max_norm_mutex;
+            }
+
+            default_type& overall_max_norm_squared;
+            default_type local_max_norm_squared;
+        };
 
         class ComposeLinearDeformKernel { MEMALIGN(ComposeLinearDeformKernel)
           public:
@@ -160,13 +195,9 @@ namespace MR
       {
         check_dimensions (input, output, 0, 3);
 
-        default_type max_norm = 0.0;
-        auto max_norm_func = [&max_norm](Image<default_type>& update) {
-          default_type norm = Eigen::Vector3d (update.row(3)).norm();
-          if (norm > max_norm)
-            max_norm = norm;
-        };
-        ThreadedLoop (update).run (max_norm_func, update);
+        default_type max_norm_squared = 0.0;
+        ThreadedLoop (update).run (MaxNormSquaredFunctor (max_norm_squared), update);
+        const default_type max_norm = std::sqrt (max_norm_squared);
         default_type min_vox_size = static_cast<default_type> (std::min (input.spacing(0), std::min (input.spacing(1), input.spacing(2))));
 
         // if the maximum update is larger than half a voxel, perform scaling and squaring to ensure the displacement field remains diffeomorphic


### PR DESCRIPTION
The following race condition was identified with TSAN:

```
WARNING: ThreadSanitizer: data race (pid=24689)
  Write of size 8 at 0x00016d515ac0 by thread T306:
    #0 MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>::operator()(MR::Iterator const&) <null>:90187328 (libmrtrix-core.dylib:arm64+0x52d0b8)
    #1 void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread::execute() <null>:90187328 (libmrtrix-core.dylib:arm64+0x52e168)
    #2 std::__1::__async_assoc_state<void, std::__1::__async_func<void (void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread::*)(), void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread*>>::__execute() <null>:90187328 (libmrtrix-core.dylib:arm64+0x52e510)
    #3 void* std::__1::__thread_proxy[abi:ne180100]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (std::__1::__async_assoc_state<void, std::__1::__async_func<void (void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread::*)(), void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread*>>::*)(), std::__1::__async_assoc_state<void, std::__1::__async_func<void (void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread::*)(), void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread*>>*>>(void*) <null>:90187328 (libmrtrix-core.dylib:arm64+0x52e628)

  Previous read of size 8 at 0x00016d515ac0 by thread T310:
    #0 MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>::operator()(MR::Iterator const&) <null>:90187328 (libmrtrix-core.dylib:arm64+0x52d0a4)
    #1 void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread::execute() <null>:90187328 (libmrtrix-core.dylib:arm64+0x52e168)
    #2 std::__1::__async_assoc_state<void, std::__1::__async_func<void (void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread::*)(), void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread*>>::__execute() <null>:90187328 (libmrtrix-core.dylib:arm64+0x52e510)
    #3 void* std::__1::__thread_proxy[abi:ne180100]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (std::__1::__async_assoc_state<void, std::__1::__async_func<void (void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread::*)(), void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread*>>::*)(), std::__1::__async_assoc_state<void, std::__1::__async_func<void (void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread::*)(), void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread*>>*>>(void*) <null>:90187328 (libmrtrix-core.dylib:arm64+0x52e628)

  Location is stack of main thread.

  Thread T306 (tid=13272096, running) created by main thread at:
    #0 pthread_create <null>:93330752 (libclang_rt.tsan_osx_dynamic.dylib:arm64e+0x309d8)
    #1 std::__1::future<std::__1::__invoke_of<__decay(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&), __decay(void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread*)>::type> std::__1::async[abi:ne180100]<void (void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread::*)(), void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread*>(std::__1::launch, MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&, void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread*&&) <null>:90187520 (libmrtrix-core.dylib:arm64+0x52dd98)
    #2 void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run<MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&)&, MR::Image<double>&>(MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&)&, MR::Image<double>&) <null>:90187520 (libmrtrix-core.dylib:arm64+0x52ac6c)
    #3 void MR::Registration::NonLinear::run<MR::Registration::Transform::Rigid, MR::Image<double>, MR::Image<double>, MR::Image<double>, MR::Image<double>>(MR::Registration::Transform::Rigid, MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, MR::Image<double>&) <null>:90187520 (libmrtrix-core.dylib:arm64+0x4fc40c)
    #4 void MR::Registration::NonLinear::run<MR::Registration::Transform::Rigid, MR::Image<double>, MR::Image<double>, MR::Image<double>, MR::Image<double>>(MR::Registration::Transform::Rigid, MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, MR::Image<double>&) <null>:90187520 (libmrtrix-core.dylib:arm64+0x4f7e94)
    #5 run() <null>:91235072 (mrregister:arm64+0x100013014)
    #6 run() <null>:91235072 (mrregister:arm64+0x1000083ec)
    #7 <null> <null> (0x000185b48274)

  Thread T310 (tid=13272100, running) created by main thread at:
    #0 pthread_create <null>:93332048 (libclang_rt.tsan_osx_dynamic.dylib:arm64e+0x309d8)
    #1 std::__1::future<std::__1::__invoke_of<__decay(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&), __decay(void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread*)>::type> std::__1::async[abi:ne180100]<void (void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread::*)(), void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread*>(std::__1::launch, MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&, void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread*&&) <null>:90187328 (libmrtrix-core.dylib:arm64+0x52dd98)
    #2 void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run<MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&)&, MR::Image<double>&>(MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&)&, MR::Image<double>&) <null>:90187328 (libmrtrix-core.dylib:arm64+0x52ac6c)
    #3 void MR::Registration::NonLinear::run<MR::Registration::Transform::Rigid, MR::Image<double>, MR::Image<double>, MR::Image<double>, MR::Image<double>>(MR::Registration::Transform::Rigid, MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, MR::Image<double>&) <null>:90187328 (libmrtrix-core.dylib:arm64+0x4fc40c)
    #4 void MR::Registration::NonLinear::run<MR::Registration::Transform::Rigid, MR::Image<double>, MR::Image<double>, MR::Image<double>, MR::Image<double>>(MR::Registration::Transform::Rigid, MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, MR::Image<double>&) <null>:90187328 (libmrtrix-core.dylib:arm64+0x4f7e94)
    #5 run() <null>:91230992 (mrregister:arm64+0x100013014)
    #6 run() <null>:91230992 (mrregister:arm64+0x1000083ec)
    #7 <null> <null> (0x000185b48274)

SUMMARY: ThreadSanitizer: data race (libmrtrix-core.dylib:arm64+0x52d0b8) in MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>::operator()(MR::Iterator const&)+0x34c
==================
==================
WARNING: ThreadSanitizer: data race (pid=24689)
  Write of size 8 at 0x00016d515ac0 by thread T312:
    #0 MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>::operator()(MR::Iterator const&) <null>:90187520 (libmrtrix-core.dylib:arm64+0x52d0b8)
    #1 void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread::execute() <null>:90187520 (libmrtrix-core.dylib:arm64+0x52e168)
    #2 std::__1::__async_assoc_state<void, std::__1::__async_func<void (void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread::*)(), void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread*>>::__execute() <null>:90187520 (libmrtrix-core.dylib:arm64+0x52e510)
    #3 void* std::__1::__thread_proxy[abi:ne180100]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (std::__1::__async_assoc_state<void, std::__1::__async_func<void (void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread::*)(), void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread*>>::*)(), std::__1::__async_assoc_state<void, std::__1::__async_func<void (void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread::*)(), void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread*>>*>>(void*) <null>:90187520 (libmrtrix-core.dylib:arm64+0x52e628)

  Previous write of size 8 at 0x00016d515ac0 by thread T310:
    #0 MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>::operator()(MR::Iterator const&) <null>:90187520 (libmrtrix-core.dylib:arm64+0x52d0b8)
    #1 void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread::execute() <null>:90187520 (libmrtrix-core.dylib:arm64+0x52e168)
    #2 std::__1::__async_assoc_state<void, std::__1::__async_func<void (void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread::*)(), void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread*>>::__execute() <null>:90187520 (libmrtrix-core.dylib:arm64+0x52e510)
    #3 void* std::__1::__thread_proxy[abi:ne180100]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (std::__1::__async_assoc_state<void, std::__1::__async_func<void (void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread::*)(), void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread*>>::*)(), std::__1::__async_assoc_state<void, std::__1::__async_func<void (void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread::*)(), void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread*>>*>>(void*) <null>:90187520 (libmrtrix-core.dylib:arm64+0x52e628)

  Location is stack of main thread.

  Thread T312 (tid=13272102, running) created by main thread at:
    #0 pthread_create <null>:93332048 (libclang_rt.tsan_osx_dynamic.dylib:arm64e+0x309d8)
    #1 std::__1::future<std::__1::__invoke_of<__decay(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&), __decay(void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread*)>::type> std::__1::async[abi:ne180100]<void (void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread::*)(), void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread*>(std::__1::launch, MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&, void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread*&&) <null>:90177536 (libmrtrix-core.dylib:arm64+0x52dd98)
    #2 void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run<MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&)&, MR::Image<double>&>(MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&)&, MR::Image<double>&) <null>:90177536 (libmrtrix-core.dylib:arm64+0x52af14)
    #3 void MR::Registration::NonLinear::run<MR::Registration::Transform::Rigid, MR::Image<double>, MR::Image<double>, MR::Image<double>, MR::Image<double>>(MR::Registration::Transform::Rigid, MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, MR::Image<double>&) <null>:90177536 (libmrtrix-core.dylib:arm64+0x4fc40c)
    #4 void MR::Registration::NonLinear::run<MR::Registration::Transform::Rigid, MR::Image<double>, MR::Image<double>, MR::Image<double>, MR::Image<double>>(MR::Registration::Transform::Rigid, MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, MR::Image<double>&) <null>:90177536 (libmrtrix-core.dylib:arm64+0x4f7e94)
    #5 run() <null>:91230992 (mrregister:arm64+0x100013014)
    #6 run() <null>:91230992 (mrregister:arm64+0x1000083ec)
    #7 <null> <null> (0x000185b48274)

  Thread T310 (tid=13272100, running) created by main thread at:
    #0 pthread_create <null>:93330752 (libclang_rt.tsan_osx_dynamic.dylib:arm64e+0x309d8)
    #1 std::__1::future<std::__1::__invoke_of<__decay(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&), __decay(void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread*)>::type> std::__1::async[abi:ne180100]<void (void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread::*)(), void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread*>(std::__1::launch, MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&, void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run_outer<MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&>(MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>&)::PerThread*&&) <null>:90187520 (libmrtrix-core.dylib:arm64+0x52dd98)
    #2 void MR::(anonymous namespace)::ThreadedLoopRunOuter<MR::LoopAlongDynamicAxes>::run<MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&)&, MR::Image<double>&>(MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&)&, MR::Image<double>&) <null>:90187520 (libmrtrix-core.dylib:arm64+0x52ac6c)
    #3 void MR::Registration::NonLinear::run<MR::Registration::Transform::Rigid, MR::Image<double>, MR::Image<double>, MR::Image<double>, MR::Image<double>>(MR::Registration::Transform::Rigid, MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, MR::Image<double>&) <null>:90187520 (libmrtrix-core.dylib:arm64+0x4fc40c)
    #4 void MR::Registration::NonLinear::run<MR::Registration::Transform::Rigid, MR::Image<double>, MR::Image<double>, MR::Image<double>, MR::Image<double>>(MR::Registration::Transform::Rigid, MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, MR::Image<double>&) <null>:90187520 (libmrtrix-core.dylib:arm64+0x4f7e94)
    #5 run() <null>:91235072 (mrregister:arm64+0x100013014)
    #6 run() <null>:91235072 (mrregister:arm64+0x1000083ec)
    #7 <null> <null> (0x000185b48274)

SUMMARY: ThreadSanitizer: data race (libmrtrix-core.dylib:arm64+0x52d0b8) in MR::(anonymous namespace)::ThreadedLoopRunInner<1, MR::Registration::Warp::update_displacement_scaling_and_squaring(MR::Image<double>&, MR::Image<double>&, MR::Image<double>&, double)::'lambda'(MR::Image<double>&), MR::Image<double>>::operator()(MR::Iterator const&)+0x34c
```

The cause was this piece of code:

```
  auto max_norm_func = [&max_norm](Image<default_type> &update) {
    default_type norm = Eigen::Vector3d(update.row(3)).norm();
    if (norm > max_norm)
      max_norm = norm;
  };
  ThreadedLoop(update).run(max_norm_func, update);
```

Here, `max_norm` is a local stack variable. The lambda captures it by reference thus the variable is subject to reads/writes from different threads without any synchronisation. This PR fixes the problem by replacing the shared max norm lambda with a thread local functor reduction and mutex-protected merge. Also rather than computing as square root inside the functor, we compute the squared norm and only at the end evaluate the square root.