### PR TITLE
clang-tidy action: Do an apt update

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -9,7 +9,9 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install dependencies
-      run: sudo apt install qt6-base-dev libqt6opengl6-dev libglvnd-dev libeigen3-dev zlib1g-dev libfftw3-dev ninja-build
+      run: |
+         sudo apt update
+         sudo apt install qt6-base-dev libqt6opengl6-dev libglvnd-dev libeigen3-dev zlib1g-dev libfftw3-dev ninja-build
 
     - name: Run CMake
       run: cmake . -DCMAKE_EXPORT_COMPILE_COMMANDS=ON


### PR DESCRIPTION
Attempt to fix `clang-tidy` action from immediately failing on PRs to `dev` due to failing to fetch `libinput` and `libinput-bin`.
