### PR TITLE
Change ThreadedLoop to default to 2 inner axes

### DIFF
--- a/cpp/cmd/5ttedit.cpp
+++ b/cpp/cmd/5ttedit.cpp
@@ -246,5 +246,5 @@ void run() {
   if (!opt.empty())
     modifier.set_none_mask(opt[0][0]);
 
-  ThreadedLoop("Modifying ACT 5TT image", in, 0, 3, 2).run(modifier);
+  ThreadedLoop("Modifying ACT 5TT image", in, 0, 3).run(modifier);
 }

--- a/cpp/cmd/dwi2fod.cpp
+++ b/cpp/cmd/dwi2fod.cpp
@@ -294,7 +294,7 @@ void run() {
 
     CSD_Processor processor(shared, mask, dwi_modelled);
     auto dwi = header_in.get_image<float>().with_direct_io(3);
-    ThreadedLoop("performing constrained spherical deconvolution", dwi, 0, 3).run(processor, dwi, fod);
+    ThreadedLoop("performing constrained spherical deconvolution", dwi, 0, 3, 1).run(processor, dwi, fod);
     break;
   }
   case Algorithm::MSMT_CSD: {
@@ -336,7 +336,8 @@ void run() {
                      ", " + str(num_tissues) + " tissue" + (num_tissues > 1 ? "s" : "") + ")",
                  dwi,
                  0,
-                 3)
+                 3,
+                 1)
         .run(processor, dwi);
     break;
   }

--- a/cpp/cmd/dwi2tensor.cpp
+++ b/cpp/cmd/dwi2tensor.cpp
@@ -344,5 +344,5 @@ void run() {
   }
 
   auto dwi = header_in.get_image<value_type>();
-  ThreadedLoop("computing tensors", dwi, 0, 3).run(processor(A, Aneq, ols, iter, mask, b0, dt, dkt, predict), dwi);
+  ThreadedLoop("computing tensors", dwi, 0, 3, 1).run(processor(A, Aneq, ols, iter, mask, b0, dt, dkt, predict), dwi);
 }

--- a/cpp/cmd/dwidenoise.cpp
+++ b/cpp/cmd/dwidenoise.cpp
@@ -299,7 +299,7 @@ void process_image(Header &data,
   auto output = Image<T>::create(output_name, header);
   // run
   DenoisingFunctor<T> func(data.size(3), extent, mask, noise, rank, exp1);
-  ThreadedLoop("running MP-PCA denoising", data, 0, 3).run(func, input, output);
+  ThreadedLoop("running MP-PCA denoising", data, 0, 3, 1).run(func, input, output);
 }
 
 void run() {

--- a/cpp/cmd/fod2dec.cpp
+++ b/cpp/cmd/fod2dec.cpp
@@ -317,5 +317,5 @@ void run() {
     w_img = map_hdr.get_image<value_type>();
 
   if (w_img.valid() || needtolum || needtoslice)
-    ThreadedLoop("(re)weighting", out_img, 0, 3, 2).run(DecWeighter(coefs, gamma, w_img), out_img);
+    ThreadedLoop("(re)weighting", out_img, 0, 3).run(DecWeighter(coefs, gamma, w_img), out_img);
 }

--- a/cpp/cmd/mrcalc.cpp
+++ b/cpp/cmd/mrcalc.cpp
@@ -919,7 +919,7 @@ void run_operations(const std::vector<StackEntry> &stack) {
 
   auto output = Header::create(stack[1].arg, header).get_image<complex_type>();
 
-  auto loop = ThreadedLoop("computing: " + operation_string(stack[0]), output, 0, output.ndim(), 2);
+  auto loop = ThreadedLoop("computing: " + operation_string(stack[0]), output);
 
   ThreadFunctor functor(loop.inner_axes, stack[0], output);
   loop.run_outer(functor);

--- a/cpp/cmd/mtnormalise.cpp
+++ b/cpp/cmd/mtnormalise.cpp
@@ -248,7 +248,7 @@ Eigen::MatrixXd initialise_basis(IndexType &index, size_t num_voxels, int order)
   Transform transform(index);
   Eigen::MatrixXd basis(num_voxels, num_basis_vec_for_order(order));
 
-  ThreadedLoop(index, 0, 3, 2).run(BasisInitialiser(transform, basis_function, basis), index);
+  ThreadedLoop(index, 0, 3).run(BasisInitialiser(transform, basis_function, basis), index);
   return basis;
 }
 
@@ -271,7 +271,7 @@ void load_data(Eigen::MatrixXd &data, std::string_view image_name, IndexType &in
     const int num;
   };
 
-  ThreadedLoop(in, 0, 3, 2).run(Loader(data, num), in, index);
+  ThreadedLoop(in, 0, 3).run(Loader(data, num), in, index);
   ++num;
 }
 

