### PR TITLE
Tck2fixel tckweights

### DIFF
--- a/cpp/cmd/tck2fixel.cpp
+++ b/cpp/cmd/tck2fixel.cpp
@@ -17,6 +17,8 @@
 #include "algo/loop.h"
 #include "command.h"
 #include "image.h"
+#include "image_helpers.h"
+#include "mutexprotected.h"
 #include "progressbar.h"
 
 #include "fixel/fixel.h"
@@ -38,19 +40,43 @@ template <class ValueType> class TrackProcessor {
 
 public:
   using SetVoxelDir = DWI::Tractography::Mapping::SetVoxelDir;
+  using VectorType = Eigen::Array<ValueType, Eigen::Dynamic, 1>;
 
   TrackProcessor(Image<index_type> &fixel_indexer,
-                 const std::vector<Eigen::Vector3d> &fixel_directions,
-                 std::vector<ValueType> &fixel_TDI,
-                 const float angular_threshold)
-      : fixel_indexer(fixel_indexer),
+                 Image<float> &fixel_directions,
+                 const size_t upsample_ratio,
+                 const float angular_threshold,
+                 std::shared_ptr<MutexProtected<VectorType>> fixel_TDI)
+      : mapper(fixel_indexer),
+        fixel_indexer(fixel_indexer),
         fixel_directions(fixel_directions),
-        fixel_TDI(fixel_TDI),
-        angular_threshold_dp(std::cos(angular_threshold * (Math::pi / 180.0))) {}
+        angular_threshold_dp(std::cos(angular_threshold * (Math::pi / 180.0))),
+        global_fixel_TDI(fixel_TDI),
+        local_fixel_TDI(VectorType::Zero(fixel_TDI->lock()->size())) {
+    mapper.set_upsample_ratio(upsample_ratio);
+    mapper.set_use_precise_mapping(true);
+  }
 
