### PR TITLE
Add weekly GitHub Action for Python command coverage

### DIFF
--- a/.github/workflows/coverage_python.yml
+++ b/.github/workflows/coverage_python.yml
@@ -1,10 +1,9 @@
-name: Python Coverage
+name: Python Coverage Analysis
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * 0'
-  # IMPORTANT: remove this before merging
-  pull_request:
 
 jobs:
   python-coverage:
@@ -98,5 +97,5 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: python-coverage-report
-        path: coverage-report/
+        path: coverage-reports/
         retention-days: 90

--- a/.github/workflows/weekly_python_coverage.yml
+++ b/.github/workflows/weekly_python_coverage.yml
@@ -30,28 +30,8 @@ jobs:
       with:
         cmakeVersion: '3.22.1'
 
-    - name: Set up neuroimaging dependencies
-      uses: mamba-org/setup-micromamba@v2
-      with:
-        micromamba-version: latest
-        environment-name: neuro
-        create-args: >-
-          -c conda-forge
-          python>=3.8
-          fsl
-          fsl-eddy-cpu
-          ants
-        cache-environment: true
-        init-shell: bash
-
-    - name: Configure external tool environment
-      run: |
-        echo "FSLDIR=$CONDA_PREFIX" >> $GITHUB_ENV
-        echo "FSLOUTPUTTYPE=NIFTI_GZ" >> $GITHUB_ENV
-        echo "ANTSPATH=$CONDA_PREFIX/bin" >> $GITHUB_ENV
-
     - name: Install Python coverage tools
-      run: pip install coverage deepatropos
+      run: pip install coverage
 
     - name: Configure
       run: |
@@ -91,7 +71,7 @@ jobs:
         echo "COVERAGE_PYTHONPATH=/tmp/pycov${PYTHONPATH:+:$PYTHONPATH}" >> $GITHUB_ENV
 
     - name: Run Python script tests
-      # Tests requiring AFNI (3dautomask), HD-BET, or SynthStrip will fail;
+      # Tests requiring any external neuroimaging software will fail;
       # their partial execution still contributes coverage for reached code paths.
       # All tests share the same working directory (script_test_data root) and
       # write to overlapping tmp* paths, so parallelism is explicitly disabled.