--- a/cpp/cmd/sh2amp.cpp
+++ b/cpp/cmd/sh2amp.cpp
@@ -177,7 +177,7 @@ void run() {
     auto transform = Math::SH::init_transform(directions, lmax);
 
     SH2Amp sh2amp(transform, nonnegative);
-    ThreadedLoop("computing amplitudes", sh_data, 0, 3, 2).run(sh2amp, sh_data, amp_data);
+    ThreadedLoop("computing amplitudes", sh_data, 0, 3).run(sh2amp, sh_data, amp_data);
 
   } else { // full gradient scheme:
 

--- a/cpp/core/algo/random_threaded_loop.h
+++ b/cpp/core/algo/random_threaded_loop.h
@@ -23,6 +23,7 @@
 
 #include "algo/iterator.h"
 #include "algo/loop.h"
+#include "algo/threaded_loop.h"
 #include "debug.h"
 #include "exception.h"
 #include "math/rng.h"

--- a/cpp/core/algo/random_threaded_loop.h
+++ b/cpp/core/algo/random_threaded_loop.h
@@ -16,15 +16,17 @@
 
 #pragma once
 
+#include <algorithm> // std::shuffle
+#include <optional>
+#include <random>
+#include <tuple>
+
 #include "algo/iterator.h"
 #include "algo/loop.h"
 #include "debug.h"
 #include "exception.h"
 #include "math/rng.h"
 #include "thread.h"
-#include <algorithm> // std::shuffle
-#include <random>
-#include <tuple>
 // #include "algo/random_loop.h"
 
 namespace MR {
@@ -198,9 +200,14 @@ inline RandomThreadedLoopRunOuter<decltype(Loop(std::vector<size_t>()))> RandomT
 }
 
 template <class HeaderType>
-inline RandomThreadedLoopRunOuter<decltype(Loop(std::vector<size_t>()))>
-RandomThreadedLoop(const HeaderType &source, const std::vector<size_t> &axes, size_t num_inner_axes = 1) {
-  return {source, Loop(get_outer_axes(axes, num_inner_axes)), get_inner_axes(axes, num_inner_axes)};
+inline RandomThreadedLoopRunOuter<decltype(Loop(std::vector<size_t>()))> RandomThreadedLoop(
+    const HeaderType &source, const std::vector<size_t> &axes, std::optional<size_t> num_inner_axes = std::nullopt) {
+  if (num_inner_axes.has_value()) {
+    assert(*num_inner_axes <= axes.size());
+  } else {
+    *num_inner_axes = axes.size() > 2 ? 2 : 1;
+  }
+  return {source, Loop(get_outer_axes(axes, *num_inner_axes)), get_inner_axes(axes, *num_inner_axes)};
 }
 
 template <class HeaderType>
@@ -208,10 +215,16 @@ inline RandomThreadedLoopRunOuter<decltype(Loop(std::vector<size_t>()))>
 RandomThreadedLoop(const HeaderType &source,
                    size_t from_axis = 0,
                    size_t to_axis = std::numeric_limits<size_t>::max(),
-                   size_t num_inner_axes = 1) {
+                   std::optional<size_t> num_inner_axes = std::nullopt) {
+  const size_t num_axes = (to_axis == std::numeric_limits<size_t>::max() ? source.ndim() : to_axis) - from_axis;
+  if (num_inner_axes.has_value()) {
+    assert(*num_inner_axes <= num_axes);
+  } else {
+    *num_inner_axes = num_axes > 2 ? 2 : 1;
+  }
   return {source,
-          Loop(get_outer_axes(source, num_inner_axes, from_axis, to_axis)),
-          get_inner_axes(source, num_inner_axes, from_axis, to_axis)};
+          Loop(get_outer_axes(source, *num_inner_axes, from_axis, to_axis)),
+          get_inner_axes(source, *num_inner_axes, from_axis, to_axis)};
 }
 
 template <class HeaderType>
@@ -228,8 +241,13 @@ inline RandomThreadedLoopRunOuter<decltype(Loop("", std::vector<size_t>()))>
 RandomThreadedLoop(std::string_view progress_message,
                    const HeaderType &source,
                    const std::vector<size_t> &axes,
-                   size_t num_inner_axes = 1) {
-  return {source, Loop(progress_message, get_outer_axes(axes, num_inner_axes)), get_inner_axes(axes, num_inner_axes)};
+                   std::optional<size_t> num_inner_axes = std::nullopt) {
+  if (num_inner_axes.has_value()) {
+    assert(*num_inner_axes <= axes.size());
+  } else {
+    *num_inner_axes = axes.size() > 2 ? 2 : 1;
+  }
+  return {source, Loop(progress_message, get_outer_axes(axes, *num_inner_axes)), get_inner_axes(axes, *num_inner_axes)};
 }
 
 template <class HeaderType>
@@ -238,10 +256,16 @@ RandomThreadedLoop(std::string_view progress_message,
                    const HeaderType &source,
                    size_t from_axis = 0,
                    size_t to_axis = std::numeric_limits<size_t>::max(),
-                   size_t num_inner_axes = 1) {
+                   std::optional<size_t> num_inner_axes = std::nullopt) {
+  const size_t num_axes = (to_axis == std::numeric_limits<size_t>::max() ? source.ndim() : to_axis) - from_axis;
+  if (num_inner_axes.has_value()) {
+    assert(*num_inner_axes <= num_axes);
+  } else {
+    *num_inner_axes = num_axes > 2 ? 2 : 1;
+  }
   return {source,
-          Loop(progress_message, get_outer_axes(source, num_inner_axes, from_axis, to_axis)),
-          get_inner_axes(source, num_inner_axes, from_axis, to_axis)};
+          Loop(progress_message, get_outer_axes(source, *num_inner_axes, from_axis, to_axis)),
+          get_inner_axes(source, *num_inner_axes, from_axis, to_axis)};
 }
 
 /*! \} */