-  bool operator()(const SetVoxelDir &in) {
+  TrackProcessor(const TrackProcessor &that)
+      : mapper(that.mapper),
+        fixel_indexer(that.fixel_indexer),
+        fixel_directions(that.fixel_directions),
+        angular_threshold_dp(that.angular_threshold_dp),
+        global_fixel_TDI(that.global_fixel_TDI),
+        local_fixel_TDI(VectorType::Zero(that.local_fixel_TDI.size())) {}
+
+  ~TrackProcessor() {
+    auto acquired_global_fixel_TDI = global_fixel_TDI.lock()->lock();
+    *acquired_global_fixel_TDI += local_fixel_TDI;
+  }
+
+  bool operator()(const DWI::Tractography::Streamline<> &in) {
+    SetVoxelDir visitations;
+    mapper(in, visitations);
     // For each voxel tract tangent, assign to a fixel
-    for (SetVoxelDir::const_iterator i = in.begin(); i != in.end(); ++i) {
+    // Ensure that a streamline is not assigned to a fixel more than once
+    std::set<index_type> fixels;
+    for (SetVoxelDir::const_iterator i = visitations.begin(); i != visitations.end(); ++i) {
       assign_pos_of(*i).to(fixel_indexer);
       fixel_indexer.index(3) = 0;
       index_type num_fibres = fixel_indexer.value();
@@ -59,37 +85,42 @@ public:
         index_type first_index = fixel_indexer.value();
         index_type last_index = first_index + num_fibres;
         index_type closest_fixel_index = 0;
-        float largest_dp = 0.0;
-        const Eigen::Vector3d dir(i->get_dir().cast<default_type>().normalized());
+        float largest_dp = 0.0F;
         for (index_type j = first_index; j < last_index; ++j) {
-          const float dp = std::fabs(dir.dot(fixel_directions[j]));
+          fixel_directions.index(0) = j;
+          const float dp = std::fabs(i->get_dir().dot(Eigen::Vector3f(fixel_directions.row(1))));
           if (dp > largest_dp) {
             largest_dp = dp;
             closest_fixel_index = j;
           }
         }
-        if (largest_dp > angular_threshold_dp) {
-          if constexpr (std::is_integral_v<ValueType>)
-            ++fixel_TDI[closest_fixel_index];
-          else
-            fixel_TDI[closest_fixel_index] += static_cast<ValueType>(in.weight);
-        }
+        if (largest_dp > angular_threshold_dp)
+          fixels.insert(closest_fixel_index);
       }
+    }
+    for (auto f : fixels) {
+      if constexpr (std::is_integral_v<ValueType>)
+        ++local_fixel_TDI[f];
+      else
+        local_fixel_TDI[f] += static_cast<ValueType>(in.weight);
     }
     return true;
   }
 
 private:
+  DWI::Tractography::Mapping::TrackMapperBase mapper;
   Image<index_type> fixel_indexer;
-  const std::vector<Eigen::Vector3d> &fixel_directions;
-  std::vector<ValueType> &fixel_TDI;
+  Image<float> fixel_directions;
   const float angular_threshold_dp;
+  std::weak_ptr<MutexProtected<VectorType>> global_fixel_TDI;
+  VectorType local_fixel_TDI;
 };
 
 // clang-format off
 void usage() {
 
-  AUTHOR = "David Raffelt (david.raffelt@florey.edu.au)";
+  AUTHOR = "David Raffelt (david.raffelt@florey.edu.au)"
+           " and Robert E. Smith (robert.smith@florey.edu.au)";
 
   SYNOPSIS = "Compute a fixel TDI map from a tractogram";
 
@@ -110,12 +141,29 @@ void usage() {
 }
 // clang-format on
 
-template <class VectorType>
-void write_fixel_output(std::string_view filename, const VectorType &data, const Header &header) {
-  auto output = Image<float>::create(filename, header);
-  for (size_t i = 0; i < data.size(); ++i) {
-    output.index(0) = i;
-    output.value() = data[i];
+template <class ValueType>
+void run(DWI::Tractography::Mapping::TrackLoader &loader,
+         Image<index_type> &index_image,
+         Image<float> &directions_image,
+         const size_t num_fixels,
+         const size_t upsample_ratio,
+         const float angular_threshold,
+         std::string_view output_path) {
+  auto fixel_TDI = std::make_shared<MutexProtected<Eigen::Array<ValueType, Eigen::Dynamic, 1>>>(
+      Eigen::Array<ValueType, Eigen::Dynamic, 1>::Zero(num_fixels));
+  {
+    TrackProcessor<ValueType> processor(index_image, directions_image, upsample_ratio, angular_threshold, fixel_TDI);
+    Thread::run_queue(loader, Thread::batch(DWI::Tractography::Streamline<float>()), Thread::multi(processor));
+  }
+  {
+    auto data = *fixel_TDI->lock();
+    Header H = Fixel::data_header_from_nfixels(num_fixels);
+    H.datatype() = DataType::from<ValueType>();
+    auto output = Image<ValueType>::create(output_path, H);
+    for (size_t i = 0; i < data.size(); ++i) {
+      output.index(0) = i;
+      output.value() = data[i];
+    }
   }
 }
 
@@ -123,72 +171,29 @@ void run() {
   const std::string input_fixel_folder = argument[1];
   Header index_header = Fixel::find_index_header(input_fixel_folder);
   auto index_image = index_header.get_image<index_type>();
-
+  auto directions_image = Fixel::find_directions_header(input_fixel_folder).get_image<float>().with_direct_io(1);
   const index_type num_fixels = Fixel::get_number_of_fixels(index_header);
 
   const float angular_threshold = get_option_value("angle", DWI::Tractography::Mapping::default_streamline2fixel_angle);
 
-  std::vector<Eigen::Vector3d> positions(num_fixels);
-  std::vector<Eigen::Vector3d> directions(num_fixels);
-
   const std::string output_fixel_folder = argument[2];
   Fixel::copy_index_and_directions_file(input_fixel_folder, output_fixel_folder);
-
-  {
-    auto directions_data = Fixel::find_directions_header(input_fixel_folder).get_image<default_type>().with_direct_io();
-    // Load template fixel directions
-    Transform image_transform(index_image);
-    for (auto i = Loop("loading template fixel directions and positions", index_image, 0, 3)(index_image); i; ++i) {
-      const Eigen::Vector3d vox(static_cast<default_type>(index_image.index(0)),
-                                static_cast<default_type>(index_image.index(1)),
-                                static_cast<default_type>(index_image.index(2)));
-      index_image.index(3) = 1;
-      index_type offset = index_image.value();
-      index_type fixel_index = 0;
-      for (auto f = Fixel::Loop(index_image)(directions_data); f; ++f, ++fixel_index) {
-        directions[offset + fixel_index] = directions_data.row(1);
-        positions[offset + fixel_index] = image_transform.voxel2scanner * vox;
-      }
-    }
-  }
 
   const std::string track_filename = argument[0];
   DWI::Tractography::Properties properties;
   DWI::Tractography::Reader<float> track_file(track_filename, properties);
-  // Read in tracts, and compute whole-brain fixel-fixel connectivity
-  const size_t num_tracks = properties["count"].empty() ? 0 : to<int>(properties["count"]);
+  const size_t num_tracks = properties["count"].empty() ? 0 : to<size_t>(properties["count"]);
   if (!num_tracks)
     throw Exception("no tracks found in input file");
+  const size_t upsample_ratio =
+      DWI::Tractography::Mapping::determine_upsample_ratio(index_header, properties, 1.0F / 3.0F);
 
-  {
-    using SetVoxelDir = DWI::Tractography::Mapping::SetVoxelDir;
-    DWI::Tractography::Mapping::TrackLoader loader(track_file, num_tracks, "mapping tracks to fixels");
-    DWI::Tractography::Mapping::TrackMapperBase mapper(index_image);
-    mapper.set_upsample_ratio(DWI::Tractography::Mapping::determine_upsample_ratio(index_header, properties, 0.333f));
-    mapper.set_use_precise_mapping(true);
+  DWI::Tractography::Mapping::TrackLoader loader(track_file, num_tracks, "mapping tracks to fixels");
+  const std::string output_path = Path::join(output_fixel_folder, argument[3]);
 
-    const Header output_header(Fixel::data_header_from_index(index_image));
-    const std::string output_path = Path::join(output_fixel_folder, argument[3]);
-
-    if (get_options("tck_weights_in").empty()) {
-      std::vector<uint16_t> fixel_TDI(num_fixels, 0);
-      TrackProcessor<uint16_t> tract_processor(index_image, directions, fixel_TDI, angular_threshold);
-      Thread::run_queue(loader,
-                        Thread::batch(DWI::Tractography::Streamline<float>()),
-                        mapper,
-                        Thread::batch(SetVoxelDir()),
-                        tract_processor);
-      write_fixel_output(output_path, fixel_TDI, output_header);
-    } else {
-      std::vector<float> fixel_TDI(num_fixels, 0.0f);
-      TrackProcessor<float> tract_processor(index_image, directions, fixel_TDI, angular_threshold);
-      Thread::run_queue(loader,
-                        Thread::batch(DWI::Tractography::Streamline<float>()),
-                        mapper,
-                        Thread::batch(SetVoxelDir()),
-                        tract_processor);
-      write_fixel_output(output_path, fixel_TDI, output_header);
-    }
+  if (get_options("tck_weights_in").empty()) {
+    run<uint32_t>(loader, index_image, directions_image, num_fixels, upsample_ratio, angular_threshold, output_path);
+  } else {
+    run<float>(loader, index_image, directions_image, num_fixels, upsample_ratio, angular_threshold, output_path);
   }
-  track_file.close();
 }

--- a/cpp/cmd/tck2fixel.cpp
+++ b/cpp/cmd/tck2fixel.cpp
@@ -45,11 +45,13 @@ public:
   TrackProcessor(Image<index_type> &fixel_indexer,
                  Image<float> &fixel_directions,
                  const size_t upsample_ratio,
+                 const bool precise,
                  const float angular_threshold,
                  std::shared_ptr<MutexProtected<VectorType>> fixel_TDI)
       : mapper(fixel_indexer),
         fixel_indexer(fixel_indexer),
         fixel_directions(fixel_directions),
+        precise(precise),
         angular_threshold_dp(std::cos(angular_threshold * (Math::pi / 180.0))),
         global_fixel_TDI(fixel_TDI),
         local_fixel_TDI(VectorType::Zero(fixel_TDI->lock()->size())) {
@@ -61,6 +63,7 @@ public:
       : mapper(that.mapper),
         fixel_indexer(that.fixel_indexer),
         fixel_directions(that.fixel_directions),
+        precise(that.precise),
         angular_threshold_dp(that.angular_threshold_dp),
         global_fixel_TDI(that.global_fixel_TDI),
         local_fixel_TDI(VectorType::Zero(that.local_fixel_TDI.size())) {}
@@ -74,8 +77,8 @@ public:
     SetVoxelDir visitations;
     mapper(in, visitations);
     // For each voxel tract tangent, assign to a fixel
-    // Ensure that a streamline is not assigned to a fixel more than once
-    std::set<index_type> fixels;
+    // For each fixel, sum the intersection lengths
+    std::map<index_type, float> fixels;
     for (SetVoxelDir::const_iterator i = visitations.begin(); i != visitations.end(); ++i) {
       assign_pos_of(*i).to(fixel_indexer);
       fixel_indexer.index(3) = 0;
@@ -94,15 +97,20 @@ public:
             closest_fixel_index = j;
           }
         }
-        if (largest_dp > angular_threshold_dp)
-          fixels.insert(closest_fixel_index);
+        if (largest_dp > angular_threshold_dp) {
+          auto existing = fixels.find(closest_fixel_index);
+          if (existing == fixels.end())
+            fixels.insert({closest_fixel_index, i->get_length()});
+          else
+            existing->second += i->get_length();
+        }
       }
     }
     for (auto f : fixels) {
       if constexpr (std::is_integral_v<ValueType>)
-        ++local_fixel_TDI[f];
+        ++local_fixel_TDI[f.first];
       else
-        local_fixel_TDI[f] += static_cast<ValueType>(in.weight);
+        local_fixel_TDI[f.first] += static_cast<ValueType>(in.weight) * (precise ? f.second : 1.0F);
     }
     return true;
   }
@@ -111,6 +119,7 @@ private:
   DWI::Tractography::Mapping::TrackMapperBase mapper;
   Image<index_type> fixel_indexer;
   Image<float> fixel_directions;
+  const bool precise;
   const float angular_threshold_dp;
   std::weak_ptr<MutexProtected<VectorType>> global_fixel_TDI;
   VectorType local_fixel_TDI;
@@ -137,6 +146,9 @@ void usage() {
                      " (default: " + str(DWI::Tractography::Mapping::default_streamline2fixel_angle, 2) + " degrees)")
     + Argument ("value").type_float(0.0, 90.0)
 
+  + Option ("precise", "utilise the precise length of streamline-voxel intersections"
+                       " rather than simply the number of streamlines / sum of streamline weights")
+
   + DWI::Tractography::TrackWeightsInOption;
 }
 // clang-format on
