### PR TITLE
A couple of utilisations of std::optional

### DIFF
--- a/cpp/core/file/mmap.cpp
+++ b/cpp/core/file/mmap.cpp
@@ -42,8 +42,8 @@
 
 namespace MR::File {
 
-MMap::MMap(const Entry &entry, bool readwrite, bool preload, int64_t mapped_size)
-    : Entry(entry), addr(nullptr), first(nullptr), msize(mapped_size), readwrite(readwrite) {
+MMap::MMap(const Entry &entry, bool readwrite, bool preload, std::optional<int64_t> mapped_size)
+    : Entry(entry), addr(nullptr), first(nullptr), msize(0), readwrite(readwrite) {
   DEBUG("memory-mapping file \"" + Entry::name + "\"...");
 
   struct stat sbuf;
@@ -52,10 +52,12 @@ MMap::MMap(const Entry &entry, bool readwrite, bool preload, int64_t mapped_size
 
   mtime = sbuf.st_mtime;
 
-  if (msize < 0)
+  if (!mapped_size.has_value())
     msize = sbuf.st_size - start;
-  else if (start + msize > sbuf.st_size)
+  else if (start + *mapped_size > sbuf.st_size)
     throw Exception("file \"" + Entry::name + "\" is smaller than expected");
+  else
+    msize = *mapped_size;
 
   bool delayed_writeback = false;
   if (readwrite) {

--- a/cpp/core/file/mmap.h
+++ b/cpp/core/file/mmap.h
@@ -19,6 +19,7 @@
 #include <cassert>
 #include <cstdint>
 #include <iostream>
+#include <optional>
 
 #include "file/entry.h"
 #include "types.h"
@@ -44,11 +45,14 @@ public:
    * the file has just been created, \a preload should be set to \c false to
    * prevent this, in which case the contents will set to zero.
    *
-   * By default, the whole file is mapped. If \a mapped_size is
-   * non-zero, then only the region of size \a mapped_size starting from
-   * the byte offset specified in \a entry will be mapped.
+   * By default, the whole file is mapped. If \a mapped_size is set,
+   * then only the region of that size starting from the byte offset
+   * specified in \a entry will be mapped.
    */
-  MMap(const Entry &entry, bool readwrite = false, bool preload = true, int64_t mapped_size = -1);
+  MMap(const Entry &entry,
+       bool readwrite = false,
+       bool preload = true,
+       std::optional<int64_t> mapped_size = std::nullopt);
   ~MMap();
 
   std::string name() const { return Entry::name; }

--- a/cpp/core/mrtrix.cpp
+++ b/cpp/core/mrtrix.cpp
@@ -68,7 +68,7 @@ std::vector<default_type> parse_floats(std::string_view spec) {
 }
 
 std::vector<std::string>
-split(std::string_view string, std::string_view delimiters, bool ignore_empty_fields, size_t num) {
+split(std::string_view string, std::string_view delimiters, bool ignore_empty_fields, std::optional<size_t> num) {
   std::vector<std::string> V;
   if (string.empty())
     return V;
@@ -84,7 +84,7 @@ split(std::string_view string, std::string_view delimiters, bool ignore_empty_fi
       start = ignore_empty_fields ? string.find_first_not_of(delimiters, end + 1) : end + 1;
       if (start > string.size())
         break;
-      if (V.size() + 1 >= num) {
+      if (num.has_value() && V.size() + 1 >= *num) {
         V.emplace_back(std::string(string.substr(start)));
         break;
       }
@@ -201,7 +201,7 @@ void replace(std::string &str, std::string_view from, std::string_view to) {
   }
 }
 
-std::vector<std::string> split_lines(std::string_view string, bool ignore_empty_fields, size_t num) {
+std::vector<std::string> split_lines(std::string_view string, bool ignore_empty_fields, std::optional<size_t> num) {
   return split(string, "\n", ignore_empty_fields, num);
 }
 

--- a/cpp/core/mrtrix.h
+++ b/cpp/core/mrtrix.h
@@ -22,6 +22,7 @@
 #include <cstring>
 #include <iostream>
 #include <limits>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -100,10 +101,10 @@ void replace(std::string &str, std::string_view from, std::string_view to);
 std::vector<std::string> split(std::string_view string,
                                std::string_view delimiters = " \t\n",
                                bool ignore_empty_fields = false,
-                               size_t num = std::numeric_limits<size_t>::max());
+                               std::optional<size_t> num = std::nullopt);
 
 std::vector<std::string>
-split_lines(std::string_view string, bool ignore_empty_fields = true, size_t num = std::numeric_limits<size_t>::max());
+split_lines(std::string_view string, bool ignore_empty_fields = true, std::optional<size_t> num = std::nullopt);
 
 /*
 inline int round (default_type x)


### PR DESCRIPTION
Relevant to #2585.

Claude was not as eager to make use of this functionality as I was. It did find the GLM variance groups that are `std::optional`-ed in #3313, which I will leave to that PR to change. It also found the DWI and phase encoding scheme extractions done in #3313, though unlike me it opted out of those due to complexity. I think my current instinct is liking this functionality because it implicitly communicates the prospect of an absence of data far more so than a sentinel value, whereas maybe the AI is less concerned with the limitations of human cognition.