### PR TITLE
amp2sh: Pre-allocate memory for Gram matrix with -noise

### DIFF
--- a/cmd/amp2sh.cpp
+++ b/cmd/amp2sh.cpp
@@ -112,7 +112,8 @@ class Amp2SH { MEMALIGN(Amp2SH)
       C (common),
       a (common.amp2sh.cols()),
       s (common.amp2sh.rows()),
-      c (common.amp2sh.rows()) { }
+      c (common.amp2sh.rows()),
+      Q (common.amp2sh.rows(), common.amp2sh.rows()) { }
 
     template <class SHImageType, class AmpImageType>
       void operator() (SHImageType& SH, AmpImageType& amp)


### PR DESCRIPTION
Prevents assertion failure when accessing the triangular view of that matrix when compiled in debug mode.
