### PR TITLE
Math::SH: Improve numerical robustness to value() and delta() functions

### DIFF
--- a/core/math/SH.h
+++ b/core/math/SH.h
@@ -268,7 +268,7 @@ namespace MR
         inline typename VectorType1::Scalar value (const VectorType1& coefs, const VectorType2& unit_dir, int lmax)
         {
           using value_type = typename VectorType1::Scalar;
-          value_type rxy = std::sqrt ( pow2(unit_dir[1]) + pow2(unit_dir[0]) );
+          value_type rxy = std::hypot(unit_dir[0], unit_dir[1]);
           value_type cp = (rxy) ? unit_dir[0]/rxy : 1.0;
           value_type sp = (rxy) ? unit_dir[1]/rxy : 0.0;
           return value (coefs, unit_dir[2], cp, sp, lmax);
@@ -280,7 +280,7 @@ namespace MR
         {
           using value_type = typename VectorType1::Scalar;
           delta_vec.resize (NforL (lmax));
-          value_type rxy = std::sqrt ( pow2(unit_dir[1]) + pow2(unit_dir[0]) );
+          value_type rxy = std::hypot(unit_dir[0], unit_dir[1]);
           value_type cp = (rxy) ? unit_dir[0]/rxy : 1.0;
           value_type sp = (rxy) ? unit_dir[1]/rxy : 0.0;
           Eigen::Matrix<value_type,Eigen::Dynamic,1,0,64> AL (lmax+1);
@@ -475,8 +475,8 @@ namespace MR
           template <class VectorType, class UnitVectorType>
             ValueType value (const VectorType& val, const UnitVectorType& unit_dir) const {
               PrecomputedFraction<ValueType> f;
-              set (f, std::acos (unit_dir[2]));
-              ValueType rxy = std::sqrt ( pow2(unit_dir[1]) + pow2(unit_dir[0]) );
+              set (f, std::acos (std::max(ValueType(-1), std::min(ValueType(1), ValueType(unit_dir[2])))));
+              ValueType rxy = std::hypot(unit_dir[0], unit_dir[1]);
               ValueType cp = (rxy) ? unit_dir[0]/rxy : 1.0;
               ValueType sp = (rxy) ? unit_dir[1]/rxy : 0.0;
               ValueType v = 0.0;


### PR DESCRIPTION
Resolving CI testing issues in #2451 on Mac turned out to require use of the same `std::hypot()` function as was introduced in #3299 for `Math::SH::get_peak()` function, but in the `Math::SH::value()` functions (both precomputed and not). It is therefore likely that exactly the same numerical imprecisions manifest there, only that they are not iterative and not detected with existing tests, whereas in #2451 testing sampling of FOD amplitudes along streamline trajectories does manifest it.
I therefore consider it to be a "bug" not previously detected that warrants back-propagation to `master`.