### PR TITLE
mrview: Proposed mitigation for segfault on -overlay.load

### DIFF
--- a/src/gui/dialog/progress.cpp
+++ b/src/gui/dialog/progress.cpp
@@ -29,6 +29,12 @@ namespace MR
 
         namespace {
           QProgressDialog* progress_dialog = nullptr;
+          // Guard against re-entrancy:
+          // qApp->processEvents() below can dispatch queued events (e.g. paint events or
+          // QTimer-driven callbacks) that themselves create a ProgressBar, recursively
+          // re-entering display() while a partial GL upload or the outer dialog is still
+          // in flight. Skip the inner pump in that case.
+          bool inside_process_events = false;
         }
 
 
@@ -48,10 +54,18 @@ namespace MR
                   0, p.show_percent() ? 100 : 0, GUI::App::main_window);
               progress_dialog->setWindowModality (Qt::ApplicationModal);
               progress_dialog->show();
-              qApp->processEvents();
+              if (!inside_process_events) {
+                inside_process_events = true;
+                qApp->processEvents();
+                inside_process_events = false;
+              }
             }
             progress_dialog->setValue (p.value());
-            qApp->processEvents();
+            if (!inside_process_events) {
+              inside_process_events = true;
+              qApp->processEvents();
+              inside_process_events = false;
+            }
           }
         }
 

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -251,7 +251,8 @@ namespace MR
         tool_has_focus (nullptr),
         best_FPS (NAN),
         show_FPS (false),
-        current_option (0) {
+        current_option (0),
+        processing_commandline_option (false) {
           main = this;
           GUI::App::set_main_window (this, glarea);
           GUI::Dialog::init();
@@ -1844,8 +1845,19 @@ namespace MR
         if (current_option >= MR::App::option.size())
           return;
 
+        // Guard against re-entrancy:
+        // a long-running ProgressBar (e.g. while uploading a large overlay texture during paint)
+        // may call qApp->processEvents(), which can dispatch this queued slot recursively while
+        // the outer invocation is still inside paintGL with an active GL context.
+        // Defer instead; the timer chain will retry shortly.
+        if (processing_commandline_option) {
+          QTimer::singleShot(10, this, SLOT(process_commandline_option_slot()));
+          return;
+        }
+        processing_commandline_option = true;
         process_commandline_option();
         ++current_option;
+        processing_commandline_option = false;
 
         QTimer::singleShot (10, this, SLOT(process_commandline_option_slot()));
         glarea->update();

--- a/src/gui/mrview/window.h
+++ b/src/gui/mrview/window.h
@@ -344,6 +344,7 @@ namespace MR
           double best_FPS, best_FPS_time;
           bool show_FPS;
           size_t current_option;
+          bool processing_commandline_option;
 
           friend class ImageBase;
           friend class Mode::Base;


### PR DESCRIPTION
Closes #1506.

Gave a verbose description of the fault to Claude, and this is what it came up with.
Have not been able to verify that it fixes the problem because I've not been successful in reproducing the problem; maybe something has been rectified in the Qt internals. So might benefit from a couple of people with different platforms testing.