### PR TITLE
Attempt to address use of uninitialised value in MR::str()

### DIFF
--- a/cpp/core/mrtrix.h
+++ b/cpp/core/mrtrix.h
@@ -20,6 +20,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <iomanip>
 #include <iostream>
 #include <limits>
 #include <sstream>
@@ -120,12 +121,13 @@ bool starts_with_dash(std::string_view arg);
 //! returns string without leading dashes
 std::string without_leading_dash(std::string_view arg);
 
-template <class T> inline std::string str(const T &value, int precision = 0) {
+template <class T> inline std::string str(const T &value, const int precision = 0) {
+  assert(precision >= 0);
   std::ostringstream stream;
-  if (precision)
-    stream.precision(precision);
+  if (precision > 0)
+    stream << std::setprecision(precision);
   else if (max_digits<T>::value())
-    stream.precision(max_digits<T>::value());
+    stream << std::setprecision(max_digits<T>::value());
   stream << value;
   if (stream.fail())
     throw Exception(std::string("error converting type \"") + typeid(T).name() + "\" value to string");


### PR DESCRIPTION
Attempting to fix local compilation with sanitisers not working.
Address sanitiser seems to be fine, but memory / thread / undefined behaviour fail because of execution of a test command during build.

Initially the problem was (as reported in #3316):
```text
[488/589] Linking CXX executable bin/mrtrix-unit-tests
FAILED: bin/mrtrix-unit-tests testing/unit_tests/mrtrix-unit-tests[1]_tests.cmake /home/unimelb.edu.au/robertes/src/worktrees/data_to_image_buffer/build_msan/testing/unit_tests/mrtrix-unit-tests[1]_tests.cmake 
: && /usr/bin/clang++-21 -fsanitize=memory -g  testing/unit_tests/CMakeFiles/mrtrix-unit-tests.dir/erfinv_tests.cpp.o testing/unit_tests/CMakeFiles/mrtrix-unit-tests.dir/icls_tests.cpp.o testing/unit_tests/CMakeFiles/mrtrix-unit-tests.dir/ordered_queue_tests.cpp.o testing/unit_tests/CMakeFiles/mrtrix-unit-tests.dir/parse_axes_tests.cpp.o testing/unit_tests/CMakeFiles/mrtrix-unit-tests.dir/parse_ints_tests.cpp.o testing/unit_tests/CMakeFiles/mrtrix-unit-tests.dir/platform_tests.cpp.o testing/unit_tests/CMakeFiles/mrtrix-unit-tests.dir/roi_tests.cpp.o testing/unit_tests/CMakeFiles/mrtrix-unit-tests.dir/sh_precomputer_tests.cpp.o testing/unit_tests/CMakeFiles/mrtrix-unit-tests.dir/shuffle_tests.cpp.o testing/unit_tests/CMakeFiles/mrtrix-unit-tests.dir/to_tests.cpp.o testing/unit_tests/CMakeFiles/mrtrix-unit-tests.dir/gputests.cpp.o -o bin/mrtrix-unit-tests  -Wl,-rpath,/home/unimelb.edu.au/robertes/src/worktrees/data_to_image_buffer/build_msan/cpp/core:/home/unimelb.edu.au/robertes/src/worktrees/data_to_image_buffer/build_msan/_deps/slang-src/lib  cpp/core/libmrtrix-core.so  cpp/core/libmrtrix-executable-version.a  lib/libgtest_main.a  /usr/lib/x86_64-linux-gnu/libpng.so  /usr/lib/x86_64-linux-gnu/libz.so  /usr/lib/x86_64-linux-gnu/libfftw3.so  cpp/core/libmrtrix-version.a  _deps/dawn-src/lib/libwebgpu_dawn.a  -ldl  _deps/slang-src/lib/libslang-compiler.so.0.2026.5.1  lib/libgtest.a && cd /home/unimelb.edu.au/robertes/src/worktrees/data_to_image_buffer/build_msan/testing/unit_tests && /usr/bin/cmake -D TEST_TARGET=mrtrix-unit-tests -D TEST_EXECUTABLE=/home/unimelb.edu.au/robertes/src/worktrees/data_to_image_buffer/build_msan/bin/mrtrix-unit-tests -D TEST_EXECUTOR= -D TEST_WORKING_DIR=/home/unimelb.edu.au/robertes/src/worktrees/data_to_image_buffer/build_msan/testing/unit_tests -D TEST_EXTRA_ARGS= -D "TEST_PROPERTIES=LABELS;unittest" -D TEST_PREFIX= -D TEST_SUFFIX= -D TEST_FILTER= -D NO_PRETTY_TYPES=FALSE -D NO_PRETTY_VALUES=FALSE -D TEST_LIST=mrtrix-unit-tests_TESTS -D CTEST_FILE=/home/unimelb.edu.au/robertes/src/worktrees/data_to_image_buffer/build_msan/testing/unit_tests/mrtrix-unit-tests[1]_tests.cmake -D TEST_DISCOVERY_TIMEOUT=5 -D TEST_XML_OUTPUT_DIR= -P /usr/share/cmake-3.22/Modules/GoogleTestAddTests.cmake
==2892907==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x5555559ab2ba in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> MR::str<double>(double const&, int) /home/unimelb.edu.au/robertes/src/worktrees/data_to_image_buffer/cpp/core/mrtrix.h:126:5
    #1 0x7ffff2d643b1 in __cxx_global_var_init.4 /home/unimelb.edu.au/robertes/src/worktrees/data_to_image_buffer/cpp/core/dwi/fmls.cpp:27:34
    #2 0x7ffff2d65f07 in _GLOBAL__sub_I_fmls.cpp /home/unimelb.edu.au/robertes/src/worktrees/data_to_image_buffer/cpp/core/dwi/fmls.cpp
    #3 0x7ffff7fc947d in call_init elf/dl-init.c:70:3
    #4 0x7ffff7fc9567 in call_init elf/dl-init.c:33:6
    #5 0x7ffff7fc9567 in _dl_init elf/dl-init.c:117:5
    #6 0x7ffff7fe32c9  (/lib64/ld-linux-x86-64.so.2+0x202c9) (BuildId: 8cfa19934886748ff4603da8aa8fdb0c2402b8cf)

SUMMARY: MemorySanitizer: use-of-uninitialized-value /home/unimelb.edu.au/robertes/src/worktrees/data_to_image_buffer/cpp/core/mrtrix.h:126:5 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> MR::str<double>(double const&, int)
Exiting
CMake Error at /usr/share/cmake-3.22/Modules/GoogleTestAddTests.cmake:83 (message):
  Error running test executable.

    Path: '/home/unimelb.edu.au/robertes/src/worktrees/data_to_image_buffer/build_msan/bin/mrtrix-unit-tests'
    Result: 1
    Output:
      

Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/GoogleTestAddTests.cmake:179 (gtest_discover_tests_impl)
```

, which implicates:

```cpp
  stream.precision(precision);
```

I changed this to:

```cpp
stream << std::setprecision(precision);
```

However this just proceeds to a secondary fault:

```text
[451/552] Linking CXX executable bin/mrtrix-unit-tests
FAILED: bin/mrtrix-unit-tests testing/unit_tests/mrtrix-unit-tests[1]_tests.cmake /home/unimelb.edu.au/robertes/src/worktrees/printf_to_cpp/build_msan/testing/unit_tests/mrtrix-unit-tests[1]_tests.cmake 
: && /usr/bin/clang++-21 -fsanitize=memory -g  testing/unit_tests/CMakeFiles/mrtrix-unit-tests.dir/erfinv_tests.cpp.o testing/unit_tests/CMakeFiles/mrtrix-unit-tests.dir/icls_tests.cpp.o testing/unit_tests/CMakeFiles/mrtrix-unit-tests.dir/ordered_queue_tests.cpp.o testing/unit_tests/CMakeFiles/mrtrix-unit-tests.dir/parse_axes_tests.cpp.o testing/unit_tests/CMakeFiles/mrtrix-unit-tests.dir/parse_ints_tests.cpp.o testing/unit_tests/CMakeFiles/mrtrix-unit-tests.dir/platform_tests.cpp.o testing/unit_tests/CMakeFiles/mrtrix-unit-tests.dir/roi_tests.cpp.o testing/unit_tests/CMakeFiles/mrtrix-unit-tests.dir/sh_precomputer_tests.cpp.o testing/unit_tests/CMakeFiles/mrtrix-unit-tests.dir/shuffle_tests.cpp.o testing/unit_tests/CMakeFiles/mrtrix-unit-tests.dir/to_tests.cpp.o testing/unit_tests/CMakeFiles/mrtrix-unit-tests.dir/gputests.cpp.o -o bin/mrtrix-unit-tests  -Wl,-rpath,/home/unimelb.edu.au/robertes/src/worktrees/printf_to_cpp/build_msan/cpp/core:/home/unimelb.edu.au/robertes/src/worktrees/printf_to_cpp/build_msan/_deps/slang-src/lib  cpp/core/libmrtrix-core.so  cpp/core/libmrtrix-executable-version.a  lib/libgtest_main.a  /usr/lib/x86_64-linux-gnu/libpng.so  /usr/lib/x86_64-linux-gnu/libz.so  /usr/lib/x86_64-linux-gnu/libfftw3.so  cpp/core/libmrtrix-version.a  _deps/dawn-src/lib/libwebgpu_dawn.a  -ldl  _deps/slang-src/lib/libslang-compiler.so.0.2026.5.1  lib/libgtest.a && cd /home/unimelb.edu.au/robertes/src/worktrees/printf_to_cpp/build_msan/testing/unit_tests && /usr/bin/cmake -D TEST_TARGET=mrtrix-unit-tests -D TEST_EXECUTABLE=/home/unimelb.edu.au/robertes/src/worktrees/printf_to_cpp/build_msan/bin/mrtrix-unit-tests -D TEST_EXECUTOR= -D TEST_WORKING_DIR=/home/unimelb.edu.au/robertes/src/worktrees/printf_to_cpp/build_msan/testing/unit_tests -D TEST_EXTRA_ARGS= -D "TEST_PROPERTIES=LABELS;unittest" -D TEST_PREFIX= -D TEST_SUFFIX= -D TEST_FILTER= -D NO_PRETTY_TYPES=FALSE -D NO_PRETTY_VALUES=FALSE -D TEST_LIST=mrtrix-unit-tests_TESTS -D CTEST_FILE=/home/unimelb.edu.au/robertes/src/worktrees/printf_to_cpp/build_msan/testing/unit_tests/mrtrix-unit-tests[1]_tests.cmake -D TEST_DISCOVERY_TIMEOUT=5 -D TEST_XML_OUTPUT_DIR= -P /usr/share/cmake-3.22/Modules/GoogleTestAddTests.cmake
==3469803==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x5555559ab76a in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> MR::str<double>(double const&, int) /home/unimelb.edu.au/robertes/src/worktrees/printf_to_cpp/cpp/core/mrtrix.h:141:7
    #1 0x7ffff2d53431 in __cxx_global_var_init.4 /home/unimelb.edu.au/robertes/src/worktrees/printf_to_cpp/cpp/core/dwi/fmls.cpp:27:34
    #2 0x7ffff2d54f87 in _GLOBAL__sub_I_fmls.cpp /home/unimelb.edu.au/robertes/src/worktrees/printf_to_cpp/cpp/core/dwi/fmls.cpp
    #3 0x7ffff7fc947d in call_init elf/dl-init.c:70:3
    #4 0x7ffff7fc9567 in call_init elf/dl-init.c:33:6
    #5 0x7ffff7fc9567 in _dl_init elf/dl-init.c:117:5
    #6 0x7ffff7fe32c9  (/lib64/ld-linux-x86-64.so.2+0x202c9) (BuildId: 8cfa19934886748ff4603da8aa8fdb0c2402b8cf)

SUMMARY: MemorySanitizer: use-of-uninitialized-value /home/unimelb.edu.au/robertes/src/worktrees/printf_to_cpp/cpp/core/mrtrix.h:141:7 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> MR::str<double>(double const&, int)
Exiting
CMake Error at /usr/share/cmake-3.22/Modules/GoogleTestAddTests.cmake:83 (message):
  Error running test executable.

    Path: '/home/unimelb.edu.au/robertes/src/worktrees/printf_to_cpp/build_msan/bin/mrtrix-unit-tests'
    Result: 1
    Output:
      

Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/GoogleTestAddTests.cmake:179 (gtest_discover_tests_impl)
```

, which implicates:

```cpp
if (stream.fail())
```

I see no good reason why empty initialisation of a `std::ostringstream` would lead to status bits being uninitialised. So no idea if this is a library problem or what's going on. This was with Clang 21. Reading `.str()` before testing `.fail()` does not fix.