--- a/cpp/core/algo/stochastic_threaded_loop.h
+++ b/cpp/core/algo/stochastic_threaded_loop.h
@@ -16,12 +16,14 @@
 
 #pragma once
 
+#include <optional>
+#include <tuple>
+
 #include "algo/iterator.h"
 #include "algo/loop.h"
 #include "debug.h"
 #include "math/rng.h"
 #include "thread.h"
-#include <tuple>
 
 namespace MR {
 
@@ -155,9 +157,14 @@ inline StochasticThreadedLoopRunOuter<decltype(Loop(std::vector<size_t>()))> Sto
 }
 
 template <class HeaderType>
-inline StochasticThreadedLoopRunOuter<decltype(Loop(std::vector<size_t>()))>
-StochasticThreadedLoop(const HeaderType &source, const std::vector<size_t> &axes, size_t num_inner_axes = 1) {
-  return {source, Loop(get_outer_axes(axes, num_inner_axes)), get_inner_axes(axes, num_inner_axes)};
+inline StochasticThreadedLoopRunOuter<decltype(Loop(std::vector<size_t>()))> StochasticThreadedLoop(
+    const HeaderType &source, const std::vector<size_t> &axes, std::optional<size_t> num_inner_axes = std::nullopt) {
+  if (num_inner_axes.has_value()) {
+    assert(*num_inner_axes <= axes.size());
+  } else {
+    *num_inner_axes = axes.size() > 2 ? 2 : 1;
+  }
+  return {source, Loop(get_outer_axes(axes, *num_inner_axes)), get_inner_axes(axes, *num_inner_axes)};
 }
 
 template <class HeaderType>
@@ -165,10 +172,17 @@ inline StochasticThreadedLoopRunOuter<decltype(Loop(std::vector<size_t>()))>
 StochasticThreadedLoop(const HeaderType &source,
                        size_t from_axis = 0,
                        size_t to_axis = std::numeric_limits<size_t>::max(),
-                       size_t num_inner_axes = 1) {
+                       std::optional<size_t> num_inner_axes = std::nullopt) {
+
+  const size_t num_axes = (to_axis == std::numeric_limits<size_t>::max() ? source.ndim() : to_axis) - from_axis;
+  if (num_inner_axes.has_value()) {
+    assert(*num_inner_axes <= num_axes);
+  } else {
+    *num_inner_axes = num_axes > 2 ? 2 : 1;
+  }
   return {source,
-          Loop(get_outer_axes(source, num_inner_axes, from_axis, to_axis)),
-          get_inner_axes(source, num_inner_axes, from_axis, to_axis)};
+          Loop(get_outer_axes(source, *num_inner_axes, from_axis, to_axis)),
+          get_inner_axes(source, *num_inner_axes, from_axis, to_axis)};
 }
 
 template <class HeaderType>
@@ -185,8 +199,13 @@ inline StochasticThreadedLoopRunOuter<decltype(Loop("", std::vector<size_t>()))>
 StochasticThreadedLoop(std::string_view progress_message,
                        const HeaderType &source,
                        const std::vector<size_t> &axes,
-                       size_t num_inner_axes = 1) {
-  return {source, Loop(progress_message, get_outer_axes(axes, num_inner_axes)), get_inner_axes(axes, num_inner_axes)};
+                       std::optional<size_t> num_inner_axes = std::nullopt) {
+  if (num_inner_axes.has_value()) {
+    assert(*num_inner_axes <= axes.size());
+  } else {
+    *num_inner_axes = axes.size() > 2 ? 2 : 1;
+  }
+  return {source, Loop(progress_message, get_outer_axes(axes, *num_inner_axes)), get_inner_axes(axes, *num_inner_axes)};
 }
 
 template <class HeaderType>
@@ -195,10 +214,16 @@ StochasticThreadedLoop(std::string_view progress_message,
                        const HeaderType &source,
                        size_t from_axis = 0,
                        size_t to_axis = std::numeric_limits<size_t>::max(),
-                       size_t num_inner_axes = 1) {
+                       std::optional<size_t> num_inner_axes = std::nullopt) {
+  const size_t num_axes = (to_axis == std::numeric_limits<size_t>::max() ? source.ndim() : to_axis) - from_axis;
+  if (num_inner_axes.has_value()) {
+    assert(*num_inner_axes <= num_axes);
+  } else {
+    *num_inner_axes = num_axes > 2 ? 2 : 1;
+  }
   return {source,
-          Loop(progress_message, get_outer_axes(source, num_inner_axes, from_axis, to_axis)),
-          get_inner_axes(source, num_inner_axes, from_axis, to_axis)};
+          Loop(progress_message, get_outer_axes(source, *num_inner_axes, from_axis, to_axis)),
+          get_inner_axes(source, *num_inner_axes, from_axis, to_axis)};
 }
 
 /*! \} */

