### PR TITLE
MR::check_keyvals(): Fix checks at ends of dicts

### DIFF
--- a/core/image_diff.h
+++ b/core/image_diff.h
@@ -122,7 +122,7 @@ namespace MR
         while (it2 != in2.keyval().end() && reserved.find (it2->first) != reserved.end())
           ++it2;
 
-        if (it1 == in1.keyval().end() || it2 == in2.keyval().end())
+        if (it1 == in1.keyval().end() && it2 == in2.keyval().end())
           break;
 
         if (it1 == in1.keyval().end()) {


### PR DESCRIPTION
Error introduced in ec2c2da7b1dd161004d1f395374cc75f44ff3044 as part of #2346.

Only spotted when looking at code due to requiring refactoring for #3349---wasn't detected through unexpected results---but looks pretty wrong to me. 