### PR TITLE
mrview: Fix ODF SH render

### DIFF
--- a/cpp/gui/shapes/halfsphere.cpp
+++ b/cpp/gui/shapes/halfsphere.cpp
@@ -22,7 +22,8 @@ namespace {
 
 constexpr float x = .525731112119133606;
 constexpr float z = .850650808352039932;
-constexpr float initial_vertices_data[]{x,   0.0, z,   //
+constexpr float initial_vertices_data[]{-x,  0.0, z,   //
+                                        x,   0.0, z,   //
                                         0.0, z,   x,   //
                                         0.0, -z,  x,   //
                                         z,   x,   0.0, //


### PR DESCRIPTION
Line omission in porting in f16060ab531410f1aa604ca065669aa9525786ec as part of #3206. 
Closes #3304.

-----

Thankfully only a visualisation problem.
Does however mean that I don't yet have an answer for #2451...