### PR TITLE
Further fixes for nightly binaries on dev

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -135,12 +135,7 @@ if(MRTRIX_ENABLE_GPU)
         )
         FetchContent_MakeAvailable(dawn)
 
-        # On Linux, Dawn prebuilt packages use lib64; others use lib
-        if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-            set(DAWN_LIB_DIR_NAME "lib64")
-        else()
-            set(DAWN_LIB_DIR_NAME "lib")
-        endif()
+        set(DAWN_LIB_DIR_NAME "lib")
         set(
           Dawn_DIR
           "${dawn_SOURCE_DIR}/${DAWN_LIB_DIR_NAME}/cmake/Dawn"

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1,4 +1,6 @@
 include(FetchContent)
+include(MacOSUniversalSlang)
+
 
 # Eigen
 if(MRTRIX_USE_SYSTEM_EIGEN)
@@ -148,11 +150,14 @@ if(MRTRIX_ENABLE_GPU)
 
     # Slang
 
-    find_package(slang QUIET)
-
-    if(NOT MRTRIX_USE_SYSTEM_SLANG)
+    if(MRTRIX_USE_SYSTEM_SLANG)
+        find_package(slang CONFIG REQUIRED)
+    else()
         message(STATUS "Downloading prebuilt binaries for Slang...")
         set(SLANG_VERSION "2026.5.1" CACHE STRING "Slang version to download from GitHub releases")
+        set(SLANG_DOWNLOAD_URL_PREFIX
+            "https://github.com/shader-slang/slang/releases/download/v${SLANG_VERSION}"
+        )
 
         if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
             set(SLANG_OS "linux")
@@ -162,31 +167,54 @@ if(MRTRIX_ENABLE_GPU)
             set(SLANG_OS "windows")
         endif()
 
-        if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
+        set(slang_use_universal FALSE)
+        if(APPLE AND CMAKE_OSX_ARCHITECTURES)
+            set(slang_requested_arches ${CMAKE_OSX_ARCHITECTURES})
+            list(LENGTH slang_requested_arches slang_requested_arch_count)
+
+            if("x86_64" IN_LIST slang_requested_arches AND "arm64" IN_LIST slang_requested_arches)
+                set(slang_use_universal TRUE)
+            elseif(slang_requested_arch_count GREATER 1)
+                message(FATAL_ERROR "Unsupported macOS architecture set for bundled Slang: ${CMAKE_OSX_ARCHITECTURES}")
+            elseif("arm64" IN_LIST slang_requested_arches)
+                set(SLANG_ARCH "aarch64")
+            else()
+                set(SLANG_ARCH "x86_64")
+            endif()
+        elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
             set(SLANG_ARCH "aarch64")
         else()
             set(SLANG_ARCH "x86_64")
         endif()
 
-        set(SLANG_SUBSTRING "-${SLANG_OS}-${SLANG_ARCH}")
+        if(slang_use_universal)
+            message(STATUS "Downloading Slang ${SLANG_VERSION} (macos/x86_64 + macos/aarch64)...")
 
-        set(SLANG_DOWNLOAD_LINK
-          "https://github.com/shader-slang/slang/releases/download/v${SLANG_VERSION}/slang-${SLANG_VERSION}${SLANG_SUBSTRING}.zip"
-        )
+            mrtrix_prepare_universal_slang(
+                "${SLANG_DOWNLOAD_URL_PREFIX}/slang-${SLANG_VERSION}-macos-x86_64.zip"
+                "${SLANG_DOWNLOAD_URL_PREFIX}/slang-${SLANG_VERSION}-macos-aarch64.zip"
+                slang_root
+            )
+        else()
+            set(slang_download_url
+                "${SLANG_DOWNLOAD_URL_PREFIX}/slang-${SLANG_VERSION}-${SLANG_OS}-${SLANG_ARCH}.zip"
+            )
 
-        message(STATUS "Downloading Slang ${SLANG_VERSION} (${SLANG_OS}/${SLANG_ARCH})...")
+            message(STATUS "Downloading Slang ${SLANG_VERSION} (${SLANG_OS}/${SLANG_ARCH})...")
 
-        FetchContent_Declare(
-          slang
-            DOWNLOAD_NO_PROGRESS         1
-            URL                          ${SLANG_DOWNLOAD_LINK}
-        )
-        FetchContent_MakeAvailable(slang)
+            FetchContent_Declare(
+              slang
+                DOWNLOAD_NO_PROGRESS         1
+                URL                          ${slang_download_url}
+            )
+            FetchContent_MakeAvailable(slang)
+            set(slang_root "${slang_SOURCE_DIR}")
+        endif()
 
         if(WIN32)
-            set(slang_DIR_PATH "${slang_SOURCE_DIR}/cmake")
+            set(slang_DIR_PATH "${slang_root}/cmake")
         else()
-            set(slang_DIR_PATH "${slang_SOURCE_DIR}/lib/cmake/slang")
+            set(slang_DIR_PATH "${slang_root}/lib/cmake/slang")
         endif()
 
         set(

--- a/cmake/MacOSUniversalSlang.cmake
+++ b/cmake/MacOSUniversalSlang.cmake
@@ -1,4 +1,6 @@
-# CMake module to prepare a universal binary version of the Slang library for macOS.
+# CMake helpers for Slang package preparation, including macOS universal binary staging.
+include_guard(GLOBAL)
+
 include(FetchContent)
 
 function(mrtrix_lipo_merge input_x86_64 input_arm64 output_file)
@@ -21,18 +23,16 @@ function(mrtrix_lipo_merge input_x86_64 input_arm64 output_file)
     endif()
 endfunction()
 
-function(mrtrix_prepare_universal_slang slang_version out_var)
-    set(slang_url_base "https://github.com/shader-slang/slang/releases/download/v${slang_version}")
-
+function(mrtrix_prepare_universal_slang slang_x86_64_url slang_aarch64_url out_var)
     FetchContent_Declare(
         slang_x86_64
         DOWNLOAD_NO_PROGRESS 1
-        URL "${slang_url_base}/slang-${slang_version}-macos-x86_64.zip"
+        URL "${slang_x86_64_url}"
     )
     FetchContent_Declare(
         slang_aarch64
         DOWNLOAD_NO_PROGRESS 1
-        URL "${slang_url_base}/slang-${slang_version}-macos-aarch64.zip"
+        URL "${slang_aarch64_url}"
     )
     FetchContent_MakeAvailable(slang_x86_64 slang_aarch64)
 
@@ -70,5 +70,5 @@ function(mrtrix_prepare_universal_slang slang_version out_var)
         endif()
     endforeach()
 
-    set(${out_var} "${staged_dir}/lib/cmake/slang" PARENT_SCOPE)
+    set(${out_var} "${staged_dir}" PARENT_SCOPE)
 endfunction()

--- a/cmake/MacOSUniversalSlang.cmake
+++ b/cmake/MacOSUniversalSlang.cmake
@@ -1,0 +1,74 @@
+# CMake module to prepare a universal binary version of the Slang library for macOS.
+include(FetchContent)
+
+function(mrtrix_lipo_merge input_x86_64 input_arm64 output_file)
+    find_program(MRTRIX_LIPO_EXECUTABLE lipo REQUIRED)
+
+    get_filename_component(output_dir "${output_file}" DIRECTORY)
+    file(MAKE_DIRECTORY "${output_dir}")
+
+    execute_process(
+        COMMAND "${MRTRIX_LIPO_EXECUTABLE}" -create "${input_x86_64}" "${input_arm64}" -output "${output_file}"
+        RESULT_VARIABLE lipo_result
+        ERROR_VARIABLE lipo_error
+    )
+
+    if(NOT lipo_result EQUAL 0)
+        message(FATAL_ERROR
+            "Failed to create universal binary '${output_file}' from '${input_x86_64}' and '${input_arm64}':\n"
+            "${lipo_error}"
+        )
+    endif()
+endfunction()
+
+function(mrtrix_prepare_universal_slang slang_version out_var)
+    set(slang_url_base "https://github.com/shader-slang/slang/releases/download/v${slang_version}")
+
+    FetchContent_Declare(
+        slang_x86_64
+        DOWNLOAD_NO_PROGRESS 1
+        URL "${slang_url_base}/slang-${slang_version}-macos-x86_64.zip"
+    )
+    FetchContent_Declare(
+        slang_aarch64
+        DOWNLOAD_NO_PROGRESS 1
+        URL "${slang_url_base}/slang-${slang_version}-macos-aarch64.zip"
+    )
+    FetchContent_MakeAvailable(slang_x86_64 slang_aarch64)
+
+    set(staged_dir "${CMAKE_BINARY_DIR}/_deps/slang-universal")
+    file(REMOVE_RECURSE "${staged_dir}")
+
+    execute_process(
+        COMMAND "${CMAKE_COMMAND}" -E copy_directory "${slang_aarch64_SOURCE_DIR}" "${staged_dir}"
+        RESULT_VARIABLE copy_result
+        ERROR_VARIABLE copy_error
+    )
+
+    if(NOT copy_result EQUAL 0)
+        message(FATAL_ERROR
+            "Failed to stage universal Slang package from '${slang_aarch64_SOURCE_DIR}' to '${staged_dir}':\n"
+            "${copy_error}"
+        )
+    endif()
+
+    set(slang_macho_files
+        bin/slangc
+        bin/slangd
+        bin/slangi
+    )
+    file(GLOB slang_dylibs RELATIVE "${slang_x86_64_SOURCE_DIR}" "${slang_x86_64_SOURCE_DIR}/lib/*.dylib")
+    list(APPEND slang_macho_files ${slang_dylibs})
+    list(REMOVE_DUPLICATES slang_macho_files)
+
+    foreach(relpath IN LISTS slang_macho_files)
+        set(input_x86_64 "${slang_x86_64_SOURCE_DIR}/${relpath}")
+        set(input_arm64 "${slang_aarch64_SOURCE_DIR}/${relpath}")
+
+        if(EXISTS "${input_x86_64}" AND EXISTS "${input_arm64}")
+            mrtrix_lipo_merge("${input_x86_64}" "${input_arm64}" "${staged_dir}/${relpath}")
+        endif()
+    endforeach()
+
+    set(${out_var} "${staged_dir}/lib/cmake/slang" PARENT_SCOPE)
+endfunction()


### PR DESCRIPTION
- Fix universal builds on macOS.
- New CMake module for constructing Slang universal binaries.
- Fix broken builds due to changes in Dawn binary artefacts.