### PR TITLE
check_syntax: Fix check for nested namespaces

### DIFF
--- a/check_syntax
+++ b/check_syntax
@@ -146,7 +146,7 @@ run_checks() {
 # - Detect namespaces that could have been nested
   res="$res"$(
     cat .check_syntax4.tmp | \
-    $grep -Po '\bnamespace [\w\:]+\s*\{(namespace [\w\:]+\s*\{)+'
+    $grep -Po '\bnamespace [\w\:]+\s*\{(\s*namespace [\w\:]+\s*\{)+'
   )
 
 # - Detect any instances of "using namespace std;":

--- a/cpp/core/enum.h
+++ b/cpp/core/enum.h
@@ -26,9 +26,7 @@
 
 #include "exception.h"
 
-namespace MR::Enum {
-
-namespace detail {
+namespace MR::Enum::detail {
 
 inline std::string lowercase(std::string_view string) {
   std::string result(string);
@@ -48,7 +46,9 @@ inline std::string join(const std::vector<std::string> &values, std::string_view
   return result;
 }
 
-} // namespace detail
+} // namespace MR::Enum::detail
+
+namespace MR::Enum {
 
 // Returns a vector of the lowercase names of the enum values, in the order they are defined in the enum.
 template <typename EnumType> inline std::vector<std::string> lower_case_names() {


### PR DESCRIPTION
Identified thanks to Claude's inner monologue when creating #3354.