--- a/cpp/core/algo/threaded_copy.h
+++ b/cpp/core/algo/threaded_copy.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include "algo/threaded_loop.h"
 
 namespace MR {
@@ -38,7 +40,7 @@ template <class InputImageType, class OutputImageType>
 inline void threaded_copy(InputImageType &source,
                           OutputImageType &destination,
                           const std::vector<size_t> &axes,
-                          size_t num_axes_in_thread = 2) {
+                          std::optional<size_t> num_axes_in_thread = std::nullopt) {
   ThreadedLoop(source, axes, num_axes_in_thread).run(__copy_func(), source, destination);
 }
 
@@ -47,7 +49,7 @@ inline void threaded_copy(InputImageType &source,
                           OutputImageType &destination,
                           size_t from_axis = 0,
                           size_t to_axis = std::numeric_limits<size_t>::max(),
-                          size_t num_axes_in_thread = 2) {
+                          std::optional<size_t> num_axes_in_thread = std::nullopt) {
   ThreadedLoop(source, from_axis, to_axis, num_axes_in_thread).run(__copy_func(), source, destination);
 }
 
@@ -56,7 +58,7 @@ inline void threaded_copy_with_progress_message(std::string_view message,
                                                 InputImageType &source,
                                                 OutputImageType &destination,
                                                 const std::vector<size_t> &axes,
-                                                size_t num_axes_in_thread = 2) {
+                                                std::optional<size_t> num_axes_in_thread = std::nullopt) {
   ThreadedLoop(message, source, axes, num_axes_in_thread).run(__copy_func(), source, destination);
 }
 
@@ -66,7 +68,7 @@ inline void threaded_copy_with_progress_message(std::string_view message,
                                                 OutputImageType &destination,
                                                 size_t from_axis = 0,
                                                 size_t to_axis = std::numeric_limits<size_t>::max(),
-                                                size_t num_axes_in_thread = 2) {
+                                                std::optional<size_t> num_axes_in_thread = std::nullopt) {
   ThreadedLoop(message, source, from_axis, to_axis, num_axes_in_thread).run(__copy_func(), source, destination);
 }
 
@@ -74,7 +76,7 @@ template <class InputImageType, class OutputImageType>
 inline void threaded_copy_with_progress(InputImageType &source,
                                         OutputImageType &destination,
                                         const std::vector<size_t> &axes,
-                                        size_t num_axes_in_thread = 2) {
+                                        std::optional<size_t> num_axes_in_thread = std::nullopt) {
   threaded_copy_with_progress_message("copying from \"" + shorten(source.name()) + "\" to \"" +
                                           shorten(destination.name()) + "\"",
                                       source,
@@ -88,7 +90,7 @@ inline void threaded_copy_with_progress(InputImageType &source,
                                         OutputImageType &destination,
                                         size_t from_axis = 0,
                                         size_t to_axis = std::numeric_limits<size_t>::max(),
-                                        size_t num_axes_in_thread = 2) {
+                                        std::optional<size_t> num_axes_in_thread = std::nullopt) {
   threaded_copy_with_progress_message("copying from \"" + shorten(source.name()) + "\" to \"" +
                                           shorten(destination.name()) + "\"",
                                       source,

--- a/cpp/core/algo/threaded_copy.h
+++ b/cpp/core/algo/threaded_copy.h
@@ -38,7 +38,7 @@ template <class InputImageType, class OutputImageType>
 inline void threaded_copy(InputImageType &source,
                           OutputImageType &destination,
                           const std::vector<size_t> &axes,
-                          size_t num_axes_in_thread = 1) {
+                          size_t num_axes_in_thread = 2) {
   ThreadedLoop(source, axes, num_axes_in_thread).run(__copy_func(), source, destination);
 }
 
@@ -47,7 +47,7 @@ inline void threaded_copy(InputImageType &source,
                           OutputImageType &destination,
                           size_t from_axis = 0,
                           size_t to_axis = std::numeric_limits<size_t>::max(),
-                          size_t num_axes_in_thread = 1) {
+                          size_t num_axes_in_thread = 2) {
   ThreadedLoop(source, from_axis, to_axis, num_axes_in_thread).run(__copy_func(), source, destination);
 }
 
@@ -56,7 +56,7 @@ inline void threaded_copy_with_progress_message(std::string_view message,
                                                 InputImageType &source,
                                                 OutputImageType &destination,
                                                 const std::vector<size_t> &axes,
-                                                size_t num_axes_in_thread = 1) {
+                                                size_t num_axes_in_thread = 2) {
   ThreadedLoop(message, source, axes, num_axes_in_thread).run(__copy_func(), source, destination);
 }
 
@@ -66,7 +66,7 @@ inline void threaded_copy_with_progress_message(std::string_view message,
                                                 OutputImageType &destination,
                                                 size_t from_axis = 0,
                                                 size_t to_axis = std::numeric_limits<size_t>::max(),
-                                                size_t num_axes_in_thread = 1) {
+                                                size_t num_axes_in_thread = 2) {
   ThreadedLoop(message, source, from_axis, to_axis, num_axes_in_thread).run(__copy_func(), source, destination);
 }
 
@@ -74,7 +74,7 @@ template <class InputImageType, class OutputImageType>
 inline void threaded_copy_with_progress(InputImageType &source,
                                         OutputImageType &destination,
                                         const std::vector<size_t> &axes,
-                                        size_t num_axes_in_thread = 1) {
+                                        size_t num_axes_in_thread = 2) {
   threaded_copy_with_progress_message("copying from \"" + shorten(source.name()) + "\" to \"" +
                                           shorten(destination.name()) + "\"",
                                       source,
@@ -88,7 +88,7 @@ inline void threaded_copy_with_progress(InputImageType &source,
                                         OutputImageType &destination,
                                         size_t from_axis = 0,
                                         size_t to_axis = std::numeric_limits<size_t>::max(),
-                                        size_t num_axes_in_thread = 1) {
+                                        size_t num_axes_in_thread = 2) {
   threaded_copy_with_progress_message("copying from \"" + shorten(source.name()) + "\" to \"" +
                                           shorten(destination.name()) + "\"",
                                       source,

--- a/cpp/core/algo/threaded_loop.h
+++ b/cpp/core/algo/threaded_loop.h
@@ -393,11 +393,11 @@ template <class HeaderType>
 inline ThreadedLoopRunOuter<decltype(Loop(std::vector<size_t>()))> ThreadedLoop(
     const HeaderType &source, const std::vector<size_t> &axes, std::optional<size_t> num_inner_axes = std::nullopt) {
   if (num_inner_axes.has_value()) {
-    assert(*num_inner_axes <= axes.size());
+    assert(num_inner_axes.value() <= axes.size());
   } else {
-    *num_inner_axes = axes.size() > 2 ? 2 : 1;
+    num_inner_axes = axes.size() > 2 ? 2 : 1;
   }
-  return {source, Loop(get_outer_axes(axes, *num_inner_axes)), get_inner_axes(axes, *num_inner_axes)};
+  return {source, Loop(get_outer_axes(axes, num_inner_axes.value())), get_inner_axes(axes, num_inner_axes.value())};
 }
 
 //! Multi-threaded loop object
@@ -410,13 +410,13 @@ ThreadedLoop(const HeaderType &source,
              std::optional<size_t> num_inner_axes = std::nullopt) {
   const size_t num_axes = (to_axis == std::numeric_limits<size_t>::max() ? source.ndim() : to_axis) - from_axis;
   if (num_inner_axes.has_value()) {
-    assert(*num_inner_axes <= num_axes);
+    assert(num_inner_axes.value() <= num_axes);
   } else {
-    *num_inner_axes = num_axes > 2 ? 2 : 1;
+    num_inner_axes = num_axes > 2 ? 2 : 1;
   }
   return {source,
-          Loop(get_outer_axes(source, *num_inner_axes, from_axis, to_axis)),
-          get_inner_axes(source, *num_inner_axes, from_axis, to_axis)};
+          Loop(get_outer_axes(source, num_inner_axes.value(), from_axis, to_axis)),
+          get_inner_axes(source, num_inner_axes.value(), from_axis, to_axis)};
 }
 
 //! Multi-threaded loop object
@@ -439,11 +439,13 @@ ThreadedLoop(std::string_view progress_message,
              const std::vector<size_t> &axes,
              std::optional<size_t> num_inner_axes = std::nullopt) {
   if (num_inner_axes.has_value()) {
-    assert(*num_inner_axes <= axes.size());
+    assert(num_inner_axes.value() <= axes.size());
   } else {
-    *num_inner_axes = axes.size() > 2 ? 2 : 1;
+    num_inner_axes = axes.size() > 2 ? 2 : 1;
   }
-  return {source, Loop(progress_message, get_outer_axes(axes, *num_inner_axes)), get_inner_axes(axes, *num_inner_axes)};
+  return {source,
+          Loop(progress_message, get_outer_axes(axes, num_inner_axes.value())),
+          get_inner_axes(axes, num_inner_axes.value())};
 }
 
 //! Multi-threaded loop object
@@ -457,13 +459,13 @@ ThreadedLoop(std::string_view progress_message,
              std::optional<size_t> num_inner_axes = std::nullopt) {
   const size_t num_axes = (to_axis == std::numeric_limits<size_t>::max() ? source.ndim() : to_axis) - from_axis;
   if (num_inner_axes.has_value()) {
-    assert(*num_inner_axes <= num_axes);
+    assert(num_inner_axes.value() <= num_axes);
   } else {
-    *num_inner_axes = num_axes > 2 ? 2 : 1;
+    num_inner_axes = num_axes > 2 ? 2 : 1;
   }
   return {source,
-          Loop(progress_message, get_outer_axes(source, *num_inner_axes, from_axis, to_axis)),
-          get_inner_axes(source, *num_inner_axes, from_axis, to_axis)};
+          Loop(progress_message, get_outer_axes(source, num_inner_axes.value(), from_axis, to_axis)),
+          get_inner_axes(source, num_inner_axes.value(), from_axis, to_axis)};
 }
 
 } // namespace MR

--- a/cpp/core/algo/threaded_loop.h
+++ b/cpp/core/algo/threaded_loop.h
@@ -16,12 +16,14 @@
 
 #pragma once
 
+#include <optional>
+#include <tuple>
+
 #include "algo/iterator.h"
 #include "algo/loop.h"
 #include "debug.h"
 #include "mutexprotected.h"
 #include "thread.h"
-#include <tuple>
 
 namespace MR {
 
@@ -241,10 +243,12 @@ namespace MR {
 namespace {
 
 inline std::vector<size_t> get_inner_axes(const std::vector<size_t> &axes, size_t num_inner_axes) {
+  assert(num_inner_axes <= axes.size());
   return {axes.begin(), axes.begin() + num_inner_axes};
 }
 
 inline std::vector<size_t> get_outer_axes(const std::vector<size_t> &axes, size_t num_inner_axes) {
+  assert(num_inner_axes <= axes.size());
   return {axes.begin() + num_inner_axes, axes.end()};
 }
 
@@ -386,9 +390,14 @@ ThreadedLoop(const HeaderType &source, const std::vector<size_t> &outer_axes, co
 //! Multi-threaded loop object
 //* \sa image_thread_looping for details */
 template <class HeaderType>
-inline ThreadedLoopRunOuter<decltype(Loop(std::vector<size_t>()))>
-ThreadedLoop(const HeaderType &source, const std::vector<size_t> &axes, size_t num_inner_axes = 1) {
-  return {source, Loop(get_outer_axes(axes, num_inner_axes)), get_inner_axes(axes, num_inner_axes)};
+inline ThreadedLoopRunOuter<decltype(Loop(std::vector<size_t>()))> ThreadedLoop(
+    const HeaderType &source, const std::vector<size_t> &axes, std::optional<size_t> num_inner_axes = std::nullopt) {
+  if (num_inner_axes.has_value()) {
+    assert(*num_inner_axes <= axes.size());
+  } else {
+    *num_inner_axes = axes.size() > 2 ? 2 : 1;
+  }
+  return {source, Loop(get_outer_axes(axes, *num_inner_axes)), get_inner_axes(axes, *num_inner_axes)};
 }
 
 //! Multi-threaded loop object
@@ -398,10 +407,16 @@ inline ThreadedLoopRunOuter<decltype(Loop(std::vector<size_t>()))>
 ThreadedLoop(const HeaderType &source,
              size_t from_axis = 0,
              size_t to_axis = std::numeric_limits<size_t>::max(),
-             size_t num_inner_axes = 1) {
+             std::optional<size_t> num_inner_axes = std::nullopt) {
+  const size_t num_axes = (to_axis == std::numeric_limits<size_t>::max() ? source.ndim() : to_axis) - from_axis;
+  if (num_inner_axes.has_value()) {
+    assert(*num_inner_axes <= num_axes);
+  } else {
+    *num_inner_axes = num_axes > 2 ? 2 : 1;
+  }
   return {source,
-          Loop(get_outer_axes(source, num_inner_axes, from_axis, to_axis)),
-          get_inner_axes(source, num_inner_axes, from_axis, to_axis)};
+          Loop(get_outer_axes(source, *num_inner_axes, from_axis, to_axis)),
+          get_inner_axes(source, *num_inner_axes, from_axis, to_axis)};
 }
 
 //! Multi-threaded loop object
@@ -418,11 +433,17 @@ ThreadedLoop(std::string_view progress_message,
 //! Multi-threaded loop object
 //* \sa image_thread_looping for details */
 template <class HeaderType>
-inline ThreadedLoopRunOuter<decltype(Loop("", std::vector<size_t>()))> ThreadedLoop(std::string_view progress_message,
-                                                                                    const HeaderType &source,
-                                                                                    const std::vector<size_t> &axes,
-                                                                                    size_t num_inner_axes = 1) {
-  return {source, Loop(progress_message, get_outer_axes(axes, num_inner_axes)), get_inner_axes(axes, num_inner_axes)};
+inline ThreadedLoopRunOuter<decltype(Loop("", std::vector<size_t>()))>
+ThreadedLoop(std::string_view progress_message,
+             const HeaderType &source,
+             const std::vector<size_t> &axes,
+             std::optional<size_t> num_inner_axes = std::nullopt) {
+  if (num_inner_axes.has_value()) {
+    assert(*num_inner_axes <= axes.size());
+  } else {
+    *num_inner_axes = axes.size() > 2 ? 2 : 1;
+  }
+  return {source, Loop(progress_message, get_outer_axes(axes, *num_inner_axes)), get_inner_axes(axes, *num_inner_axes)};
 }
 
 //! Multi-threaded loop object
@@ -433,10 +454,16 @@ ThreadedLoop(std::string_view progress_message,
              const HeaderType &source,
              size_t from_axis = 0,
              size_t to_axis = std::numeric_limits<size_t>::max(),
-             size_t num_inner_axes = 1) {
+             std::optional<size_t> num_inner_axes = std::nullopt) {
+  const size_t num_axes = (to_axis == std::numeric_limits<size_t>::max() ? source.ndim() : to_axis) - from_axis;
+  if (num_inner_axes.has_value()) {
+    assert(*num_inner_axes <= num_axes);
+  } else {
+    *num_inner_axes = num_axes > 2 ? 2 : 1;
+  }
   return {source,
-          Loop(progress_message, get_outer_axes(source, num_inner_axes, from_axis, to_axis)),
-          get_inner_axes(source, num_inner_axes, from_axis, to_axis)};
+          Loop(progress_message, get_outer_axes(source, *num_inner_axes, from_axis, to_axis)),
+          get_inner_axes(source, *num_inner_axes, from_axis, to_axis)};
 }
 
 } // namespace MR

--- a/cpp/core/degibbs/unring3d.h
+++ b/cpp/core/degibbs/unring3d.h
@@ -213,7 +213,7 @@ public:
 
       // apply unringing operation on desired axis:
       INFO("performing unringing along axis " + str(axis) + "...");
-      ThreadedLoop(vol_filtered, strides_for_axis(axis))
+      ThreadedLoop(vol_filtered, strides_for_axis(axis), 1)
           .run_outer(LineProcessor<VolumeOut>(axis, vol_filtered, output, minW, maxW, num_shifts));
 
       ++progress;

--- a/cpp/core/filter/smooth.h
+++ b/cpp/core/filter/smooth.h
@@ -151,7 +151,7 @@ public:
         }
         DEBUG("smoothing dimension " + str(dim) + " in place with stride order: " + str(axes));
         SmoothFunctor1D<ImageType> smooth(in_and_output, stdev[dim], dim, extent[dim], zero_boundary);
-        ThreadedLoop(in_and_output, axes, std::min<size_t>(2, axes.size())).run(smooth, in_and_output);
+        ThreadedLoop(in_and_output, axes).run(smooth, in_and_output);
         if (progress)
           ++(*progress);
       }

--- a/cpp/core/filter/warp.h
+++ b/cpp/core/filter/warp.h
@@ -85,8 +85,7 @@ void warp(ImageTypeSource &source,
                        (jacobian_modulate ? " with Jacobian intensity modulation" : ""),
                    interp,
                    0,
-                   3,
-                   1)
+                   3)
           .run(CopyKernel4D(), interp, destination);
     else
       threaded_copy_with_progress_message("warping \"" + source.name() + "\"" +
@@ -103,8 +102,7 @@ void warp(ImageTypeSource &source,
                        (jacobian_modulate ? " with Jacobian intensity modulation" : ""),
                    interp,
                    0,
-                   3,
-                   1)
+                   3)
           .run(CopyKernel4D(), interp, destination);
     else
       threaded_copy_with_progress_message("warping \"" + source.name() + "\"" +
@@ -112,8 +110,7 @@ void warp(ImageTypeSource &source,
                                           interp,
                                           destination,
                                           0,
-                                          destination.ndim(),
-                                          2);
+                                          destination.ndim());
   }
 }
 

--- a/cpp/core/registration/metric/evaluate.h
+++ b/cpp/core/registration/metric/evaluate.h
@@ -145,7 +145,7 @@ public:
   //       DEBUG ("stochastic gradient descent, density: " + str(params.loop_density));
   //       Math::RNG rng;
   //       gradient.setZero();
-  //       auto loop = ThreadedLoop (params.midway_image, 0, 3, 2);
+  //       auto loop = ThreadedLoop (params.midway_image, 0, 3);
   //       if (overlap_count)
   //         *overlap_count = 0;
   //       StochasticThreadKernel <MetricType, ParamType> functor (loop.inner_axes, params.loop_density, metric, params,
@@ -216,7 +216,7 @@ public:
       DEBUG("stochastic gradient descent, density: " + str(params.loop_density));
       Math::RNG rng;
       gradient.setZero();
-      auto loop = ThreadedLoop(params.midway_image, 0, 3, 2);
+      auto loop = ThreadedLoop(params.midway_image, 0, 3);
       overlap_count = 0;
       StochasticThreadKernel<MetricType, ParamType> functor(
           loop.inner_axes, params.loop_density, metric, params, overall_cost_function, gradient, rng, &overlap_count);

--- a/cpp/core/registration/transform/initialiser_helpers.cpp
+++ b/cpp/core/registration/transform/initialiser_helpers.cpp
@@ -283,10 +283,9 @@ void get_centre_of_mass(Image<default_type> &im,
   centre_of_mass.setZero();
   default_type mass(0.0);
 
-  ThreadedLoop(im, 0, 3, 2)
-      .run(WeightedMassFunctor<Image<default_type>, Image<default_type>>(
-               im, mask, mass, centre_of_mass, contrast_settings),
-           im);
+  ThreadedLoop(im, 0, 3).run(
+      WeightedMassFunctor<Image<default_type>, Image<default_type>>(im, mask, mass, centre_of_mass, contrast_settings),
+      im);
 
   if (mass == 0.0)
     throw Exception("centre of mass initialisation not possible for empty image");
@@ -509,7 +508,7 @@ bool MomentsInitialiser::calculate_eigenvectors(Image<default_type> &image_1,
   Eigen::VectorXd m = Eigen::VectorXd::Zero(4);  // m000, m100, m010, m001
   Eigen::VectorXd mu = Eigen::VectorXd::Zero(6); // mu110, mu011, mu101, mu200, mu020, mu002
   get_geometric_centre(image_1, im1_centre);
-  ThreadedLoop(image_1, 0, 3, 2)
+  ThreadedLoop(image_1, 0, 3)
       .run(WeightedMomentsFunctor<Image<default_type>, Image<default_type>>(
                image_1, mask_1, im1_centre, m, mu, contrast_settings),
            image_1);
@@ -527,7 +526,7 @@ bool MomentsInitialiser::calculate_eigenvectors(Image<default_type> &image_1,
   get_geometric_centre(image_2, im2_centre);
   m.setZero();
   mu.setZero();
-  ThreadedLoop(image_2, 0, 3, 2)
+  ThreadedLoop(image_2, 0, 3)
       .run(WeightedMomentsFunctor<Image<default_type>, Image<default_type>>(
                image_2, mask_2, im2_centre, m, mu, contrast_settings),
            image_2);

--- a/cpp/core/registration/transform/reorient.h
+++ b/cpp/core/registration/transform/reorient.h
@@ -155,13 +155,13 @@ void reorient(FODImageType &input_fod_image,
 
   if (!start_nvols.empty()) {
     assert(max_n_SH > 1);
-    ThreadedLoop(input_fod_image, 0, 3)
+    ThreadedLoop(input_fod_image, 0, 3, 1)
         .run(LinearKernelMultiContrast<FODImageType>(
                  input_fod_image.size(3), max_n_SH, transform, directions, start_nvols, modulate),
              input_fod_image,
              output_fod_image);
   } else {
-    ThreadedLoop(input_fod_image, 0, 3)
+    ThreadedLoop(input_fod_image, 0, 3, 1)
         .run(LinearKernel<FODImageType>(input_fod_image.size(3), transform, directions, modulate),
              input_fod_image,
              output_fod_image);
@@ -188,13 +188,13 @@ void reorient(const std::string progress_message,
 
   if (!start_nvols.empty()) {
     assert(max_n_SH > 1);
-    ThreadedLoop(progress_message, input_fod_image, 0, 3)
+    ThreadedLoop(progress_message, input_fod_image, 0, 3, 1)
         .run(LinearKernelMultiContrast<FODImageType>(
                  input_fod_image.size(3), max_n_SH, transform, directions, start_nvols, modulate),
              input_fod_image,
              output_fod_image);
   } else {
-    ThreadedLoop(progress_message, input_fod_image, 0, 3)
+    ThreadedLoop(progress_message, input_fod_image, 0, 3, 1)
         .run(LinearKernel<FODImageType>(input_fod_image.size(3), transform, directions, modulate),
              input_fod_image,
              output_fod_image);
@@ -347,13 +347,13 @@ void reorient_warp(const std::string progress_message,
     start_nvols = multiContrastSetting2start_nvols(multi_contrast_settings, max_n_SH);
   if (!start_nvols.empty()) {
     DEBUG("reorienting warp using MultiContrast NonLinearKernel");
-    ThreadedLoop(progress_message, fod_image, 0, 3)
+    ThreadedLoop(progress_message, fod_image, 0, 3, 1)
         .run(NonLinearKernelMultiContrast<FODImageType>(
                  fod_image.size(3), max_n_SH, warp, directions, start_nvols, modulate),
              fod_image);
   } else {
     DEBUG("reorienting warp using NonLinearKernel");
-    ThreadedLoop(progress_message, fod_image, 0, 3)
+    ThreadedLoop(progress_message, fod_image, 0, 3, 1)
         .run(NonLinearKernel<FODImageType>(fod_image.size(3), warp, directions, modulate), fod_image);
   }
 }
@@ -373,13 +373,13 @@ void reorient_warp(FODImageType &fod_image,
 
   if (!start_nvols.empty()) {
     DEBUG("reorienting warp using MultiContrast NonLinearKernel");
-    ThreadedLoop(fod_image, 0, 3)
+    ThreadedLoop(fod_image, 0, 3, 1)
         .run(NonLinearKernelMultiContrast<FODImageType>(
                  fod_image.size(3), max_n_SH, warp, directions, start_nvols, modulate),
              fod_image);
   } else {
     DEBUG("reorienting warp using NonLinearKernel");
-    ThreadedLoop(fod_image, 0, 3)
+    ThreadedLoop(fod_image, 0, 3, 1)
         .run(NonLinearKernel<FODImageType>(fod_image.size(3), warp, directions, modulate), fod_image);
   }
 }


### PR DESCRIPTION
Extension of #3280.

Closes #3284.

-----

As proven in #3280, where an image processing operation is comparatively cheap, it can be substantially faster to place 2 image axes rather than 1 within the inner loop of the multi-threading mechanism, as there is less time spent achieving synchronisation across threads.
Conversely, I believe the purpose of processing 1D stripes of image data by default rather than slices is that, for a large number of threads relative to the number of slices, a substantial fraction of the runtime could be spent waiting for the last slices to complete, during which time not all threads available are utilised.
As such, my expectation is that fastest execution will be achieved using:
- 1 axis in the inner loop for very expensive voxel-wise operations
- 2 axes in the inner loop for inexpensive operations

Exactly where the threshold lies I do not know.
I did however find after a first attempt at refining that it is likely a *minority* of multi-threaded image operations that are sufficiently expensive to warrant the use of one axis in the inner loop. Currently this is exclusively:
-   `dwi2fod`
-   `dwi2tensor`
-   `dwidenoise`
-   FOD reorientation

If there's contention about what should & shouldn't be in this list we can do speed tests; but it needs to be with realistic data, not the CI test data.

(@MRtrix3/mrtrix3-devs note also use of `std::optional` for function arguments; facilitates differentiation between explicit and default values)