### PR TITLE
for_each: Warn on connection to pipe

### DIFF
--- a/python/mrtrix3/commands/for_each.py
+++ b/python/mrtrix3/commands/for_each.py
@@ -14,7 +14,7 @@
 # For more details, see http://www.mrtrix.org/.
 
 
-import os, re, sys, threading
+import os, re, stat, sys, threading
 
 
 
@@ -202,6 +202,13 @@ KEYLIST = [ 'IN', 'NAME', 'PRE', 'UNI' ]
 def execute(): #pylint: disable=unused-variable
   from mrtrix3 import ANSI, MRtrixError #pylint: disable=no-name-in-module, import-outside-toplevel
   from mrtrix3 import app, run #pylint: disable=no-name-in-module, import-outside-toplevel
+
+  mode = os.fstat(sys.stdout.fileno()).st_mode
+  if stat.S_ISFIFO(mode):
+    app.warn('for_each command output is connected to a pipe;'
+             ' if the command you intend for_each to execute itself includes piping,'
+             ' make sure that pipe symbols are quote-escaped'
+             ' (see example usages)')
 
   inputs = app.ARGS.inputs
   app.debug(f'All inputs: {inputs}')

--- a/testing/binaries/tests/tckgen/seed_rejection_per_coordinate
+++ b/testing/binaries/tests/tckgen/seed_rejection_per_coordinate
@@ -8,7 +8,7 @@ printf "3 3 3 1\n-3 -3 -3 0.1" > tmp_in.txt
 tckgen SIFT_phantom/dwi.mif tmp_out.tck \
     -algo seedtest \
     -seed_rejection_per_coordinate tmp_in.txt \
-    -select 5K \
+    -select 11K \
     -force
 
 rm -f tmp_out*.txt


### PR DESCRIPTION
If the user attempts to run within for_each a series of commands connected through pipes, but fails to quote-escape the pipe symbols to hide them from the shell interpreter, then the content of stdout generated by for_each (which will be empty) will be passed to whatever appears after the first pipe symbol, which can result in confusing error messages. This change produces a suitable warning to catch that case, given it will almost certainly be erroneous, based on for_each's stdout being connected to a FIFO pipe.
