### PR TITLE
mrinfo: surface axis realignment as a first-class behaviour

### DIFF
--- a/cpp/cmd/mrinfo.cpp
+++ b/cpp/cmd/mrinfo.cpp
@@ -103,6 +103,18 @@ void usage() {
       " More information can be found on this issue at:"
       " https://mrtrix.readthedocs.io/en/" MRTRIX_BASE_VERSION "/concepts/pe_scheme.html"
 
+    + "By default, mrinfo reports the image *as interpreted by MRtrix3*."
+      " If the image's on-disk axes do not approximately conform to the RAS convention,"
+      " MRtrix3 permutes and flips them at load time so the loaded image appears axial;"
+      " the reported transform, strides, and axis-dependent metadata"
+      " (e.g. PhaseEncodingDirection, pe_scheme, SliceEncodingDirection, SliceTiming)"
+      " may therefore differ from the values stored on disk."
+      " The default human-readable output annotates any such differences inline."
+      " Use the -realignment option to summarise the applied shuffle,"
+      " and -ondisk to make -transform / -strides / -petable / -property queries"
+      " report the pre-realignment (on-disk) values."
+      " See: https://mrtrix.readthedocs.io/en/" MRTRIX_BASE_VERSION "/concepts/axis_realignment.html"
+
     + DWI::bvalue_scaling_description;
 
   ARGUMENTS
@@ -122,6 +134,14 @@ void usage() {
     + Option ("multiplier", "image intensity multiplier")
     + Option ("transform", "the transformation from image coordinates [mm]"
                            " to scanner / real world coordinates [mm]")
+    + Option ("realignment", "if MRtrix3 realigned the image axes to approximate RAS"
+                             " at load time, print a per-output-axis summary of the"
+                             " shuffle; print nothing otherwise")
+    + Option ("ondisk", "report the on-disk view rather than the realigned (interpreted) view"
+                        " for -transform, -strides, -petable, and -property queries of"
+                        " axis-dependent metadata (PhaseEncodingDirection, pe_scheme,"
+                        " SliceEncodingDirection, SliceTiming). No effect for images that"
+                        " were not realigned at load time.")
 
     + FieldExportOptions
 
@@ -167,14 +187,16 @@ void print_spacing(const Header &header) {
   std::cout << buffer << "\n";
 }
 
-void print_strides(const Header &header) {
+void print_strides(const Header &header, const bool ondisk) {
   std::string buffer;
-  std::vector<ssize_t> strides(Stride::get(header));
+  std::vector<ssize_t> strides = ondisk ? std::vector<ssize_t>(header.realignment().orig_strides().begin(),
+                                                               header.realignment().orig_strides().end())
+                                        : Stride::get(header);
   Stride::symbolise(strides);
   for (size_t i = 0; i < header.ndim(); ++i) {
     if (i)
       buffer += " ";
-    buffer += header.stride(i) ? str(strides[i]) : "?";
+    buffer += strides[i] ? str(strides[i]) : "?";
   }
   std::cout << buffer << "\n";
 }
@@ -201,23 +223,30 @@ void print_shells(const Eigen::MatrixXd &grad,
   }
 }
 
-void print_transform(const Header &header) {
+void print_transform(const Header &header, const bool ondisk) {
   Eigen::IOFormat fmt(Eigen::FullPrecision, 0, " ", "\n", "", "", "", "\n");
   Eigen::Matrix<default_type, 4, 4> matrix;
-  matrix.topLeftCorner<3, 4>() = header.transform().matrix();
+  const auto &source = ondisk ? header.realignment().orig_transform() : header.transform();
+  matrix.topLeftCorner<3, 4>() = source.matrix();
   matrix.row(3) << 0.0, 0.0, 0.0, 1.0;
   std::cout << matrix.format(fmt);
 }
 
-void print_properties(const Header &header, std::string_view key, const size_t indent = 0) {
+void print_realignment(const Header &header) {
+  for (const auto &line : header.realignment().describe_axis_mapping())
+    std::cout << line << "\n";
+}
+
+void print_properties(const Header &header, std::string_view key, const bool ondisk, const size_t indent = 0) {
+  const KeyValues &source = ondisk ? header.realignment().orig_keyval() : header.keyval();
   if (lowercase(key) == "all") {
-    for (const auto &it : header.keyval()) {
+    for (const auto &it : source) {
       std::cout << it.first << ": ";
-      print_properties(header, it.first, it.first.size() + 2);
+      print_properties(header, it.first, ondisk, it.first.size() + 2);
     }
   } else {
-    const auto values = header.keyval().find(std::string(key));
-    if (values != header.keyval().end()) {
+    const auto values = source.find(std::string(key));
+    if (values != source.end()) {
       auto lines = split(values->second, "\n");
       INFO("showing property " + std::string(key) + ":");
       std::cout << lines[0] << "\n";
@@ -226,7 +255,8 @@ void print_properties(const Header &header, std::string_view key, const size_t i
         std::cout << lines[i] << "\n";
       }
     } else {
-      WARN("no \"" + std::string(key) + "\" entries found in \"" + header.name() + "\"");
+      WARN("no \"" + std::string(key) + "\" entries found in \"" + header.name() + "\"" +
+           (ondisk ? " (on-disk view)" : ""));
     }
   }
 }
@@ -255,6 +285,31 @@ void header2json(const Header &header, nlohmann::json &json) {
                        {T(1, 0), T(1, 1), T(1, 2), T(1, 3)},
                        {T(2, 0), T(2, 1), T(2, 2), T(2, 3)},
                        {0.0, 0.0, 0.0, 1.0}};
+  if (!header.realignment().is_identity()) {
+    nlohmann::json realignment;
+    const auto &perm = header.realignment().permutations();
+    const auto &flip = header.realignment().flips();
+    realignment["permutations"] = {perm[0], perm[1], perm[2]};
+    realignment["flips"] = {flip[0], flip[1], flip[2]};
+    realignment["axis_mapping"] = header.realignment().describe_axis_mapping();
+    const transform_type &To(header.realignment().orig_transform());
+    realignment["transform_on_disk"] = {{To(0, 0), To(0, 1), To(0, 2), To(0, 3)},
+                                        {To(1, 0), To(1, 1), To(1, 2), To(1, 3)},
+                                        {To(2, 0), To(2, 1), To(2, 2), To(2, 3)},
+                                        {0.0, 0.0, 0.0, 1.0}};
+    std::vector<ssize_t> orig_strides(header.realignment().orig_strides().begin(),
+                                      header.realignment().orig_strides().end());
+    Stride::symbolise(orig_strides);
+    realignment["strides_on_disk"] = orig_strides;
+    nlohmann::json keyval_on_disk = nlohmann::json::object();
+    for (const auto &kv : header.realignment().orig_keyval()) {
+      const auto live = header.keyval().find(kv.first);
+      if (live == header.keyval().end() || live->second != kv.second)
+        keyval_on_disk[kv.first] = kv.second;
+    }
+    realignment["keyval_on_disk"] = keyval_on_disk;
+    json["realignment"] = realignment;
+  }
   // Load key-value entries into a nested keyval.* member
   File::JSON::write(header, json["keyval"], header.path());
 }
@@ -295,15 +350,18 @@ void run() {
   const bool multiplier = !get_options("multiplier").empty();
   const auto properties = get_options("property");
   const bool transform = !get_options("transform").empty();
+  const bool realignment_flag = !get_options("realignment").empty();
+  const bool ondisk = !get_options("ondisk").empty();
   const bool dwgrad = !get_options("dwgrad").empty();
   const bool shell_bvalues = !get_options("shell_bvalues").empty();
   const bool shell_sizes = !get_options("shell_sizes").empty();
   const bool shell_indices = !get_options("shell_indices").empty();
   const bool petable = !get_options("petable").empty();
 
-  const bool print_full_header = !(format || ndim || size || spacing || datatype || strides || offset || multiplier ||
-                                   !properties.empty() || transform || dwgrad || export_grad || shell_bvalues ||
-                                   shell_sizes || shell_indices || export_pe || petable || json_keyval || json_all);
+  const bool print_full_header =
+      !(format || ndim || size || spacing || datatype || strides || offset || multiplier || !properties.empty() ||
+        transform || realignment_flag || dwgrad || export_grad || shell_bvalues || shell_sizes || shell_indices ||
+        export_pe || petable || json_keyval || json_all);
 
   for (size_t i = 0; i < argument.size(); ++i) {
     const auto header = Header::open(argument[i]);
@@ -321,18 +379,24 @@ void run() {
     if (datatype)
       std::cout << header.datatype().specifier() << "\n";
     if (strides)
-      print_strides(header);
+      print_strides(header, ondisk);
     if (offset)
       std::cout << header.intensity_offset() << "\n";
     if (multiplier)
       std::cout << header.intensity_scale() << "\n";
     if (transform)
-      print_transform(header);
-    if (petable)
-      std::cout << Metadata::PhaseEncoding::get_scheme(header) << "\n";
+      print_transform(header, ondisk);
+    if (realignment_flag)
+      print_realignment(header);
+    if (petable) {
+      if (ondisk)
+        std::cout << Metadata::PhaseEncoding::parse_scheme(header.realignment().orig_keyval(), header) << "\n";
+      else
+        std::cout << Metadata::PhaseEncoding::get_scheme(header) << "\n";
+    }
 
     for (size_t n = 0; n < properties.size(); ++n)
-      print_properties(header, properties[n][0]);
+      print_properties(header, properties[n][0], ondisk);
 
     Eigen::MatrixXd grad;
     if (export_grad || check_option_group(GradImportOptions) || dwgrad || shell_bvalues || shell_sizes ||

--- a/cpp/cmd/mrinfo.cpp
+++ b/cpp/cmd/mrinfo.cpp
@@ -292,8 +292,7 @@ void header2json(const Header &header, nlohmann::json &json) {
                                         {To(1, 0), To(1, 1), To(1, 2), To(1, 3)},
                                         {To(2, 0), To(2, 1), To(2, 2), To(2, 3)},
                                         {0.0, 0.0, 0.0, 1.0}};
-    std::vector<ssize_t> orig_strides(header.realignment().orig_strides().begin(),
-                                      header.realignment().orig_strides().end());
+    std::vector<ssize_t> orig_strides(header.realignment().orig_strides());
     Stride::symbolise(orig_strides);
     realignment["strides_on_disk"] = orig_strides;
     nlohmann::json keyval_on_disk = nlohmann::json::object();
@@ -322,16 +321,17 @@ void run() {
 
   const bool ondisk = !get_options("ondisk").empty();
   const bool realignment_flag = !get_options("realignment").empty();
-  if (ondisk && realignment_flag)
-    throw Exception("options -ondisk and -realignment are mutually exclusive:" //
-                    " when -ondisk is specified the image is never realigned,"
-                    " so there is no realignment to summarise");
+  if ((ondisk || !Header::do_realign_transform) && realignment_flag)
+    throw Exception("option -realignment is of no utility" //
+                    " in conjunction with either RealignTransform: false in configuration"
+                    " or the -ondisk option,"
+                    " as both disable realignment by definition");
   // Make -ondisk fully equivalent to -config RealignTransform false:
-  //   suppress MRtrix3's load-time axis realignment globally for this
-  //   invocation so that every downstream output path (the default
-  //   pretty printout, -transform / -strides / -petable, -property,
-  //   -json_keyval / -json_all) reports the on-disk view through a
-  //   single mechanism.
+  //   suppress MRtrix3's load-time axis realignment globally for this invocation
+  //   so that every downstream output path
+  //   (the default pretty printout,
+  //   -transform / -strides / -petable, -property, -json_keyval / -json_all)
+  //   reports the on-disk view through a single mechanism.
   if (ondisk)
     Header::do_realign_transform = false;
 

--- a/cpp/cmd/mrinfo.cpp
+++ b/cpp/cmd/mrinfo.cpp
@@ -111,8 +111,8 @@ void usage() {
       " may therefore differ from the values stored on disk."
       " The default human-readable output annotates any such differences inline."
       " Use the -realignment option to summarise the applied shuffle,"
-      " and -ondisk to make -transform / -strides / -petable / -property queries"
-      " report the pre-realignment (on-disk) values."
+      " or -ondisk to bypass realignment entirely (equivalent to"
+      " -config RealignTransform false) so that every query reports the on-disk view."
       " See: https://mrtrix.readthedocs.io/en/" MRTRIX_BASE_VERSION "/concepts/axis_realignment.html"
 
     + DWI::bvalue_scaling_description;
@@ -134,14 +134,12 @@ void usage() {
     + Option ("multiplier", "image intensity multiplier")
     + Option ("transform", "the transformation from image coordinates [mm]"
                            " to scanner / real world coordinates [mm]")
-    + Option ("realignment", "if MRtrix3 realigned the image axes to approximate RAS"
-                             " at load time, print a per-output-axis summary of the"
-                             " shuffle; print nothing otherwise")
-    + Option ("ondisk", "report the on-disk view rather than the realigned (interpreted) view"
-                        " for -transform, -strides, -petable, and -property queries of"
-                        " axis-dependent metadata (PhaseEncodingDirection, pe_scheme,"
-                        " SliceEncodingDirection, SliceTiming). No effect for images that"
-                        " were not realigned at load time.")
+    + Option ("realignment", "print a per-output-axis summary of the realignment applied"
+                              " by MRtrix3 at load time; prints nothing if no realignment"
+                              " was applied")
+    + Option ("ondisk", "report the on-disk view rather than the realigned (interpreted) view;"
+                        " equivalent to -config RealignTransform false (mutually exclusive"
+                        " with -realignment)")
 
     + FieldExportOptions
 
@@ -187,11 +185,9 @@ void print_spacing(const Header &header) {
   std::cout << buffer << "\n";
 }
 
-void print_strides(const Header &header, const bool ondisk) {
+void print_strides(const Header &header) {
   std::string buffer;
-  std::vector<ssize_t> strides = ondisk ? std::vector<ssize_t>(header.realignment().orig_strides().begin(),
-                                                               header.realignment().orig_strides().end())
-                                        : Stride::get(header);
+  std::vector<ssize_t> strides = Stride::get(header);
   Stride::symbolise(strides);
   for (size_t i = 0; i < header.ndim(); ++i) {
     if (i)
@@ -223,11 +219,10 @@ void print_shells(const Eigen::MatrixXd &grad,
   }
 }
 
-void print_transform(const Header &header, const bool ondisk) {
+void print_transform(const Header &header) {
   Eigen::IOFormat fmt(Eigen::FullPrecision, 0, " ", "\n", "", "", "", "\n");
   Eigen::Matrix<default_type, 4, 4> matrix;
-  const auto &source = ondisk ? header.realignment().orig_transform() : header.transform();
-  matrix.topLeftCorner<3, 4>() = source.matrix();
+  matrix.topLeftCorner<3, 4>() = header.transform().matrix();
   matrix.row(3) << 0.0, 0.0, 0.0, 1.0;
   std::cout << matrix.format(fmt);
 }
@@ -237,12 +232,12 @@ void print_realignment(const Header &header) {
     std::cout << line << "\n";
 }
 
-void print_properties(const Header &header, std::string_view key, const bool ondisk, const size_t indent = 0) {
-  const KeyValues &source = ondisk ? header.realignment().orig_keyval() : header.keyval();
+void print_properties(const Header &header, std::string_view key, const size_t indent = 0) {
+  const KeyValues &source = header.keyval();
   if (lowercase(key) == "all") {
     for (const auto &it : source) {
       std::cout << it.first << ": ";
-      print_properties(header, it.first, ondisk, it.first.size() + 2);
+      print_properties(header, it.first, it.first.size() + 2);
     }
   } else {
     const auto values = source.find(std::string(key));
@@ -255,8 +250,7 @@ void print_properties(const Header &header, std::string_view key, const bool ond
         std::cout << lines[i] << "\n";
       }
     } else {
-      WARN("no \"" + std::string(key) + "\" entries found in \"" + header.name() + "\"" +
-           (ondisk ? " (on-disk view)" : ""));
+      WARN("no \"" + std::string(key) + "\" entries found in \"" + header.name() + "\"");
     }
   }
 }
@@ -285,7 +279,7 @@ void header2json(const Header &header, nlohmann::json &json) {
                        {T(1, 0), T(1, 1), T(1, 2), T(1, 3)},
                        {T(2, 0), T(2, 1), T(2, 2), T(2, 3)},
                        {0.0, 0.0, 0.0, 1.0}};
-  if (!header.realignment().is_identity()) {
+  if (header.realignment().applied()) {
     nlohmann::json realignment;
     const auto &perm = header.realignment().permutations();
     const auto &flip = header.realignment().flips();
@@ -325,6 +319,21 @@ void run() {
   if (!get_options("nodelete").empty())
     ImageIO::Pipe::delete_piped_images = false;
 
+  const bool ondisk = !get_options("ondisk").empty();
+  const bool realignment_flag = !get_options("realignment").empty();
+  if (ondisk && realignment_flag)
+    throw Exception("options -ondisk and -realignment are mutually exclusive:" //
+                    " when -ondisk is specified the image is never realigned,"
+                    " so there is no realignment to summarise");
+  // Make -ondisk fully equivalent to -config RealignTransform false:
+  //   suppress MRtrix3's load-time axis realignment globally for this
+  //   invocation so that every downstream output path (the default
+  //   pretty printout, -transform / -strides / -petable, -property,
+  //   -json_keyval / -json_all) reports the on-disk view through a
+  //   single mechanism.
+  if (ondisk)
+    Header::do_realign_transform = false;
+
   const bool export_grad = check_option_group(GradExportOptions);
   const bool export_pe = check_option_group(Metadata::PhaseEncoding::ExportOptions);
 
@@ -350,8 +359,6 @@ void run() {
   const bool multiplier = !get_options("multiplier").empty();
   const auto properties = get_options("property");
   const bool transform = !get_options("transform").empty();
-  const bool realignment_flag = !get_options("realignment").empty();
-  const bool ondisk = !get_options("ondisk").empty();
   const bool dwgrad = !get_options("dwgrad").empty();
   const bool shell_bvalues = !get_options("shell_bvalues").empty();
   const bool shell_sizes = !get_options("shell_sizes").empty();
@@ -379,24 +386,20 @@ void run() {
     if (datatype)
       std::cout << header.datatype().specifier() << "\n";
     if (strides)
-      print_strides(header, ondisk);
+      print_strides(header);
     if (offset)
       std::cout << header.intensity_offset() << "\n";
     if (multiplier)
       std::cout << header.intensity_scale() << "\n";
     if (transform)
-      print_transform(header, ondisk);
+      print_transform(header);
     if (realignment_flag)
       print_realignment(header);
-    if (petable) {
-      if (ondisk)
-        std::cout << Metadata::PhaseEncoding::parse_scheme(header.realignment().orig_keyval(), header) << "\n";
-      else
-        std::cout << Metadata::PhaseEncoding::get_scheme(header) << "\n";
-    }
+    if (petable)
+      std::cout << Metadata::PhaseEncoding::get_scheme(header) << "\n";
 
     for (size_t n = 0; n < properties.size(); ++n)
-      print_properties(header, properties[n][0], ondisk);
+      print_properties(header, properties[n][0]);
 
     Eigen::MatrixXd grad;
     if (export_grad || check_option_group(GradImportOptions) || dwgrad || shell_bvalues || shell_sizes ||

--- a/cpp/cmd/mrinfo.cpp
+++ b/cpp/cmd/mrinfo.cpp
@@ -192,7 +192,7 @@ void print_strides(const Header &header) {
   for (size_t i = 0; i < header.ndim(); ++i) {
     if (i)
       buffer += " ";
-    buffer += strides[i] ? str(strides[i]) : "?";
+    buffer += strides[i] == 0 ? "?" : str(strides[i]);
   }
   std::cout << buffer << "\n";
 }
@@ -232,6 +232,7 @@ void print_realignment(const Header &header) {
     std::cout << line << "\n";
 }
 
+// NOLINTNEXTLINE(misc-no-recursion)
 void print_properties(const Header &header, std::string_view key, const size_t indent = 0) {
   const KeyValues &source = header.keyval();
   if (lowercase(key) == "all") {

--- a/cpp/core/axes.h
+++ b/cpp/core/axes.h
@@ -45,6 +45,7 @@ public:
     return permutations.is_identity() && std::none_of(flips.begin(), flips.end(), [](bool b) { return b; });
   }
   bool valid() const { return permutations.valid(); }
+  // Always interpret as application of flip then permutation
   permutations_type permutations;
   flips_type flips;
 };

--- a/cpp/core/axes.h
+++ b/cpp/core/axes.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <limits>
 #include <set>
@@ -40,7 +41,9 @@ using flips_type = std::array<bool, 3>;
 class Shuffle {
 public:
   Shuffle() : permutations(), flips({false, false, false}) {}
-  bool is_identity() const { return (permutations.is_identity() && !std::max(flips.begin(), flips.end())); }
+  bool is_identity() const {
+    return permutations.is_identity() && std::none_of(flips.begin(), flips.end(), [](bool b) { return b; });
+  }
   bool valid() const { return permutations.valid(); }
   permutations_type permutations;
   flips_type flips;

--- a/cpp/core/file/config.cpp
+++ b/cpp/core/file/config.cpp
@@ -76,6 +76,17 @@ void Config::init() {
   // CONF A boolean value to indicate whether all images should be realigned
   // CONF to an approximately axial orientation at load.
   Header::do_realign_transform = get_bool("RealignTransform", true);
+
+  // CONF option: RealignmentVerbosity
+  // CONF default: auto
+  // CONF Controls the on-load console notification emitted when MRtrix3
+  // CONF realigns an image's axes to approximate RAS at load time.
+  // CONF Value "auto" (default) emits a single console line per affected
+  // CONF image, summarising the shuffle and any reoriented metadata fields.
+  // CONF Value "quiet" suppresses the notification; the realignment itself
+  // CONF still occurs (use RealignTransform: false to disable the realignment
+  // CONF itself). The -info / -debug command-line flags emit additional
+  // CONF detail independently of this setting.
 }
 
 std::string Config::get(std::string_view key) {

--- a/cpp/core/file/config.cpp
+++ b/cpp/core/file/config.cpp
@@ -76,17 +76,6 @@ void Config::init() {
   // CONF A boolean value to indicate whether all images should be realigned
   // CONF to an approximately axial orientation at load.
   Header::do_realign_transform = get_bool("RealignTransform", true);
-
-  // CONF option: RealignmentVerbosity
-  // CONF default: auto
-  // CONF Controls the on-load console notification emitted when MRtrix3
-  // CONF realigns an image's axes to approximate RAS at load time.
-  // CONF Value "auto" (default) emits a single console line per affected
-  // CONF image, summarising the shuffle and any reoriented metadata fields.
-  // CONF Value "quiet" suppresses the notification; the realignment itself
-  // CONF still occurs (use RealignTransform: false to disable the realignment
-  // CONF itself). The -info / -debug command-line flags emit additional
-  // CONF detail independently of this setting.
 }
 
 std::string Config::get(std::string_view key) {

--- a/cpp/core/file/json_utils.cpp
+++ b/cpp/core/file/json_utils.cpp
@@ -132,7 +132,7 @@ void read(const nlohmann::json &json, Header &header) {
   //   prominently — it is a common source of confusion when a downstream
   //   tool sees a PhaseEncodingDirection that differs from the JSON
   //   file on disk.
-  if (!header.realignment().is_identity()) {
+  if (header.realignment().applied()) {
     std::vector<std::string> modified_fields;
     for (const auto &kv : keyval) {
       const auto pre = pre_transform.find(kv.first);

--- a/cpp/core/file/json_utils.cpp
+++ b/cpp/core/file/json_utils.cpp
@@ -110,46 +110,55 @@ KeyValues read(const nlohmann::json &json) {
 }
 
 void read(const nlohmann::json &json, Header &header) {
-  KeyValues keyval = read(json);
   // Stash the full on-import (pre-transformation) snapshot of every
   //   JSON-imported field into Realignment::orig_keyval, so that
   //   mrinfo's -ondisk queries and the default annotated description
-  //   can recover the original values after realignment has been
-  //   applied below. We deliberately do *not* restrict this to a
-  //   hard-coded list of axis-dependent keys: any field added to
-  //   transform_for_image_load() in the future is then handled with
-  //   no further plumbing.
-  const KeyValues pre_transform = keyval;
-  KeyValues &orig = header.realignment().orig_keyval();
-  for (const auto &kv : pre_transform)
-    orig[kv.first] = kv.second;
+  //   can recover the original values after realignment has been applied.
+  header.realignment().orig_keyval() = read(json);
   // Reorientation based on image load should be applied
   //   exclusively to metadata loaded via JSON; not anything pre-existing
+  KeyValues keyval = header.realignment().orig_keyval();
   Metadata::PhaseEncoding::transform_for_image_load(keyval, header);
   Metadata::SliceEncoding::transform_for_image_load(keyval, header);
   // If the host image was realigned on load AND any JSON-imported field
-  //   was actually modified by transform_for_image_load, surface this
+  //   was actually modified by transform_for_image_load(), surface this
   //   prominently — it is a common source of confusion when a downstream
   //   tool sees a PhaseEncodingDirection that differs from the JSON
   //   file on disk.
   if (header.realignment().applied()) {
     std::vector<std::string> modified_fields;
     for (const auto &kv : keyval) {
-      const auto pre = pre_transform.find(kv.first);
-      if (pre == pre_transform.end() || pre->second != kv.second)
+      const auto pre = header.realignment().orig_keyval().find(kv.first);
+      if (pre == header.realignment().orig_keyval().end() || pre->second != kv.second)
         modified_fields.emplace_back(kv.first);
     }
-    for (const auto &kv : pre_transform) {
+    for (const auto &kv : header.realignment().orig_keyval()) {
       if (keyval.find(kv.first) == keyval.end())
         modified_fields.emplace_back(kv.first);
     }
-    if (!modified_fields.empty())
-      WARN("JSON metadata for image \"" + header.name() +
-           "\""                                                           //
-           " was reoriented on import to match MRtrix3's realignment"     //
-           " of the image axes; affected fields: "                        //
-           + join(modified_fields, ", ") +                                //
-           " (mrinfo -property <field> -ondisk to recover JSON values)"); //
+    if (!modified_fields.empty()) {
+      const std::string msg1 = "JSON metadata for image \"" + header.name() + "\"" +      //
+                               " was reoriented on import to match MRtrix3's realignment" //
+                               " of the corresponding image axes";                        //
+      const std::string msg2 = "  (affected fields: " + join(modified_fields, ", ") + ")";
+      if (File::Config::get_bool("RealignmentVerbose", true)) {
+        CONSOLE(msg1);
+        CONSOLE(msg2);
+      } else {
+        INFO(msg1);
+        INFO(msg2);
+      }
+      for (const auto &item : modified_fields) {
+        DEBUG("    \"" + item + "\": " +                                                                 //
+              (header.realignment().orig_keyval().find(item) == header.realignment().orig_keyval().end() //
+                   ? "<not present>"                                                                     //
+                   : ("\"" + header.realignment().orig_keyval().at(item) + "\"")) +                      //
+              " -> " +                                                                                   //
+              (keyval.find(item) == keyval.end()                                                         //
+                   ? "<not present>"                                                                     //
+                   : ("\"" + keyval.at(item) + "\"")));                                                  //
+      }
+    }
   }
   header.merge_keyval(keyval);
 }

--- a/cpp/core/file/json_utils.cpp
+++ b/cpp/core/file/json_utils.cpp
@@ -17,6 +17,7 @@
 #include <array>
 #include <fstream>
 #include <sstream>
+#include <string_view>
 
 #include "file/json_utils.h"
 #include "file/nifti_utils.h"
@@ -110,10 +111,46 @@ KeyValues read(const nlohmann::json &json) {
 
 void read(const nlohmann::json &json, Header &header) {
   KeyValues keyval = read(json);
+  // Stash the full on-import (pre-transformation) snapshot of every
+  //   JSON-imported field into Realignment::orig_keyval, so that
+  //   mrinfo's -ondisk queries and the default annotated description
+  //   can recover the original values after realignment has been
+  //   applied below. We deliberately do *not* restrict this to a
+  //   hard-coded list of axis-dependent keys: any field added to
+  //   transform_for_image_load() in the future is then handled with
+  //   no further plumbing.
+  const KeyValues pre_transform = keyval;
+  KeyValues &orig = header.realignment().orig_keyval();
+  for (const auto &kv : pre_transform)
+    orig[kv.first] = kv.second;
   // Reorientation based on image load should be applied
   //   exclusively to metadata loaded via JSON; not anything pre-existing
   Metadata::PhaseEncoding::transform_for_image_load(keyval, header);
   Metadata::SliceEncoding::transform_for_image_load(keyval, header);
+  // If the host image was realigned on load AND any JSON-imported field
+  //   was actually modified by transform_for_image_load, surface this
+  //   prominently — it is a common source of confusion when a downstream
+  //   tool sees a PhaseEncodingDirection that differs from the JSON
+  //   file on disk.
+  if (!header.realignment().is_identity()) {
+    std::vector<std::string> modified_fields;
+    for (const auto &kv : keyval) {
+      const auto pre = pre_transform.find(kv.first);
+      if (pre == pre_transform.end() || pre->second != kv.second)
+        modified_fields.emplace_back(kv.first);
+    }
+    for (const auto &kv : pre_transform) {
+      if (keyval.find(kv.first) == keyval.end())
+        modified_fields.emplace_back(kv.first);
+    }
+    if (!modified_fields.empty())
+      WARN("JSON metadata for image \"" + header.name() +
+           "\""                                                           //
+           " was reoriented on import to match MRtrix3's realignment"     //
+           " of the image axes; affected fields: "                        //
+           + join(modified_fields, ", ") +                                //
+           " (mrinfo -property <field> -ondisk to recover JSON values)"); //
+  }
   header.merge_keyval(keyval);
 }
 

--- a/cpp/core/header.cpp
+++ b/cpp/core/header.cpp
@@ -479,9 +479,6 @@ std::string Header::description(bool print_all) const {
                    "\"\n"
                    "************************************************\n");
 
-  const bool applied = realignment().applied();
-  const bool disabled = realignment().state() == Realignment::State::Disabled;
-
   desc += "  Dimensions:        ";
   size_t i;
   for (i = 0; i < ndim(); i++) {
@@ -508,9 +505,9 @@ std::string Header::description(bool print_all) const {
     return out;
   };
 
-  desc += disabled ? "  On-disk strides:   " : "  Data strides:      ";
+  desc += (realignment().state() == Realignment::State::Disabled) ? "  On-disk strides:   " : "  Data strides:      ";
   desc += format_symbolic_strides(Stride::get(*this));
-  if (applied)
+  if (realignment().applied())
     desc += "    (on-disk: " + format_symbolic_strides(realignment().orig_strides()) + ")";
   desc += "\n";
 
@@ -538,12 +535,14 @@ std::string Header::description(bool print_all) const {
     }
   };
 
-  append_transform_block(transform(), disabled ? "On-disk transform:" : "Transform:");
-  if (applied) {
+  append_transform_block(transform(),
+                         (realignment().state() == Realignment::State::Disabled) ? "On-disk transform:" : "Transform:");
+  if (realignment().applied()) {
     append_transform_block(realignment().orig_transform(), "On-disk transform:");
-    desc += "  Axes realignment:\n";
-    for (const auto &line : realignment().describe_axis_mapping())
-      desc += "                     " + line + "\n";
+    const auto axis_mapping = realignment().describe_axis_mapping();
+    desc += "  Axes realignment:  " + axis_mapping[0] + "\n";
+    desc += "                     " + axis_mapping[1] + "\n";
+    desc += "                     " + axis_mapping[2] + "\n";
     desc += "                     (disable with -config RealignTransform false or mrinfo -ondisk)\n";
   }
 
@@ -553,13 +552,11 @@ std::string Header::description(bool print_all) const {
       key.resize(21, ' ');
     const auto entries = split_lines(p.second);
     // Compute per-line on-disk annotations by directly comparing the live
-    //   value against the snapshot in Realignment::orig_keyval; any field
-    //   whose realigned value differs from its on-disk value gets
-    //   annotated, without needing to enumerate which fields are
-    //   axis-dependent.
+    //   value against the snapshot in Realignment::orig_keyval;
+    //   any field whose realigned value differs from its on-disk value gets annotated
     std::vector<std::string> ondisk_entries;
     bool annotate = false;
-    if (applied) {
+    if (realignment().applied()) {
       const auto orig_it = realignment().orig_keyval().find(p.first);
       if (orig_it != realignment().orig_keyval().end() && orig_it->second != p.second) {
         ondisk_entries = split_lines(orig_it->second);
@@ -582,8 +579,9 @@ std::string Header::description(bool print_all) const {
         key = "  [" + str(entries.size()) + " entries] ";
         if (key.size() < 21)
           key.resize(21, ' ');
-      } else
+      } else {
         key = "                     ";
+      }
       for (size_t n = 1; n < (shorten ? size_t(2) : entries.size()); ++n) {
         desc += key + entries[n] + annotation_for(n) + "\n";
         key = "                     ";
@@ -664,7 +662,7 @@ void Header::realign_transform() {
   realignment_.shuffle_ = Axes::get_shuffle_to_make_RAS(transform());
 
   // check if image is already near-axial, return if true:
-  if (realignment_.is_identity()) {
+  if (realignment_.shuffle_.is_identity()) {
     realignment_.state_ = Realignment::State::Identity;
     return;
   }
@@ -719,32 +717,54 @@ void Header::realign_transform() {
   Metadata::PhaseEncoding::transform_for_image_load(keyval(), *this);
   Metadata::SliceEncoding::transform_for_image_load(keyval(), *this);
 
+  // CONF option: RealignmentVerbose
+  // CONF default: true
+  // CONF Controls the on-load console notification emitted when MRtrix3
+  // CONF realigns an image's axes to approximate RAS at load time.
+  // CONF True value (default) emits a single console line per affected
+  // CONF image, summarising the shuffle and any reoriented metadata fields.
+  // CONF False value suppresses the notification; the realignment itself
+  // CONF still occurs (use RealignTransform: false to disable the realignment
+  // CONF itself). The -info / -debug command-line flags emit additional
+  // CONF detail independently of this setting.
+
   // Default-visible notification that a non-trivial axis realignment was
   //   applied; users who do not want this in every pipeline can set
-  //   RealignmentVerbosity: quiet in their config file or via
-  //   -config RealignmentVerbosity quiet.
-  if (File::Config::get("RealignmentVerbosity", "auto") != "quiet") {
-    // Enumerate every keyval field whose value was actually modified by
-    //   transform_for_image_load by comparing the live keyval against
-    //   the pre-transformation snapshot in orig_keyval; this avoids
-    //   maintaining an explicit list of axis-dependent fields and
-    //   automatically tracks any new fields added in the future.
-    std::vector<std::string> modified_fields;
-    for (const auto &kv : keyval()) {
-      const auto orig = realignment_.orig_keyval_.find(kv.first);
-      if (orig == realignment_.orig_keyval_.end() || orig->second != kv.second)
-        modified_fields.emplace_back(kv.first);
-    }
-    for (const auto &kv : realignment_.orig_keyval_) {
-      if (keyval().find(kv.first) == keyval().end())
-        modified_fields.emplace_back(kv.first);
-    }
-    std::string msg = "Image \"" + name() + "\" axes realigned to approximate RAS";
-    if (!modified_fields.empty())
-      msg += "; reoriented metadata: " + join(modified_fields, ", ");
-    msg += " (mrinfo -realignment / -ondisk for details;"
-           " suppress with -config RealignmentVerbosity quiet)";
+  //   RealignmentVerbose: false in their config file or via
+  //   -config RealignmentVerbose false.
+
+  // Enumerate every keyval field whose value was actually modified by
+  //   transform_for_image_load() by comparing the live keyval against
+  //   the pre-transformation snapshot in orig_keyval
+  std::vector<std::string> modified_fields;
+  for (const auto &kv : keyval()) {
+    const auto orig = realignment_.orig_keyval_.find(kv.first);
+    if (orig == realignment_.orig_keyval_.end() || orig->second != kv.second)
+      modified_fields.emplace_back(kv.first);
+  }
+  for (const auto &kv : realignment_.orig_keyval_) {
+    if (keyval().find(kv.first) == keyval().end())
+      modified_fields.emplace_back(kv.first);
+  }
+  std::string msg = "Image \"" + name() + "\" axes realigned to approximate RAS";
+  if (!modified_fields.empty())
+    msg += "; reoriented metadata: " + join(modified_fields, ", ");
+  if (File::Config::get_bool("RealignmentVerbose", true)) {
     CONSOLE(msg);
+    CONSOLE("  (mrinfo -realignment / -ondisk for details;"
+            " suppress with -config RealignmentVerbose false)");
+  } else {
+    INFO(msg);
+  }
+  for (const auto &item : modified_fields) {
+    DEBUG("    \"" + item + "\": " +                                                   //
+          (realignment().orig_keyval().find(item) == realignment().orig_keyval().end() //
+               ? "<not present>"                                                       //
+               : ("\"" + realignment().orig_keyval().at(item) + "\"")) +               //
+          " -> " +                                                                     //
+          (keyval().find(item) == keyval().end()                                       //
+               ? "<not present>"                                                       //
+               : ("\"" + keyval().at(item) + "\"")));                                  //
   }
 }
 
@@ -957,22 +977,21 @@ concatenate(const std::vector<Header> &headers, const size_t axis_to_concat, con
   return result;
 }
 
-Header::Realignment::Realignment() : applied_transform_(applied_transform_type::Identity()), orig_keyval_() {
+Header::Realignment::Realignment() : state_(State::Unknown), applied_transform_(applied_transform_type::Identity()) {
   orig_transform_.matrix().fill(std::numeric_limits<default_type>::quiet_NaN());
 }
 
 std::vector<std::string> Header::Realignment::describe_axis_mapping() const {
-  if (is_identity())
+  if (state_ == State::Identity)
     return {};
   static constexpr std::array<std::string_view, 3> output_labels{"R", "A", "S"};
   std::vector<std::string> lines;
   lines.reserve(3);
   for (size_t output = 0; output != 3; ++output) {
-    const size_t source = shuffle_.permutations[output];
-    const bool flipped = shuffle_.flips[source];
-    lines.push_back("output axis " + str(output) + " (" + std::string(output_labels.at(output)) + ")" //
-                    + " <- source axis " + str(source)                                                //
-                    + ", sign " + (flipped ? "reversed" : "preserved"));                              //
+    const size_t source_axis = shuffle_.permutations[output];
+    lines.push_back("output axis " + str(output) + " (~" + std::string(output_labels.at(output)) + ")" //
+                    + " <- source axis " + str(source_axis)                                            //
+                    + ", sign " + (shuffle_.flips[source_axis] ? "reversed" : "preserved"));           //
   }
   return lines;
 }

--- a/cpp/core/header.cpp
+++ b/cpp/core/header.cpp
@@ -479,7 +479,8 @@ std::string Header::description(bool print_all) const {
                    "\"\n"
                    "************************************************\n");
 
-  const bool realigned = !realignment().is_identity();
+  const bool applied = realignment().applied();
+  const bool disabled = realignment().state() == Realignment::State::Disabled;
 
   desc += "  Dimensions:        ";
   size_t i;
@@ -507,8 +508,9 @@ std::string Header::description(bool print_all) const {
     return out;
   };
 
-  desc += "  Data strides:      " + format_symbolic_strides(Stride::get(*this));
-  if (realigned)
+  desc += disabled ? "  On-disk strides:   " : "  Data strides:      ";
+  desc += format_symbolic_strides(Stride::get(*this));
+  if (applied)
     desc += "    (on-disk: " + format_symbolic_strides(realignment().orig_strides()) + ")";
   desc += "\n";
 
@@ -536,13 +538,13 @@ std::string Header::description(bool print_all) const {
     }
   };
 
-  append_transform_block(transform(), "Transform:");
-  if (realigned) {
+  append_transform_block(transform(), disabled ? "On-disk transform:" : "Transform:");
+  if (applied) {
     append_transform_block(realignment().orig_transform(), "On-disk transform:");
     desc += "  Axes realignment:\n";
     for (const auto &line : realignment().describe_axis_mapping())
       desc += "                     " + line + "\n";
-    desc += "                     (disable with -config RealignTransform false)\n";
+    desc += "                     (disable with -config RealignTransform false or mrinfo -ondisk)\n";
   }
 
   for (const auto &p : keyval()) {
@@ -557,7 +559,7 @@ std::string Header::description(bool print_all) const {
     //   axis-dependent.
     std::vector<std::string> ondisk_entries;
     bool annotate = false;
-    if (realigned) {
+    if (applied) {
       const auto orig_it = realignment().orig_keyval().find(p.first);
       if (orig_it != realignment().orig_keyval().end() && orig_it->second != p.second) {
         ondisk_entries = split_lines(orig_it->second);
@@ -653,15 +655,19 @@ void Header::realign_transform() {
   realignment_.orig_strides_ = Stride::get(*this);
   realignment_.orig_keyval_ = keyval();
 
-  if (!do_realign_transform)
+  if (!do_realign_transform) {
+    realignment_.state_ = Realignment::State::Disabled;
     return;
+  }
 
   // find which row of the transform is closest to each scanner axis:
   realignment_.shuffle_ = Axes::get_shuffle_to_make_RAS(transform());
 
   // check if image is already near-axial, return if true:
-  if (realignment_.is_identity())
+  if (realignment_.is_identity()) {
+    realignment_.state_ = Realignment::State::Identity;
     return;
+  }
 
   auto M(transform());
   auto translation = M.translation();
@@ -705,6 +711,8 @@ void Header::realign_transform() {
   axes_[0] = a[0];
   axes_[1] = a[1];
   axes_[2] = a[2];
+
+  realignment_.state_ = Realignment::State::Applied;
 
   INFO("Axes and transform of image \"" + name() + "\" altered to approximate RAS coordinate system");
 

--- a/cpp/core/header.cpp
+++ b/cpp/core/header.cpp
@@ -503,7 +503,7 @@ std::string Header::description(bool print_all) const {
     Stride::symbolise(sym);
     std::string out("[ ");
     for (size_t n = 0; n < ndim() && n < sym.size(); ++n)
-      out += sym[n] ? (str(sym[n]) + " ") : "? ";
+      out += sym[n] == 0 ? "? " : (str(sym[n]) + " ");
     out += "]";
     return out;
   };
@@ -526,10 +526,10 @@ std::string Header::description(bool print_all) const {
     const ssize_t pad = 21 - 2 - static_cast<ssize_t>(label.size());
     if (pad > 0)
       desc.append(pad, ' ');
-    for (size_t r = 0; r < 3; r++) {
-      if (r)
+    for (Eigen::Index r = 0; r < 3; r++) {
+      if (r > 0)
         desc += "                     ";
-      for (size_t c = 0; c < 4; c++) {
+      for (Eigen::Index c = 0; c < 4; c++) {
         std::ostringstream oss;
         oss << std::setprecision(4) << std::setw(12) << T(r, c);
         desc += oss.str();
@@ -970,9 +970,9 @@ std::vector<std::string> Header::Realignment::describe_axis_mapping() const {
   for (size_t output = 0; output != 3; ++output) {
     const size_t source = shuffle_.permutations[output];
     const bool flipped = shuffle_.flips[source];
-    lines.push_back("output axis " + str(output) + " (" + std::string(output_labels[output]) + ")" //
-                    + " <- source axis " + str(source)                                             //
-                    + ", sign " + (flipped ? "reversed" : "preserved"));                           //
+    lines.push_back("output axis " + str(output) + " (" + std::string(output_labels.at(output)) + ")" //
+                    + " <- source axis " + str(source)                                                //
+                    + ", sign " + (flipped ? "reversed" : "preserved"));                              //
   }
   return lines;
 }

--- a/cpp/core/header.cpp
+++ b/cpp/core/header.cpp
@@ -16,13 +16,16 @@
 
 #include "header.h"
 
+#include <array>
 #include <cctype>
 #include <iomanip>
 #include <set>
 #include <sstream>
+#include <string_view>
 
 #include "app.h"
 #include "axes.h"
+#include "file/config.h"
 #include "file/name_parser.h"
 #include "file/path.h"
 #include "formats/list.h"
@@ -476,6 +479,8 @@ std::string Header::description(bool print_all) const {
                    "\"\n"
                    "************************************************\n");
 
+  const bool realigned = !realignment().is_identity();
+
   desc += "  Dimensions:        ";
   size_t i;
   for (i = 0; i < ndim(); i++) {
@@ -492,12 +497,20 @@ std::string Header::description(bool print_all) const {
   }
   desc += "\n";
 
-  desc += "  Data strides:      [ ";
-  auto strides(Stride::get(*this));
-  Stride::symbolise(strides);
-  for (i = 0; i < ndim(); i++)
-    desc += stride(i) ? str(strides[i]) + " " : "? ";
-  desc += "]\n";
+  auto format_symbolic_strides = [&](const Stride::List &raw) -> std::string {
+    Stride::List sym(raw);
+    Stride::symbolise(sym);
+    std::string out("[ ");
+    for (size_t n = 0; n < ndim() && n < sym.size(); ++n)
+      out += sym[n] ? (str(sym[n]) + " ") : "? ";
+    out += "]";
+    return out;
+  };
+
+  desc += "  Data strides:      " + format_symbolic_strides(Stride::get(*this));
+  if (realigned)
+    desc += "    (on-disk: " + format_symbolic_strides(realignment().orig_strides()) + ")";
+  desc += "\n";
 
   if (io) {
     desc += std::string("  Format:            ") + (format().empty() ? "undefined" : format()) + "\n";
@@ -506,16 +519,30 @@ std::string Header::description(bool print_all) const {
         "  Intensity scaling: offset = " + str(intensity_offset()) + ", multiplier = " + str(intensity_scale()) + "\n";
   }
 
-  desc += "  Transform:         ";
-  for (size_t i = 0; i < 3; i++) {
-    if (i)
-      desc += "                     ";
-    for (size_t j = 0; j < 4; j++) {
-      std::ostringstream oss;
-      oss << std::setprecision(4) << std::setw(12) << transform()(i, j);
-      desc += oss.str();
+  auto append_transform_block = [&desc](const transform_type &T, std::string_view label) {
+    desc += "  " + std::string(label);
+    const ssize_t pad = 21 - 2 - static_cast<ssize_t>(label.size());
+    if (pad > 0)
+      desc.append(pad, ' ');
+    for (size_t r = 0; r < 3; r++) {
+      if (r)
+        desc += "                     ";
+      for (size_t c = 0; c < 4; c++) {
+        std::ostringstream oss;
+        oss << std::setprecision(4) << std::setw(12) << T(r, c);
+        desc += oss.str();
+      }
+      desc += "\n";
     }
-    desc += "\n";
+  };
+
+  append_transform_block(transform(), "Transform:");
+  if (realigned) {
+    append_transform_block(realignment().orig_transform(), "On-disk transform:");
+    desc += "  Axes realignment:\n";
+    for (const auto &line : realignment().describe_axis_mapping())
+      desc += "                     " + line + "\n";
+    desc += "                     (disable with -config RealignTransform false)\n";
   }
 
   for (const auto &p : keyval()) {
@@ -523,9 +550,32 @@ std::string Header::description(bool print_all) const {
     if (key.size() < 21)
       key.resize(21, ' ');
     const auto entries = split_lines(p.second);
+    // Compute per-line on-disk annotations by directly comparing the live
+    //   value against the snapshot in Realignment::orig_keyval; any field
+    //   whose realigned value differs from its on-disk value gets
+    //   annotated, without needing to enumerate which fields are
+    //   axis-dependent.
+    std::vector<std::string> ondisk_entries;
+    bool annotate = false;
+    if (realigned) {
+      const auto orig_it = realignment().orig_keyval().find(p.first);
+      if (orig_it != realignment().orig_keyval().end() && orig_it->second != p.second) {
+        ondisk_entries = split_lines(orig_it->second);
+        annotate = true;
+      }
+    }
+    auto annotation_for = [&](size_t line_index) -> std::string {
+      if (!annotate)
+        return {};
+      if (line_index >= ondisk_entries.size())
+        return "    (on-disk: <missing>)";
+      if (line_index < entries.size() && ondisk_entries[line_index] == entries[line_index])
+        return {};
+      return "    (on-disk: " + ondisk_entries[line_index] + ")";
+    };
     if (!entries.empty()) {
       bool shorten = (!print_all && entries.size() > 5);
-      desc += key + entries[0] + "\n";
+      desc += key + entries[0] + annotation_for(0) + "\n";
       if (entries.size() > 5) {
         key = "  [" + str(entries.size()) + " entries] ";
         if (key.size() < 21)
@@ -533,13 +583,13 @@ std::string Header::description(bool print_all) const {
       } else
         key = "                     ";
       for (size_t n = 1; n < (shorten ? size_t(2) : entries.size()); ++n) {
-        desc += key + entries[n] + "\n";
+        desc += key + entries[n] + annotation_for(n) + "\n";
         key = "                     ";
       }
       if (!print_all && entries.size() > 5) {
         desc += key + "...\n";
         for (size_t n = entries.size() - 2; n < entries.size(); ++n)
-          desc += key + entries[n] + "\n";
+          desc += key + entries[n] + annotation_for(n) + "\n";
       }
     } else {
       desc += key + "(empty)\n";
@@ -660,6 +710,34 @@ void Header::realign_transform() {
 
   Metadata::PhaseEncoding::transform_for_image_load(keyval(), *this);
   Metadata::SliceEncoding::transform_for_image_load(keyval(), *this);
+
+  // Default-visible notification that a non-trivial axis realignment was
+  //   applied; users who do not want this in every pipeline can set
+  //   RealignmentVerbosity: quiet in their config file or via
+  //   -config RealignmentVerbosity quiet.
+  if (File::Config::get("RealignmentVerbosity", "auto") != "quiet") {
+    // Enumerate every keyval field whose value was actually modified by
+    //   transform_for_image_load by comparing the live keyval against
+    //   the pre-transformation snapshot in orig_keyval; this avoids
+    //   maintaining an explicit list of axis-dependent fields and
+    //   automatically tracks any new fields added in the future.
+    std::vector<std::string> modified_fields;
+    for (const auto &kv : keyval()) {
+      const auto orig = realignment_.orig_keyval_.find(kv.first);
+      if (orig == realignment_.orig_keyval_.end() || orig->second != kv.second)
+        modified_fields.emplace_back(kv.first);
+    }
+    for (const auto &kv : realignment_.orig_keyval_) {
+      if (keyval().find(kv.first) == keyval().end())
+        modified_fields.emplace_back(kv.first);
+    }
+    std::string msg = "Image \"" + name() + "\" axes realigned to approximate RAS";
+    if (!modified_fields.empty())
+      msg += "; reoriented metadata: " + join(modified_fields, ", ");
+    msg += " (mrinfo -realignment / -ondisk for details;"
+           " suppress with -config RealignmentVerbosity quiet)";
+    CONSOLE(msg);
+  }
 }
 
 Header
@@ -873,6 +951,22 @@ concatenate(const std::vector<Header> &headers, const size_t axis_to_concat, con
 
 Header::Realignment::Realignment() : applied_transform_(applied_transform_type::Identity()), orig_keyval_() {
   orig_transform_.matrix().fill(std::numeric_limits<default_type>::quiet_NaN());
+}
+
+std::vector<std::string> Header::Realignment::describe_axis_mapping() const {
+  if (is_identity())
+    return {};
+  static constexpr std::array<std::string_view, 3> output_labels{"R", "A", "S"};
+  std::vector<std::string> lines;
+  lines.reserve(3);
+  for (size_t output = 0; output != 3; ++output) {
+    const size_t source = shuffle_.permutations[output];
+    const bool flipped = shuffle_.flips[source];
+    lines.push_back("output axis " + str(output) + " (" + std::string(output_labels[output]) + ")" //
+                    + " <- source axis " + str(source)                                             //
+                    + ", sign " + (flipped ? "reversed" : "preserved"));                           //
+  }
+  return lines;
 }
 
 } // namespace MR

--- a/cpp/core/header.h
+++ b/cpp/core/header.h
@@ -234,8 +234,10 @@ public:
     Realignment();
     State state() const { return state_; }
     bool applied() const { return state_ == State::Applied; }
-    bool is_identity() const { return shuffle_.is_identity(); }
-    bool valid() const { return shuffle_.valid(); }
+    bool valid() const {
+      assert((state_ != State::Unknown) == shuffle_.valid());
+      return state_ != State::Unknown;
+    }
     const Axes::permutations_type &permutations() const { return shuffle_.permutations; }
     size_t permutation(const size_t axis) const {
       assert(axis < 3);
@@ -252,20 +254,8 @@ public:
     KeyValues &orig_keyval() { return orig_keyval_; }
     const KeyValues &orig_keyval() const { return orig_keyval_; }
 
-    //! For each output spatial axis (0,1,2 ≡ R,A,S), the source axis index
-    //!   that was placed at that position.
-    size_t source_axis_for_output(size_t output_axis) const {
-      assert(output_axis < 3);
-      return shuffle_.permutations[output_axis];
-    }
-    //! Whether the source axis placed at the given output position had its
-    //!   sign reversed during realignment.
-    bool source_flipped_for_output(size_t output_axis) const {
-      assert(output_axis < 3);
-      return shuffle_.flips[shuffle_.permutations[output_axis]];
-    }
     //! Human-readable per-output-axis enumeration of the shuffle.
-    //!  Returns 3 lines (R, A, S); empty if is_identity().
+    //!  Returns 3 lines (~R, ~A, ~S); empty if is_identity().
     std::vector<std::string> describe_axis_mapping() const;
 
   private:
@@ -280,8 +270,8 @@ public:
   //! get information on how the transform was modified on image load
   const Realignment &realignment() const { return realignment_; }
   //! non-const accessor; used by external metadata importers (JSON, etc.)
-  //!   to seed Realignment::orig_keyval() with the pre-transformation view
-  //!   of axis-dependent fields.
+  //!   to populate Realignment::orig_keyval() with the pre-transformation
+  //!   view of axis-dependent fields.
   Realignment &realignment() { return realignment_; }
 
   class NDimProxy {

--- a/cpp/core/header.h
+++ b/cpp/core/header.h
@@ -228,8 +228,26 @@ public:
       return shuffle_.flips[axis];
     }
     const transform_type &orig_transform() const { return orig_transform_; }
+    const Stride::List &orig_strides() const { return orig_strides_; }
     const applied_transform_type &applied_transform() const { return applied_transform_; }
     KeyValues &orig_keyval() { return orig_keyval_; }
+    const KeyValues &orig_keyval() const { return orig_keyval_; }
+
+    //! For each output spatial axis (0,1,2 ≡ R,A,S), the source axis index
+    //!   that was placed at that position.
+    size_t source_axis_for_output(size_t output_axis) const {
+      assert(output_axis < 3);
+      return shuffle_.permutations[output_axis];
+    }
+    //! Whether the source axis placed at the given output position had its
+    //!   sign reversed during realignment.
+    bool source_flipped_for_output(size_t output_axis) const {
+      assert(output_axis < 3);
+      return shuffle_.flips[shuffle_.permutations[output_axis]];
+    }
+    //! Human-readable per-output-axis enumeration of the shuffle.
+    //!  Returns 3 lines (R, A, S); empty if is_identity().
+    std::vector<std::string> describe_axis_mapping() const;
 
   private:
     Axes::Shuffle shuffle_;
@@ -241,6 +259,10 @@ public:
   };
   //! get information on how the transform was modified on image load
   const Realignment &realignment() const { return realignment_; }
+  //! non-const accessor; used by external metadata importers (JSON, etc.)
+  //!   to seed Realignment::orig_keyval() with the pre-transformation view
+  //!   of axis-dependent fields.
+  Realignment &realignment() { return realignment_; }
 
   class NDimProxy {
   public:

--- a/cpp/core/header.h
+++ b/cpp/core/header.h
@@ -208,13 +208,32 @@ public:
   // Class to store all information relating to internal transform realignment
   class Realignment {
   public:
+    //! state of axis realignment for an image header
+    /*! Used to distinguish:
+     *  - Unknown: the Realignment object was default-constructed
+     *    (e.g. for a scratch image or for a Header copy-constructed
+     *    from a non-Header source); realign_transform() was never run,
+     *    so orig_* members carry no meaningful "on-disk" view.
+     *  - Disabled: realign_transform() ran but Header::do_realign_transform
+     *    was false (e.g. RealignTransform: false in the configuration
+     *    file, or -config RealignTransform false on the command line);
+     *    the live header values *are* the on-disk values.
+     *  - Identity: realign_transform() ran and the computed shuffle was
+     *    identity (image was already approximately RAS); the live
+     *    header values match the on-disk values.
+     *  - Applied: realign_transform() ran and a non-identity shuffle was
+     *    applied; the live header diverges from the on-disk view, and
+     *    orig_* members capture the latter.
+     */
+    enum class State : uint8_t { Unknown, Disabled, Identity, Applied };
     // From one image space to another image space;
     //   linear component is permutations & flips only,
     //   transformation is in voxel count,
     //   therefore can store as integer
     using applied_transform_type = Eigen::Matrix<int, 3, 3>;
     Realignment();
-    Realignment(Header &);
+    State state() const { return state_; }
+    bool applied() const { return state_ == State::Applied; }
     bool is_identity() const { return shuffle_.is_identity(); }
     bool valid() const { return shuffle_.valid(); }
     const Axes::permutations_type &permutations() const { return shuffle_.permutations; }
@@ -250,6 +269,7 @@ public:
     std::vector<std::string> describe_axis_mapping() const;
 
   private:
+    State state_{State::Unknown};
     Axes::Shuffle shuffle_;
     transform_type orig_transform_;
     Stride::List orig_strides_;

--- a/cpp/core/metadata/phase_encoding.cpp
+++ b/cpp/core/metadata/phase_encoding.cpp
@@ -237,16 +237,25 @@ void transform_for_image_load(KeyValues &keyval, const Header &H) {
           " with load of image \"" + H.name() + "\"");                            //
     return;
   }
-  if (H.realignment().is_identity()) {
-    INFO("No transformation of phase encoding data for load of image \"" + H.name() + "\" required");
+  switch (H.realignment().state()) {
+  case MR::Header::Realignment::State::Unknown:
+    assert(false);
+    return;
+  case MR::Header::Realignment::State::Disabled:
+    return;
+  case MR::Header::Realignment::State::Identity:
+    return;
+  case MR::Header::Realignment::State::Applied:
+    set_scheme(keyval, transform_for_image_load(pe_scheme, H));
+    return;
+  default:
+    assert(false);
     return;
   }
-  set_scheme(keyval, transform_for_image_load(pe_scheme, H));
-  INFO("Phase encoding data transformed to match RAS realignment of image \"" + H.name() + "\"");
 }
 
 scheme_type transform_for_image_load(const scheme_type &pe_scheme, const Header &H) {
-  if (H.realignment().is_identity())
+  if (H.realignment().state() != MR::Header::Realignment::State::Applied)
     return pe_scheme;
   scheme_type result(pe_scheme.rows(), pe_scheme.cols());
   for (ssize_t row = 0; row != pe_scheme.rows(); ++row) {

--- a/cpp/core/metadata/slice_encoding.cpp
+++ b/cpp/core/metadata/slice_encoding.cpp
@@ -17,6 +17,7 @@
 #include "metadata/slice_encoding.h"
 
 #include "axes.h"
+#include "file/config.h"
 #include "file/nifti_utils.h"
 #include "header.h"
 #include "metadata/bids.h"
@@ -29,8 +30,18 @@ void transform_for_image_load(KeyValues &keyval, const Header &header) {
   auto slice_encoding_it = keyval.find("SliceEncodingDirection");
   auto slice_timing_it = keyval.find("SliceTiming");
   if (!(slice_encoding_it == keyval.end() && slice_timing_it == keyval.end())) {
-    if (header.realignment().is_identity()) {
-      INFO("No transformation of slice encoding direction for load of image \"" + header.name() + "\" required");
+    switch (header.realignment().state()) {
+    case MR::Header::Realignment::State::Unknown:
+      assert(false);
+      return;
+    case MR::Header::Realignment::State::Disabled:
+      return;
+    case MR::Header::Realignment::State::Identity:
+      return;
+    case MR::Header::Realignment::State::Applied:
+      break;
+    default:
+      assert(false);
       return;
     }
     Metadata::BIDS::axis_vector_type orig_dir = Metadata::BIDS::axis_vector_type({0, 0, 1});
@@ -39,41 +50,44 @@ void transform_for_image_load(KeyValues &keyval, const Header &header) {
         orig_dir = Metadata::BIDS::axisid2vector(slice_encoding_it->second);
       } catch (Exception &e) {
         // clang-format off
-        INFO("Unable to conform slice encoding direction \"" + slice_encoding_it->second + "\""
-             " to image realignment for image \"" + header.name() + "\";"
-             " erasing");
+        WARN("Unable to conform slice encoding direction \"" + slice_encoding_it->second + "\""
+             " to image realignment for image \"" + header.name() + "\"; erasing");
         // clang-format on
         clear(keyval);
         return;
       }
     }
     const Metadata::BIDS::axis_vector_type new_dir = header.realignment().applied_transform() * orig_dir;
+    std::string msg;
     if (slice_encoding_it != keyval.end()) {
+      if (new_dir == orig_dir)
+        return;
       slice_encoding_it->second = Metadata::BIDS::vector2axisid(new_dir);
       // clang-format off
-      INFO("Slice encoding direction has been modified"
-           " to conform to MRtrix3 internal header transform realignment"
-           " of image \"" + header.name() + "\"");
+      msg = "Slice encoding direction has been modified"
+            " to conform to MRtrix3 internal header transform realignment"
+            " of image \"" + header.name() + "\"";
       // clang-format on
     } else if ((new_dir * -1).dot(orig_dir) == 1) {
       auto slice_timing = parse_floats(slice_timing_it->second);
       std::reverse(slice_timing.begin(), slice_timing.end());
       slice_timing_it->second = join(slice_timing, ",");
       // clang-format off
-      WARN("Slice timing vector reversed"
-           " to conform to MRtrix3 internal transform realignment"
-           " of image \"" + header.name() + "\""
-           " (mrinfo -property SliceTiming -ondisk to see the original)");
+      msg = "Slice timing vector reversed"
+            " to conform to MRtrix3 internal transform realignment"
+            " of image \"" + header.name() + "\""
+            " (mrinfo -property SliceTiming -ondisk to see the original)";
       // clang-format on
     } else {
       keyval["SliceEncodingDirection"] = Metadata::BIDS::vector2axisid(new_dir);
       // clang-format off
-      WARN("Slice encoding direction of image \"" + header.name() + "\""
-           " inferred to be \"k\""
-           " in order to preserve interpretation of existing \"SliceTiming\" field"
-           " after MRtrix3 internal transform realignment");
+      msg = "Slice encoding direction of image \"" + header.name() + "\""
+            " inferred to be \"k\""
+            " in order to preserve interpretation of existing \"SliceTiming\" field"
+            " after MRtrix3 internal transform realignment";
       // clang-format on
     }
+    INFO(msg);
   }
 }
 

--- a/cpp/core/metadata/slice_encoding.cpp
+++ b/cpp/core/metadata/slice_encoding.cpp
@@ -60,9 +60,10 @@ void transform_for_image_load(KeyValues &keyval, const Header &header) {
       std::reverse(slice_timing.begin(), slice_timing.end());
       slice_timing_it->second = join(slice_timing, ",");
       // clang-format off
-      INFO("Slice timing vector reversed"
+      WARN("Slice timing vector reversed"
            " to conform to MRtrix3 internal transform realignment"
-           " of image \"" + header.name() + "\"");
+           " of image \"" + header.name() + "\""
+           " (mrinfo -property SliceTiming -ondisk to see the original)");
       // clang-format on
     } else {
       keyval["SliceEncodingDirection"] = Metadata::BIDS::vector2axisid(new_dir);

--- a/docs/concepts/axis_realignment.rst
+++ b/docs/concepts/axis_realignment.rst
@@ -189,7 +189,7 @@ Two scopes:
 See also
 --------
 
--  :ref:`image_data` — coordinate system, transform and strides.
+-  :ref:`image_handling` — coordinate system, transform and strides.
 -  :ref:`pe_scheme` — phase encoding scheme storage and interaction with
    realignment.
 -  :ref:`dw_scheme` — diffusion gradient table conventions, including

--- a/docs/concepts/axis_realignment.rst
+++ b/docs/concepts/axis_realignment.rst
@@ -1,0 +1,198 @@
+.. _axis_realignment:
+
+Axis realignment at image load
+==============================
+
+*MRtrix3* adopts a single canonical coordinate convention for image data,
+referred to as **RAS**: the positive direction of the first image axis is
+closest to subject **R**\ ight, the positive direction of the second axis is
+closest to subject **A**\ nterior, and the positive direction of the third
+axis is closest to subject **S**\ uperior. Any image whose stored axes do
+*not* approximately conform to this convention is silently permuted and / or
+flipped at load time so that the loaded image *appears* axial without
+moving any voxel intensities.
+
+This page describes that mechanism, what it changes, what it does **not**
+change, how to inspect the on-disk versus interpreted values, and how to
+disable it. The realignment itself is performed by
+``Header::realign_transform`` (``cpp/core/header.cpp``) when
+``Header::open`` is called on a non-RAS source.
+
+What realignment changes
+------------------------
+
+When the on-disk image is not approximately RAS, MRtrix3 modifies the
+following fields *in the in-memory header only*. The voxel intensities on
+disk are never touched.
+
+-  The 4x4 affine **transform** matrix is rotated by a permutation of its
+   columns and / or sign-flips, so the leading 3x3 block is close to the
+   identity in the RAS sense.
+-  The image **strides** are permuted (and possibly sign-flipped) to match
+   the new axis ordering, so iterating axis 0 → 1 → 2 traverses R → A → S
+   relative to the scanner.
+-  Axis-dependent **metadata** that encode directions or per-slice
+   ordering with respect to the image axes are reoriented to remain valid:
+
+   -  ``pe_scheme`` and the BIDS-style ``PhaseEncodingDirection`` field
+      (phase encoding direction expressed in image-axis space; see
+      :ref:`pe_scheme`).
+   -  ``SliceEncodingDirection`` and ``SliceTiming`` (slice-ordering
+      direction and per-slice timing offsets).
+
+-  Axis-dependent metadata that arrive *after* image open via
+   ``-json_import`` (or the equivalent JSON sidecar accompanying a NIfTI)
+   are transformed in the same way on import, so they remain consistent
+   with the realigned image axes.
+
+What is **not** realignment
+---------------------------
+
+Some other transformations occur at load time and are sometimes confused
+with realignment, but are independent:
+
+-  **FSL bvec ↔ MRtrix gradient table conversion.** FSL stores
+   diffusion gradient directions in *image-axis space* by convention,
+   whereas MRtrix3 stores the gradient table (``dw_scheme``) in
+   *scanner-space* coordinates. When a gradient table is read via
+   ``-fslgrad`` it is multiplied by the on-disk image-to-scanner linear
+   transform to enter scanner space, and an inverse transform is applied
+   when writing out FSL bvecs. This conversion is performed for every
+   image regardless of whether realignment was applied, and is
+   intentionally silent: it is a convention bridge, not a side-effect of
+   realignment. See :ref:`dw_scheme` for the gradient-table conventions.
+-  **NIfTI write-time axis shuffling.** When writing to a NIfTI file from
+   a header whose strides are not RAS, MRtrix3 may shuffle the spatial
+   axes on write in order to fit within the NIfTI format's limited
+   stride support. This is a separate, write-side step and may modify
+   the same fields independently of the load-time realignment.
+-  **Voxel data.** Realignment never modifies the voxel intensity array.
+
+What realignment does **not** change
+-------------------------------------
+
+-  The bytes of the image file on disk.
+-  Quantitative voxel values, gradient magnitudes, or any scalar metadata.
+-  The total number of axes (``ndim``) or the size of any axis.
+-  The voxel spacing along each (post-permutation) image axis.
+
+Internal convention for the applied shuffle
+-------------------------------------------
+
+Internally, the applied shuffle is stored as a permutation triple and a
+flip triple. The convention is:
+
+-  The flip is applied **first**, to the source-axis columns of the
+   original transform (``flips[i]`` is indexed by **source** axis).
+-  The permutation is then applied as a column rearrangement
+   (``permutations[i]`` is the **source** axis index placed at output
+   position ``i``).
+
+The user-facing description, produced by ``mrinfo`` and exported through
+``-json_all``, does not require the reader to know this convention: it
+enumerates per output axis the source axis it came from and whether the
+sign was reversed, e.g.::
+
+   Axes realignment:
+     output axis 0 (R) <- source axis 2, sign reversed
+     output axis 1 (A) <- source axis 0, sign preserved
+     output axis 2 (S) <- source axis 1, sign reversed
+
+How to see the on-disk values
+-----------------------------
+
+``mrinfo`` by default prints the *interpreted* (post-realignment) view.
+When realignment is non-identity, the default output additionally
+annotates the affected lines inline::
+
+   $ mrinfo dwi_sag.nii.gz
+   ...
+   Data strides:      [ 1 2 3 4 ]    (on-disk: [ 3 -1 -2 4 ])
+   Transform:                0.9999       ...
+                             ...
+     On-disk transform:      0.07944      ...
+                             ...
+     Axes realignment:
+                     output axis 0 (R) <- source axis 2, sign reversed
+                     output axis 1 (A) <- source axis 0, sign preserved
+                     output axis 2 (S) <- source axis 1, sign reversed
+                     (disable with -config RealignTransform false)
+   ...
+
+Two new options on ``mrinfo`` give scriptable access:
+
+-  ``-realignment`` prints the per-output-axis enumeration above (and
+   nothing if the image was not realigned).
+-  ``-ondisk`` modifies ``-transform``, ``-strides``, ``-petable``, and
+   ``-property`` so they report the pre-realignment values, e.g.::
+
+      $ mrinfo dwi_sag.nii.gz -property PhaseEncodingDirection
+      i-
+      $ mrinfo dwi_sag.nii.gz -property PhaseEncodingDirection -ondisk
+      j-
+
+For machine consumption, ``mrinfo -json_all out.json`` includes a
+top-level ``realignment`` object whenever realignment was non-identity,
+containing ``permutations``, ``flips``, ``axis_mapping``,
+``transform_on_disk``, ``strides_on_disk`` and ``keyval_on_disk`` (the
+subset of keyvals whose values differ between interpreted and on-disk).
+
+When to worry
+-------------
+
+There are three common situations where realignment can mislead an
+unsuspecting user:
+
+#. **Comparing PhaseEncodingDirection across tools.** Running
+   ``mrinfo image.nii.gz -property PhaseEncodingDirection`` and reading
+   the same field from a sibling JSON file may produce *different*
+   strings. The JSON contains the value as it sits on disk; ``mrinfo``
+   reports it relative to the realigned (interpreted) axes.
+
+#. **Piping NIfTI → MRtrix → NIfTI.** Realignment information is stored
+   only in the in-memory ``Header``. Once an image has been written to
+   any file format, the next process to read it sees the realigned axes
+   as if they were the on-disk axes. ``mrinfo`` on a ``.mif`` written
+   from a non-axial NIfTI will therefore show *no* on-disk annotation,
+   because by construction ``.mif`` stores arbitrary strides faithfully
+   and the new load is identity-realignment.
+
+#. **Mixing -json_import with intermediate piped images.** Using
+   ``-json_import`` against an intermediate piped image to which
+   realignment has already been applied will reorient the JSON's
+   axis-dependent fields *as if they referred to the realigned axes*,
+   which is typically not what was intended. Always pass
+   ``-json_import`` together with the original source image. See
+   :ref:`pe_scheme` for a worked example.
+
+How to disable
+--------------
+
+Two scopes:
+
+-  **Disable the realignment entirely.** Set ``RealignTransform: false``
+   in your MRtrix3 configuration file, or pass ``-config RealignTransform
+   false`` on the command line. The image is then loaded with on-disk
+   axes / strides / transform / metadata unchanged. Beware that
+   downstream MRtrix3 commands then receive data that may not be in the
+   expected canonical orientation, which has consequences for tools that
+   assume RAS-relative coordinates (for instance the manual
+   PhaseEncodingDirection argument to ``dwifslpreproc``).
+
+-  **Disable only the on-load notification.** Set
+   ``RealignmentVerbosity: quiet`` in your configuration file, or
+   pass ``-config RealignmentVerbosity quiet`` on the command line. The
+   realignment itself still occurs; only the default-visible console
+   line is suppressed. Useful in large pipelines where every image is
+   known to be non-axial.
+
+See also
+--------
+
+-  :ref:`image_data` — coordinate system, transform and strides.
+-  :ref:`pe_scheme` — phase encoding scheme storage and interaction with
+   realignment.
+-  :ref:`dw_scheme` — diffusion gradient table conventions, including
+   the FSL bvec ↔ MRtrix scanner-space conversion.
+-  ``-config RealignTransform`` / ``-config RealignmentVerbosity``
+   in :ref:`config_file_options`.

--- a/docs/concepts/axis_realignment.rst
+++ b/docs/concepts/axis_realignment.rst
@@ -18,6 +18,36 @@ disable it. The realignment itself is performed by
 ``Header::realign_transform`` (``cpp/core/header.cpp``) when
 ``Header::open`` is called on a non-RAS source.
 
+Why "closest to"?
+-----------------
+
+The language used in the introduction above,
+where each image axis is described as being "closest to" an anatomical direction,
+is highly deliberate.
+When an image is described as being "RAS",
+this does **not** guarantee that the direction in space traversed by first image axis
+corresponds *exactly* to anatomical right
+(similarly for the other two spatial axes).
+It only means that
+---assuming the patient orientation was entered correctly at the scanner console---
+the anatomical axis that the positive direction of the first image axis
+*most closely* corresponds to is Right.
+
+This might be expressed symbolically as:
+
+.. math:
+
+    +i \approx Right
+    +j \approx Anterior
+    +k \approx Superior
+
+, where *i*, *j* and *k* are used to symbolise the three spatial image axes,
+as is used in the Brain Imaging Data Structure (BIDS).
+Indeed, intentionally disambiguating between image axes *i*, *j* and *k*
+versus anatomical directions *L* / *R* / *A* / *P* / *I*  *S*
+frequently assists in communicating and understanding ideas
+relating to spatial transformations such as in this page.
+
 What realignment changes
 ------------------------
 
@@ -26,24 +56,26 @@ following fields *in the in-memory header only*. The voxel intensities on
 disk are never touched.
 
 -  The 4x4 affine **transform** matrix is rotated by a permutation of its
-   columns and / or sign-flips, so the leading 3x3 block is close to the
-   identity in the RAS sense.
--  The image **strides** are permuted (and possibly sign-flipped) to match
-   the new axis ordering, so iterating axis 0 → 1 → 2 traverses R → A → S
-   relative to the scanner.
+   columns and / or sign-flips, so the leading 3x3 block is as close to the
+   identity matrix as can be achieved through those operations
+   (ie. image axes *i*, *j*, *k* are as close to anatomical R, A, S
+   as can be achieved using axis permutations and flips only).
+-  The image **strides** are permuted and / or sign-flipped to match
+   the new axis ordering, so iterating axes 0 → 1 → 2 approximately traverses
+   anatomical R → A → S.
 -  Axis-dependent **metadata** that encode directions or per-slice
    ordering with respect to the image axes are reoriented to remain valid:
 
    -  ``pe_scheme`` and the BIDS-style ``PhaseEncodingDirection`` field
-      (phase encoding direction expressed in image-axis space; see
-      :ref:`pe_scheme`).
-   -  ``SliceEncodingDirection`` and ``SliceTiming`` (slice-ordering
-      direction and per-slice timing offsets).
+      (phase encoding direction is expressed in image-axis space;
+      see :ref:`pe_scheme`).
+   -  ``SliceEncodingDirection`` and ``SliceTiming``
+      (slice-ordering direction and per-slice timing offsets).
 
 -  Axis-dependent metadata that arrive *after* image open via
    ``-json_import`` (or the equivalent JSON sidecar accompanying a NIfTI)
-   are transformed in the same way on import, so they remain consistent
-   with the realigned image axes.
+   are subjected to the same transformation as was applied to the corresponding image,
+   to preserve correspondence between image data and metadata.
 
 What is **not** realignment
 ---------------------------
@@ -51,36 +83,49 @@ What is **not** realignment
 Some other transformations occur at load time and are sometimes confused
 with realignment, but are independent:
 
--  **FSL bvec ↔ MRtrix gradient table conversion.** FSL stores
-   diffusion gradient directions in *image-axis space* by convention,
-   whereas MRtrix3 stores the gradient table (``dw_scheme``) in
-   *scanner-space* coordinates. When a gradient table is read via
-   ``-fslgrad`` it is multiplied by the on-disk image-to-scanner linear
-   transform to enter scanner space, and an inverse transform is applied
-   when writing out FSL bvecs. This conversion is performed for every
-   image regardless of whether realignment was applied, and is
-   intentionally silent: it is a convention bridge, not a side-effect of
-   realignment. See :ref:`dw_scheme` for the gradient-table conventions.
+-  **FSL bvec import.** The FSL `bvecs` / `bvals` convention stores
+   diffusion gradient directions as cosine angles relative to *image axes*
+   (with a caveat; see :ref:`dw_scheme`).
+   This contrasts with the MRtrix3 convention
+   (for both storage in header metadata (``dw_scheme``)
+   / text files / internal computations),
+   where the gradient table contains cosine angles relative to the physical
+   axes of the scanner (so-called *real-space* or *scanner-space* coordinates).
+   When a gradient table is read by MRtrix3 via ``-fslgrad``,
+   it is immediately transformed into scanner-space,
+   with the inverse transform applied when writing out FSL bvecs (``-export_grad_fsl``).
+   This conversion is performed for every image
+   regardless of whether any axis realignment was applied,
+   as it is a fundamental contrast between format conventions.
+   See :ref:`dw_scheme` for more detail on gradient-table conventions.
 -  **NIfTI write-time axis shuffling.** When writing to a NIfTI file from
    a header whose strides are not RAS, MRtrix3 may shuffle the spatial
-   axes on write in order to fit within the NIfTI format's limited
-   stride support. This is a separate, write-side step and may modify
-   the same fields independently of the load-time realignment.
--  **Voxel data.** Realignment never modifies the voxel intensity array.
+   axes on write so that the image intensity data appear in the same order
+   in which they are encoded within the internal representation
+   of the image being written.
+   This is because unlike the MRtrix image formats,
+   the NIfTI format does not support arbitrary axis strides.
+   This is a separate write-side step,
+   though may modify the same set of metadata fields
+   as can be affected by the load-time realignment.
 
 What realignment does **not** change
 -------------------------------------
 
 -  The bytes of the image file on disk.
--  Quantitative voxel values, gradient magnitudes, or any scalar metadata.
+-  Quantitative voxel values
+-  Diffusion gradient magnitudes
+-  Metadata that are either scalar, or that are not explicitly programmed
+   to possess an encoding related to image axes.
 -  The total number of axes (``ndim``) or the size of any axis.
 -  The voxel spacing along each (post-permutation) image axis.
 
 Internal convention for the applied shuffle
 -------------------------------------------
 
-Internally, the applied shuffle is stored as a permutation triple and a
-flip triple. The convention is:
+Internally, the applied shuffle is stored as a triplet of permutation indices
+and a triplet of boolean flips.
+The convention is:
 
 -  The flip is applied **first**, to the source-axis columns of the
    original transform (``flips[i]`` is indexed by **source** axis).
@@ -94,16 +139,16 @@ enumerates per output axis the source axis it came from and whether the
 sign was reversed, e.g.::
 
    Axes realignment:
-     output axis 0 (R) <- source axis 2, sign reversed
-     output axis 1 (A) <- source axis 0, sign preserved
-     output axis 2 (S) <- source axis 1, sign reversed
+     output axis 0 (~R) <- source axis 2, sign reversed
+     output axis 1 (~A) <- source axis 0, sign preserved
+     output axis 2 (~S) <- source axis 1, sign reversed
 
 How to see the on-disk values
 -----------------------------
 
-``mrinfo`` by default prints the *interpreted* (post-realignment) view.
-When realignment is non-identity, the default output additionally
-annotates the affected lines inline::
+``mrinfo`` by default prints the *interpreted* (post-realignment) view of an image.
+When realignment is non-identity,
+the default output additionally annotates the affected lines inline::
 
    $ mrinfo dwi_sag.nii.gz
    ...
@@ -113,9 +158,9 @@ annotates the affected lines inline::
      On-disk transform:      0.07944      ...
                              ...
      Axes realignment:
-                     output axis 0 (R) <- source axis 2, sign reversed
-                     output axis 1 (A) <- source axis 0, sign preserved
-                     output axis 2 (S) <- source axis 1, sign reversed
+                     output axis 0 (~R) <- source axis 2, sign reversed
+                     output axis 1 (~A) <- source axis 0, sign preserved
+                     output axis 2 (~S) <- source axis 1, sign reversed
                      (disable with -config RealignTransform false)
    ...
 
@@ -134,8 +179,8 @@ Two new options on ``mrinfo`` give scriptable access:
 For machine consumption, ``mrinfo -json_all out.json`` includes a
 top-level ``realignment`` object whenever realignment was non-identity,
 containing ``permutations``, ``flips``, ``axis_mapping``,
-``transform_on_disk``, ``strides_on_disk`` and ``keyval_on_disk`` (the
-subset of keyvals whose values differ between interpreted and on-disk).
+``transform_on_disk``, ``strides_on_disk`` and ``keyval_on_disk``
+(the subset of keyvals whose values differ between interpreted and on-disk).
 
 When to worry
 -------------
@@ -149,42 +194,57 @@ unsuspecting user:
    strings. The JSON contains the value as it sits on disk; ``mrinfo``
    reports it relative to the realigned (interpreted) axes.
 
-#. **Piping NIfTI → MRtrix → NIfTI.** Realignment information is stored
-   only in the in-memory ``Header``. Once an image has been written to
-   any file format, the next process to read it sees the realigned axes
-   as if they were the on-disk axes. ``mrinfo`` on a ``.mif`` written
-   from a non-axial NIfTI will therefore show *no* on-disk annotation,
-   because by construction ``.mif`` stores arbitrary strides faithfully
-   and the new load is identity-realignment.
+#. **Piping NIfTI → MRtrix → NIfTI.**
+   Realignment information is stored only in the in-memory representation;
+   it is not encoded in the metadata of any image on disk.
+   Once an image has been written to any file format,
+   the next process to read it sees the realigned axes
+   as if they were the on-disk axes.
+   ``mrinfo`` executed on a ``.mif`` written from a non-axial NIfTI
+   will therefore show *no* realignment / on-disk annotation:
+   the ``.mif`` format faithfully stores the arbitrary strides
+   that resulted from the prior axis realignment,
+   and so the resulting image is already approximately RAS.
 
-#. **Mixing -json_import with intermediate piped images.** Using
-   ``-json_import`` against an intermediate piped image to which
-   realignment has already been applied will reorient the JSON's
-   axis-dependent fields *as if they referred to the realigned axes*,
-   which is typically not what was intended. Always pass
-   ``-json_import`` together with the original source image. See
-   :ref:`pe_scheme` for a worked example.
+#. **Mixing -json_import with non-corresponding images.**
+   Using ``-json_import`` in conjunction with an image
+   to which realignment was applied *by a previous command*
+   will **fail** to reorient the JSON's axis-dependent fields
+   to conform to the prior realignment of that image.
+   Only pass ``-json_import`` when the metadata file
+   is a direct sidecar of the source image.
+   A benefit of utilising the MRtrix image formats throughout a pipeline
+   is that associated metadata embedded in the image header
+   should have any requisite conversions or transformations
+   to accompany an image operation applied automatically.
+   See :ref:`pe_scheme` for a worked example.
 
 How to disable
 --------------
 
 Two scopes:
 
--  **Disable the realignment entirely.** Set ``RealignTransform: false``
-   in your MRtrix3 configuration file, or pass ``-config RealignTransform
-   false`` on the command line. The image is then loaded with on-disk
-   axes / strides / transform / metadata unchanged. Beware that
-   downstream MRtrix3 commands then receive data that may not be in the
-   expected canonical orientation, which has consequences for tools that
-   assume RAS-relative coordinates (for instance the manual
-   PhaseEncodingDirection argument to ``dwifslpreproc``).
+-  **Disable the realignment entirely.**
+   Set ``RealignTransform: false`` in your MRtrix3 configuration file,
+   or pass ``-config RealignTransform false`` on the command line.
+   The image is then loaded
+   with on-disk axes / strides / transform / metadata unchanged.
+   Beware that downstream MRtrix3 commands then receive data
+   that may not be in the expected canonical orientation;
+   this has consequences for:
 
--  **Disable only the on-load notification.** Set
-   ``RealignmentVerbosity: quiet`` in your configuration file, or
-   pass ``-config RealignmentVerbosity quiet`` on the command line. The
-   realignment itself still occurs; only the default-visible console
-   line is suppressed. Useful in large pipelines where every image is
-   known to be non-axial.
+   -   Tools that assume RAS-relative coordinates
+       (for instance the manual ``-pe_dir`` argument to ``dwifslpreproc``);
+   -   Commands that receive as input multiple images
+       that must reside on the same image voxel gradient
+       to facilitate per-voxel operations across them,
+       but those images do not all already possess the same strides.
+
+-  **Disable only the on-load notification.**
+   Set ``RealignmentVerbose: false`` in your configuration file,
+   or pass ``-config RealignmentVerbose false`` on the command line.
+   The realignment itself still occurs;
+   only the default-visible console line is suppressed.
 
 See also
 --------
@@ -194,5 +254,5 @@ See also
    realignment.
 -  :ref:`dw_scheme` — diffusion gradient table conventions, including
    the FSL bvec ↔ MRtrix scanner-space conversion.
--  ``-config RealignTransform`` / ``-config RealignmentVerbosity``
+-  ``-config RealignTransform`` / ``-config RealignmentVerbose``
    in :ref:`config_file_options`.

--- a/docs/concepts/dw_scheme.rst
+++ b/docs/concepts/dw_scheme.rst
@@ -424,8 +424,9 @@ NIfTI headers (i.e. the ``sform`` / ``qform``); the transform as reported by
 with the data), as the *MRtrix3* image loading backend will try to provide the
 image transform in a near-axial orientation (by inverting / exchanging columns
 of the transform, and adjusting the :ref:`strides` to match - see
-:ref:`transform` for details). To find out the actual transform that
-was stored in the NIfTI header, use :ref:`mrinfo` with the ``-config
-RealignTransform false`` option.
+:ref:`transform` and :ref:`axis_realignment` for details). To find out the
+actual transform that was stored in the NIfTI header, use :ref:`mrinfo` with
+the ``-ondisk`` option (or ``-config RealignTransform false`` to disable
+realignment altogether).
 
 

--- a/docs/concepts/pe_scheme.rst
+++ b/docs/concepts/pe_scheme.rst
@@ -135,9 +135,10 @@ correspond to RAS convention (i.e. first axis increases from left to right, seco
 axis increases from posterior to anterior, third axis increases from inferior to
 superior), *MRtrix3* will automatically alter the axis :ref:`strides` & transform
 in order to make the image *appear* as close to an axial acquisition as possible.
-This is briefly mentioned in :ref:`transform` section. The behaviour may
-also be observed by running ``mrinfo`` with and without the
-``-config RealignTransform false`` option, which temporarily disables this behaviour.
+This is briefly mentioned in :ref:`transform` section, and described in detail
+under :ref:`axis_realignment`. The behaviour may also be observed by running
+``mrinfo`` with and without the ``-config RealignTransform false`` option, which
+temporarily disables this behaviour.
 
 Because phase encoding is defined with respect to the image axes, any
 transformation of image axes must correspondingly be applied to the phase encoding

--- a/docs/concepts/pe_scheme.rst
+++ b/docs/concepts/pe_scheme.rst
@@ -1,3 +1,5 @@
+.. _pe_scheme:
+
 Phase encoding scheme handling
 ==============================
 

--- a/docs/getting_started/image_data.rst
+++ b/docs/getting_started/image_data.rst
@@ -340,8 +340,11 @@ It is important to bear this in mind when interpreting for output of
 :ref:`mrinfo` for example, since this produces the strides and transform *as
 interpreted by MRtrix3*, rather than those actually stored on file - although
 the two representations should be strictly equivalent. If you need to inspect
-the information as stored on file, use :ref:`mrinfo`'s ``-config
-RealignTransform false`` option.
+the information as stored on file, use :ref:`mrinfo`'s ``-ondisk`` modifier
+together with ``-transform`` / ``-strides`` / ``-property``, or use ``-config
+RealignTransform false`` to disable the realignment entirely. See
+:ref:`axis_realignment` for an end-to-end description of the mechanism, the
+metadata it reorients, and how to disable it.
 
 
 .. _supported_image_formats:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -207,6 +207,7 @@ Table of Contents
    :maxdepth: 1
    :caption: Concepts
 
+   concepts/axis_realignment
    concepts/dw_scheme
    concepts/pe_scheme
    concepts/global_intensity_normalisation

--- a/docs/reference/commands/mrinfo.rst
+++ b/docs/reference/commands/mrinfo.rst
@@ -30,6 +30,8 @@ The -dwgrad, -export_* and -shell_* options provide (information about) the diff
 
 The -petable option exports the MRtrix3 internal representation of the phase encoding table, regardless of whether the relevant metadata are stored in the BIDS fields "PhaseEncodingDirection" and "TotalReadoutTime" or the MRtrix3-specific "pe_scheme". The contents of this query should however *not* be provided to FSL tools: despite the contents being of the same format, the phase encoding directions may be erroneously interpreted. If extracting phase encoding information to interface with FSL tools, use the -export_pe_topup or -export_pe_eddy options. More information can be found on this issue at: https://mrtrix.readthedocs.io/en/3.0.8/concepts/pe_scheme.html
 
+By default, mrinfo reports the image *as interpreted by MRtrix3*. If the image's on-disk axes do not approximately conform to the RAS convention, MRtrix3 permutes and flips them at load time so the loaded image appears axial; the reported transform, strides, and axis-dependent metadata (e.g. PhaseEncodingDirection, pe_scheme, SliceEncodingDirection, SliceTiming) may therefore differ from the values stored on disk. The default human-readable output annotates any such differences inline. Use the -realignment option to summarise the applied shuffle, or -ondisk to bypass realignment entirely (equivalent to -config RealignTransform false) so that every query reports the on-disk view. See: https://mrtrix.readthedocs.io/en/3.0.8/concepts/axis_realignment.html
+
 The -bvalue_scaling option controls an aspect of the import of diffusion gradient tables. When the input diffusion-weighting direction vectors have norms that differ substantially from unity, the b-values will be scaled by the square of their corresponding vector norm (this is how multi-shell acquisitions are frequently achieved on scanner platforms). However in some rare instances, the b-values may be correct, despite the vectors not being of unit norm (or conversely, the b-values may need to be rescaled even though the vectors are close to unit norm). This option allows the user to control this operation and override MRrtix3's automatic detection.
 
 Options
@@ -56,6 +58,10 @@ Options
 -  **-multiplier** image intensity multiplier
 
 -  **-transform** the transformation from image coordinates [mm] to scanner / real world coordinates [mm]
+
+-  **-realignment** print a per-output-axis summary of the realignment applied by MRtrix3 at load time; prints nothing if no realignment was applied
+
+-  **-ondisk** report the on-disk view rather than the realigned (interpreted) view; equivalent to -config RealignTransform false (mutually exclusive with -realignment)
 
 Options for exporting image header fields
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/reference/config_file_options.rst
+++ b/docs/reference/config_file_options.rst
@@ -625,6 +625,19 @@ List of MRtrix3 configuration file options
      A boolean value to indicate whether all images should be realigned
      to an approximately axial orientation at load.
 
+.. option:: RealignmentVerbosity
+
+    *default: auto*
+
+     Controls the on-load console notification emitted when MRtrix3
+     realigns an image's axes to approximate RAS at load time.
+     Value "auto" (default) emits a single console line per affected
+     image, summarising the shuffle and any reoriented metadata fields.
+     Value "quiet" suppresses the notification; the realignment itself
+     still occurs (use RealignTransform: false to disable the realignment
+     itself). The -info / -debug command-line flags emit additional
+     detail independently of this setting.
+
 .. option:: RegAnalyseDescent
 
     *default: 0 (false)*

--- a/docs/reference/config_file_options.rst
+++ b/docs/reference/config_file_options.rst
@@ -625,15 +625,15 @@ List of MRtrix3 configuration file options
      A boolean value to indicate whether all images should be realigned
      to an approximately axial orientation at load.
 
-.. option:: RealignmentVerbosity
+.. option:: RealignmentVerbose
 
-    *default: auto*
+    *default: true*
 
      Controls the on-load console notification emitted when MRtrix3
      realigns an image's axes to approximate RAS at load time.
-     Value "auto" (default) emits a single console line per affected
+     True value (default) emits a single console line per affected
      image, summarising the shuffle and any reoriented metadata fields.
-     Value "quiet" suppresses the notification; the realignment itself
+     False value suppresses the notification; the realignment itself
      still occurs (use RealignTransform: false to disable the realignment
      itself). The -info / -debug command-line flags emit additional
      detail independently of this setting.


### PR DESCRIPTION
Closes #2526.

Claude was initially prompted to consider the complexity of this confound, the potential effects on users, and the appropriate mechanism and verbosity with which to communicate this to users (since I had been stuck on that last point for some time). I think what's come out of the process is pretty reasonable, though I'm aware of the prospect of user panic due to elevated verbosity. Happy to take any feedback in this respect.

As an example, here's the T1w from the BATMAN tutorial data:

### `dev`

```text
mrinfo: [done] scanning folder "T1" for DICOM data
mrinfo: [100%] reading DICOM series "T1 mp-rage3d we sag 1mm"
************************************************
Image name:          "Snake_T1 (17.09.13-18:50:37-DST-1.3.12.2.1107.5.2.43.166002) [MR] T1 mp-rage3d we sag 1mm"
************************************************
  Dimensions:        160 x 256 x 256
  Voxel size:        1 x 0.976562 x 0.976562
  Data strides:      [ 3 -1 -2 ]
  Format:            DICOM
  Data type:         unsigned 16 bit integer (little endian)
  Intensity scaling: offset = 0, multiplier = 1
  Transform:               0.9978     0.05839     0.03009      -92.42
                         -0.05883      0.9982     0.01396      -108.6
                         -0.02922     -0.0157      0.9994      -131.1
  EchoTime:          0.00367
  FlipAngle:         9
  InversionTime:     1.04
  PixelBandwidth:    180
  RepetitionTime:    1.91
  comments:          Snake_T1 (17.09.13-18:50:37-DST-1.3.12.2.1107.5.2.43.166002) [MR] T1 mp-rage3d we sag 1mm
                     study: AG Schwarzbach^SEQUENCE_TESTING [ ORIGINAL PRIMARY M NORM DIS2D ]
                     DOB: 15/03/1994
                     DOS: 13/09/2017 19:16:10
```

### PR

```text
mrinfo: [done] scanning folder "T1" for DICOM data
mrinfo: [100%] reading DICOM series "T1 mp-rage3d we sag 1mm"
mrinfo: Image "Snake_T1 (17.09.13-18:50:37-DST-1.3.12.2.1107.5.2.43.166002) [MR] T1 mp-rage3d we sag 1mm" axes realigned to approximate RAS (mrinfo -realignment / -ondisk for details; suppress with -config RealignmentVerbosity quiet)
************************************************
Image name:          "Snake_T1 (17.09.13-18:50:37-DST-1.3.12.2.1107.5.2.43.166002) [MR] T1 mp-rage3d we sag 1mm"
************************************************
  Dimensions:        160 x 256 x 256
  Voxel size:        1 x 0.976562 x 0.976562
  Data strides:      [ 3 -1 -2 ]    (on-disk: [ 1 2 3 ])
  Format:            DICOM
  Data type:         unsigned 16 bit integer (little endian)
  Intensity scaling: offset = 0, multiplier = 1
  Transform:               0.9978     0.05839     0.03009      -92.42
                         -0.05883      0.9982     0.01396      -108.6
                         -0.02922     -0.0157      0.9994      -131.1
  On-disk transform:     -0.05839    -0.03009      0.9978      -70.39
                          -0.9982    -0.01396    -0.05883       143.5
                           0.0157     -0.9994    -0.02922       113.9
  Axes realignment:
                     output axis 0 (R) <- source axis 2, sign preserved
                     output axis 1 (A) <- source axis 0, sign reversed
                     output axis 2 (S) <- source axis 1, sign reversed
                     (disable with -config RealignTransform false)
  EchoTime:          0.00367
  FlipAngle:         9
  InversionTime:     1.04
  PixelBandwidth:    180
  RepetitionTime:    1.91
  comments:          Snake_T1 (17.09.13-18:50:37-DST-1.3.12.2.1107.5.2.43.166002) [MR] T1 mp-rage3d we sag 1mm
                     study: AG Schwarzbach^SEQUENCE_TESTING [ ORIGINAL PRIMARY M NORM DIS2D ]
                     DOB: 15/03/1994
                     DOS: 13/09/2017 19:16:10
```

-----

- [x] Manual code review by @Lestropie 
- [x] Look at `mrinfo -ondisk` option; perhaps this should completely suppress from `mrinfo` any information about the prospect of realignment
- [x] When run with `RealignTransform: false`, should `mrinfo` present both "`Data strides:`" and "`Transform:`" as being "on-disk"?
- [x] Prevent `mrinfo` from showing information about on-disk data strides and transform / axes realignment if no realignment occurred (whether due to `RealignTransform: false` or due to the input image already being RAS).