--- a/.github/workflows/weekly_python_coverage.yml
+++ b/.github/workflows/weekly_python_coverage.yml
@@ -1,0 +1,123 @@
+name: Python Coverage
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  python-coverage:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash -el {0}
+
+    env:
+      QT_SELECT: qt6
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          qt6-base-dev libglvnd-dev zlib1g-dev libfftw3-dev \
+          libpng-dev ninja-build python3-numpy mesa-vulkan-drivers
+
+    - name: Get CMake
+      uses: lukka/get-cmake@latest
+      with:
+        cmakeVersion: '3.22.1'
+
+    - name: Set up neuroimaging dependencies
+      uses: mamba-org/setup-micromamba@v2
+      with:
+        micromamba-version: latest
+        environment-name: neuro
+        create-args: >-
+          -c conda-forge
+          python>=3.8
+          fsl
+          fsl-eddy-cpu
+          ants
+        cache-environment: true
+        init-shell: bash
+
+    - name: Configure external tool environment
+      run: |
+        echo "FSLDIR=$CONDA_PREFIX" >> $GITHUB_ENV
+        echo "FSLOUTPUTTYPE=NIFTI_GZ" >> $GITHUB_ENV
+        echo "ANTSPATH=$CONDA_PREFIX/bin" >> $GITHUB_ENV
+
+    - name: Install Python coverage tools
+      run: pip install coverage deepatropos
+
+    - name: Configure
+      run: |
+        cmake \
+          -B build_debug \
+          -G Ninja \
+          -D CMAKE_BUILD_TYPE=Release \
+          -D MRTRIX_BUILD_TESTS=ON
+
+    - name: Build
+      # Also downloads test data via ExternalProject_Add
+      run: cmake --build build_debug -j $(nproc)
+
+    - name: Set up coverage instrumentation
+      run: |
+        mkdir -p /tmp/pycov
+        printf 'import coverage\ncoverage.process_startup()\n' \
+          > /tmp/pycov/sitecustomize.py
+
+        cat > "$GITHUB_WORKSPACE/.coveragerc" << EOF
+        [run]
+        branch = True
+        parallel = True
+        data_file = $GITHUB_WORKSPACE/.coverage
+        source = $GITHUB_WORKSPACE/python/mrtrix3
+
+        [paths]
+        source =
+            $GITHUB_WORKSPACE/python/mrtrix3
+            $GITHUB_WORKSPACE/build_debug/lib/mrtrix3
+
+        [html]
+        title = MRtrix3 Python Coverage
+        EOF
+
+        echo "COVERAGE_PYTHONPATH=/tmp/pycov${PYTHONPATH:+:$PYTHONPATH}" >> $GITHUB_ENV
+
+    - name: Run Python script tests
+      # Tests requiring AFNI (3dautomask), HD-BET, or SynthStrip will fail;
+      # their partial execution still contributes coverage for reached code paths.
+      # All tests share the same working directory (script_test_data root) and
+      # write to overlapping tmp* paths, so parallelism is explicitly disabled.
+      run: cd build_debug && ctest -L script -j 1 --output-on-failure || true
+      env:
+        COVERAGE_PROCESS_START: ${{ github.workspace }}/.coveragerc
+        PYTHONPATH: ${{ env.COVERAGE_PYTHONPATH }}
+
+    - name: Generate coverage report
+      run: |
+        cd "$GITHUB_WORKSPACE"
+        coverage combine
+        coverage html -d coverage-report
+        coverage report | tee coverage-summary.txt
+        {
+          echo '### Python Coverage Summary'
+          echo '```'
+          cat coverage-summary.txt
+          echo '```'
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Upload coverage report
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-coverage-report
+        path: coverage-report/
+        retention-days: 90

--- a/.github/workflows/weekly_python_coverage.yml
+++ b/.github/workflows/weekly_python_coverage.yml
@@ -86,7 +86,7 @@ jobs:
         cd "$GITHUB_WORKSPACE"
         coverage combine
         coverage html -d coverage-report
-        coverage report | tee coverage-summary.txt
+        coverage report --branch -m | tee coverage-summary.txt
         {
           echo '### Python Coverage Summary'
           echo '```'

--- a/.github/workflows/weekly_python_coverage.yml
+++ b/.github/workflows/weekly_python_coverage.yml
@@ -3,7 +3,8 @@ name: Python Coverage
 on:
   schedule:
     - cron: '0 0 * * 0'
-  workflow_dispatch:
+  # IMPORTANT: remove this before merging
+  pull_request:
 
 jobs:
   python-coverage:
@@ -12,9 +13,6 @@ jobs:
     defaults:
       run:
         shell: bash -el {0}
-
-    env:
-      QT_SELECT: qt6
 
     steps:
     - uses: actions/checkout@v4
@@ -25,8 +23,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y \
-          qt6-base-dev libglvnd-dev zlib1g-dev libfftw3-dev \
-          libpng-dev ninja-build python3-numpy mesa-vulkan-drivers
+           libfftw3-dev libpng-dev ninja-build python3-numpy zlib1g-dev
 
     - name: Get CMake
       uses: lukka/get-cmake@latest
@@ -59,14 +56,15 @@ jobs:
     - name: Configure
       run: |
         cmake \
-          -B build_debug \
+          -B build_release \
           -G Ninja \
           -D CMAKE_BUILD_TYPE=Release \
-          -D MRTRIX_BUILD_TESTS=ON
+          -D MRTRIX_BUILD_TESTS=ON \
+          -D MRTRIX_BUILD_GUI=OFF
 
     - name: Build
       # Also downloads test data via ExternalProject_Add
-      run: cmake --build build_debug -j $(nproc)
+      run: cmake --build build_release -j $(nproc)
 
     - name: Set up coverage instrumentation
       run: |
@@ -97,7 +95,7 @@ jobs:
       # their partial execution still contributes coverage for reached code paths.
       # All tests share the same working directory (script_test_data root) and
       # write to overlapping tmp* paths, so parallelism is explicitly disabled.
-      run: cd build_debug && ctest -L script -j 1 --output-on-failure || true
+      run: cd build_release && ctest -L script -j 1 --output-on-failure || true
       env:
         COVERAGE_PROCESS_START: ${{ github.workspace }}/.coveragerc
         PYTHONPATH: ${{ env.COVERAGE_PYTHONPATH }}

--- a/.github/workflows/weekly_python_coverage.yml
+++ b/.github/workflows/weekly_python_coverage.yml
@@ -18,6 +18,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
+        ref: dev
 
     - name: Install system dependencies
       run: |


### PR DESCRIPTION
Completes #2773 in conjunction with #2786.

Comprehensiveness of testing can be improved once #3073 is completed. There, for each external neuroimaging software dependency, a list of only those files required to execute MRtrix3 scripts will be created. Consequently, just as the container build process will install those softwares then strip out all unnecessary content, this workflow could do the same. It might also be possible to cache them just for the Action.

- [x] Change to execute on Pull Request in order to trigger the Action.
- [x] Remove GUI from dependencies & build.
- [x] Resolve content naming consistency between this and #2786.
- [x] Verify artifact storage on GitHub.
- [x] Disable execution on Pull Request before merging.
- Evaluate generation of more exhaustive coverage data.
    -   **Edit**: Deferring novel tests until after third-party dependencies are dealt with.