### PR TITLE
fixelconnectivity: New option -normalise

### DIFF
--- a/cpp/cmd/fixelconnectivity.cpp
+++ b/cpp/cmd/fixelconnectivity.cpp
@@ -43,6 +43,8 @@ void usage() {
     " which encodes the fixel-fixel connectivity matrix."
     " Documentation regarding this format and how to use it will come in the future."
 
+  // TODO Add description RE: normalisation
+
   + Fixel::format_description;
 
   ARGUMENTS
@@ -70,6 +72,11 @@ void usage() {
              "provide a fixel data file containing a mask of those fixels to be computed;"
              " fixels outside the mask will be empty in the output matrix")
       + Argument("file").type_image_in()
+
+    + Option("normalise",
+             "controls whether the matrix elements are row-normalised (see Description)"
+             " (default: yes)")
+      + Argument("value").type_bool()
 
   + DWI::Tractography::TrackWeightsInOption
 
@@ -100,6 +107,7 @@ void run() {
   const value_type connectivity_threshold = get_option_value("connectivity", default_connectivity_threshold);
   const value_type angular_threshold =
       get_option_value("angle", static_cast<value_type>(DWI::Tractography::Mapping::default_streamline2fixel_angle));
+  const bool normalise = get_option_value<bool>("normalise", true);
 
   const std::string input_fixel_directory = argument[0];
   Header index_header = Fixel::find_index_header(input_fixel_directory);
@@ -129,12 +137,12 @@ void run() {
         Fixel::Matrix::generate_unweighted(argument[1], index_image, fixel_mask, angular_threshold);
     Fixel::Matrix::Writer<Fixel::Matrix::InitMatrixUnweighted> writer(connectivity_matrix, connectivity_threshold);
     set_optional_outputs(writer);
-    writer.save(argument[2]);
+    writer.save(argument[2], normalise);
   } else {
     auto connectivity_matrix =
         Fixel::Matrix::generate_weighted(argument[1], index_image, fixel_mask, angular_threshold);
     Fixel::Matrix::Writer<Fixel::Matrix::InitMatrixWeighted> writer(connectivity_matrix, connectivity_threshold);
     set_optional_outputs(writer);
-    writer.save(argument[2]);
+    writer.save(argument[2], normalise);
   }
 }

--- a/cpp/core/fixel/matrix.cpp
+++ b/cpp/core/fixel/matrix.cpp
@@ -240,7 +240,7 @@ template <class MatrixType> void Writer<MatrixType>::set_extent_path(std::string
   extent_image = Image<connectivity_value_type>::create(path, MR::Fixel::data_header_from_nfixels(matrix.size()));
 }
 
-template <class MatrixType> void Writer<MatrixType>::save(std::string_view path) const {
+template <class MatrixType> void Writer<MatrixType>::save(std::string_view path, const bool normalise) const {
   if (Path::exists(path)) {
     if (Path::is_dir(path)) {
       if (!App::overwrite_files &&
@@ -283,9 +283,15 @@ template <class MatrixType> void Writer<MatrixType>::save(std::string_view path)
     ProgressBar progress("Computing number of supra-threshold fixel-fixel connections", matrix.size());
 
     for (size_t fixel_index = 0; fixel_index != matrix.size(); ++fixel_index) {
-      const connectivity_value_type normalisation_factor = matrix[fixel_index].norm_factor();
+      const default_type normalisation_factor = matrix[fixel_index].norm_factor();
       for (auto &it : matrix[fixel_index]) {
-        const connectivity_value_type connectivity = normalisation_factor * it.value();
+        // If normalising, then each _directed_ connection can be thresholded individually.
+        // However for non-normalised matrices, want to preserve matrix symmetry.
+        // In that case, check whether the connection survives the threhsold in either direction
+        //   (so that low-density / poorly reconstructed fixels have the best chance to preserve connectivity)
+        const connectivity_value_type connectivity = static_cast<connectivity_value_type>(
+            it.value() *
+            (normalise ? normalisation_factor : std::max(normalisation_factor, matrix[it.index()].norm_factor())));
         if (connectivity >= threshold)
           ++num_connections;
       }
@@ -324,22 +330,25 @@ template <class MatrixType> void Writer<MatrixType>::save(std::string_view path)
     throw Exception(e, "Unable to allocate space on filesystem for fixel-fixel connectivity matrix data");
   }
 
-  ProgressBar progress("Normalising and writing fixel-fixel connectivity matrix to directory \"" + path + "\"",
-                       matrix.size());
+  ProgressBar progress(std::string(normalise ? "Normalising and writing" : "Writing un-normalised") + //
+                           " fixel-fixel connectivity matrix to directory \"" + path + "\"",          //
+                       matrix.size());                                                                //
   for (size_t fixel_index = 0; fixel_index != matrix.size(); ++fixel_index) {
 
     const ssize_t connection_offset = fixel_image.index(0);
     index_type connection_count = 0;
     connectivity_value_type sum_connectivity = connectivity_value_type(0.0);
-    const connectivity_value_type normalisation_factor = matrix[fixel_index].norm_factor();
+    const default_type normalisation_factor = matrix[fixel_index].norm_factor();
     for (auto &it : matrix[fixel_index]) {
-      const connectivity_value_type connectivity = normalisation_factor * it.value();
+      const connectivity_value_type connectivity = static_cast<connectivity_value_type>(
+          it.value() *
+          (normalise ? normalisation_factor : std::max(normalisation_factor, matrix[it.index()].norm_factor())));
       if (connectivity >= threshold) {
         ++connection_count;
         sum_connectivity += connectivity;
         fixel_image.value() = it.index();
         ++fixel_image.index(0);
-        value_image.value() = connectivity;
+        value_image.value() = normalise ? connectivity : it.value();
         ++value_image.index(0);
       }
     }

--- a/cpp/core/fixel/matrix.h
+++ b/cpp/core/fixel/matrix.h
@@ -199,7 +199,7 @@ public:
   void set_keyvals(KeyValues &kv) { keyvals = kv; }
   void set_count_path(std::string_view path);
   void set_extent_path(std::string_view path);
-  void save(std::string_view path) const;
+  void save(std::string_view path, const bool normalise) const;
 
 private:
   MatrixType &matrix;

--- a/docs/reference/commands/fixelconnectivity.rst
+++ b/docs/reference/commands/fixelconnectivity.rst
@@ -39,6 +39,8 @@ Options that influence generation of the connectivity matrix / matrices
 
 -  **-mask file** provide a fixel data file containing a mask of those fixels to be computed; fixels outside the mask will be empty in the output matrix
 
+-  **-normalise value** controls whether the matrix elements are row-normalised (see Description) (default: yes)
+
 -  **-tck_weights_in path** specify a text scalar file containing the streamline weights
 
 Options for additional outputs to be generated


### PR DESCRIPTION
Closes #3337.

Plz test @ppruc.

Outstanding tasks hence listed as draft PR:

- [ ] Before committing to public code would want to check that a user providing such a matrix to eg. fixelfilter or fixelcfestats would result in either identical results or obviously erroneous results, not something that is subtlely wrong.

- [ ] Describe consequences of presence or absence of normalisation in command documentation.