### PR TITLE
Make use of std::byte

### DIFF
--- a/cpp/core/dwi/fixel_map.h
+++ b/cpp/core/dwi/fixel_map.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <cstddef>
+#include <memory>
 
 #include "algo/loop.h"
 #include "dwi/fmls.h"
@@ -81,18 +81,13 @@ private:
 template <class Fixel> class Fixel_map<Fixel>::MapVoxel {
 public:
   MapVoxel(const FMLS::FOD_lobes &in, const size_t first)
-      : first_fixel_index(first), count(in.size()), lookup_table(new std::byte[in.lut.size()]) {
-    memcpy(lookup_table, &in.lut[0], in.lut.size());
+      : first_fixel_index(first), count(in.size()), lookup_table(std::make_unique<uint8_t[]>(in.lut.size())) {
+    memcpy(lookup_table.get(), &in.lut[0], in.lut.size());
   }
 
   MapVoxel(const size_t first, const size_t size) : first_fixel_index(first), count(size), lookup_table(nullptr) {}
 
-  ~MapVoxel() {
-    if (lookup_table) {
-      delete[] lookup_table;
-      lookup_table = nullptr;
-    }
-  }
+  ~MapVoxel() = default;
 
   size_t first_index() const { return first_fixel_index; }
   size_t num_fixels() const { return count; }
@@ -101,13 +96,13 @@ public:
   // Direction must have been assigned to a histogram bin first
   size_t dir2fixel(const size_t dir) const {
     assert(lookup_table);
-    const size_t offset = std::to_integer<size_t>(lookup_table[dir]);
+    const size_t offset = static_cast<size_t>(lookup_table[dir]);
     return ((offset == count) ? 0 : (first_fixel_index + offset));
   }
 
 private:
   size_t first_fixel_index, count;
-  std::byte *lookup_table;
+  std::unique_ptr<uint8_t[]> lookup_table;
 };
 
 template <class Fixel> class Fixel_map<Fixel>::Iterator {

--- a/cpp/core/dwi/fixel_map.h
+++ b/cpp/core/dwi/fixel_map.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 #include "algo/loop.h"
 #include "dwi/fmls.h"
 #include "header.h"
@@ -79,8 +81,8 @@ private:
 template <class Fixel> class Fixel_map<Fixel>::MapVoxel {
 public:
   MapVoxel(const FMLS::FOD_lobes &in, const size_t first)
-      : first_fixel_index(first), count(in.size()), lookup_table(new uint8_t[in.lut.size()]) {
-    memcpy(lookup_table, &in.lut[0], in.lut.size() * sizeof(uint8_t));
+      : first_fixel_index(first), count(in.size()), lookup_table(new std::byte[in.lut.size()]) {
+    memcpy(lookup_table, &in.lut[0], in.lut.size());
   }
 
   MapVoxel(const size_t first, const size_t size) : first_fixel_index(first), count(size), lookup_table(nullptr) {}
@@ -99,13 +101,13 @@ public:
   // Direction must have been assigned to a histogram bin first
   size_t dir2fixel(const size_t dir) const {
     assert(lookup_table);
-    const size_t offset = lookup_table[dir];
+    const size_t offset = std::to_integer<size_t>(lookup_table[dir]);
     return ((offset == count) ? 0 : (first_fixel_index + offset));
   }
 
 private:
   size_t first_fixel_index, count;
-  uint8_t *lookup_table;
+  std::byte *lookup_table;
 };
 
 template <class Fixel> class Fixel_map<Fixel>::Iterator {

--- a/cpp/core/file/dicom/csa_entry.h
+++ b/cpp/core/file/dicom/csa_entry.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <array>
+#include <cstddef>
 #include <string_view>
 
 #include "datatype.h"
@@ -28,15 +29,16 @@ namespace MR::File::Dicom {
 
 class CSAEntry {
 public:
-  CSAEntry(const uint8_t *start_p, const uint8_t *end_p, bool output_fields = false)
+  CSAEntry(const std::byte *start_p, const std::byte *end_p, bool output_fields = false)
       : start(start_p), end(end_p), print(output_fields), cnum(0) {
     if (std::string_view(reinterpret_cast<const char *>(start), 4) == "SV10") {
       DEBUG("Siemens CSA entry does not start with \"SV10\"; ignoring");
       num = 0;
       next = end;
     } else {
-      const uint8_t *const unused1 = start + 4;
-      if (unused1[0] != 0x04U || unused1[1] != 0x03U || unused1[2] != 0x02U || unused1[3] != 0x01U)
+      const std::byte *const unused1 = start + 4;
+      if (unused1[0] != std::byte{0x04} || unused1[1] != std::byte{0x03} || unused1[2] != std::byte{0x02} ||
+          unused1[3] != std::byte{0x01})
         DEBUG("WARNING: CSA2 \'unused1\' int8 field contains unexpected data");
       num = Raw::fetch_LE<uint32_t>(start + 8);
       const uint32_t unused2 = Raw::fetch_LE<uint32_t>(start + 12);
@@ -75,7 +77,7 @@ public:
       if (next + size > end)
         return false;
       if (print)
-        fprintf(stdout, "%.*s ", length, (const char *)next + 16);
+        fprintf(stdout, "%.*s ", length, reinterpret_cast<const char *>(next) + 16);
       next += size;
     }
     if (print)
@@ -91,7 +93,7 @@ public:
   uint32_t size() const { return num; }
 
   int get_int() const {
-    const uint8_t *p = start + 84;
+    const std::byte *p = start + 84;
     for (uint32_t m = 0; m < nitems; m++) {
       uint32_t length = Raw::fetch_LE<uint32_t>(p);
       if (length)
@@ -102,7 +104,7 @@ public:
   }
 
   default_type get_float() const {
-    const uint8_t *p = start + 84;
+    const std::byte *p = start + 84;
     for (uint32_t m = 0; m < nitems; m++) {
       uint32_t length = Raw::fetch_LE<uint32_t>(p);
       if (length)
@@ -113,7 +115,7 @@ public:
   }
 
   template <typename Container> void get_float(Container &v) const {
-    const uint8_t *p = start + 84;
+    const std::byte *p = start + 84;
     if (nitems < v.size())
       DEBUG("CSA entry contains fewer items than expected - trailing entries will be set to NaN");
     for (uint32_t m = 0; m < std::min<size_t>(nitems, v.size()); m++) {
@@ -128,7 +130,7 @@ public:
 
   std::vector<std::string> get_string() const {
     std::vector<std::string> result;
-    const uint8_t *p = start + 84;
+    const std::byte *p = start + 84;
     for (uint32_t m = 0; m < nitems; m++) {
       const uint32_t length = Raw::fetch_LE<uint32_t>(p);
       std::string s(reinterpret_cast<const char *>(p) + 16, length);
@@ -140,12 +142,12 @@ public:
 
   friend std::ostream &operator<<(std::ostream &stream, const CSAEntry &item) {
     stream << "[CSA] " << item.name << " (" + str(item.nitems) + " items):";
-    const uint8_t *next = item.start + 84;
+    const std::byte *next = item.start + 84;
 
     for (uint32_t m = 0; m < item.nitems; m++) {
       uint32_t length = Raw::fetch_LE<uint32_t>(next);
       size_t size = 16 + 4 * ((length + 3) / 4);
-      while (length > 0 && !next[16 + length - 1])
+      while (length > 0 && next[16 + length - 1] == std::byte{0})
         length--;
       stream << " ";
       stream.write(reinterpret_cast<const char *>(next) + 16, length);
@@ -157,9 +159,9 @@ public:
   }
 
 protected:
-  const uint8_t *start;
-  const uint8_t *next;
-  const uint8_t *end;
+  const std::byte *start;
+  const std::byte *next;
+  const std::byte *end;
   bool print;
   std::string name;
   std::array<char, 4> vr;

--- a/cpp/core/file/dicom/element.cpp
+++ b/cpp/core/file/dicom/element.cpp
@@ -284,10 +284,10 @@ Element::Type Element::type() const {
 std::vector<int32_t> Element::get_int() const {
   std::vector<int32_t> V;
   if (VR == VR_SL)
-    for (const uint8_t *p = data; p < data + size; p += sizeof(int32_t))
+    for (const std::byte *p = data; p < data + size; p += sizeof(int32_t))
       V.push_back(Raw::fetch_<int32_t>(p, is_BE));
   else if (VR == VR_SS)
-    for (const uint8_t *p = data; p < data + size; p += sizeof(int16_t))
+    for (const std::byte *p = data; p < data + size; p += sizeof(int16_t))
       V.push_back(Raw::fetch_<int16_t>(p, is_BE));
   else if (VR == VR_IS) {
     auto strings = split(std::string(reinterpret_cast<const char *>(data), size), "\\", false);
@@ -303,10 +303,10 @@ std::vector<int32_t> Element::get_int() const {
 std::vector<uint32_t> Element::get_uint() const {
   std::vector<uint32_t> V;
   if (VR == VR_UL)
-    for (const uint8_t *p = data; p < data + size; p += sizeof(uint32_t))
+    for (const std::byte *p = data; p < data + size; p += sizeof(uint32_t))
       V.push_back(Raw::fetch_<uint32_t>(p, is_BE));
   else if (VR == VR_US)
-    for (const uint8_t *p = data; p < data + size; p += sizeof(uint16_t))
+    for (const std::byte *p = data; p < data + size; p += sizeof(uint16_t))
       V.push_back(Raw::fetch_<uint16_t>(p, is_BE));
   else if (VR == VR_IS) {
     auto strings = split(std::string(reinterpret_cast<const char *>(data), size), "\\", false);
@@ -321,10 +321,10 @@ std::vector<uint32_t> Element::get_uint() const {
 std::vector<default_type> Element::get_float() const {
   std::vector<default_type> V;
   if (VR == VR_FD)
-    for (const uint8_t *p = data; p < data + size; p += sizeof(float64))
+    for (const std::byte *p = data; p < data + size; p += sizeof(float64))
       V.push_back(Raw::fetch_<float64>(p, is_BE));
   else if (VR == VR_FL)
-    for (const uint8_t *p = data; p < data + size; p += sizeof(float32))
+    for (const std::byte *p = data; p < data + size; p += sizeof(float32))
       V.push_back(Raw::fetch_<float32>(p, is_BE));
   else if (VR == VR_DS || VR == VR_IS) {
     auto strings = split(std::string(reinterpret_cast<const char *>(data), size), "\\", false);

--- a/cpp/core/file/dicom/element.h
+++ b/cpp/core/file/dicom/element.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <unordered_map>
 
 #include "file/dicom/definitions.h"
@@ -28,9 +29,9 @@ namespace MR::File::Dicom {
 
 class Sequence {
 public:
-  Sequence(uint16_t group, uint16_t element, uint8_t *end) : group(group), element(element), end(end) {}
+  Sequence(uint16_t group, uint16_t element, std::byte *end) : group(group), element(element), end(end) {}
   uint16_t group, element;
-  uint8_t *end;
+  std::byte *end;
 
   bool is(uint16_t Group, uint16_t Element) const {
     if (group != Group)
@@ -91,7 +92,7 @@ public:
 
   uint16_t group, element, VR;
   uint32_t size;
-  uint8_t *data;
+  std::byte *data;
   std::vector<Sequence> parents;
   bool transfer_syntax_supported;
 
@@ -125,7 +126,7 @@ public:
     return val.i;
   }
 
-  size_t offset(uint8_t *address) const { return address - fmap->address(); }
+  size_t offset(std::byte *address) const { return address - fmap->address(); }
   bool is_big_endian() const { return is_BE; }
   bool is_new_sequence() const {
     return VR == VR_SQ || (group == group_data && element == element_data && size == undefined_length);
@@ -181,11 +182,11 @@ protected:
   void set_explicit_encoding();
   bool read_GR_EL();
 
-  uint8_t *next;
-  uint8_t *start;
+  std::byte *next;
+  std::byte *start;
   bool is_explicit, is_BE, is_transfer_syntax_BE;
 
-  std::vector<uint8_t *> end_seq;
+  std::vector<std::byte *> end_seq;
 
   static uint16_t get_VR_from_tag_name(std::string_view name) {
     union {

--- a/cpp/core/file/dicom/image.cpp
+++ b/cpp/core/file/dicom/image.cpp
@@ -337,7 +337,7 @@ template <typename T> void phoenix_vector(const KeyValues &keyval, std::string_v
 }
 } // namespace
 
-void Image::decode_csa(const uint8_t *start, const uint8_t *end) {
+void Image::decode_csa(const std::byte *start, const std::byte *end) {
   CSAEntry entry(start, end);
 
   while (entry.parse()) {

--- a/cpp/core/file/dicom/image.h
+++ b/cpp/core/file/dicom/image.h
@@ -150,7 +150,7 @@ public:
 
   void read();
   void parse_item(Element &item);
-  void decode_csa(const uint8_t *start, const uint8_t *end);
+  void decode_csa(const std::byte *start, const std::byte *end);
   KeyValues read_csa_ascii(const std::vector<std::string> &data);
 
   bool operator<(const Image &ima) const { return Frame::operator<(ima); }

--- a/cpp/core/file/mmap.cpp
+++ b/cpp/core/file/mmap.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <array>
+#include <cstddef>
 #include <fcntl.h>
 #include <unistd.h>
 #include <zlib.h>
@@ -123,7 +124,7 @@ MMap::MMap(const Entry &entry, bool readwrite, bool preload, int64_t mapped_size
 
     if (delayed_writeback) {
       try {
-        first = new uint8_t[msize];
+        first = new std::byte[msize];
         if (!first)
           throw 1;
       } catch (...) {
@@ -159,13 +160,13 @@ MMap::MMap(const Entry &entry, bool readwrite, bool preload, int64_t mapped_size
         (HANDLE)_get_osfhandle(fd), nullptr, (readwrite ? PAGE_READWRITE : PAGE_READONLY), 0, start + msize, nullptr);
     if (!handle)
       throw 0;
-    addr = static_cast<uint8_t *>(
+    addr = static_cast<std::byte *>(
         MapViewOfFile(handle, (readwrite ? FILE_MAP_ALL_ACCESS : FILE_MAP_READ), 0, 0, start + msize));
     if (!addr)
       throw 0;
     CloseHandle(handle);
 #else
-    addr = static_cast<uint8_t *>(
+    addr = static_cast<std::byte *>(
         mmap(nullptr, start + msize, (readwrite ? PROT_WRITE | PROT_READ : PROT_READ), MAP_SHARED, fd, 0));
     if (addr == MAP_FAILED)
       throw 0;

--- a/cpp/core/file/mmap.h
+++ b/cpp/core/file/mmap.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <iostream>
 
@@ -53,8 +54,8 @@ public:
 
   std::string name() const { return Entry::name; }
   int64_t size() const { return msize; }
-  uint8_t *address() { return first; }
-  const uint8_t *address() const { return first; }
+  std::byte *address() { return first; }
+  const std::byte *address() const { return first; }
 
   bool is_read_write() const { return readwrite; }
   bool changed() const;
@@ -68,10 +69,10 @@ public:
 
 protected:
   int fd;
-  uint8_t *addr;  /**< The address in memory where the file has been mapped. */
-  uint8_t *first; /**< The address in memory to the start of the region of interest. */
-  int64_t msize;  /**< The size of the file. */
-  time_t mtime;   /**< The modification time of the file at the last check. */
+  std::byte *addr;  /**< The address in memory where the file has been mapped. */
+  std::byte *first; /**< The address in memory to the start of the region of interest. */
+  int64_t msize;    /**< The size of the file. */
+  time_t mtime;     /**< The modification time of the file at the last check. */
   bool readwrite;
 
   void map();

--- a/cpp/core/file/npy.h
+++ b/cpp/core/file/npy.h
@@ -87,9 +87,9 @@ template <class ContType> void save_vector(const ContType &data, std::string_vie
   using ValueType = typename container_value_type<ContType>::type;
   const WriteInfo info = prepare_ND_write(path, DataType::from<ValueType>(), {static_cast<size_t>(data.size())});
   if (info.data_type == DataType::Bit) {
-    uint8_t *const out = reinterpret_cast<uint8_t *const>(info.mmap->address());
+    std::byte *const out = info.mmap->address();
     for (ssize_t i = 0; i != static_cast<ssize_t>(data.size()); ++i)
-      out[i] = data[i] ? uint8_t(1) : uint8_t(0);
+      out[i] = std::byte(data[i] ? 1 : 0);
     return;
   }
   auto store_func = __set_store_function<ValueType>(info.data_type);
@@ -102,11 +102,11 @@ template <class ContType> void save_matrix(const ContType &data, std::string_vie
   const WriteInfo info = prepare_ND_write(
       path, DataType::from<ValueType>(), {static_cast<size_t>(data.rows()), static_cast<size_t>(data.cols())});
   if (info.data_type == DataType::Bit) {
-    uint8_t *const out = reinterpret_cast<uint8_t *const>(info.mmap->address());
+    std::byte *const out = info.mmap->address();
     size_t i = 0;
     for (ssize_t col = 0; col != data.cols(); ++col)
       for (ssize_t row = 0; row != data.rows(); ++row) {
-        out[i++] = data(row, col) ? uint8_t(1) : uint8_t(0);
+        out[i++] = std::byte(data(row, col) ? 1 : 0);
       }
     return;
   }

--- a/cpp/core/file/png.cpp
+++ b/cpp/core/file/png.cpp
@@ -20,6 +20,7 @@
 
 #include <array>
 #include <chrono>
+#include <cstddef>
 #include <zlib.h>
 
 #include "app.h"
@@ -126,7 +127,7 @@ void Reader::set_expand() {
   output_bitdepth = std::max(8, bit_depth);
 }
 
-void Reader::load(uint8_t *image_data) {
+void Reader::load(std::byte *image_data) {
   if (setjmp(png_jmpbuf(png_ptr))) {
     png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
     throw Exception("Fatal error reading PNG image");
@@ -134,7 +135,7 @@ void Reader::load(uint8_t *image_data) {
   const int row_bytes = png_get_rowbytes(png_ptr, info_ptr);
   png_bytepp row_pointers = new png_bytep[height];
   for (png_uint_32 i = 0; i != height; ++i)
-    row_pointers[i] = image_data + i * row_bytes;
+    row_pointers[i] = reinterpret_cast<png_bytep>(image_data + i * row_bytes);
   png_read_image(png_ptr, row_pointers);
   delete[] row_pointers;
   row_pointers = nullptr;
@@ -297,7 +298,7 @@ Writer::~Writer() {
   }
 }
 
-void Writer::save(uint8_t *data) {
+void Writer::save(std::byte *data) {
   if (setjmp(jmpbuf)) {
     png_destroy_write_struct(&png_ptr, &info_ptr);
     png_ptr = nullptr;
@@ -306,10 +307,10 @@ void Writer::save(uint8_t *data) {
   }
   const size_t row_bytes = png_get_rowbytes(png_ptr, info_ptr);
 
-  auto finish = [&](uint8_t *to_write) {
+  auto finish = [&](std::byte *to_write) {
     std::unique_ptr<png_bytep[]> row_pointers(new png_bytep[height]);
     for (size_t row = 0; row != height; ++row)
-      row_pointers[row] = to_write + row * row_bytes;
+      row_pointers[row] = reinterpret_cast<png_bytep>(to_write + row * row_bytes);
     png_write_image(png_ptr, row_pointers.get());
     png_write_end(png_ptr, info_ptr);
   };
@@ -317,10 +318,9 @@ void Writer::save(uint8_t *data) {
   if (data_type == DataType::UInt8 || data_type == DataType::UInt16BE) {
     finish(data);
   } else {
-    uint8_t scratch[row_bytes * height];
-    // Convert from "data" into "scratch"
-    // This may include changes to fundamental type, changes to bit depth, changes to endianness
-    uint8_t *in_ptr = data, *out_ptr = scratch;
+    std::byte scratch[row_bytes * height];
+    std::byte *in_ptr = data;
+    std::byte *out_ptr = scratch;
     const uint8_t channels = png_get_channels(png_ptr, info_ptr);
     const size_t num_elements = channels * width * height;
     switch (bit_depth) {

--- a/cpp/core/file/png.h
+++ b/cpp/core/file/png.h
@@ -18,6 +18,7 @@
 
 #ifdef MRTRIX_PNG_SUPPORT
 
+#include <cstddef>
 #include <png.h>
 
 #include "fetch_store.h"
@@ -44,7 +45,7 @@ public:
 
   void set_expand();
 
-  void load(uint8_t *);
+  void load(std::byte *);
 
 private:
   FILE *infile;
@@ -64,7 +65,7 @@ public:
 
   size_t get_size() const { return png_get_rowbytes(png_ptr, info_ptr) * height; }
 
-  void save(uint8_t *);
+  void save(std::byte *);
 
 private:
   png_structp png_ptr;
@@ -80,11 +81,11 @@ private:
   static jmp_buf jmpbuf;
 
   template <typename T>
-  void fill(uint8_t *in_ptr, uint8_t *out_ptr, const DataType data_type, const size_t num_elements);
+  void fill(std::byte *in_ptr, std::byte *out_ptr, const DataType data_type, const size_t num_elements);
 };
 
 template <typename T>
-void Writer::fill(uint8_t *in_ptr, uint8_t *out_ptr, const DataType data_type, const size_t num_elements) {
+void Writer::fill(std::byte *in_ptr, std::byte *out_ptr, const DataType data_type, const size_t num_elements) {
   std::function<default_type(const void *, size_t, default_type, default_type)> fetch_func;
   std::function<void(default_type, void *, size_t, default_type, default_type)> store_func;
   __set_fetch_store_scale_functions<default_type>(fetch_func, store_func, data_type);

--- a/cpp/core/formats/mri.cpp
+++ b/cpp/core/formats/mri.cpp
@@ -14,6 +14,8 @@
  * For more details, see http://www.mrtrix.org/.
  */
 
+#include <cstddef>
+
 #include "file/config.h"
 #include "file/mmap.h"
 #include "file/ofstream.h"
@@ -105,11 +107,11 @@ inline char order2char(size_t axis, bool forward) {
   return ('\0');
 }
 
-inline uint32_t type(const uint8_t *pos, bool is_BE) { return Raw::fetch_<uint32_t>(pos, is_BE); }
-inline size_t size(const uint8_t *pos, bool is_BE) { return (Raw::fetch_<uint32_t>(pos + sizeof(uint32_t), is_BE)); }
-inline const uint8_t *data(const uint8_t *pos) { return (pos + 2 * sizeof(uint32_t)); }
+inline uint32_t type(const std::byte *pos, bool is_BE) { return Raw::fetch_<uint32_t>(pos, is_BE); }
+inline size_t size(const std::byte *pos, bool is_BE) { return (Raw::fetch_<uint32_t>(pos + sizeof(uint32_t), is_BE)); }
+inline const std::byte *data(const std::byte *pos) { return (pos + 2 * sizeof(uint32_t)); }
 
-inline const uint8_t *next(const uint8_t *current_pos, bool is_BE) {
+inline const std::byte *next(const std::byte *current_pos, bool is_BE) {
   return (current_pos + 2 * sizeof(uint32_t) + size(current_pos, is_BE));
 }
 
@@ -162,13 +164,13 @@ std::unique_ptr<ImageIO::Base> MRI::read(Header &H) const {
   H.ndim() = 4;
 
   size_t data_offset = 0;
-  const uint8_t *current = fmap.address() + sizeof(int32_t) + sizeof(uint16_t);
-  const uint8_t *last = fmap.address() + fmap.size() - 2 * sizeof(uint32_t);
+  const std::byte *current = fmap.address() + sizeof(int32_t) + sizeof(uint16_t);
+  const std::byte *last = fmap.address() + fmap.size() - 2 * sizeof(uint32_t);
 
   while (current <= last) {
     switch (type(current, is_BE)) {
     case mriformat_index_data:
-      H.datatype() = fetch_datatype(data(current)[-4]);
+      H.datatype() = fetch_datatype(std::to_integer<uint8_t>(data(current)[-4]));
       data_offset = current + 5 - fmap.address();
       break;
     case mriformat_index_dimensions:

--- a/cpp/core/image.h
+++ b/cpp/core/image.h
@@ -18,6 +18,7 @@
 
 #define IMAGE_H
 
+#include <cstddef>
 #include <functional>
 #include <tuple>
 #include <type_traits>
@@ -237,7 +238,7 @@ public:
     store_func(val, io->segment(nseg), offset - nseg * io->segment_size(), intensity_offset(), intensity_scale());
   }
 
-  std::unique_ptr<uint8_t[]> data_buffer;
+  std::unique_ptr<std::byte[]> data_buffer;
   void *get_data_pointer();
 
   FORCE_INLINE ImageIO::Base *get_io() const { return io.get(); }
@@ -379,7 +380,7 @@ template <typename ValueType> Image<ValueType> Image<ValueType>::with_direct_io(
 
   // the buffer into which to copy the data:
   const auto buffer_size = footprint<ValueType>(voxel_count(*this));
-  buffer->data_buffer = std::unique_ptr<uint8_t[]>(new uint8_t[buffer_size]);
+  buffer->data_buffer = std::unique_ptr<std::byte[]>(new std::byte[buffer_size]);
 
   if (buffer->get_io()->is_image_new()) {
     // no need to preload if data is zero anyway:

--- a/cpp/core/image_io/base.h
+++ b/cpp/core/image_io/base.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <unistd.h>
 
@@ -65,7 +66,7 @@ public:
       writable = readwrite;
   }
 
-  uint8_t *segment(size_t n) const {
+  std::byte *segment(size_t n) const {
     assert(n < addresses.size());
     return addresses[n].get();
   }
@@ -92,7 +93,7 @@ public:
 
 protected:
   size_t segsize;
-  std::vector<std::unique_ptr<uint8_t[]>> addresses;
+  std::vector<std::unique_ptr<std::byte[]>> addresses;
   bool is_new, writable;
 
   void check() const { assert(addresses.size()); }

--- a/cpp/core/image_io/default.cpp
+++ b/cpp/core/image_io/default.cpp
@@ -14,6 +14,7 @@
  * For more details, see http://www.mrtrix.org/.
  */
 
+#include <cstddef>
 #include <limits>
 
 #include "app.h"
@@ -53,7 +54,7 @@ void Default::unload(const Header &header) {
       for (size_t n = 0; n < files.size(); n++) {
         File::OFStream out(files[n].name, std::ios::in | std::ios::out | std::ios::binary);
         out.seekp(files[n].start, out.beg);
-        out.write((char *)(addresses[0].get() + n * bytes_per_segment), bytes_per_segment);
+        out.write(reinterpret_cast<const char *>(addresses[0].get() + n * bytes_per_segment), bytes_per_segment);
         if (!out.good())
           throw Exception("error writing back contents of file \"" + files[n].name + "\": " + strerror(errno));
       }
@@ -79,7 +80,7 @@ void Default::copy_to_mem(const Header &header) {
   addresses.resize(files.size() > 1 && header.datatype().bits() * segsize != 8 * static_cast<size_t>(bytes_per_segment)
                        ? files.size()
                        : 1);
-  addresses[0].reset(new uint8_t[files.size() * bytes_per_segment]);
+  addresses[0].reset(new std::byte[files.size() * bytes_per_segment]);
   if (!addresses[0])
     throw Exception("failed to allocate memory for image \"" + header.name() + "\"");
 

--- a/cpp/core/image_io/gz.cpp
+++ b/cpp/core/image_io/gz.cpp
@@ -35,7 +35,7 @@ void GZ::load(const Header &header, size_t) {
 
   DEBUG("loading image \"" + header.name() + "\"...");
   addresses.resize(header.datatype().bits() == 1 && files.size() > 1 ? files.size() : 1);
-  addresses[0].reset(new uint8_t[files.size() * bytes_per_segment]);
+  addresses[0].reset(new std::byte[files.size() * bytes_per_segment]);
   if (!addresses[0])
     throw Exception("failed to allocate memory for image \"" + header.name() + "\"");
 
@@ -47,8 +47,8 @@ void GZ::load(const Header &header, size_t) {
     for (size_t n = 0; n < files.size(); n++) {
       File::GZ zf(files[n].name, "rb");
       zf.seek(files[n].start);
-      uint8_t *address = addresses[0].get() + n * bytes_per_segment;
-      uint8_t *last = address + bytes_per_segment - bytes_per_zcall;
+      std::byte *address = addresses[0].get() + n * bytes_per_segment;
+      std::byte *last = address + bytes_per_segment - bytes_per_zcall;
       while (address < last) {
         zf.read(reinterpret_cast<char *>(address), bytes_per_zcall);
         address += bytes_per_zcall;
@@ -79,8 +79,8 @@ void GZ::unload(const Header &header) {
         File::GZ zf(files[n].name, "wb");
         if (lead_in)
           zf.write(reinterpret_cast<const char *>(lead_in.get()), lead_in_size);
-        uint8_t *address = addresses[0].get() + n * bytes_per_segment;
-        uint8_t *last = address + bytes_per_segment - bytes_per_zcall;
+        std::byte *address = addresses[0].get() + n * bytes_per_segment;
+        std::byte *last = address + bytes_per_segment - bytes_per_zcall;
         while (address < last) {
           zf.write(reinterpret_cast<const char *>(address), bytes_per_zcall);
           address += bytes_per_zcall;

--- a/cpp/core/image_io/gz.h
+++ b/cpp/core/image_io/gz.h
@@ -28,17 +28,18 @@ public:
       : Base(header),
         lead_in_size(file_header_size),
         lead_out_size(file_tailer_size),
-        lead_in(file_header_size ? new uint8_t[file_header_size] : nullptr),
-        lead_out(file_tailer_size ? new uint8_t[file_tailer_size] : nullptr) {}
+        lead_in(file_header_size ? new std::byte[file_header_size] : nullptr),
+        lead_out(file_tailer_size ? new std::byte[file_tailer_size] : nullptr) {}
 
-  uint8_t *header() { return lead_in.get(); }
+  std::byte *header() { return lead_in.get(); }
 
-  uint8_t *tailer() { return lead_out.get(); }
+  std::byte *tailer() { return lead_out.get(); }
 
 protected:
   int64_t bytes_per_segment;
   size_t lead_in_size, lead_out_size;
-  std::unique_ptr<uint8_t[]> lead_in, lead_out;
+  std::unique_ptr<std::byte[]> lead_in;
+  std::unique_ptr<std::byte[]> lead_out;
 
   virtual void load(const Header &, size_t);
   virtual void unload(const Header &);

--- a/cpp/core/image_io/mosaic.cpp
+++ b/cpp/core/image_io/mosaic.cpp
@@ -35,12 +35,12 @@ void Mosaic::load(const Header &header, size_t) {
 
   DEBUG("loading mosaic image \"" + header.name() + "\"...");
   addresses.resize(1);
-  addresses[0].reset(new uint8_t[files.size() * bytes_per_segment]);
+  addresses[0].reset(new std::byte[files.size() * bytes_per_segment]);
   if (!addresses[0])
     throw Exception("failed to allocate memory for image \"" + header.name() + "\"");
 
   ProgressBar progress("reformatting DICOM mosaic images", slices * files.size());
-  uint8_t *data = addresses[0].get();
+  std::byte *data = addresses[0].get();
   for (size_t n = 0; n < files.size(); n++) {
     File::MMap file(files[n], false, false, m_xdim * m_ydim * header.datatype().bytes());
     size_t nx = 0, ny = 0;

--- a/cpp/core/image_io/png.cpp
+++ b/cpp/core/image_io/png.cpp
@@ -30,7 +30,7 @@ void PNG::load(const Header &header, size_t) {
         + " \"" + header.name() + "\"");          //
   segsize = (header.datatype().bits() * voxel_count(header) + 7) / 8;
   addresses.resize(1);
-  addresses[0].reset(new uint8_t[segsize]);
+  addresses[0].reset(new std::byte[segsize]);
   if (is_new) {
     memset(addresses[0].get(), 0x00, segsize);
   } else {

--- a/cpp/core/image_io/ram.cpp
+++ b/cpp/core/image_io/ram.cpp
@@ -27,7 +27,7 @@ void RAM::load(const Header &header, size_t) {
   DEBUG("allocating RAM buffer for image \"" + header.name() + "\"...");
   int64_t bytes_per_segment = (header.datatype().bits() * segsize + 7) / 8;
   addresses.resize(1);
-  addresses[0].reset(new uint8_t[bytes_per_segment]);
+  addresses[0].reset(new std::byte[bytes_per_segment]);
 }
 
 } // namespace MR::ImageIO

--- a/cpp/core/image_io/scratch.cpp
+++ b/cpp/core/image_io/scratch.cpp
@@ -27,7 +27,7 @@ void Scratch::load(const Header &header, size_t buffer_size) {
   assert(buffer_size);
   DEBUG("allocating scratch buffer for image \"" + header.name() + "\"...");
   try {
-    addresses.push_back(std::unique_ptr<uint8_t[]>(new uint8_t[buffer_size]));
+    addresses.push_back(std::unique_ptr<std::byte[]>(new std::byte[buffer_size]));
     memset(addresses[0].get(), 0, buffer_size);
   } catch (...) {
     throw Exception("Error allocating memory for scratch buffer");

--- a/cpp/core/image_io/variable_scaling.cpp
+++ b/cpp/core/image_io/variable_scaling.cpp
@@ -36,7 +36,7 @@ void VariableScaling::load(const Header &header, size_t) {
 
   DEBUG("loading variable-scaling DICOM image \"" + header.name() + "\"...");
   addresses.resize(1);
-  addresses[0].reset(new uint8_t[segsize * sizeof(float32)]);
+  addresses[0].reset(new std::byte[segsize * sizeof(float32)]);
   if (!addresses[0])
     throw Exception("failed to allocate memory for image \"" + header.name() + "\"");
 

--- a/cpp/core/surface/freesurfer.h
+++ b/cpp/core/surface/freesurfer.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <fstream>
 #include <stdint.h>
 
@@ -34,10 +35,10 @@ constexpr int32_t quad_file_magic_number = 16777215;
 constexpr int32_t new_curv_file_magic_number = 16777215;
 
 inline int32_t get_int24_BE(std::ifstream &stream) {
-  std::array<uint8_t, 3> bytes{};
+  std::array<std::byte, 3> bytes{};
   stream.read(reinterpret_cast<char *>(bytes.data()), 3);
-  return (static_cast<int32_t>(bytes[0]) << 16) | (static_cast<int32_t>(bytes[1]) << 8) |
-         static_cast<int32_t>(bytes[2]);
+  return (std::to_integer<int32_t>(bytes[0]) << 16) | (std::to_integer<int32_t>(bytes[1]) << 8) |
+         std::to_integer<int32_t>(bytes[2]);
 }
 
 template <typename T> inline T get_BE(std::ifstream &stream) {


### PR DESCRIPTION
Task item in #2585.

Makes it clearer looking at code when data being pointed to is untyped.