### PR TITLE
population_template: Fix linear registration with -info / -debug

### DIFF
--- a/bin/population_template
+++ b/bin/population_template
@@ -1172,7 +1172,7 @@ def execute(): #pylint: disable=unused-variable
           if linear_estimator:
             metric_option = ' -rigid_metric.diff.estimator ' + linear_estimator
           if app.VERBOSITY >= 2:
-            mrregister_log_option = ' -info -rigid_log ' + os.path.join('log', inp.uid + contrast[cid] + "_" + str(level) + '.log')
+            mrregister_log_option = ' -info -rigid_log ' + os.path.join('log', inp.uid + "_" + str(level) + '.log')
         else:
           scale_option = ' -affine_scale ' + str(scale)
           niter_option = ' -affine_niter ' + str(niter)
@@ -1186,7 +1186,7 @@ def execute(): #pylint: disable=unused-variable
           if linear_estimator:
             metric_option = ' -affine_metric.diff.estimator ' + linear_estimator
           if write_log:
-            mrregister_log_option = ' -info -affine_log ' + os.path.join('log', inp.uid + contrast[cid] + "_" + str(level) + '.log')
+            mrregister_log_option = ' -info -affine_log ' + os.path.join('log', inp.uid + "_" + str(level) + '.log')
 
         if leave_one_out:
           tmpl = []


### PR DESCRIPTION
When run with `-info` or `-debug`, `population_template` instructs `mrregister` to generate additional log files in the scratch directory. However the derivation of the filesystem path for that file attempts to include a string from "the currently processed contrast". This is erroneous as `mrregister` is run once taking as input all contrasts. The relevant code is not inside of a `for` loop over contrasts. So index `cid` is invalid and the code emits `IndexException: string index out of range`.

Discovered on `dev`.
With refactoring, the filesystem path is first determined, and then the choice of whether to insert it into the `mrregister` call is made subsequently.
Since it's the construction of the filesystem path that yields the Exception, the issue was encountered even when `population_template` was run at default verbosity.
The bug is however present on `master` so should be rectified there.