### PR TITLE
Fix intermediate image visualisation

### DIFF
--- a/core/file/utils.h
+++ b/core/file/utils.h
@@ -212,19 +212,32 @@ namespace MR
 
 
 
+    inline std::string name_tempfile (const char* suffix = NULL) {
+      std::string filename (Path::join (tmpfile_dir(), tmpfile_prefix()) + "XXXXXX.");
+      int rand_index = filename.size() - 7;
+      if (suffix)
+        filename += suffix;
+
+      int fid(0);
+      do {
+        for (int n = 0; n < 6; n++)
+          filename[rand_index + n] = random_char();
+        fid = open(filename.c_str(), O_RDONLY, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
+      } while (fid >= 0);
+
+      return filename;
+    }
+
+
 
     inline std::string create_tempfile (int64_t size = 0, const char* suffix = NULL)
     {
       DEBUG ("creating temporary file of size " + str (size));
 
-      std::string filename (Path::join (tmpfile_dir(), tmpfile_prefix()) + "XXXXXX.");
-      int rand_index = filename.size() - 7;
-      if (suffix) filename += suffix;
-
-      int fid;
+      int fid(0);
+      std::string filename;
       do {
-        for (int n = 0; n < 6; n++)
-          filename[rand_index+n] = random_char();
+        filename = name_tempfile(suffix);
         fid = open (filename.c_str(), O_CREAT | O_RDWR | O_EXCL, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
       } while (fid < 0 && errno == EEXIST);
 

--- a/core/image.h
+++ b/core/image.h
@@ -539,7 +539,7 @@ namespace MR
   //! display the contents of an image in MRView (for debugging only)
   template <class ImageType>
     typename enable_if_image_type<ImageType,void>::type display (ImageType& x) {
-      std::string filename = save (x, "-");
+      std::string filename = save (x, File::name_tempfile(".mif"));
       CONSOLE ("displaying image \"" + filename + "\"");
       if (system (("bash -c \"mrview " + filename + "\"").c_str()))
         WARN (std::string("error invoking viewer: ") + strerror(errno));


### PR DESCRIPTION
If either `mrregister` or `mrfilter zclean` is run with the `-debug` option, the command invokes `MR::display(ImageType)`, which writes an intermediate image to a temporary file and then invokes `system(bash -c mrview)` to visualise it.

However it achieved this by writing to an image named "`-`", which would invoke the pipe format handler. This handler now ensures that there is something at the receiving end of the stdout pipe, and throws an Exception if there is not. This resulted in failure of either of these commands if run with the `-debug` option.

With this change, those intermediate images are instead written to an explicitly named temporary image file. By default `mrview` will still delete it once it's done with it; it's just ensuring that the MRtrix image format handler is invoked rather than the pipe handler.

Technically there's a small race condition here in that there's a delay between finding an unused temporary file name and the format handler then attempting to create that file. But the probability of that causing problems is very low. And atomicity of `create_tempfile()` should be preserved.