### PR TITLE
Python test data update

### DIFF
--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -27,7 +27,7 @@ ExternalProject_Add(BinariesTestData
 ExternalProject_Add(ScriptsTestData
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/scripts_data
     GIT_REPOSITORY ${mrtrix_scripts_data_url}
-    GIT_TAG 82c1ef31b1361f3be0614d3de3964295c911880d
+    GIT_TAG 17e0f19411656481ded3f524042785cf53e39ac9
     GIT_PROGRESS TRUE
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""


### PR DESCRIPTION
This resolves a divergence on references to the `script_test_data` repository.

In #3057, commit https://github.com/MRtrix3/script_test_data/commit/7f3dae1e1bbbb383d710c0db66f469b5f812a298 added test data. #3057 was merged March 14 2025.

In #2918, commit https://github.com/MRtrix3/script_test_data/commit/82c1ef31b1361f3be0614d3de3964295c911880d added test data. #2918 was merged September 18 2025.

The `dev` branch on the code repo currently points to the latter; so the data from the former have disappeared somewhere along the way. This commit just points to an explicit merge on the test data repo, after which I will do some branch top cleanup on the test data repo.