### PR TITLE
tcksift: Fix -nthreads 0

### DIFF
--- a/src/dwi/tractography/SIFT/sifter.cpp
+++ b/src/dwi/tractography/SIFT/sifter.cpp
@@ -131,7 +131,9 @@ namespace MR
           // Trying a heuristic for now; go for a sort size of 1000 following initial sort, assuming half of all
           //   remaining streamlines have a negative gradient
 
-          const track_t sort_size = std::min (std::ceil(num_tracks() / double(Thread::number_of_threads())), std::round (2000.0 * double(num_tracks()) / double(tracks_remaining)));
+          track_t sort_size = std::round (2000.0 * double(num_tracks()) / double(tracks_remaining));
+          if (Thread::number_of_threads() != 0)
+            sort_size = std::min(sort_size, track_t(std::ceil(num_tracks() / double(Thread::number_of_threads()))));
           MT_gradient_vector_sorter sorter (gradient_vector, sort_size);
 
           // Remove candidate streamlines one at a time, and correspondingly modify the fixels to which they were attributed


### PR DESCRIPTION
The purpose of this code block is to say that if the total number of streamlines is very small, divide that set of streamlines equally amongst the number of available threads. However it failed to account for the prospect of `-nthreads 0`, leading to a divide-by-zero.