### PR TITLE
warpcorrect: Fix comparison to marker

### DIFF
--- a/cmd/warpcorrect.cpp
+++ b/cmd/warpcorrect.cpp
@@ -43,7 +43,7 @@ void usage ()
   + Option ("marker", "single value or a comma separated list of values that define out of bounds voxels in the input warp image."
     " Default: (0,0,0).")
     + Argument ("coordinates").type_sequence_float()
-  + Option ("tolerance", "numerical precision used for L2 matrix norm comparison. Default: " + str(PRECISION) + ".")
+  + Option ("tolerance", "numerical precision used for comparison to marker. Default: " + str(PRECISION) + ".")
     + Argument ("value").type_float(PRECISION);
 }
 
@@ -61,7 +61,7 @@ class BoundsCheck { MEMALIGN(BoundsCheck)
       void operator() (ImageTypeIn& in, ImageTypeOut& out)
       {
         val = Eigen::Matrix<value_type, 3, 1>(in.row(3));
-        if ((vec - val).isMuchSmallerThan(precision) || (vec.hasNaN() && val.hasNaN())) {
+        if ((vec - val).isZero(precision) || (vec.hasNaN() && val.hasNaN())) {
           count++;
           for (auto l = Loop (3) (out); l; ++l)
             out.value() = NaN;

--- a/docs/reference/commands/warpcorrect.rst
+++ b/docs/reference/commands/warpcorrect.rst
@@ -28,7 +28,7 @@ Options
 
 -  **-marker coordinates** single value or a comma separated list of values that define out of bounds voxels in the input warp image. Default: (0,0,0).
 
--  **-tolerance value** numerical precision used for L2 matrix norm comparison. Default: 9.99999975e-06.
+-  **-tolerance value** numerical precision used for comparison to marker. Default: 9.99999975e-06.
 
 Standard options
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Using `(vec-val).isMuchSmallerThan(precision)` had two issues: firstly, the help string claimed that the precision term related to the L2 norm, but no such norm was computed; secondly, the input scalar to `.isMuchSmallerThan()` was treated as the scalar value to which to compare, to which a default precision multiplier was then applied. Comparison to zero with a precision tolerance is more consistent with intent.

Discovered while trying to process the same data set as that which exposed #3362.