### PR TITLE
dirgen: Reduce verbosity level of messages

### DIFF
--- a/cpp/cmd/dirgen.cpp
+++ b/cpp/cmd/dirgen.cpp
@@ -180,13 +180,13 @@ public:
   void execute() {
     size_t this_start = 0;
     while ((this_start = current_start++) < restarts) {
-      INFO("launching start " + str(this_start));
+      DEBUG("launching start " + str(this_start));
       double E = 0.0;
 
       for (power = 1; power <= target_power; power *= 2) {
         Math::GradientDescent<Energy, ProjectedUpdate> optim(*this, ProjectedUpdate());
 
-        INFO("start " + str(this_start) + ": setting power = " + str(power));
+        DEBUG("start " + str(this_start) + ": setting power = " + str(power));
         optim.init();
 
         size_t iter = 0;


### PR DESCRIPTION
Prevents spamming of terminal whenever a Python script that itself invokes `dirgen` is executed with the `-debug` flag (which executes any underlying MRtrix3 commands with the `-info` flag).
