### PR TITLE
Fix GUI compilation Qt6

### DIFF
--- a/cpp/gui/CMakeLists.txt
+++ b/cpp/gui/CMakeLists.txt
@@ -22,18 +22,15 @@ set_target_properties(mrtrix-gui PROPERTIES
     LINK_DEPENDS_NO_SHARED ON
 )
 
-# Qt5's moc cannot parse libstdc++'s <filesystem>: the header's
+# Qt's moc cannot parse libstdc++'s <filesystem>: the header's
 # "#pragma GCC system_header" stops moc following the include chain that defines
 # _GLIBCXX_VISIBILITY, so bits/fs_fwd.h fails to parse. moc only extracts the
 # meta-object and never compiles, so predefine the <filesystem> include guard
 # for moc only, making the header expand to nothing; std::filesystem::path then
-# survives merely as an unparsed type token in declarations. Qt6's moc does not
-# have this defect, so the workaround is scoped to the Qt5 path.
-if(MRTRIX_USE_QT5)
-    set_target_properties(mrtrix-gui PROPERTIES
-        AUTOMOC_MOC_OPTIONS "-D_GLIBCXX_FILESYSTEM"
-    )
-endif()
+# survives merely as an unparsed type token in declarations.
+set_target_properties(mrtrix-gui PROPERTIES
+    AUTOMOC_MOC_OPTIONS "-D_GLIBCXX_FILESYSTEM"
+)
 
 if(MRTRIX_USE_PCH)
     target_precompile_headers(mrtrix-gui PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/gui_pch.h)


### PR DESCRIPTION
In #3361 I made the assumption that the issue was specific to Qt5 based on compilation failing on my machine after having passed CI. However I was experimenting with some prospective OpenGL changes, and when I tried to compile using Qt6 to test compatibility the same issue manifested. So I don't have an explanation for why CI passes without this addition but both Qt5 and Qt6 fail to compile on my machine.

If the fix goes on to cause issues on some other machine will need to investigate further.