@@ -147,12 +159,17 @@ void run(DWI::Tractography::Mapping::TrackLoader &loader,
          Image<float> &directions_image,
          const size_t num_fixels,
          const size_t upsample_ratio,
+         const bool precise,
          const float angular_threshold,
          std::string_view output_path) {
+  if constexpr (std::is_integral_v<ValueType>) {
+    assert(!precise);
+  }
   auto fixel_TDI = std::make_shared<MutexProtected<Eigen::Array<ValueType, Eigen::Dynamic, 1>>>(
       Eigen::Array<ValueType, Eigen::Dynamic, 1>::Zero(num_fixels));
   {
-    TrackProcessor<ValueType> processor(index_image, directions_image, upsample_ratio, angular_threshold, fixel_TDI);
+    TrackProcessor<ValueType> processor(
+        index_image, directions_image, upsample_ratio, precise, angular_threshold, fixel_TDI);
     Thread::run_queue(loader, Thread::batch(DWI::Tractography::Streamline<float>()), Thread::multi(processor));
   }
   {
@@ -175,6 +192,7 @@ void run() {
   const index_type num_fixels = Fixel::get_number_of_fixels(index_header);
 
   const float angular_threshold = get_option_value("angle", DWI::Tractography::Mapping::default_streamline2fixel_angle);
+  const bool precise = !get_options("precise").empty();
 
   const std::string output_fixel_folder = argument[2];
   Fixel::copy_index_and_directions_file(input_fixel_folder, output_fixel_folder);
@@ -186,14 +204,16 @@ void run() {
   if (!num_tracks)
     throw Exception("no tracks found in input file");
   const size_t upsample_ratio =
-      DWI::Tractography::Mapping::determine_upsample_ratio(index_header, properties, 1.0F / 3.0F);
+      DWI::Tractography::Mapping::determine_upsample_ratio(index_header, properties, precise ? 0.1F : (1.0F / 3.0F));
 
   DWI::Tractography::Mapping::TrackLoader loader(track_file, num_tracks, "mapping tracks to fixels");
   const std::string output_path = Path::join(output_fixel_folder, argument[3]);
 
-  if (get_options("tck_weights_in").empty()) {
-    run<uint32_t>(loader, index_image, directions_image, num_fixels, upsample_ratio, angular_threshold, output_path);
+  if (get_options("tck_weights_in").empty() && !precise) {
+    run<uint32_t>(
+        loader, index_image, directions_image, num_fixels, upsample_ratio, precise, angular_threshold, output_path);
   } else {
-    run<float>(loader, index_image, directions_image, num_fixels, upsample_ratio, angular_threshold, output_path);
+    run<float>(
+        loader, index_image, directions_image, num_fixels, upsample_ratio, precise, angular_threshold, output_path);
   }
 }

--- a/cpp/cmd/tck2fixel.cpp
+++ b/cpp/cmd/tck2fixel.cpp
@@ -27,20 +27,21 @@
 #include "dwi/tractography/mapping/mapper.h"
 #include "dwi/tractography/mapping/mapping.h"
 #include "dwi/tractography/mapping/writer.h"
+#include "dwi/tractography/weights.h"
 
 using namespace MR;
 using namespace App;
 
 using Fixel::index_type;
 
-class TrackProcessor {
+template <class ValueType> class TrackProcessor {
 
 public:
   using SetVoxelDir = DWI::Tractography::Mapping::SetVoxelDir;
 
   TrackProcessor(Image<index_type> &fixel_indexer,
                  const std::vector<Eigen::Vector3d> &fixel_directions,
-                 std::vector<uint16_t> &fixel_TDI,
+                 std::vector<ValueType> &fixel_TDI,
                  const float angular_threshold)
       : fixel_indexer(fixel_indexer),
         fixel_directions(fixel_directions),
@@ -49,7 +50,6 @@ public:
 
   bool operator()(const SetVoxelDir &in) {
     // For each voxel tract tangent, assign to a fixel
-    std::vector<int32_t> tract_fixel_indices;
     for (SetVoxelDir::const_iterator i = in.begin(); i != in.end(); ++i) {
       assign_pos_of(*i).to(fixel_indexer);
       fixel_indexer.index(3) = 0;
@@ -69,8 +69,10 @@ public:
           }
         }
         if (largest_dp > angular_threshold_dp) {
-          tract_fixel_indices.push_back(closest_fixel_index);
-          fixel_TDI[closest_fixel_index]++;
+          if constexpr (std::is_integral_v<ValueType>)
+            ++fixel_TDI[closest_fixel_index];
+          else
+            fixel_TDI[closest_fixel_index] += static_cast<ValueType>(in.weight);
         }
       }
     }
@@ -80,7 +82,7 @@ public:
 private:
   Image<index_type> fixel_indexer;
   const std::vector<Eigen::Vector3d> &fixel_directions;
-  std::vector<uint16_t> &fixel_TDI;
+  std::vector<ValueType> &fixel_TDI;
   const float angular_threshold_dp;
 };
 
@@ -102,7 +104,9 @@ void usage() {
   OPTIONS
   + Option ("angle", "the max angle threshold for assigning streamline tangents to fixels"
                      " (default: " + str(DWI::Tractography::Mapping::default_streamline2fixel_angle, 2) + " degrees)")
-    + Argument ("value").type_float(0.0, 90.0);
+    + Argument ("value").type_float(0.0, 90.0)
+
+  + DWI::Tractography::TrackWeightsInOption;
 }
 // clang-format on
 
@@ -148,7 +152,6 @@ void run() {
     }
   }
 
-  std::vector<uint16_t> fixel_TDI(num_fixels, 0.0);
   const std::string track_filename = argument[0];
   DWI::Tractography::Properties properties;
   DWI::Tractography::Reader<float> track_file(track_filename, properties);
@@ -163,16 +166,29 @@ void run() {
     DWI::Tractography::Mapping::TrackMapperBase mapper(index_image);
     mapper.set_upsample_ratio(DWI::Tractography::Mapping::determine_upsample_ratio(index_header, properties, 0.333f));
     mapper.set_use_precise_mapping(true);
-    TrackProcessor tract_processor(index_image, directions, fixel_TDI, angular_threshold);
-    Thread::run_queue(loader,
-                      Thread::batch(DWI::Tractography::Streamline<float>()),
-                      mapper,
-                      Thread::batch(SetVoxelDir()),
-                      tract_processor);
+
+    const Header output_header(Fixel::data_header_from_index(index_image));
+    const std::string output_path = Path::join(output_fixel_folder, argument[3]);
+
+    if (get_options("tck_weights_in").empty()) {
+      std::vector<uint16_t> fixel_TDI(num_fixels, 0);
+      TrackProcessor<uint16_t> tract_processor(index_image, directions, fixel_TDI, angular_threshold);
+      Thread::run_queue(loader,
+                        Thread::batch(DWI::Tractography::Streamline<float>()),
+                        mapper,
+                        Thread::batch(SetVoxelDir()),
+                        tract_processor);
+      write_fixel_output(output_path, fixel_TDI, output_header);
+    } else {
+      std::vector<float> fixel_TDI(num_fixels, 0.0f);
+      TrackProcessor<float> tract_processor(index_image, directions, fixel_TDI, angular_threshold);
+      Thread::run_queue(loader,
+                        Thread::batch(DWI::Tractography::Streamline<float>()),
+                        mapper,
+                        Thread::batch(SetVoxelDir()),
+                        tract_processor);
+      write_fixel_output(output_path, fixel_TDI, output_header);
+    }
   }
   track_file.close();
-
-  Header output_header(Fixel::data_header_from_index(index_image));
-
-  write_fixel_output(Path::join(output_fixel_folder, argument[3]), fixel_TDI, output_header);
 }

--- a/cpp/cmd/tck2fixel.cpp
+++ b/cpp/cmd/tck2fixel.cpp
@@ -14,7 +14,8 @@
  * For more details, see http://www.mrtrix.org/.
  */
 
-#include "algo/loop.h"
+#include <set>
+
 #include "command.h"
 #include "image.h"
 #include "image_helpers.h"
@@ -23,7 +24,6 @@
 
 #include "fixel/fixel.h"
 #include "fixel/helpers.h"
-#include "fixel/loop.h"
 
 #include "dwi/tractography/mapping/loader.h"
 #include "dwi/tractography/mapping/mapper.h"

--- a/docs/reference/commands/tck2fixel.rst
+++ b/docs/reference/commands/tck2fixel.rst
@@ -25,6 +25,8 @@ Options
 
 -  **-angle value** the max angle threshold for assigning streamline tangents to fixels (default: 45 degrees)
 
+-  **-precise** utilise the precise length of streamline-voxel intersections rather than simply the number of streamlines / sum of streamline weights
+
 -  **-tck_weights_in path** specify a text scalar file containing the streamline weights
 
 Standard options

--- a/docs/reference/commands/tck2fixel.rst
+++ b/docs/reference/commands/tck2fixel.rst
@@ -25,6 +25,8 @@ Options
 
 -  **-angle value** the max angle threshold for assigning streamline tangents to fixels (default: 45 degrees)
 
+-  **-tck_weights_in path** specify a text scalar file containing the streamline weights
+
 Standard options
 ^^^^^^^^^^^^^^^^
 
@@ -53,7 +55,7 @@ Tournier, J.-D.; Smith, R. E.; Raffelt, D.; Tabbara, R.; Dhollander, T.; Pietsch
 
 
 
-**Author:** David Raffelt (david.raffelt@florey.edu.au)
+**Author:** David Raffelt (david.raffelt@florey.edu.au) and Robert E. Smith (robert.smith@florey.edu.au)
 
 **Copyright:** Copyright (c) 2008-2026 the MRtrix3 contributors.
 

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -16,7 +16,7 @@ include(ExternalProject)
 ExternalProject_Add(BinariesTestData
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/binaries_data
     GIT_REPOSITORY ${mrtrix_binaries_data_url}
-    GIT_TAG 61387dbd33d6e8a1988060df81e8c066da24731b
+    GIT_TAG abaf89a2de10add888b99e50933623bdc37ca1ca
     GIT_PROGRESS TRUE
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -16,7 +16,7 @@ include(ExternalProject)
 ExternalProject_Add(BinariesTestData
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/binaries_data
     GIT_REPOSITORY ${mrtrix_binaries_data_url}
-    GIT_TAG 3d30c7fff58f9ca0bae5ccfe5565f35aa76b6dc6
+    GIT_TAG 61387dbd33d6e8a1988060df81e8c066da24731b
     GIT_PROGRESS TRUE
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""

--- a/testing/binaries/CMakeLists.txt
+++ b/testing/binaries/CMakeLists.txt
@@ -403,6 +403,10 @@ add_bash_binary_test(shconv/msmt)
 add_bash_binary_test(tck2connectome/assignment_forward_search)
 add_bash_binary_test(tck2connectome/default)
 
+add_bash_binary_test(tck2fixel/default)
+add_bash_binary_test(tck2fixel/phantom_unweighted)
+add_bash_binary_test(tck2fixel/phantom_weighted)
+
 add_bash_binary_test(tckconvert/rib_write)
 add_bash_binary_test(tckconvert/scanner2voxel)
 add_bash_binary_test(tckconvert/text_read_range)

--- a/testing/binaries/CMakeLists.txt
+++ b/testing/binaries/CMakeLists.txt
@@ -404,6 +404,7 @@ add_bash_binary_test(tck2connectome/assignment_forward_search)
 add_bash_binary_test(tck2connectome/default)
 
 add_bash_binary_test(tck2fixel/default)
+add_bash_binary_test(tck2fixel/phantom_precise)
 add_bash_binary_test(tck2fixel/phantom_unweighted)
 add_bash_binary_test(tck2fixel/phantom_weighted)
 

--- a/testing/binaries/tests/tck2fixel/default
+++ b/testing/binaries/tests/tck2fixel/default
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Verification of default operation of command,
+#   run on a subset FoV of in vivo data
+# Output is compared to that generated using a prior software version
+rm -rf tmp/
+tck2fixel tracks.tck fixel_image tmp/ tdi.mif
+testing_diff_image tmp/tdi.mif tck2fixel/default.mif -abs 0.5

--- a/testing/binaries/tests/tck2fixel/phantom_precise
+++ b/testing/binaries/tests/tck2fixel/phantom_precise
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Verification of operation of command
+#   run on the SIFT phantom with inclusion of SIFT2 per-streamline weights
+#   and also use of the -precise option;
+#   this should produce a distribution of fixel track densities
+#   that is more homogeneous than simply utilising the SIFT2 weights
+#   but performing a binary assignment of streamlines to fixels
+# Output is compared to that generated using a prior software version
+rm -rf tmp/
+tck2fixel SIFT_phantom/tracks.tck SIFT_phantom/fixels tmp/ td.mif \
+    -tck_weights_in SIFT_phantom/weights.csv \
+    -precise
+testing_diff_image tmp/td.mif tck2fixel/phantom_precise.mif -abs 0.1

--- a/testing/binaries/tests/tck2fixel/phantom_unweighted
+++ b/testing/binaries/tests/tck2fixel/phantom_unweighted
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Verification of default operation of command,
+#   run on the SIFT phantom without SIFT2 per-streamline weights
+# Output is compared to that generated using a prior software version
+rm -rf tmp/
+tck2fixel SIFT_phantom/tracks.tck SIFT_phantom/fixels tmp/ tdi.mif
+testing_diff_image tmp/tdi.mif tck2fixel/phantom_unweighted.mif -abs 0.5

--- a/testing/binaries/tests/tck2fixel/phantom_weighted
+++ b/testing/binaries/tests/tck2fixel/phantom_weighted
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Verification of default operation of command,
+#   run on the SIFT phantom with inclusion of SIFT2 per-streamline weights
+# Output is compared to that generated using a prior software version
+rm -rf tmp/
+tck2fixel SIFT_phantom/tracks.tck SIFT_phantom/fixels tmp/ sumweights.mif \
+    -tck_weights_in SIFT_phantom/weights.csv
+testing_diff_image tmp/sumweights.mif tck2fixel/phantom_weighted.mif -abs 0.1


### PR DESCRIPTION
For @ppruc.

While #2674 will deprecate `tck2fixel` entirely (it gets integrated into `tckmap), it's likely to be a while before I can finalise that one, and there was a desire to have the `-tck_weights_in` option for `tck2fixel` in a more accessible manner.

Demonstrated initial generation using a more context-aware prompt. Though the closer I looked the more problems I found with the original `tck2fixel` code, so quite a lot of it got refactored in the end.

Note simultaneous use of `MutexProtected` and `std::weak_ptr<>` that spawned #3295.