### PR TITLE
Various changes to tckgen internals

### DIFF
--- a/cpp/core/algo/implicit_mask.h
+++ b/cpp/core/algo/implicit_mask.h
@@ -1,0 +1,144 @@
+/* Copyright (c) 2008-2026 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Covered Software is provided under this License on an "as is"
+ * basis, without warranty of any kind, either expressed, implied, or
+ * statutory, including, without limitation, warranties that the
+ * Covered Software is free of defects, merchantable, fit for a
+ * particular purpose or non-infringing.
+ * See the Mozilla Public License v. 2.0 for more details.
+ *
+ * For more details, see http://www.mrtrix.org/.
+ */
+
+#pragma once
+
+#include <cmath>
+
+#include "algo/loop.h"
+#include "filter/connected_components.h"
+#include "image.h"
+
+namespace MR {
+
+//! \addtogroup algo
+// @{
+
+//! Controls whether voxels with only zero (finite) values are excluded from the mask
+enum class ZeroExclusion {
+  Enabled, //!< Exclude voxels that have at least one finite value, all of which are zero
+  Disabled //!< Zero values do not contribute to voxel exclusion
+};
+
+//! Controls whether voxels containing non-finite values are excluded from the mask
+enum class NonFiniteExclusion {
+  Any,     //!< Exclude voxels that contain at least one non-finite value
+  All,     //!< Exclude voxels only when all values are non-finite
+  Disabled //!< Non-finite values do not contribute to voxel exclusion
+};
+
+//! Controls whether interior holes in the mask are filled using connected-components analysis,
+//! and whether exclusion criteria are re-applied to voxels admitted by that operation
+enum class HoleFilling {
+  Disabled,            //!< No hole-filling is performed
+  Enabled,             //!< Fill interior holes; re-apply NonFiniteExclusion only (zero-filled holes are admitted)
+  EnabledWithReRemoval //!< Fill interior holes; re-apply both ZeroExclusion and NonFiniteExclusion
+};
+
+//! @}
+
+//! Construct a binary mask from image data using configurable exclusion and hole-filling criteria
+/*! The mask is a 3D scratch Image<bool> aligned to the spatial grid of \a source.
+ * A voxel is initially excluded if it fails the zero test (ZeroExclusion::Enabled), the
+ * non-finite test (NonFiniteExclusion), or both; otherwise it is included.
+ *
+ * Zero test (when ZeroExclusion::Enabled): the voxel has at least one finite value, but no
+ * finite non-zero value (i.e. all finite values are zero).
+ *
+ * If HoleFilling is not Disabled, the mask is inverted, the largest connected component
+ * (the exterior background) is retained, and the mask is inverted back — filling interior
+ * holes.  Excluded voxels are then selectively re-removed according to the HoleFilling mode:
+ * Enabled re-removes only those that failed the non-finite test; EnabledWithReRemoval
+ * re-removes all originally-excluded voxels.
+ */
+template <class ImageType>
+Image<bool> make_implicit_mask(const ImageType &source,
+                               ZeroExclusion zero_excl,
+                               NonFiniteExclusion nonfinite_excl,
+                               HoleFilling hole_filling) {
+  Header header3d(source);
+  header3d.ndim() = 3;
+  auto mask = Image<bool>::scratch(header3d, "implicit mask");
+
+  auto img = source;
+  const bool has_volumes = img.ndim() > 3;
+  const bool do_hole_fill = hole_filling != HoleFilling::Disabled;
+
+  struct Classification {
+    bool valid;
+    bool reexclude;
+  };
+  auto classify = [&]() -> Classification {
+    bool has_finite_nonzero = false;
+    bool has_finite = false;
+    bool has_nonfinite = false;
+    auto check = [&]() {
+      const auto v = static_cast<double>(img.value());
+      if (!std::isfinite(v)) {
+        has_nonfinite = true;
+      } else {
+        has_finite = true;
+        if (v != 0.0)
+          has_finite_nonzero = true;
+      }
+    };
+    if (has_volumes) {
+      for (auto l_v = Loop(img, 3)(img); l_v; ++l_v)
+        check();
+    } else {
+      check();
+    }
+    const bool zero_failed = (zero_excl == ZeroExclusion::Enabled) && has_finite && !has_finite_nonzero;
+    const bool nonfinite_failed = (nonfinite_excl == NonFiniteExclusion::Any && has_nonfinite) ||
+                                  (nonfinite_excl == NonFiniteExclusion::All && !has_finite);
+    return {!(zero_failed || nonfinite_failed),
+            (hole_filling == HoleFilling::EnabledWithReRemoval) ? (zero_failed || nonfinite_failed) : nonfinite_failed};
+  };
+
+  if (do_hole_fill) {
+    auto reexclude = Image<bool>::scratch(header3d, "implicit mask re-exclusion");
+    for (auto l = Loop(mask)(mask, reexclude); l; ++l) {
+      img.index(0) = mask.index(0);
+      img.index(1) = mask.index(1);
+      img.index(2) = mask.index(2);
+      const auto [valid, should_reexclude] = classify();
+      mask.value() = valid;
+      reexclude.value() = should_reexclude;
+    }
+    for (auto l = Loop(mask)(mask); l; ++l)
+      mask.value() = !mask.value();
+    Filter::ConnectedComponents cc_filter(mask);
+    cc_filter.set_largest_only(true);
+    cc_filter(mask, mask);
+    for (auto l = Loop(mask)(mask); l; ++l)
+      mask.value() = !mask.value();
+    for (auto l = Loop(mask)(mask, reexclude); l; ++l) {
+      if (reexclude.value())
+        mask.value() = false;
+    }
+  } else {
+    for (auto l = Loop(mask)(mask); l; ++l) {
+      img.index(0) = mask.index(0);
+      img.index(1) = mask.index(1);
+      img.index(2) = mask.index(2);
+      mask.value() = classify().valid;
+    }
+  }
+
+  return mask;
+}
+
+} // namespace MR

