### PR TITLE
MR::printf(): Change from C to C++ variadic arguments

### DIFF
--- a/cpp/core/mrtrix.cpp
+++ b/cpp/core/mrtrix.cpp
@@ -16,7 +16,6 @@
 
 #include "mrtrix.h"
 
-#include <cstdarg>
 #include <string_view>
 
 namespace MR {
@@ -165,19 +164,6 @@ std::string uppercase(std::string_view string) {
   ret.resize(string.size());
   transform(string.begin(), string.end(), ret.begin(), toupper);
   return ret;
-}
-
-std::string printf(const char *format, ...) { // check_syntax off
-  size_t len = 0;
-  va_list list1, list2;
-  va_start(list1, format);
-  va_copy(list2, list1);
-  len = vsnprintf(nullptr, 0, format, list1) + 1;
-  va_end(list1);
-  VLA(buf, char, len);
-  vsnprintf(buf, len, format, list2);
-  va_end(list2);
-  return buf;
 }
 
 std::string strip(std::string_view string, std::string_view ws, bool left, bool right) {

--- a/cpp/core/mrtrix.h
+++ b/cpp/core/mrtrix.h
@@ -78,7 +78,15 @@ std::string lowercase(std::string_view string);
 //! return uppercase version of string
 std::string uppercase(std::string_view string);
 
-std::string printf(const char *format, ...); // check_syntax off
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
+template <typename... Args> std::string printf(const std::string format, Args... args) {
+  const int len = std::snprintf(nullptr, 0, format.c_str(), args...) + 1;
+  VLA(buf, char, len);
+  std::snprintf(buf, len, format.c_str(), args...);
+  return std::string(buf);
+}
+#pragma GCC diagnostic pop
 
 std::string strip(std::string_view string, std::string_view ws = {" \0\t\r\n", 5}, bool left = true, bool right = true);
 


### PR DESCRIPTION
Closes #3316.

Even though I may have initially honed in on the wrong piece of code (#3316), it still struck me as unusual to be using the C variadic argument structure (which I'm not I'd ever even seen before). `MR::printf()` is probably pre-C++11 code.

- [x] Identify a few commands that make use of `MR::printf()`, and make sure that strings generated with such (eg. terminal progress bar messages) appear as they should.