### PR TITLE
DICOM: Relax slicegap and slice separation checks

### DIFF
--- a/core/file/dicom/image.cpp
+++ b/core/file/dicom/image.cpp
@@ -595,12 +595,27 @@ namespace MR {
           sum_separation += separation;
         }
 
-        if (max_gap > 1e-4)
+        const default_type mean_separation = sum_separation / static_cast<default_type>(nslices - 1);
+        const default_type gap_threshold = std::sqrt(Eigen::NumTraits<float>::dummy_precision()) * mean_separation;
+        DEBUG("Threshold for evaluating slice gap:");
+        DEBUG("Mean separation = " + str(mean_separation) + ";" +
+              " maximal gap = " + str(max_gap) + ";" +
+              " auto-threshold = " + str(gap_threshold));
+        if (max_gap > gap_threshold) {
           WARN ("slice gap detected (maximum gap: " + str(max_gap, 3) + "mm)");
-        if (max_separation - min_separation > 2e-4)
+        }
+        const default_type separation_range_threshold = 2.0 * gap_threshold;
+        DEBUG("Threshold for evaluating variance in slice separation:");
+        DEBUG("Mean separation = " + str(mean_separation) + ";" +
+              " minimum separation = " + str(min_separation) + ";" +
+              " maximum separation = " + str(max_separation) + ";" +
+              " range = " + str(max_separation - min_separation) + ";" +
+              " auto-threshold = " + str(separation_range_threshold));
+        if (max_separation - min_separation > separation_range_threshold) {
           WARN ("slice separation is not constant (from " + str(min_separation, 8) + " to " + str(max_separation, 8) + "mm)");
+        }
 
-        return (sum_separation / default_type(nslices-1));
+        return mean_separation;
       }
 
 


### PR DESCRIPTION
For quite a while now I've been getting warnings whenever I load locally-acquired DWI data into MRtrix:

```text
mrinfo: [WARNING] slice gap detected (maximum gap: 0.000585mm)
mrinfo: [WARNING] slice separation is not constant (from 1.7994149 to 1.8004002mm)
```

This is frustrating as it's a 1.8mm isotropic acquisition---well, 1.79688 x 1.79688 x 1.8---with zero slice gap.
So this imprecision is coming either from calculations happening on the scanner or from calculations happening within MRtrix. 
Now the latter should all be double-precision, which makes me suspicious of the former.
But I think the software should only be issuing a warning if there's something detected in the input data that could possibly warrant user intervention; and in this case I already know that the slice gap os zero.
So perhaps the thresholds for the warnings should be relaxed.
I tried using `Eigen::NumTraits::dummy_precision()`, since this is the default within Eigen for comparing floating-point matrices, and is generally intended as a suitable tolerance on floating-point precision given the prospect of typical not-perfectly-conditioned floating-point calculations.
But that is too stringent.
Maybe the scanner is going back and forth with multiple vector cross-products that blow out the imprecision.
So I threw a `std::sqrt()` around that precision to simulate ill-posedness of upstream calculations.
Now the thresholds are about 10x what my no-slice-gap data come out as, which I think is reasonable.
Also the thresholds are now proportional to the mean slice separation rather than being an absolute value in mm.

```text
mrinfo: [DEBUG] Threshold for evaluating slice gap:
mrinfo: [DEBUG] Mean separation = 1.8000002113222811; maximal gap = 0.00058510613354489927; auto-threshold = 0.005692100401537877
mrinfo: [DEBUG] Threshold for evaluating variance in slice separation:
mrinfo: [DEBUG] Mean separation = 1.8000002113222811; minimum separation = 1.7994148938664551; maximum separation = 1.8004002330441295; range = 0.00098533917767440471; auto-threshold = 0.011384200803075754
```