--- a/cpp/core/algo/implicit_mask.h
+++ b/cpp/core/algo/implicit_mask.h
@@ -126,12 +126,8 @@ template <class ImageType> Image<bool> make_implicit_mask(const ImageType &sourc
     Filter::ConnectedComponents cc_filter(mask);
     cc_filter.set_largest_only(true);
     cc_filter(mask, mask);
-    for (auto l = Loop(mask)(mask); l; ++l)
-      mask.value() = !mask.value();
-    for (auto l = Loop(mask)(mask, reexclude); l; ++l) {
-      if (reexclude.value())
-        mask.value() = false;
-    }
+    for (auto l = Loop(mask)(mask, reexclude); l; ++l)
+      mask.value() = reexclude.value() ? false : !mask.value();
   } else {
     for (auto l = Loop(mask)(mask); l; ++l) {
       img.index(0) = mask.index(0);

--- a/cpp/core/algo/implicit_mask.h
+++ b/cpp/core/algo/implicit_mask.h
@@ -71,7 +71,9 @@ struct ImplicitMaskConfig {
  * re-removed; for Enabled, all filled voxels are admitted without further removal.
  */
 template <class ImageType> Image<bool> make_implicit_mask(const ImageType &source, const ImplicitMaskConfig &config) {
-  const auto &[zero_excl, nonfinite_excl, hole_filling] = config;
+  const ZeroExclusion zero_excl = config.zero_excl;
+  const NonFiniteExclusion nonfinite_excl = config.nonfinite_excl;
+  const HoleFilling hole_filling = config.hole_filling;
   Header header3d(source);
   header3d.ndim() = 3;
   auto mask = Image<bool>::scratch(header3d, "scratch implicit mask from \"" + source.name() + "\"");

--- a/cpp/core/algo/implicit_mask.h
+++ b/cpp/core/algo/implicit_mask.h
@@ -41,11 +41,18 @@ enum class NonFiniteExclusion {
 };
 
 //! Controls whether interior holes in the mask are filled using connected-components analysis,
-//! and whether exclusion criteria are re-applied to voxels admitted by that operation
+//! and whether the non-finite exclusion criterion is re-applied to voxels admitted by that operation
 enum class HoleFilling {
-  Disabled,            //!< No hole-filling is performed
-  Enabled,             //!< Fill interior holes; re-apply NonFiniteExclusion only (zero-filled holes are admitted)
-  EnabledWithReRemoval //!< Fill interior holes; re-apply both ZeroExclusion and NonFiniteExclusion
+  Disabled,               //!< No hole-filling is performed
+  Enabled,                //!< Fill interior holes; all filled voxels are admitted
+  EnabledExcludeNonFinite //!< Fill interior holes; re-apply NonFiniteExclusion (zero-filled holes remain admitted)
+};
+
+//! Encapsulates the three settings that control implicit mask construction
+struct ImplicitMaskConfig {
+  ZeroExclusion zero_excl;
+  NonFiniteExclusion nonfinite_excl;
+  HoleFilling hole_filling;
 };
 
 //! @}
@@ -60,18 +67,14 @@ enum class HoleFilling {
  *
  * If HoleFilling is not Disabled, the mask is inverted, the largest connected component
  * (the exterior background) is retained, and the mask is inverted back — filling interior
- * holes.  Excluded voxels are then selectively re-removed according to the HoleFilling mode:
- * Enabled re-removes only those that failed the non-finite test; EnabledWithReRemoval
- * re-removes all originally-excluded voxels.
+ * holes.  For EnabledExcludeNonFinite, voxels that failed the non-finite test are then
+ * re-removed; for Enabled, all filled voxels are admitted without further removal.
  */
-template <class ImageType>
-Image<bool> make_implicit_mask(const ImageType &source,
-                               ZeroExclusion zero_excl,
-                               NonFiniteExclusion nonfinite_excl,
-                               HoleFilling hole_filling) {
+template <class ImageType> Image<bool> make_implicit_mask(const ImageType &source, const ImplicitMaskConfig &config) {
+  const auto &[zero_excl, nonfinite_excl, hole_filling] = config;
   Header header3d(source);
   header3d.ndim() = 3;
-  auto mask = Image<bool>::scratch(header3d, "implicit mask");
+  auto mask = Image<bool>::scratch(header3d, "scratch implicit mask from \"" + source.name() + "\"");
 
   auto img = source;
   const bool has_volumes = img.ndim() > 3;
@@ -105,7 +108,7 @@ Image<bool> make_implicit_mask(const ImageType &source,
     const bool nonfinite_failed = (nonfinite_excl == NonFiniteExclusion::Any && has_nonfinite) ||
                                   (nonfinite_excl == NonFiniteExclusion::All && !has_finite);
     return {!(zero_failed || nonfinite_failed),
-            (hole_filling == HoleFilling::EnabledWithReRemoval) ? (zero_failed || nonfinite_failed) : nonfinite_failed};
+            hole_filling == HoleFilling::EnabledExcludeNonFinite && nonfinite_failed};
   };
 
   if (do_hole_fill) {

--- a/cpp/core/dwi/tractography/ACT/method.h
+++ b/cpp/core/dwi/tractography/ACT/method.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include "dwi/tractography/ACT/act.h"
 #include "dwi/tractography/ACT/tissues.h"
 
@@ -44,7 +46,7 @@ public:
 
   const Tissues &tissues() const { return tissue_values; }
 
-  term_t check_structural(const Eigen::Vector3f &pos) {
+  std::optional<term_t> check_structural(const Eigen::Vector3f &pos) {
     if (!fetch_tissue_data(pos))
       return term_t::EXIT_IMAGE;
 
@@ -59,12 +61,12 @@ public:
       if (seed_in_sgm && !sgm_seed_to_wm) {
         sgm_seed_to_wm = true;
         sgm_depth = 0;
-        return term_t::CONTINUE;
+        return std::nullopt;
       }
       return term_t::EXIT_SGM;
     }
 
-    return term_t::CONTINUE;
+    return std::nullopt;
   }
 
   bool check_seed(const Eigen::Vector3f &pos) {

--- a/cpp/core/dwi/tractography/ACT/method.h
+++ b/cpp/core/dwi/tractography/ACT/method.h
@@ -37,7 +37,10 @@ class ACT_Method_additions {
 
 public:
   ACT_Method_additions(const SharedBase &shared)
-      : sgm_depth(0), seed_in_sgm(false), sgm_seed_to_wm(false), act_image(shared.act().voxel) {}
+      : sgm_depth(0),
+        seed_in_sgm(false),
+        sgm_seed_to_wm(false),
+        act_image(shared.act().voxel, shared.act().voxel_mask) {}
 
   ACT_Method_additions(const ACT_Method_additions &that)
       : sgm_depth(0), seed_in_sgm(false), sgm_seed_to_wm(false), act_image(that.act_image) {}

--- a/cpp/core/dwi/tractography/ACT/shared.h
+++ b/cpp/core/dwi/tractography/ACT/shared.h
@@ -32,7 +32,7 @@ public:
   ACT_Shared_additions(std::string_view path, Properties &property_set)
       : voxel(Image<float>::open(path)),
         voxel_mask(make_implicit_mask(
-            voxel, {ZeroExclusion::Enabled, NonFiniteExclusion::All, HoleFilling::EnabledExcludeNonFinite})),
+            voxel, {ZeroExclusion::Enabled, NonFiniteExclusion::Any, HoleFilling::EnabledExcludeNonFinite})),
         bt(false),
         trunc(sgm_trunc_t::DEFAULT) {
     debug_validate_5TT_image(voxel);

--- a/cpp/core/dwi/tractography/ACT/shared.h
+++ b/cpp/core/dwi/tractography/ACT/shared.h
@@ -18,6 +18,7 @@
 
 #include <memory>
 
+#include "algo/implicit_mask.h"
 #include "dwi/tractography/ACT/gmwmi.h"
 #include "dwi/tractography/ACT/validate.h"
 #include "dwi/tractography/properties.h"
@@ -29,7 +30,11 @@ class ACT_Shared_additions {
 
 public:
   ACT_Shared_additions(std::string_view path, Properties &property_set)
-      : voxel(Image<float>::open(path)), bt(false), trunc(sgm_trunc_t::DEFAULT) {
+      : voxel(Image<float>::open(path)),
+        voxel_mask(make_implicit_mask(
+            voxel, {ZeroExclusion::Enabled, NonFiniteExclusion::All, HoleFilling::EnabledExcludeNonFinite})),
+        bt(false),
+        trunc(sgm_trunc_t::DEFAULT) {
     debug_validate_5TT_image(voxel);
     property_set.set(bt, "backtrack");
     if (property_set.find("crop_at_gmwmi") != property_set.end())
@@ -56,6 +61,7 @@ public:
 
 private:
   Image<float> voxel;
+  Image<bool> voxel_mask;
   bool bt;
   sgm_trunc_t trunc;
 

--- a/cpp/core/dwi/tractography/algorithms/fact.h
+++ b/cpp/core/dwi/tractography/algorithms/fact.h
@@ -36,7 +36,10 @@ public:
   class Shared : public SharedBase {
   public:
     Shared(std::string_view diff_path, DWI::Tractography::Properties &property_set)
-        : SharedBase(diff_path, property_set), num_vec(source.size(3) / 3) {
+        : SharedBase(diff_path,
+                     property_set,
+                     {ZeroExclusion::Enabled, NonFiniteExclusion::All, HoleFilling::EnabledExcludeNonFinite}),
+          num_vec(source.size(3) / 3) {
 
       if (source.size(3) % 3)
         throw Exception("Number of volumes in FACT algorithm input image should be a multiple of 3");
@@ -67,9 +70,9 @@ public:
     float dot_threshold;
   };
 
-  FACT(const Shared &shared) : MethodBase(shared), S(shared), source(S.source) {}
+  FACT(const Shared &shared) : MethodBase(shared), S(shared), source(S.source, S.source_mask) {}
 
-  FACT(const FACT &that) : MethodBase(that.S), S(that.S), source(S.source) {}
+  FACT(const FACT &that) : MethodBase(that.S), S(that.S), source(S.source, S.source_mask) {}
 
   ~FACT() {}
 

--- a/cpp/core/dwi/tractography/algorithms/fact.h
+++ b/cpp/core/dwi/tractography/algorithms/fact.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include "interp/masked.h"
 #include "interp/nearest.h"
 
@@ -81,7 +83,7 @@ public:
     return select_fixel(dir) >= S.threshold;
   }
 
-  term_t next() override {
+  std::optional<term_t> next() override {
     if (!get_data(source))
       return term_t::EXIT_IMAGE;
 
@@ -91,7 +93,7 @@ public:
       return term_t::MODEL;
 
     pos += S.step_size * dir;
-    return term_t::CONTINUE;
+    return std::nullopt;
   }
 
   float get_metric(const Eigen::Vector3f &position, const Eigen::Vector3f &direction) override {

--- a/cpp/core/dwi/tractography/algorithms/fact.h
+++ b/cpp/core/dwi/tractography/algorithms/fact.h
@@ -18,6 +18,8 @@
 
 #include <optional>
 
+#include "fixel/validate.h"
+
 #include "interp/masked.h"
 #include "interp/nearest.h"
 
@@ -41,8 +43,8 @@ public:
                      {ZeroExclusion::Enabled, NonFiniteExclusion::All, HoleFilling::EnabledExcludeNonFinite}),
           num_vec(source.size(3) / 3) {
 
-      if (source.size(3) % 3)
-        throw Exception("Number of volumes in FACT algorithm input image should be a multiple of 3");
+      Peaks::validate_header(source_header);
+      Peaks::debug_validate_image(source);
 
       if (is_act()) {
         if (act().backtrack())

--- a/cpp/core/dwi/tractography/algorithms/iFOD1.h
+++ b/cpp/core/dwi/tractography/algorithms/iFOD1.h
@@ -38,7 +38,9 @@ public:
   class Shared : public SharedBase {
   public:
     Shared(std::string_view diff_path, DWI::Tractography::Properties &property_set)
-        : SharedBase(diff_path, property_set),
+        : SharedBase(diff_path,
+                     property_set,
+                     {ZeroExclusion::Enabled, NonFiniteExclusion::Any, HoleFilling::EnabledExcludeNonFinite}),
           lmax(Math::SH::LforN(source.size(3))),
           max_trials(Defaults::max_trials_per_step),
           sin_max_angle_1o(std::sin(max_angle_1o)),
@@ -116,7 +118,7 @@ public:
   iFOD1(const Shared &shared)
       : MethodBase(shared),
         S(shared),
-        source(S.source),
+        source(S.source, S.source_mask),
         mean_sample_num(0),
         num_sample_runs(0),
         num_truncations(0),

--- a/cpp/core/dwi/tractography/algorithms/iFOD1.h
+++ b/cpp/core/dwi/tractography/algorithms/iFOD1.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include "dwi/tractography/ACT/act.h"
 #include "dwi/tractography/algorithms/calibrator.h"
 #include "dwi/tractography/tracking/method.h"
@@ -156,7 +158,7 @@ public:
     return false;
   }
 
-  term_t next() override {
+  std::optional<term_t> next() override {
     if (!get_data(source))
       return term_t::EXIT_IMAGE;
 
@@ -195,7 +197,7 @@ public:
           dir.normalize();
           pos += S.step_size * dir;
           mean_sample_num += n;
-          return term_t::CONTINUE;
+          return std::nullopt;
         }
       }
     }

--- a/cpp/core/dwi/tractography/algorithms/iFOD2.h
+++ b/cpp/core/dwi/tractography/algorithms/iFOD2.h
@@ -302,7 +302,7 @@ public:
       dir.setConstant(NaNF);
       return;
     }
-    half_log_prob0 = 0.5 * std::log(fod_amp);
+    half_log_prob0 = 0.5F * std::log(fod_amp);
 
     // Make sure that arc is re-calculated when next() is called
     sample_idx = S.num_samples;

--- a/cpp/core/dwi/tractography/algorithms/iFOD2.h
+++ b/cpp/core/dwi/tractography/algorithms/iFOD2.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <algorithm>
+#include <optional>
 
 #include "dwi/tractography/ACT/act.h"
 #include "dwi/tractography/algorithms/calibrator.h"
@@ -204,12 +205,12 @@ public:
     return true;
   }
 
-  term_t next() override {
+  std::optional<term_t> next() override {
 
     if (++sample_idx < S.num_samples) {
       pos = positions[sample_idx];
       dir = tangents[sample_idx];
-      return term_t::CONTINUE;
+      return std::nullopt;
     }
 
     Eigen::Vector3f next_pos, next_dir;
@@ -247,7 +248,7 @@ public:
         pos = positions[0];
         dir = tangents[0];
         sample_idx = 0;
-        return term_t::CONTINUE;
+        return std::nullopt;
       }
     }
 
@@ -282,16 +283,24 @@ public:
       return;
     }
     const size_t new_size = length_to_revert_from - points_to_remove;
-    if (tck.size() == 2 || new_size == 1)
-      dir = (tck[1] - tck[0]).normalized();
-    else if (new_size != tck.size())
-      dir = (tck[new_size] - tck[new_size - 2]).normalized();
+    dir = Tractography::tangent(tck, new_size);
     tck.resize(new_size);
 
     // Need to get the path probability contribution from the FOD at this point
+    // If FOD amplitude sample is non-positive
+    //   (possible even if the streamline passed through this vertex previously
+    //   since the tangent direction may not be exactly the same),
+    //   can't re-track from this point as the path probability will not be finite
     pos = tck.back();
     get_data(source);
-    half_log_prob0 = 0.5 * std::log(FOD(dir));
+    const float fod_amp = FOD(dir);
+    if (fod_amp <= 0.0F) {
+      tck.clear();
+      pos.setConstant(NaNF);
+      dir.setConstant(NaNF);
+      return;
+    }
+    half_log_prob0 = 0.5 * std::log(fod_amp);
 
     // Make sure that arc is re-calculated when next() is called
     sample_idx = S.num_samples;

--- a/cpp/core/dwi/tractography/algorithms/iFOD2.h
+++ b/cpp/core/dwi/tractography/algorithms/iFOD2.h
@@ -41,7 +41,9 @@ public:
   class Shared : public SharedBase {
   public:
     Shared(std::string_view diff_path, DWI::Tractography::Properties &property_set)
-        : SharedBase(diff_path, property_set),
+        : SharedBase(diff_path,
+                     property_set,
+                     {ZeroExclusion::Enabled, NonFiniteExclusion::Any, HoleFilling::EnabledExcludeNonFinite}),
           lmax(Math::SH::LforN(source.size(3))),
           num_samples(Defaults::ifod2_nsamples),
           max_trials(Defaults::max_trials_per_step),
@@ -137,7 +139,7 @@ public:
   iFOD2(const Shared &shared)
       : MethodBase(shared),
         S(shared),
-        source(S.source),
+        source(S.source, S.source_mask),
         mean_sample_num(0),
         num_sample_runs(0),
         num_truncations(0),
@@ -153,7 +155,7 @@ public:
   iFOD2(const iFOD2 &that)
       : MethodBase(that.S),
         S(that.S),
-        source(S.source),
+        source(S.source, S.source_mask),
         calibrate_ratio(that.calibrate_ratio),
         mean_sample_num(0),
         num_sample_runs(0),

--- a/cpp/core/dwi/tractography/algorithms/nulldist.h
+++ b/cpp/core/dwi/tractography/algorithms/nulldist.h
@@ -32,7 +32,9 @@ public:
   class Shared : public SharedBase {
   public:
     Shared(std::string_view diff_path, DWI::Tractography::Properties &property_set)
-        : SharedBase(diff_path, property_set) {
+        : SharedBase(diff_path,
+                     property_set,
+                     {ZeroExclusion::Enabled, NonFiniteExclusion::Any, HoleFilling::EnabledExcludeNonFinite}) {
       set_step_and_angle(rk4 ? Defaults::stepsize_voxels_rk4 : Defaults::stepsize_voxels_firstorder,
                          Defaults::angle_ifod1,
                          rk4 ? intrinsic_integration_order_t::HIGHER : intrinsic_integration_order_t::FIRST,
@@ -47,7 +49,7 @@ public:
     float sin_max_angle_1o;
   };
 
-  NullDist1(const Shared &shared) : MethodBase(shared), S(shared), source(S.source) {}
+  NullDist1(const Shared &shared) : MethodBase(shared), S(shared), source(S.source, S.source_mask) {}
 
   bool init() override {
     if (!get_data(source))
@@ -92,7 +94,7 @@ public:
   NullDist2(const Shared &shared)
       : iFOD2(shared),
         S(shared),
-        source(S.source),
+        source(S.source, S.source_mask),
         positions(S.num_samples),
         tangents(S.num_samples),
         sample_idx(S.num_samples) {}
@@ -100,7 +102,7 @@ public:
   NullDist2(const NullDist2 &that)
       : iFOD2(that),
         S(that.S),
-        source(S.source),
+        source(S.source, S.source_mask),
         positions(S.num_samples),
         tangents(S.num_samples),
         sample_idx(S.num_samples) {}

--- a/cpp/core/dwi/tractography/algorithms/nulldist.h
+++ b/cpp/core/dwi/tractography/algorithms/nulldist.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include "dwi/tractography/algorithms/iFOD2.h"
 #include "dwi/tractography/tracking/method.h"
 #include "dwi/tractography/tracking/shared.h"
@@ -54,13 +56,13 @@ public:
     return true;
   }
 
-  term_t next() override {
+  std::optional<term_t> next() override {
     if (!get_data(source))
       return term_t::EXIT_IMAGE;
     dir = rand_dir(dir);
     dir.normalize();
     pos += S.step_size * dir;
-    return term_t::CONTINUE;
+    return std::nullopt;
   }
 
   float get_metric(const Eigen::Vector3f &, const Eigen::Vector3f &) override { return uniform(rng); }
@@ -111,12 +113,12 @@ public:
     return true;
   }
 
-  term_t next() override {
+  std::optional<term_t> next() override {
 
     if (++sample_idx < S.num_samples) {
       pos = positions[sample_idx];
       dir = tangents[sample_idx];
-      return term_t::CONTINUE;
+      return std::nullopt;
     }
 
     iFOD2::get_path(positions, tangents, iFOD2::rand_dir(dir));
@@ -127,7 +129,7 @@ public:
     pos = positions[0];
     dir = tangents[0];
     sample_idx = 0;
-    return term_t::CONTINUE;
+    return std::nullopt;
   }
 
   void reverse_track() override {

--- a/cpp/core/dwi/tractography/algorithms/sd_stream.h
+++ b/cpp/core/dwi/tractography/algorithms/sd_stream.h
@@ -34,7 +34,10 @@ public:
   class Shared : public SharedBase {
   public:
     Shared(std::string_view diff_path, DWI::Tractography::Properties &property_set)
-        : SharedBase(diff_path, property_set), lmax(Math::SH::LforN(source.size(3))) {
+        : SharedBase(diff_path,
+                     property_set,
+                     {ZeroExclusion::Enabled, NonFiniteExclusion::Any, HoleFilling::EnabledExcludeNonFinite}),
+          lmax(Math::SH::LforN(source.size(3))) {
       try {
         Math::SH::check(source);
       } catch (Exception &e) {
@@ -74,9 +77,9 @@ public:
     Math::SH::PrecomputedAL<float> *precomputer;
   };
 
-  SDStream(const Shared &shared) : MethodBase(shared), S(shared), source(S.source) {}
+  SDStream(const Shared &shared) : MethodBase(shared), S(shared), source(S.source, S.source_mask) {}
 
-  SDStream(const SDStream &that) : MethodBase(that.S), S(that.S), source(S.source) {}
+  SDStream(const SDStream &that) : MethodBase(that.S), S(that.S), source(S.source, S.source_mask) {}
 
   ~SDStream() {}
 

--- a/cpp/core/dwi/tractography/algorithms/sd_stream.h
+++ b/cpp/core/dwi/tractography/algorithms/sd_stream.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include "dwi/tractography/ACT/act.h"
 #include "dwi/tractography/tracking/method.h"
 #include "dwi/tractography/tracking/shared.h"
@@ -95,7 +97,7 @@ public:
     return true;
   }
 
-  term_t next() override {
+  std::optional<term_t> next() override {
     if (!get_data(source))
       return term_t::EXIT_IMAGE;
 
@@ -108,7 +110,7 @@ public:
       return term_t::HIGH_CURVATURE;
 
     pos += dir * S.step_size;
-    return term_t::CONTINUE;
+    return std::nullopt;
   }
 
   float get_metric(const Eigen::Vector3f &position, const Eigen::Vector3f &direction) override {

--- a/cpp/core/dwi/tractography/algorithms/sd_stream.h
+++ b/cpp/core/dwi/tractography/algorithms/sd_stream.h
@@ -37,7 +37,7 @@ public:
         : SharedBase(diff_path,
                      property_set,
                      {ZeroExclusion::Enabled, NonFiniteExclusion::Any, HoleFilling::EnabledExcludeNonFinite}),
-          lmax(Math::SH::LforN(source.size(3))) {
+          lmax(static_cast<int>(Math::SH::LforN(static_cast<int>(source.size(3))))) {
       try {
         Math::SH::check(source);
       } catch (Exception &e) {

--- a/cpp/core/dwi/tractography/algorithms/seedtest.h
+++ b/cpp/core/dwi/tractography/algorithms/seedtest.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include "dwi/tractography/tracking/method.h"
 #include "dwi/tractography/tracking/shared.h"
 #include "dwi/tractography/tracking/types.h"
@@ -43,7 +45,7 @@ public:
   Seedtest(const Shared &shared) : MethodBase(shared), S(shared) {}
 
   bool init() override { return true; }
-  term_t next() override { return term_t::EXIT_IMAGE; }
+  std::optional<term_t> next() override { return term_t::EXIT_IMAGE; }
   float get_metric(const Eigen::Vector3f & /*position*/, const Eigen::Vector3f & /*direction*/) override {
     return 1.0F;
   }

--- a/cpp/core/dwi/tractography/algorithms/seedtest.h
+++ b/cpp/core/dwi/tractography/algorithms/seedtest.h
@@ -32,7 +32,9 @@ public:
   class Shared : public SharedBase {
   public:
     Shared(std::string_view diff_path, DWI::Tractography::Properties &property_set)
-        : SharedBase(diff_path, property_set) {
+        : SharedBase(diff_path,
+                     property_set,
+                     {ZeroExclusion::Enabled, NonFiniteExclusion::Any, HoleFilling::EnabledExcludeNonFinite}) {
       set_step_and_angle(1.0F, 90.0F, intrinsic_integration_order_t::FIRST, curvature_constraint_t::POSTHOC_THRESHOLD);
       min_num_points_preds = min_num_points_postds = 1;
       max_num_points_preds = max_num_points_postds = 2;

--- a/cpp/core/dwi/tractography/algorithms/tensor_det.h
+++ b/cpp/core/dwi/tractography/algorithms/tensor_det.h
@@ -42,7 +42,9 @@ public:
   class Shared : public SharedBase {
   public:
     Shared(std::string_view diff_path, DWI::Tractography::Properties &property_set)
-        : SharedBase(diff_path, property_set) {
+        : SharedBase(diff_path,
+                     property_set,
+                     {ZeroExclusion::Enabled, NonFiniteExclusion::Any, HoleFilling::EnabledExcludeNonFinite}) {
 
       if (is_act()) {
         if (act().backtrack())
@@ -73,7 +75,8 @@ public:
     Eigen::MatrixXf bmat, binv;
   };
 
-  Tensor_Det(const Shared &shared) : MethodBase(shared), S(shared), source(S.source), eig(3), M(3, 3), dt(6) {}
+  Tensor_Det(const Shared &shared)
+      : MethodBase(shared), S(shared), source(S.source, S.source_mask), eig(3), M(3, 3), dt(6) {}
 
   bool init() override {
     if (!get_data(source))

--- a/cpp/core/dwi/tractography/algorithms/tensor_det.h
+++ b/cpp/core/dwi/tractography/algorithms/tensor_det.h
@@ -22,6 +22,8 @@
 #include <Eigen/Eigenvalues>
 #pragma GCC diagnostic pop
 
+#include <optional>
+
 #include "dwi/gradient.h"
 #include "dwi/tensor.h"
 #include "dwi/tractography/ACT/act.h"
@@ -85,7 +87,7 @@ public:
     return true;
   }
 
-  term_t next() override {
+  std::optional<term_t> next() override {
     if (!get_data(source))
       return term_t::EXIT_IMAGE;
     return do_next();
@@ -128,7 +130,7 @@ protected:
     return true;
   }
 
-  term_t do_next() {
+  std::optional<term_t> do_next() {
 
     dwi2tensor(dt, S.binv, values);
 
@@ -148,7 +150,7 @@ protected:
 
     pos += dir * S.step_size;
 
-    return term_t::CONTINUE;
+    return std::nullopt;
   }
 };
 

--- a/cpp/core/dwi/tractography/algorithms/tensor_prob.h
+++ b/cpp/core/dwi/tractography/algorithms/tensor_prob.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include "dwi/bootstrap.h"
 #include "dwi/tractography/algorithms/tensor_det.h"
 #include "dwi/tractography/rng.h"
@@ -58,7 +60,7 @@ public:
     return Tensor_Det::do_init();
   }
 
-  term_t next() override {
+  std::optional<term_t> next() override {
     if (!source.get(pos, values))
       return term_t::EXIT_IMAGE;
     return Tensor_Det::do_next();

--- a/cpp/core/dwi/tractography/algorithms/tensor_prob.h
+++ b/cpp/core/dwi/tractography/algorithms/tensor_prob.h
@@ -48,10 +48,14 @@ public:
   };
 
   Tensor_Prob(const Shared &shared)
-      : Tensor_Det(shared), S(shared), source(Bootstrap<Image<float>, WildBootstrap>(S.source, WildBootstrap(S.Hat))) {}
+      : Tensor_Det(shared),
+        S(shared),
+        source(Bootstrap<Image<float>, WildBootstrap>(S.source, WildBootstrap(S.Hat)), S.source_mask) {}
 
   Tensor_Prob(const Tensor_Prob &F)
-      : Tensor_Det(F.S), S(F.S), source(Bootstrap<Image<float>, WildBootstrap>(S.source, WildBootstrap(S.Hat))) {}
+      : Tensor_Det(F.S),
+        S(F.S),
+        source(Bootstrap<Image<float>, WildBootstrap>(S.source, WildBootstrap(S.Hat)), S.source_mask) {}
 
   bool init() override {
     source.clear();
@@ -96,8 +100,8 @@ protected:
 
   class Interp : public Interpolator<Bootstrap<Image<float>, WildBootstrap>>::type {
   public:
-    Interp(const Bootstrap<Image<float>, WildBootstrap> &bootstrap_vox)
-        : Interpolator<Bootstrap<Image<float>, WildBootstrap>>::type(bootstrap_vox) {
+    Interp(const Bootstrap<Image<float>, WildBootstrap> &bootstrap_vox, Image<bool> mask)
+        : Interpolator<Bootstrap<Image<float>, WildBootstrap>>::type(bootstrap_vox, std::move(mask)) {
       for (size_t i = 0; i < 8; ++i)
         raw_signals.push_back(Eigen::VectorXf(size(3)));
     }

--- a/cpp/core/dwi/tractography/tracking/exec.h
+++ b/cpp/core/dwi/tractography/tracking/exec.h
@@ -569,29 +569,34 @@ private:
     std::optional<term_t> termination;
     const Eigen::Vector3f init_pos(method.pos);
     const Eigen::Vector3f init_dir(method.dir);
-    if ((termination = method.next()).has_value())
+    termination = method.next();
+    if (termination.has_value())
       return termination;
     const Eigen::Vector3f dir_rk1(method.dir);
     method.pos = init_pos + (dir_rk1 * (0.5 * S.step_size));
     method.dir = init_dir;
-    if ((termination = method.next()).has_value())
+    termination = method.next();
+    if (termination.has_value())
       return termination;
     const Eigen::Vector3f dir_rk2(method.dir);
     method.pos = init_pos + (dir_rk2 * (0.5 * S.step_size));
     method.dir = init_dir;
-    if ((termination = method.next()).has_value())
+    termination = method.next();
+    if (termination.has_value())
       return termination;
     const Eigen::Vector3f dir_rk3(method.dir);
     method.pos = init_pos + (dir_rk3 * S.step_size);
     method.dir = (dir_rk2 + dir_rk3).normalized();
-    if ((termination = method.next()).has_value())
+    termination = method.next();
+    if (termination.has_value())
       return termination;
     const Eigen::Vector3f dir_rk4(method.dir);
     method.dir = (dir_rk1 + (dir_rk2 * 2.0) + (dir_rk3 * 2.0) + dir_rk4).normalized();
     method.pos = init_pos + (method.dir * S.step_size);
     const Eigen::Vector3f final_pos(method.pos);
     const Eigen::Vector3f final_dir(method.dir);
-    if ((termination = method.next()).has_value())
+    termination = method.next();
+    if (termination.has_value())
       return termination;
     if (dir_rk1.dot(method.dir) < S.cos_max_angle_ho)
       return term_t::HIGH_CURVATURE;

--- a/cpp/core/dwi/tractography/tracking/exec.h
+++ b/cpp/core/dwi/tractography/tracking/exec.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <deque>
+#include <optional>
 
 #include "dwi/directions/set.h"
 #include "dwi/tractography/rng.h"
@@ -133,15 +134,15 @@ private:
   bool track_excluded;
   IncludeROIVisitation include_visitation;
 
-  term_t iterate() {
-    const term_t method_term = (S.rk4 ? next_rk4() : method.next());
+  std::optional<term_t> iterate() {
+    const std::optional<term_t> method_term = S.rk4 ? next_rk4() : method.next();
 
-    if (method_term != term_t::CONTINUE)
+    if (method_term.has_value())
       return (S.is_act() && method.act().sgm_depth) ? term_t::TERM_IN_SGM : method_term;
 
     if (S.is_act()) {
-      const term_t structural_term = method.act().check_structural(method.pos);
-      if (structural_term != term_t::CONTINUE)
+      const std::optional<term_t> structural_term = method.act().check_structural(method.pos);
+      if (structural_term.has_value())
         return structural_term;
     }
 
@@ -159,7 +160,7 @@ private:
     if (S.stop_on_all_include && bool(include_visitation))
       return term_t::TRAVERSE_ALL_INCLUDE;
 
-    return term_t::CONTINUE;
+    return std::nullopt;
   }
 
   bool seed_track(GeneratedTrack &tck) {
@@ -218,7 +219,7 @@ private:
   }
 
   void gen_track_unidir(GeneratedTrack &tck) {
-    term_t termination = term_t::CONTINUE;
+    std::optional<term_t> termination;
 
     if (S.is_act() && S.act().backtrack()) {
 
@@ -228,11 +229,11 @@ private:
 
       do {
         termination = iterate();
-        if (termination_info.at(termination).add_term_to_tck)
+        if (!termination.has_value() || termination_info.at(termination.value()).add_term_to_tck)
           tck.push_back(method.pos);
-        if (termination != term_t::CONTINUE) {
+        if (termination.has_value()) {
           apply_priors(termination);
-          if (track_excluded && termination != term_t::ENTER_EXCLUDE) {
+          if (track_excluded && termination.value() != term_t::ENTER_EXCLUDE) {
             if (tck.size() > max_size_at_backtrack) {
               max_size_at_backtrack = tck.size();
               revert_step = 1;
@@ -246,23 +247,23 @@ private:
             method.truncate_track(tck, max_size_at_backtrack, revert_step);
             if (method.pos.allFinite()) {
               track_excluded = false;
-              termination = term_t::CONTINUE;
+              termination.reset();
             }
           }
         } else if (tck.size() >= S.max_num_points_preds) {
-          termination = term_t::LENGTH_EXCEED;
+          termination.emplace(term_t::LENGTH_EXCEED);
         }
-      } while (termination == term_t::CONTINUE);
+      } while (!termination.has_value());
 
     } else {
 
       do {
         termination = iterate();
-        if (termination_info.at(termination).add_term_to_tck)
+        if (!termination.has_value() || termination_info.at(termination.value()).add_term_to_tck)
           tck.push_back(method.pos);
-        if (termination == term_t::CONTINUE && tck.size() >= S.max_num_points_preds)
-          termination = term_t::LENGTH_EXCEED;
-      } while (termination == term_t::CONTINUE);
+        if (!termination.has_value() && tck.size() >= S.max_num_points_preds)
+          termination.emplace(term_t::LENGTH_EXCEED);
+      } while (!termination.has_value());
     }
 
     apply_priors(termination);
@@ -273,7 +274,8 @@ private:
     }
 
     if (track_excluded) {
-      switch (termination) {
+      assert(termination.has_value());
+      switch (termination.value()) {
       case term_t::CALIBRATOR:
       case term_t::ENTER_CSF:
       case term_t::MODEL:
@@ -286,29 +288,25 @@ private:
       case term_t::ENTER_EXCLUDE:
         S.add_rejection(reject_t::ENTER_EXCLUDE_REGION);
         break;
-      default:
-        throw Exception("\nFIXME: Unidirectional track excluded but termination is good!\n");
       }
     }
 
-    if (S.is_act() && (termination == term_t::ENTER_CGM) && S.act().crop_at_gmwmi())
+    if (S.is_act() && (termination.value() == term_t::ENTER_CGM) && S.act().crop_at_gmwmi())
       S.act().crop_at_gmwmi(tck);
 
 #ifdef DEBUG_TERMINATIONS
-    S.add_termination(termination, method.pos);
+    S.add_termination(termination.value(), method.pos);
 #else
-    S.add_termination(termination);
+    S.add_termination(termination.value());
 #endif
   }
 
-  void apply_priors(term_t &termination) {
+  void apply_priors(std::optional<term_t> &termination) {
+    assert(termination.has_value());
 
     if (S.is_act()) {
 
-      switch (termination) {
-
-      case term_t::CONTINUE:
-        throw Exception("\nFIXME: undefined termination of track in apply_priors()\n");
+      switch (termination.value()) {
 
       case term_t::ENTER_CGM:
       case term_t::EXIT_IMAGE:
@@ -336,10 +334,7 @@ private:
 
     } else {
 
-      switch (termination) {
-
-      case term_t::CONTINUE:
-        throw Exception("\nFIXME: undefined termination of track in apply_priors()\n");
+      switch (termination.value()) {
 
       case term_t::ENTER_CGM:
       case term_t::ENTER_CSF:
@@ -426,6 +421,8 @@ private:
   }
 
   void truncate_exit_sgm(std::vector<Eigen::Vector3f> &tck) {
+    assert(S.is_act());
+    assert(method.act().sgm_depth <= tck.size());
     switch (S.act().sgm_trunc()) {
     case ACT::sgm_trunc_t::DEFAULT:
       throw Exception("FIXME: Algorithm failed to set default SGM truncation method");
@@ -566,39 +563,39 @@ private:
     tck[index] = tck[index - 1] + ((tck[index] - tck[index - 1]).normalized() * (S.max_dist - length_sum));
   }
 
-  term_t next_rk4() {
-    term_t termination = term_t::CONTINUE;
+  std::optional<term_t> next_rk4() {
+    std::optional<term_t> termination;
     const Eigen::Vector3f init_pos(method.pos);
     const Eigen::Vector3f init_dir(method.dir);
-    if ((termination = method.next()) != term_t::CONTINUE)
+    if ((termination = method.next()).has_value())
       return termination;
     const Eigen::Vector3f dir_rk1(method.dir);
     method.pos = init_pos + (dir_rk1 * (0.5 * S.step_size));
     method.dir = init_dir;
-    if ((termination = method.next()) != term_t::CONTINUE)
+    if ((termination = method.next()).has_value())
       return termination;
     const Eigen::Vector3f dir_rk2(method.dir);
     method.pos = init_pos + (dir_rk2 * (0.5 * S.step_size));
     method.dir = init_dir;
-    if ((termination = method.next()) != term_t::CONTINUE)
+    if ((termination = method.next()).has_value())
       return termination;
     const Eigen::Vector3f dir_rk3(method.dir);
     method.pos = init_pos + (dir_rk3 * S.step_size);
     method.dir = (dir_rk2 + dir_rk3).normalized();
-    if ((termination = method.next()) != term_t::CONTINUE)
+    if ((termination = method.next()).has_value())
       return termination;
     const Eigen::Vector3f dir_rk4(method.dir);
     method.dir = (dir_rk1 + (dir_rk2 * 2.0) + (dir_rk3 * 2.0) + dir_rk4).normalized();
     method.pos = init_pos + (method.dir * S.step_size);
     const Eigen::Vector3f final_pos(method.pos);
     const Eigen::Vector3f final_dir(method.dir);
-    if ((termination = method.next()) != term_t::CONTINUE)
+    if ((termination = method.next()).has_value())
       return termination;
     if (dir_rk1.dot(method.dir) < S.cos_max_angle_ho)
       return term_t::HIGH_CURVATURE;
     method.pos = final_pos;
     method.dir = final_dir;
-    return term_t::CONTINUE;
+    return std::nullopt;
   }
 };
 

--- a/cpp/core/dwi/tractography/tracking/exec.h
+++ b/cpp/core/dwi/tractography/tracking/exec.h
@@ -288,6 +288,8 @@ private:
       case term_t::ENTER_EXCLUDE:
         S.add_rejection(reject_t::ENTER_EXCLUDE_REGION);
         break;
+      default:
+        assert(false);
       }
     }
 

--- a/cpp/core/dwi/tractography/tracking/method.h
+++ b/cpp/core/dwi/tractography/tracking/method.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include "dwi/tractography/ACT/method.h"
 #include "dwi/tractography/rng.h"
 #include "dwi/tractography/tracking/shared.h"
@@ -55,7 +57,7 @@ public:
   }
 
   virtual bool init() = 0;
-  virtual term_t next() = 0;
+  virtual std::optional<term_t> next() = 0;
   virtual float get_metric(const Eigen::Vector3f &position, const Eigen::Vector3f &direction) = 0;
   float get_threshold() const { return S.threshold; }
 

--- a/cpp/core/dwi/tractography/tracking/shared.cpp
+++ b/cpp/core/dwi/tractography/tracking/shared.cpp
@@ -38,10 +38,12 @@ SharedBase::SharedBase(std::string_view diff_path, Properties &property_set, Imp
       step_size(NaNF),
       min_radius(NaNF),
       threshold(NaNF),
+      init_threshold(NaNF),
       unidirectional(false),
       rk4(false),
       stop_on_all_include(false),
       implicit_max_num_seeds(properties.find("max_num_seeds") == properties.end()),
+      curvature_constraint(curvature_constraint_t::POSTHOC_THRESHOLD),
       downsampler(1)
 #ifdef DEBUG_TERMINATIONS
       ,

--- a/cpp/core/dwi/tractography/tracking/shared.cpp
+++ b/cpp/core/dwi/tractography/tracking/shared.cpp
@@ -47,11 +47,6 @@ SharedBase::SharedBase(std::string_view diff_path, Properties &property_set)
       transform(debug_header)
 #endif
 {
-  for (size_t i = 0; i != termination_reason_count; ++i)
-    std::atomic_init(&terminations[i], 0);
-  for (size_t i = 0; i != rejection_reason_count; ++i)
-    std::atomic_init(&rejections[i], 0);
-
   if (properties.find("max_num_tracks") == properties.end())
     max_num_tracks = (properties.find("max_num_seeds") == properties.end()) ? Defaults::num_selected_tracks : 0;
   properties.set(max_num_tracks, "max_num_tracks");
@@ -88,29 +83,27 @@ SharedBase::SharedBase(std::string_view diff_path, Properties &property_set)
   if (properties.find("downsample_factor") != properties.end())
     downsampler.set_ratio(to<int>(properties["downsample_factor"]));
 
-  for (size_t i = 0; i != termination_reason_count; ++i)
-    std::atomic_init(&terminations[i], 0);
-  for (size_t i = 0; i != rejection_reason_count; ++i)
-    std::atomic_init(&rejections[i], 0);
 #ifdef DEBUG_TERMINATIONS
   debug_header.ndim() = 3;
   debug_header.datatype() = DataType::UInt32;
-  for (const auto &i : termination_info)
-    debug_images.emplace_back(
-        new Image<uint32_t>(Image<uint32_t>::create("terms_" + i.second.name + ".mif", debug_header)));
+  for (const auto &i : termination_info) {
+    if (termination_relevant(i.first))
+      debug_images.emplace_back(
+          Image<uint32_t>::create("terms_" + Enum::lowercase_name(i.first) + ".mif", debug_header));
+    else
+      debug_images.emplace_back(Image<uint32_t>());
+  }
 #endif
 }
 
 SharedBase::~SharedBase() {
-  size_t sum_terminations = 0;
-  for (const auto &i : terminations)
-    sum_terminations += i;
+  const size_t sum_terminations = terminations.total();
   INFO("Total number of track terminations: " + str(sum_terminations));
   INFO("Termination reason probabilities:");
   for (const auto &i : termination_info) {
     if (termination_relevant(i.first))
       INFO("  " + i.second.description + ": " +
-           str(100.0 * static_cast<default_type>(terminations[static_cast<ssize_t>(i.first)]) /
+           str(100.0 * static_cast<default_type>(terminations.get(i.first)) /
                    static_cast<default_type>(sum_terminations),
                3) +
            "\%");
@@ -119,7 +112,7 @@ SharedBase::~SharedBase() {
   INFO("Track rejection counts:");
   for (const auto &i : rejection_strings) {
     if (rejection_relevant(i.first))
-      INFO("  " + i.second + ": " + str(rejections[static_cast<ssize_t>(i.first)]));
+      INFO("  " + i.second + ": " + str(rejections.get(i.first)));
   }
 }
 
@@ -236,8 +229,9 @@ void SharedBase::set_cutoff(float cutoff) {
 
 #ifdef DEBUG_TERMINATIONS
 void SharedBase::add_termination(const term_t i, const Eigen::Vector3f &p) const {
-  terminations[i].fetch_add(1, std::memory_order_relaxed);
-  Image<uint32_t> image(*debug_images[i]);
+  terminations.add(i);
+  assert(debug_images[*magic_enum::enum_index(i)].valid());
+  Image<uint32_t> image(debug_images[*magic_enum::enum_index(i)]);
   const auto pv = (transform.scanner2voxel * p.cast<default_type>()).array().round().cast<ssize_t>();
   image.index(0) = pv[0];
   image.index(1) = pv[1];
@@ -249,8 +243,6 @@ void SharedBase::add_termination(const term_t i, const Eigen::Vector3f &p) const
 
 bool SharedBase::termination_relevant(const term_t i) const {
   switch (i) {
-  case term_t::CONTINUE:
-    return false;
   case term_t::ENTER_CGM:
     return is_act();
   case term_t::CALIBRATOR:

--- a/cpp/core/dwi/tractography/tracking/shared.cpp
+++ b/cpp/core/dwi/tractography/tracking/shared.cpp
@@ -15,12 +15,14 @@
  */
 
 #include "dwi/tractography/tracking/shared.h"
+#include "algo/implicit_mask.h"
 
 namespace MR::DWI::Tractography::Tracking {
 
-SharedBase::SharedBase(std::string_view diff_path, Properties &property_set)
+SharedBase::SharedBase(std::string_view diff_path, Properties &property_set, ImplicitMaskConfig source_mask_config)
     : source_header(Header::open(diff_path)),
       source(source_header.get_image<float>().with_direct_io(3)),
+      source_mask(make_implicit_mask(source, source_mask_config)),
       properties(property_set),
       init_dir(Eigen::Vector3f::Constant(NaN)),
       min_num_points_preds(0),

--- a/cpp/core/dwi/tractography/tracking/shared.cpp
+++ b/cpp/core/dwi/tractography/tracking/shared.cpp
@@ -163,6 +163,12 @@ void SharedBase::set_step_and_angle(const float voxel_frac,
   //   then it is impossible for a streamline to be terminated specifically due to a curvature constraint;
   //   this should therefore be omitted from reporting of termination statistics
   curvature_constraint = curvature_constraint_type;
+#ifdef DEBUG_TERMINATIONS
+  if (curvature_constraint == curvature_constraint_t::POSTHOC_THRESHOLD) {
+    debug_images[*magic_enum::enum_index(term_t::HIGH_CURVATURE)] =
+        Image<uint32_t>::create("terms_" + Enum::lowercase_name(term_t::HIGH_CURVATURE) + ".mif", debug_header);
+  }
+#endif
 }
 
 void SharedBase::set_num_points() {

--- a/cpp/core/dwi/tractography/tracking/shared.h
+++ b/cpp/core/dwi/tractography/tracking/shared.h
@@ -16,14 +16,13 @@
 
 #pragma once
 
-#include <atomic>
-
 #include "dwi/tractography/ACT/shared.h"
 #include "dwi/tractography/properties.h"
 #include "dwi/tractography/resampling/downsampler.h"
 #include "dwi/tractography/roi.h"
 #include "dwi/tractography/tracking/tractography.h"
 #include "dwi/tractography/tracking/types.h"
+#include "enum.h"
 #include "header.h"
 #include "image.h"
 #include "memory.h"
@@ -31,7 +30,7 @@
 
 // If this is enabled, images will be output in the current directory showing the density of streamline terminations due
 // to different termination mechanisms throughout the brain
-// #define DEBUG_TERMINATIONS
+#define DEBUG_TERMINATIONS
 
 namespace MR::DWI::Tractography::Tracking {
 
@@ -79,36 +78,28 @@ public:
   // (Only utilised for Exec::satisfy_wm_requirement())
   virtual float internal_step_size() const { return step_size; }
 
-  void add_termination(const term_t i) const {
-    terminations[static_cast<ssize_t>(i)].fetch_add(1, std::memory_order_relaxed);
-  }
-  void add_rejection(const reject_t i) const {
-    rejections[static_cast<ssize_t>(i)].fetch_add(1, std::memory_order_relaxed);
-  }
+  void add_termination(const term_t i) const { terminations.add(i); }
+  void add_rejection(const reject_t i) const { rejections.add(i); }
 
 #ifdef DEBUG_TERMINATIONS
   void add_termination(const term_t i, const Eigen::Vector3f &p) const;
 #endif
 
-  size_t termination_count(const term_t i) const {
-    return terminations[static_cast<ssize_t>(i)].load(std::memory_order_seq_cst);
-  }
-  size_t rejection_count(const reject_t i) const {
-    return rejections[static_cast<ssize_t>(i)].load(std::memory_order_seq_cst);
-  }
+  size_t termination_count(const term_t i) const { return terminations.get(i); }
+  size_t rejection_count(const reject_t i) const { return rejections.get(i); }
 
   bool termination_relevant(const term_t i) const;
   bool rejection_relevant(const reject_t i) const;
 
 private:
-  mutable std::array<std::atomic<size_t>, termination_reason_count> terminations;
-  mutable std::array<std::atomic<size_t>, rejection_reason_count> rejections;
+  Enum::AtomicCounters<term_t> terminations;
+  Enum::AtomicCounters<reject_t> rejections;
 
   std::unique_ptr<ACT::ACT_Shared_additions> act_shared_additions;
 
 #ifdef DEBUG_TERMINATIONS
   Header debug_header;
-  std::vector<std::unique_ptr<Image<uint32_t>>> debug_images;
+  std::vector<Image<uint32_t>> debug_images;
   const Transform transform;
 #endif
 };

--- a/cpp/core/dwi/tractography/tracking/shared.h
+++ b/cpp/core/dwi/tractography/tracking/shared.h
@@ -31,7 +31,7 @@
 
 // If this is enabled, images will be output in the current directory showing the density of streamline terminations due
 // to different termination mechanisms throughout the brain
-#define DEBUG_TERMINATIONS
+// #define DEBUG_TERMINATIONS
 
 namespace MR::DWI::Tractography::Tracking {
 

--- a/cpp/core/dwi/tractography/tracking/shared.h
+++ b/cpp/core/dwi/tractography/tracking/shared.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "algo/implicit_mask.h"
 #include "dwi/tractography/ACT/shared.h"
 #include "dwi/tractography/properties.h"
 #include "dwi/tractography/resampling/downsampler.h"
@@ -37,12 +38,13 @@ namespace MR::DWI::Tractography::Tracking {
 class SharedBase {
 
 public:
-  SharedBase(std::string_view diff_path, Properties &property_set);
+  SharedBase(std::string_view diff_path, Properties &property_set, ImplicitMaskConfig source_mask_config);
 
   virtual ~SharedBase();
 
   Header source_header;
   Image<float> source;
+  Image<bool> source_mask;
   Properties &properties;
   Eigen::Vector3f init_dir;
   size_t max_num_tracks, max_num_seeds;

--- a/cpp/core/dwi/tractography/tracking/types.h
+++ b/cpp/core/dwi/tractography/tracking/types.h
@@ -23,7 +23,6 @@
 namespace MR::DWI::Tractography::Tracking {
 
 enum class term_t {
-  CONTINUE,
   ENTER_CGM,
   CALIBRATOR,
   EXIT_IMAGE,
@@ -37,26 +36,23 @@ enum class term_t {
   ENTER_EXCLUDE,
   TRAVERSE_ALL_INCLUDE
 };
-constexpr ssize_t termination_reason_count = 13;
 struct term_info {
-  std::string name;
   std::string description;
   bool add_term_to_tck;
 };
 const std::map<term_t, term_info> termination_info{
-    {term_t::CONTINUE, {"continue", "Continue", true}},
-    {term_t::ENTER_CGM, {"enter_cgm", "Entered cortical grey matter", true}},
-    {term_t::CALIBRATOR, {"calibrator", "Calibrator sub-threshold", false}},
-    {term_t::EXIT_IMAGE, {"exit_image", "Exited image", false}},
-    {term_t::ENTER_CSF, {"enter_csf", "Entered CSF", true}},
-    {term_t::MODEL, {"model", "Diffusion model sub-threshold", false}},
-    {term_t::HIGH_CURVATURE, {"curvature", "Excessive curvature", false}},
-    {term_t::LENGTH_EXCEED, {"max_length", "Max length exceeded", true}},
-    {term_t::TERM_IN_SGM, {"term_in_sgm", "Terminated in subcortex", false}},
-    {term_t::EXIT_SGM, {"exit_sgm", "Exiting sub-cortical GM", false}},
-    {term_t::EXIT_MASK, {"exit_mask", "Exited mask", false}},
-    {term_t::ENTER_EXCLUDE, {"enter_exclude", "Entered exclusion region", true}},
-    {term_t::TRAVERSE_ALL_INCLUDE, {"all_include", "Traversed all include regions", true}}};
+    {term_t::ENTER_CGM, {"Entered cortical grey matter", true}},
+    {term_t::CALIBRATOR, {"Calibrator sub-threshold", false}},
+    {term_t::EXIT_IMAGE, {"Exited image", false}},
+    {term_t::ENTER_CSF, {"Entered CSF", true}},
+    {term_t::MODEL, {"Diffusion model sub-threshold", false}},
+    {term_t::HIGH_CURVATURE, {"Excessive curvature", false}},
+    {term_t::LENGTH_EXCEED, {"Max length exceeded", true}},
+    {term_t::TERM_IN_SGM, {"Terminated in subcortex", false}},
+    {term_t::EXIT_SGM, {"Exiting sub-cortical GM", false}},
+    {term_t::EXIT_MASK, {"Exited mask", false}},
+    {term_t::ENTER_EXCLUDE, {"Entered exclusion region", true}},
+    {term_t::TRAVERSE_ALL_INCLUDE, {"Traversed all include regions", true}}};
 
 enum class reject_t {
   INVALID_SEED,
@@ -68,7 +64,6 @@ enum class reject_t {
   ACT_POOR_TERMINATION,
   ACT_FAILED_WM_REQUIREMENT
 };
-constexpr ssize_t rejection_reason_count = 8;
 const std::map<reject_t, std::string> rejection_strings{
     {reject_t::INVALID_SEED, "Invalid seed point"},
     {reject_t::NO_PROPAGATION_FROM_SEED, "No propagation from seed"},

--- a/cpp/core/dwi/tractography/tracking/write_kernel.h
+++ b/cpp/core/dwi/tractography/tracking/write_kernel.h
@@ -32,6 +32,7 @@
 #include "dwi/tractography/tracking/generated_track.h"
 #include "dwi/tractography/tracking/shared.h"
 #include "dwi/tractography/tracking/types.h"
+#include "enum.h"
 
 namespace MR::DWI::Tractography::Tracking {
 
@@ -80,7 +81,7 @@ public:
       data["Generation"]["Selected"] = selected;
       for (const auto &i : termination_info) {
         if (S.termination_relevant(i.first))
-          data["Terminations"][i.second.name] = S.termination_count(i.first);
+          data["Terminations"][Enum::lowercase_name(i.first)] = S.termination_count(i.first);
       }
       for (const auto &i : rejection_strings) {
         if (S.rejection_relevant(i.first))

--- a/cpp/core/enum.h
+++ b/cpp/core/enum.h
@@ -17,9 +17,14 @@
 #pragma once
 
 #include <algorithm>
+#include <array>
+#include <atomic>
 #include <cctype>
+#include <cstddef>
 #include <string>
 #include <string_view>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
 #include <magic_enum/magic_enum.hpp>
@@ -75,6 +80,54 @@ template <typename EnumType> inline std::string name(EnumType value) {
 template <typename EnumType> inline std::string lowercase_name(EnumType value) {
   return detail::lowercase(magic_enum::enum_name(value));
 }
+
+// Atomic counter array indexed by enum value.
+// Provides thread-safe accumulation of per-enumerator counts without manual
+// cardinality tracking or explicit atomic_init loops.
+template <typename EnumType> class AtomicCounters {
+  static_assert(std::is_enum_v<EnumType>, "AtomicCounters requires an enum type");
+
+  // std::atomic is not copy- or move-constructible, so a std::array of
+  // std::atomic cannot be value-initialised through aggregate brace init.
+  // Wrapping it gives a default constructor that zero-initialises the value.
+  // The atomic is marked mutable so that thread-safe accumulation can be
+  // exposed through const member functions of the enclosing helper.
+  struct Counter {
+    mutable std::atomic<std::size_t> value;
+    Counter() noexcept : value(0) {}
+  };
+
+  static constexpr std::size_t N = magic_enum::enum_count<EnumType>();
+  std::array<Counter, N> counters;
+
+public:
+  AtomicCounters() = default;
+  AtomicCounters(const AtomicCounters &) = delete;
+  AtomicCounters &operator=(const AtomicCounters &) = delete;
+
+  static constexpr std::size_t size() noexcept { return N; }
+
+  void add(EnumType value, std::size_t increment = 1) const noexcept {
+    counters[*magic_enum::enum_index(value)].value.fetch_add(increment, std::memory_order_relaxed);
+  }
+
+  std::size_t get(EnumType value) const noexcept {
+    return counters[*magic_enum::enum_index(value)].value.load(std::memory_order_seq_cst);
+  }
+
+  std::size_t total() const noexcept {
+    std::size_t sum = 0;
+    for (const auto &counter : counters)
+      sum += counter.value.load(std::memory_order_seq_cst);
+    return sum;
+  }
+
+  template <typename Callable> void for_each(Callable &&callable) const {
+    constexpr auto values = magic_enum::enum_values<EnumType>();
+    for (std::size_t i = 0; i != N; ++i)
+      std::forward<Callable>(callable)(values[i], counters[i].value.load(std::memory_order_seq_cst));
+  }
+};
 
 // Converts a string to the corresponding enum value, ignoring case.
 // If no matching enum value is found, throws an exception.

--- a/cpp/core/enum.h
+++ b/cpp/core/enum.h
@@ -93,11 +93,11 @@ template <typename EnumType> class AtomicCounters {
   // The atomic is marked mutable so that thread-safe accumulation can be
   // exposed through const member functions of the enclosing helper.
   struct Counter {
-    mutable std::atomic<std::size_t> value;
+    mutable std::atomic<size_t> value;
     Counter() noexcept : value(0) {}
   };
 
-  static constexpr std::size_t N = magic_enum::enum_count<EnumType>();
+  static constexpr size_t N = magic_enum::enum_count<EnumType>();
   std::array<Counter, N> counters;
 
 public:
@@ -105,18 +105,18 @@ public:
   AtomicCounters(const AtomicCounters &) = delete;
   AtomicCounters &operator=(const AtomicCounters &) = delete;
 
-  static constexpr std::size_t size() noexcept { return N; }
+  static constexpr size_t size() noexcept { return N; }
 
-  void add(EnumType value, std::size_t increment = 1) const noexcept {
+  void add(EnumType value, size_t increment = 1) const noexcept {
     counters[*magic_enum::enum_index(value)].value.fetch_add(increment, std::memory_order_relaxed);
   }
 
-  std::size_t get(EnumType value) const noexcept {
+  size_t get(EnumType value) const noexcept {
     return counters[*magic_enum::enum_index(value)].value.load(std::memory_order_seq_cst);
   }
 
-  std::size_t total() const noexcept {
-    std::size_t sum = 0;
+  size_t total() const noexcept {
+    size_t sum = 0;
     for (const auto &counter : counters)
       sum += counter.value.load(std::memory_order_seq_cst);
     return sum;
@@ -124,7 +124,7 @@ public:
 
   template <typename Callable> void for_each(Callable &&callable) const {
     constexpr auto values = magic_enum::enum_values<EnumType>();
-    for (std::size_t i = 0; i != N; ++i)
+    for (size_t i = 0; i != N; ++i)
       std::forward<Callable>(callable)(values[i], counters[i].value.load(std::memory_order_seq_cst));
   }
 };
@@ -134,8 +134,8 @@ public:
 template <typename EnumType> inline EnumType from_name(std::string_view enum_name) {
   const auto value = magic_enum::enum_cast<EnumType>(enum_name, magic_enum::case_insensitive);
   if (!value.has_value()) {
-    const std::string error = "Unsupported value '" + std::string(enum_name) +
-                              "'. Supported values are: " + detail::join(lower_case_names<EnumType>(), ", ");
+    const std::string error = "Unsupported value '" + std::string(enum_name) + "';" + //
+                              " supported values are: " + detail::join(lower_case_names<EnumType>(), ", ");
     throw Exception(error);
   }
   return value.value();

--- a/cpp/core/filter/connected_components.cpp
+++ b/cpp/core/filter/connected_components.cpp
@@ -82,11 +82,12 @@ void Connector::Adjacency::initialise(const Header &header, const Voxel2Vector &
     }
     data.push_back(indices);
   }
+  is_initialised = true;
   DEBUG("Adjacency data for " + str(data.size()) + " voxels initialised");
 }
 
 void Connector::run(std::vector<Cluster> &clusters, std::vector<uint32_t> &labels) const {
-  assert(adjacency.size());
+  assert(adjacency.valid());
   labels.resize(adjacency.size(), 0);
   uint32_t current_label = 0;
   for (uint32_t i = 0; i < labels.size(); i++) {

--- a/cpp/core/filter/connected_components.h
+++ b/cpp/core/filter/connected_components.h
@@ -43,7 +43,7 @@ public:
     using index_t = Voxel2Vector::index_t;
     using axis_mask_type = Eigen::Array<bool, Eigen::Dynamic, 1>;
 
-    Adjacency() : use_26_neighbours(false), enabled_axes(axis_mask_type::Ones(3)) {}
+    Adjacency() : use_26_neighbours(false), enabled_axes(axis_mask_type::Ones(3)), is_initialised(false) {}
 
     void toggle_axis(const size_t axis, const bool value) {
       if (axis > enabled_axes.size())
@@ -71,11 +71,14 @@ public:
     }
 
     size_t size() const { return data.size(); }
+    bool empty() const { return data.empty(); }
+    bool valid() const { return is_initialised; }
 
   private:
     bool use_26_neighbours;
     axis_mask_type enabled_axes;
     std::vector<std::vector<index_t>> data;
+    bool is_initialised;
   } adjacency;
 
   class Cluster {
@@ -253,8 +256,8 @@ public:
   void set_axes(const std::vector<int> &i) {
     const size_t max_axis = *std::max_element(i.begin(), i.end());
     if (max_axis >= ndim())
-      throw Exception("Requested axis for connected-component filter (" + str(max_axis) +
-                      " is beyond the dimensionality of the image (" + str(ndim()) + "D)");
+      throw Exception("Requested axis for connected-component filter (" + str(max_axis) + ")" + //
+                      " is beyond the dimensionality of the image (" + str(ndim()) + "D)");     //
     enabled_axes = axis_mask_type::Zero(std::max(max_axis + 1, static_cast<size_t>(ndim())));
     for (const auto &axis : i) {
       if (axis < 0)
@@ -265,8 +268,8 @@ public:
 
   void set_axes(const axis_mask_type &i) {
     if (i.size() != ndim())
-      throw Exception("Length of axis selection flag vector (" + str(i.size()) +
-                      ") does not match dimensionality of connected-component filter (" + str(ndim()) + "D)");
+      throw Exception("Length of axis selection flag vector (" + str(i.size()) + ")" +                        //
+                      " does not match dimensionality of connected-component filter (" + str(ndim()) + "D)"); //
     enabled_axes = i;
   }
 

--- a/cpp/core/interp/masked.h
+++ b/cpp/core/interp/masked.h
@@ -16,8 +16,8 @@
 
 #pragma once
 
-#include "algo/loop.h"
 #include "datatype.h"
+#include "image.h"
 #include "interp/base.h"
 
 namespace MR::Interp {
@@ -26,14 +26,12 @@ namespace MR::Interp {
 // @{
 
 //! Implicit masking for interpolator class
-/*! Wrap a image interpolator in a way that returns false not only if
+/*! Wrap an image interpolator in a way that returns false not only if
  * the position is outside of the field of view of the image, but also
- * if the image is zero-filled or contains non-finite values at that
- * location.
+ * if the corresponding voxel in the supplied binary mask is false.
  *
- * (NaN values are permitted in order to be compatible with 3-vectors
- * images, i.e. sets of XYZ triplets; but there needs to be at least
- * one non-NaN & non-zero value in the voxel)
+ * The mask must share the spatial voxel grid of the parent image
+ * (same dimensions, spacing, and scanner-space transform).
  */
 template <class InterpType> class Masked : public InterpType {
 public:
@@ -41,29 +39,25 @@ public:
 
   Masked(
       const typename InterpType::image_type &parent,
+      Image<bool> mask,
       const value_type value_when_out_of_bounds = Base<typename InterpType::image_type>::default_out_of_bounds_value())
-      : InterpType(parent, value_when_out_of_bounds) {}
+      : InterpType(parent, value_when_out_of_bounds), voxel_mask(std::move(mask)) {
+    check_voxel_grids_match_in_scanner_space(parent, voxel_mask);
+  }
 
   //! Set the current position to <b>voxel space</b> position \a pos
-  /* Unlike other interpolators, this sets the .index() location of
-   * the parent image, and checks to see whether or not there is
-   * any finite & non-zero data present; if there is not, then the
-   * function returns false, as though the location is outside of the
-   * image FoV.
-   *
-   * See file interp/base.h for details. */
+  /*! See file interp/base.h for details. */
   template <class VectorType> bool voxel(const VectorType &pos) {
     if (InterpType::set_out_of_bounds(pos))
       return false;
-    InterpType::image_type::index(0) = std::round(pos[0]);
-    InterpType::image_type::index(1) = std::round(pos[1]);
-    InterpType::image_type::index(2) = std::round(pos[2]);
-    for (auto l_inner = Loop(*this, 3)(*this); l_inner; ++l_inner) {
-      if (InterpType::image_type::value())
-        return InterpType::voxel(pos);
+    voxel_mask.index(0) = static_cast<ssize_t>(std::round(pos[0]));
+    voxel_mask.index(1) = static_cast<ssize_t>(std::round(pos[1]));
+    voxel_mask.index(2) = static_cast<ssize_t>(std::round(pos[2]));
+    if (!voxel_mask.value()) {
+      InterpType::set_out_of_bounds(true);
+      return true;
     }
-    InterpType::set_out_of_bounds(true);
-    return true;
+    return InterpType::voxel(pos);
   }
 
   //! Set the current position to <b>image space</b> position \a pos
@@ -77,6 +71,9 @@ public:
   template <class VectorType> FORCE_INLINE bool scanner(const VectorType &pos) {
     return voxel(Transform::scanner2voxel * pos.template cast<default_type>());
   }
+
+private:
+  Image<bool> voxel_mask;
 };
 
 //! @}

--- a/cpp/core/misc/voxel2vector.h
+++ b/cpp/core/misc/voxel2vector.h
@@ -52,6 +52,7 @@ public:
           str(reverse.size()) + " elements");
   }
 
+  bool empty() const { return reverse.empty(); }
   size_t size() const { return reverse.size(); }
 
   const std::vector<index_t> &operator[](const size_t index) const {


### PR DESCRIPTION
Mentioned in [comment](https://github.com/MRtrix3/mrtrix3/issues/2585#issuecomment-3358752073) in #2585.

Closes #3347.

-----

This started with trying to finally address some very ugly `tckgen` code for aggregating statistics on streamline terminations and rejections, as the last component of #2585. Along the way, in making corresponding changes to the export of endpoint density images (hidden behind `// #define DEBUG_TERMINATIONS`), I discovered that streamlines terminating at the lateral ventricles were being labelled as `EXIT_IMAGE`. This led to listing #3347, which I ended up addressing on the same branch.

There's a change to a long-standing API that's worth mentioning here. Continuing my current love-affair with `std::optional`, I realised that it made a lot more sense for both the `next()` function of streamline algorithms, and some of the internal handling within `exec.h`, to use `std::optional<term_t>` to reflect possible encountering of a termination, rather than the self-contradictory `term_t::CONTINUE`. Unlikely to impact anybody, but worth noting nonetheless.

-----

- [x] @Lestropie to re-review via GitHub.