### PR TITLE
Clang-tidy enforcement (rebased)

### DIFF
--- a/.clang-tidy-enforce
+++ b/.clang-tidy-enforce
@@ -1,0 +1,8 @@
+Checks: >
+  -*,
+  bugprone-*,
+  clang-analyzer-*,
+  concurrency-*,
+  -bugprone-easily-swappable-parameters,
+WarningsAsErrors: '*'
+HeaderFilterRegex: '*.(h|hpp)'

--- a/.clang-tidy-enforce
+++ b/.clang-tidy-enforce
@@ -5,4 +5,5 @@ Checks: >
   concurrency-*,
   -bugprone-easily-swappable-parameters,
 WarningsAsErrors: '*'
-HeaderFilterRegex: '*.(h|hpp)'
+HeaderFilterRegex: '(cpp\/|testing\/(lib\/|tools\/|unit_tests\/)).*\.(h|hpp)'
+ExcludeHeaderFilterRegex: '(_deps\/|cpp\/core\/eigen_plugins\/|cpp\/gui\/opengl\/gl_core_3_3).*'

--- a/.clang-tidy-enforce
+++ b/.clang-tidy-enforce
@@ -1,9 +1,14 @@
 Checks: >
   -*,
+  -cpp/core/eigen_plugins/*,
+  -cpp/gui/opengl/gl_core_3_3.*,
   bugprone-*,
   clang-analyzer-*,
   concurrency-*,
   -bugprone-easily-swappable-parameters,
+  -bugprone-narrowing-conversions,
+  -clang-analyzer-optin.core.EnumCastOutOfRange,
+  -clang-analyzer-unix.Malloc,
 WarningsAsErrors: '*'
 HeaderFilterRegex: '(cpp\/|testing\/(lib\/|tools\/|unit_tests\/)).*\.(h|hpp)'
 ExcludeHeaderFilterRegex: '(_deps\/|cpp\/core\/eigen_plugins\/|cpp\/gui\/opengl\/gl_core_3_3).*'

--- a/.clang-tidy-enforce
+++ b/.clang-tidy-enforce
@@ -11,4 +11,4 @@ Checks: >
   -clang-analyzer-unix.Malloc,
 WarningsAsErrors: '*'
 HeaderFilterRegex: '(cpp\/|testing\/(lib\/|tools\/|unit_tests\/)).*\.(h|hpp)'
-ExcludeHeaderFilterRegex: '(_deps\/|cpp\/core\/eigen_plugins\/|cpp\/gui\/opengl\/gl_core_3_3).*'
+#ExcludeHeaderFilterRegex: '(_deps\/|cpp\/core\/eigen_plugins\/|cpp\/gui\/opengl\/gl_core_3_3).*'

--- a/.clang-tidy-review
+++ b/.clang-tidy-review
@@ -15,4 +15,4 @@ Checks: >
   -readability-identifier-length,
   -readability-function-cognitive-complexity,
   -readability-magic-numbers,
-HeaderFilterRegex: '*.(h|hpp)'
+HeaderFilterRegex: '(cpp\/|testing\/(lib\/|tools\/|unit_tests\/)).*\.(h|hpp)'

--- a/.clang-tidy-review
+++ b/.clang-tidy-review
@@ -10,6 +10,8 @@ Checks: >
   portability-*,
   readability-*,
   -bugprone-easily-swappable-parameters,
+  -clang-analyzer-optin.core.EnumCastOutOfRange,
+  -clang-analyzer-unix.Malloc,
   -cppcoreguidelines-avoid-magic-numbers,
   -readability-braces-around-statements,
   -readability-identifier-length,

--- a/.github/workflows/clang-tidy-enforce.yml
+++ b/.github/workflows/clang-tidy-enforce.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt update
-        sudo apt install clang-tidy-18 qt6-base-dev libqt6opengl6-dev libglvnd-dev libeigen3-dev zlib1g-dev libfftw3-dev ninja-build
+        sudo apt install clang-tidy-19 qt6-base-dev libqt6opengl6-dev libglvnd-dev libeigen3-dev zlib1g-dev libfftw3-dev ninja-build
 
     - name: Run CMake
       run: cmake . -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
@@ -38,4 +38,4 @@ jobs:
         fi
         echo "Files to check:"
         echo "${CHANGED}"
-        echo "${CHANGED}" | xargs clang-tidy-18 --config-file=.clang-tidy-enforce -p=.
+        echo "${CHANGED}" | xargs clang-tidy-19 --config-file=.clang-tidy-enforce --header-filter='(cpp\\/|testing\\/(lib\\/|tools\\/|unit_tests\\/)).*' --exclude-header-filter='(_deps\\/|cpp\\/core\\/eigen_plugins\\/|cpp\\/gui\\/opengl\\/gl_core_3_3).*' -p=.

--- a/.github/workflows/clang-tidy-enforce.yml
+++ b/.github/workflows/clang-tidy-enforce.yml
@@ -1,0 +1,41 @@
+name: clang-tidy-enforce
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches: [master, dev]
+  merge_group:
+    types: [checks_requested]
+    branches: [master]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  clang-tidy-enforce:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Install dependencies
+      run: |
+        sudo apt update
+        sudo apt install clang-tidy-18 qt6-base-dev libqt6opengl6-dev libglvnd-dev libeigen3-dev zlib1g-dev libfftw3-dev ninja-build
+
+    - name: Run CMake
+      run: cmake . -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+
+    - name: Run clang-tidy on changed C++ files
+      run: |
+        BASE=${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+        CHANGED=$(git diff --name-only "${BASE}...HEAD" | grep -E '\.(cpp|cxx|cc|h|hpp|hxx)$' || true)
+        if [ -z "${CHANGED}" ]; then
+          echo "No C++ files changed; nothing to check."
+          exit 0
+        fi
+        echo "Files to check:"
+        echo "${CHANGED}"
+        echo "${CHANGED}" | xargs clang-tidy-18 --config-file=.clang-tidy-enforce -p=.

--- a/.github/workflows/clang-tidy-enforce.yml
+++ b/.github/workflows/clang-tidy-enforce.yml
@@ -26,16 +26,16 @@ jobs:
         sudo apt install clang-tidy-19 qt6-base-dev libqt6opengl6-dev libglvnd-dev libeigen3-dev zlib1g-dev libfftw3-dev ninja-build
 
     - name: Run CMake
-      run: cmake . -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+      run: cmake . -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DMRTRIX_USE_PCH=OFF
 
     - name: Run clang-tidy on changed C++ files
       run: |
         BASE=${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
-        CHANGED=$(git diff --name-only "${BASE}...HEAD" | grep -E '\.(cpp|cxx|cc|h|hpp|hxx)$' || true)
+        CHANGED=$(git diff --name-only "${BASE}...HEAD" | grep -E '\.(cpp|cxx|cc|h|hpp|hxx)$' | grep -vE 'cpp/core/eigen_plugins/|cpp/gui/opengl/gl_core_3_3' || true)
         if [ -z "${CHANGED}" ]; then
           echo "No C++ files changed; nothing to check."
           exit 0
         fi
         echo "Files to check:"
         echo "${CHANGED}"
-        echo "${CHANGED}" | xargs clang-tidy-19 --config-file=.clang-tidy-enforce --header-filter='(cpp\\/|testing\\/(lib\\/|tools\\/|unit_tests\\/)).*' --exclude-header-filter='(_deps\\/|cpp\\/core\\/eigen_plugins\\/|cpp\\/gui\\/opengl\\/gl_core_3_3).*' -p=.
+        echo "${CHANGED}" | xargs clang-tidy-19 --config-file=.clang-tidy-enforce --header-filter='(cpp\/|testing\/(lib\/|tools\/|unit_tests\/)).*' --exclude-header-filter='(_deps\/|cpp\/core\/eigen_plugins\/|cpp\/gui\/opengl\/gl_core_3_3).*' -p=.

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -14,7 +14,7 @@ jobs:
          sudo apt install qt6-base-dev libqt6opengl6-dev libglvnd-dev libeigen3-dev zlib1g-dev libfftw3-dev ninja-build
 
     - name: Run CMake
-      run: cmake . -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+      run: cmake . -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DMRTRIX_USE_PCH=OFF
 
     - uses: ZedThree/clang-tidy-review@v0.21.0
       id: review

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -20,8 +20,8 @@ jobs:
       id: review
       with:
         apt_packages: g++,qt6-base-dev,libqt6opengl6-dev,libglvnd-dev,zlib1g-dev,libfftw3-dev,ninja-build
-        config_file: .clang-tidy
-        clang_tidy_version: 16
+        config_file: .clang-tidy-review
+        clang_tidy_version: 19
 
     - uses: ZedThree/clang-tidy-review/upload@v0.21.0
       id: upload-review

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,10 @@ repos:
         name: clang-format
         types_or: [c++]
         language: python
+  - repo: local
+    hooks:
+      - id: clang-tidy-enforce
+        name: clang-tidy (enforce)
+        entry: clang-tidy --config-file=.clang-tidy-enforce -p build_debug
+        language: system
+        types_or: [c++]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,10 +16,3 @@ repos:
         name: clang-format
         types_or: [c++]
         language: python
-#  - repo: local
-#    hooks:
-#      - id: clang-tidy-enforce
-#        name: clang-tidy (enforce)
-#        entry: clang-tidy --config-file=.clang-tidy-enforce -p build_debug
-#        language: system
-#        types_or: [c++]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,10 +16,10 @@ repos:
         name: clang-format
         types_or: [c++]
         language: python
-  - repo: local
-    hooks:
-      - id: clang-tidy-enforce
-        name: clang-tidy (enforce)
-        entry: clang-tidy --config-file=.clang-tidy-enforce -p build_debug
-        language: system
-        types_or: [c++]
+#  - repo: local
+#    hooks:
+#      - id: clang-tidy-enforce
+#        name: clang-tidy (enforce)
+#        entry: clang-tidy --config-file=.clang-tidy-enforce -p build_debug
+#        language: system
+#        types_or: [c++]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,6 @@ add_custom_target(Github SOURCES
     .github/workflows/package-windows-msys2.yml
     .github/workflows/clang-tidy-review.yml
     .github/workflows/clang-tidy-enforce.yml
-    .clang-tidy-enforce
 )
 
 mrtrix_print_build_instructions()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,7 @@ add_custom_target(Github SOURCES
     .github/workflows/package-macos-anaconda.yml
     .github/workflows/package-macos-native.yml
     .github/workflows/package-windows-msys2.yml
-    .github/workflows/clang-tidy.yml
+    .github/workflows/clang-tidy-review.yml
     .github/workflows/clang-tidy-enforce.yml
     .clang-tidy-enforce
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,8 @@ add_custom_target(Github SOURCES
     .github/workflows/package-macos-native.yml
     .github/workflows/package-windows-msys2.yml
     .github/workflows/clang-tidy.yml
+    .github/workflows/clang-tidy-enforce.yml
+    .clang-tidy-enforce
 )
 
 mrtrix_print_build_instructions()

--- a/check_syntax
+++ b/check_syntax
@@ -73,6 +73,18 @@ run_checks() {
     $grep -Po '\#ifndef\s+__.*__\s+\#define\s+__.*__'
   )
 
+# detect the inclusion of Eigen headers without eigen_plugins/eigen_plugins.h appearing upstream;
+#   this can cause issues with compilation on some systems
+  if [[ ! "$f" -ef "cpp/core/eigen_plugins/eigen_plugins.h" ]]; then
+    res="$res"$(
+      cat .check_syntax1.tmp | \
+      $grep -Po '^#include .*' | \
+      tr '\n' ' ' | \
+      $grep -Po '.*#include <Eigen\/[\w\/]+>' | \
+      $grep -Pv '#include "eigen_plugins\/eigen_plugins\.h"'
+    )
+  fi
+
 #############################################################
 # Process the file to strip macros and single-line comments #
 #############################################################
@@ -256,6 +268,7 @@ else
   echo "" >> $LOG
   echo "Please check the following syntax requirements:
   - Use #pragma once rather than #ifndef __headername__;
+  - #include \"eigen_plugins/eigen_plugins.h\" must appear before inclusion of any Eigen headers;
   - Use nested namespaces rather than sequentially-defined namespaces;
   - Define numerical constants using constexpr rather than preprocessor macros;
   - Use static_cast<>() rather than C-style casts;

--- a/check_syntax
+++ b/check_syntax
@@ -170,7 +170,7 @@ run_checks() {
 # - Detect any instances of C-style casts
   res="$res"$(
     cat .check_syntax4.tmp | \
-    $grep -Po '(\((?!void\))[a-zA-Z][a-zA-Z0-9_]*\)[a-zA-Z][a-zA-Z0-9_]*|\([a-zA-Z][a-zA-Z0-9_]*\s?\*(\s?const)?\)[a-zA-Z][a-zA-Z0-9_]*|(?<!\bstd::function<)\b(GLint|GLfloat|c?float|c?double|(default|value|index)_type|[^\w_](unsigned\s+)?int|u?int(8|16|32|64)_t|s?size_t|ValueType|(?<!Scalar)::Scalar)\(\(*\**(?![\d\-\.]*\)))'
+    $grep -Po '(\((?!void\))[a-zA-Z][a-zA-Z0-9_]*\)[a-zA-Z][a-zA-Z0-9_]*|\([a-zA-Z][a-zA-Z0-9_]*\s?\*(\s?const)?\)[a-zA-Z][a-zA-Z0-9_]*|\(\s?void\s?\*(\s?const)?\)[\w&(]|(?<!\bstd::function<)\b(GLint|GLfloat|c?float|c?double|(default|value|index)_type|[^\w_](unsigned\s+)?int|u?int(8|16|32|64)_t|s?size_t|ValueType|(?<!Scalar)::Scalar)\(\(*\**(?![\d\-\.]*\)))'
   )
 
 # - Detect any instances of macros NULL (nullptr is better), NAN, INFINITY

--- a/check_syntax
+++ b/check_syntax
@@ -80,7 +80,7 @@ run_checks() {
       cat .check_syntax1.tmp | \
       $grep -Po '^#include .*' | \
       tr '\n' ' ' | \
-      $grep -Po '.*#include <Eigen\/[\w\/]+>' | \
+      $grep -Po '.*#include <(unsupported\/)?Eigen\/[\w\/]+>' | \
       $grep -Pv '#include "eigen_plugins\/eigen_plugins\.h"'
     )
   fi

--- a/check_syntax
+++ b/check_syntax
@@ -128,11 +128,23 @@ run_checks() {
     $grep -Po '(const\s+|)char(\s?\*(\s?const|)\s?(?![>\(\)])|\s+[a-zA-Z_][a-zA-Z0-9_]*\[(\d*\]|))'
   )
 
-# - Detect any instances of C-style string manipulation functions
-#   (need to permit strerror() for interfacing with external libraries)
+# - Detect any instances of C-style string manipulation functions,
+#   including direct strerror() calls (use MR::C_strerror() instead)
   res="$res"$(
     cat .check_syntax4.tmp | \
-    $grep -Po '\b(strcpy|strncpy|strcat|strncat|strxfrm|strlen|strcmp|strncmp|strcoll|strchr|strrchr|strspn|strcspn|strpbrk|strstr|strtok|wcscpy|wcsncpy|wcscat|wcsncat|wcsxfrm|wcslen|wcscmp|wcsncmp|wcscoll|wcschr|wcsrchr|wcsspn|wcscspn|wcspbrk|wcsstr|wcstok)\s*\('
+    $grep -Po '\b(strcpy|strncpy|strcat|strncat|strxfrm|strlen|strcmp|strncmp|strcoll|strchr|strrchr|strspn|strcspn|strpbrk|strstr|strtok|wcscpy|wcsncpy|wcscat|wcsncat|wcsxfrm|wcslen|wcscmp|wcsncmp|wcscoll|wcschr|wcsrchr|wcsspn|wcscspn|wcspbrk|wcsstr|wcstok|strerror)\s*\('
+  )
+
+# - Detect direct calls to std::getenv() or getenv() (use MR::get_env() instead)
+  res="$res"$(
+    cat .check_syntax4.tmp | \
+    $grep -Po '\bgetenv\s*\('
+  )
+
+# - Detect any instances of C rand() or srand() (use <random> STL instead)
+  res="$res"$(
+    cat .check_syntax4.tmp | \
+    $grep -Po '\b(srand|rand)\s*\('
   )
 
 # - Detect instances of const std::string &
@@ -255,6 +267,9 @@ else
   - Use nullptr rather than NULL macro;
   - Use std::numeric_limits<> or MR::NaN(F) / MR::Inf(F) rather than macros NAN / INFINITY;
   - Do not use C-style arrays (replace with eg. std::array<>);
-  - Use MR::match_v() rather than std::visit() with a lambda function." >> $LOG
+  - Use MR::match_v() rather than std::visit() with a lambda function;
+  - Replace all instances of strerror() with MR::C_strerror() (declared in exception.h);
+  - Replace all instances of std::getenv() or getenv() with MR::get_env() (declared in env.h);
+  - Replace all instances of rand() and srand() with C++ <random> equivalents (e.g. std::mt19937 + std::uniform_int_distribution); use thread_local engines or per-instance member engines to ensure thread-safety." >> $LOG
   exit 1
 fi

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -27,6 +27,16 @@ else()
     endif()
 endif()
 
+# Wrapper that re-exposes Eigen's headers via -isystem so that the high
+# warning level (and -Werror) applied to MRtrix3 sources does not flag
+# diagnostics originating from within Eigen headers. Consumers should link
+# against mrtrix::eigen rather than Eigen3::Eigen directly.
+add_library(mrtrix-eigen INTERFACE)
+add_library(mrtrix::eigen ALIAS mrtrix-eigen)
+get_target_property(MRTRIX_EIGEN_INCLUDE_DIRS Eigen3::Eigen INTERFACE_INCLUDE_DIRECTORIES)
+target_include_directories(mrtrix-eigen SYSTEM INTERFACE ${MRTRIX_EIGEN_INCLUDE_DIRS})
+target_link_libraries(mrtrix-eigen INTERFACE Eigen3::Eigen)
+
 
 # Json for Modern C++
 if(MRTRIX_USE_SYSTEM_JSON)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -22,6 +22,7 @@ if(MRTRIX_WARNINGS_AS_ERRORS)
     target_compile_options(mrtrix-common INTERFACE
         $<$<CXX_COMPILER_ID:MSVC>:/WX>
         $<$<CXX_COMPILER_ID:GNU,Clang>:-Werror>
+        $<$<CXX_COMPILER_ID:GNU>:-Wno-ignored-attributes>
     )
 endif()
 
@@ -29,6 +30,9 @@ endif()
 if(MINGW AND CMAKE_BUILD_TYPE MATCHES "Debug")
     target_compile_options(mrtrix-common INTERFACE -Wa,-mbig-obj)
 endif()
+
+# Add "#pragma once" to precompiled headers to stop clang-tidy confusion
+set(CMAKE_PCH_PROLOGUE "#pragma once")
 
 add_subdirectory(cmd)
 add_subdirectory(core)

--- a/cpp/cmd/CMakeLists.txt
+++ b/cpp/cmd/CMakeLists.txt
@@ -15,7 +15,7 @@ if(MRTRIX_USE_PCH)
     file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/pch_cmd.cpp CONTENT "int main(){}")
     add_executable(pch_cmd ${CMAKE_CURRENT_BINARY_DIR}/pch_cmd.cpp)
     target_include_directories(pch_cmd PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../core)
-    target_link_libraries(pch_cmd PRIVATE Eigen3::Eigen mrtrix::common magic_enum::magic_enum)
+    target_link_libraries(pch_cmd PRIVATE mrtrix::eigen mrtrix::common magic_enum::magic_enum)
     target_precompile_headers(pch_cmd PRIVATE
         [["app.h"]]
         [["image.h"]]

--- a/cpp/cmd/amp2response.cpp
+++ b/cpp/cmd/amp2response.cpp
@@ -14,7 +14,9 @@
  * For more details, see http://www.mrtrix.org/.
  */
 
+#include "eigen_plugins/eigen_plugins.h"
 #include <Eigen/Dense>
+#include <filesystem>
 
 #include "command.h"
 #include "dwi/directions/validate.h"
@@ -30,8 +32,6 @@
 #include "math/rng.h"
 #include "math/sphere.h"
 #include "types.h"
-
-#include <filesystem>
 
 using namespace MR;
 using namespace App;

--- a/cpp/cmd/dcmedit.cpp
+++ b/cpp/cmd/dcmedit.cpp
@@ -111,7 +111,7 @@ void run() {
   }
 
   for (size_t n = 0; n < VRs.size(); ++n) {
-    union __VR {
+    union {
       uint16_t i;
       char c[2]; // check_syntax off
     } VR;

--- a/cpp/cmd/dcminfo.cpp
+++ b/cpp/cmd/dcminfo.cpp
@@ -68,8 +68,6 @@ void run() {
   const std::filesystem::path input_path{argument[0]};
   auto opt = get_options("tag");
   if (!opt.empty()) {
-    std::istringstream hex;
-
     std::vector<Tag> tags(opt.size());
     for (size_t n = 0; n < opt.size(); ++n) {
       tags[n].group = read_hex(opt[n][0]);

--- a/cpp/cmd/dwidenoise.cpp
+++ b/cpp/cmd/dwidenoise.cpp
@@ -160,7 +160,7 @@ public:
                    bool exp1)
       : extent{{extent[0] / 2, extent[1] / 2, extent[2] / 2}},
         m(ndwi),
-        n(extent[0] * extent[1] * extent[2]),
+        n(static_cast<ssize_t>(extent[0]) * static_cast<ssize_t>(extent[1]) * static_cast<ssize_t>(extent[2])),
         r(std::min(m, n)),
         q(std::max(m, n)),
         exp1(exp1),
@@ -335,12 +335,12 @@ void run() {
         throw Exception("-extent must not exceed the image dimensions");
     }
   } else {
-    uint32_t e = 1;
+    ssize_t e = 1;
     while (e * e * e < dwi.size(3))
       e += 2;
-    extent = {std::min(e, static_cast<uint32_t>(dwi.size(0))),
-              std::min(e, static_cast<uint32_t>(dwi.size(1))),
-              std::min(e, static_cast<uint32_t>(dwi.size(2)))};
+    extent = {std::min(static_cast<uint32_t>(e), static_cast<uint32_t>(dwi.size(0))),
+              std::min(static_cast<uint32_t>(e), static_cast<uint32_t>(dwi.size(1))),
+              std::min(static_cast<uint32_t>(e), static_cast<uint32_t>(dwi.size(2)))};
   }
   INFO("selected patch size: " + str(extent[0]) + " x " + str(extent[1]) + " x " + str(extent[2]) + ".");
 
@@ -392,6 +392,9 @@ void run() {
   case 3:
     INFO("select complex float64 for processing");
     process_image<cdouble>(dwi, mask, noise, rank, output_path, extent, exp1);
+    break;
+  default:
+    assert(false);
     break;
   }
 }

--- a/cpp/cmd/dwidenoise.cpp
+++ b/cpp/cmd/dwidenoise.cpp
@@ -14,6 +14,7 @@
  * For more details, see http://www.mrtrix.org/.
  */
 
+#include "eigen_plugins/eigen_plugins.h"
 #include <Eigen/Dense>
 #include <Eigen/Eigenvalues>
 #include <algorithm>
@@ -23,6 +24,7 @@
 
 #include "command.h"
 #include "image.h"
+#include "image_helpers.h"
 
 using namespace MR;
 using namespace App;

--- a/cpp/cmd/dwidenoise.cpp
+++ b/cpp/cmd/dwidenoise.cpp
@@ -14,13 +14,15 @@
  * For more details, see http://www.mrtrix.org/.
  */
 
-#include "command.h"
-#include "image.h"
-
 #include <Eigen/Dense>
 #include <Eigen/Eigenvalues>
-
+#include <algorithm>
+#include <cassert>
 #include <filesystem>
+#include <stddef.h>
+
+#include "command.h"
+#include "image.h"
 
 using namespace MR;
 using namespace App;

--- a/cpp/cmd/dwidenoise.cpp
+++ b/cpp/cmd/dwidenoise.cpp
@@ -21,6 +21,7 @@
 #include <cassert>
 #include <filesystem>
 #include <stddef.h>
+#include <sys/types.h>
 
 #include "command.h"
 #include "image.h"

--- a/cpp/cmd/fixel2peaks.cpp
+++ b/cpp/cmd/fixel2peaks.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <cstddef>
+#include <cstdint>
 
 #include "command.h"
 #include "image.h"

--- a/cpp/cmd/fixel2peaks.cpp
+++ b/cpp/cmd/fixel2peaks.cpp
@@ -14,6 +14,8 @@
  * For more details, see http://www.mrtrix.org/.
  */
 
+#include <cstddef>
+
 #include "command.h"
 #include "image.h"
 #include "progressbar.h"
@@ -122,7 +124,7 @@ void run() {
   Header out_header(index_header);
   out_header.datatype() = DataType::Float32;
   out_header.datatype().set_byte_order_native();
-  out_header.size(3) = 3 * max_fixel_count;
+  out_header.size(3) = 3 * static_cast<ssize_t>(max_fixel_count);
   out_header.path() = output_path;
   Image<float> out_image(Image<float>::create(output_path, out_header));
 

--- a/cpp/cmd/fixelreorient.cpp
+++ b/cpp/cmd/fixelreorient.cpp
@@ -83,7 +83,7 @@ void run() {
 
   auto input_index_image = Fixel::find_index_header(input_fixel_directory).get_image<index_type>();
 
-  Header warp_header = Header::open(argument[1]);
+  Header warp_header = Header::open(input_warp_file);
   Registration::Warp::validate_header(warp_header);
   check_dimensions(input_index_image, warp_header, 0, 3);
   auto warp_image = warp_header.get_image<float>();

--- a/cpp/cmd/mrcalc.cpp
+++ b/cpp/cmd/mrcalc.cpp
@@ -25,6 +25,8 @@
 #undef BINARY_OP
 #undef TERNARY_OP
 
+// NOLINTBEGIN(bugprone-macro-parentheses)
+
 #if SECTION == 1 // usage section
 
 #define SECTION_TITLE(TITLE) +OptionGroup(TITLE)
@@ -312,6 +314,8 @@ UNARY_OP(
 
 #undef SECTION
 
+// NOLINTEND(bugprone-macro-parentheses)
+
 #else
 
 /**********************************************************************
@@ -423,7 +427,7 @@ ARGUMENTS
 OPTIONS
 
 #define SECTION 1 // check_syntax off
-#include "mrcalc.cpp"
+#include "mrcalc.cpp" //NOLINT(bugprone-suspicious-include)
 
   + DataType::options();
 }
@@ -982,8 +986,8 @@ public:
         EXPAND OPERATIONS:
 **********************************************************************/
 
-#define SECTION 2 // check_syntax off
-#include "mrcalc.cpp"
+#define SECTION 2     // check_syntax off
+#include "mrcalc.cpp" // NOLINT(bugprone-suspicious-include)
 
 /**********************************************************************
   MAIN BODY OF COMMAND:
@@ -1004,8 +1008,8 @@ void run() {
       else if (opt->is("config"))
         n += 2;
 
-#define SECTION 3 // check_syntax off
-#include "mrcalc.cpp"
+#define SECTION 3     // check_syntax off
+#include "mrcalc.cpp" // NOLINT(bugprone-suspicious-include)
 
       else
         throw Exception(std::string("operation \"") + opt->id + "\" not yet implemented!");

--- a/cpp/cmd/mrcalc.cpp
+++ b/cpp/cmd/mrcalc.cpp
@@ -427,7 +427,7 @@ ARGUMENTS
 OPTIONS
 
 #define SECTION 1 // check_syntax off
-#include "mrcalc.cpp" //NOLINT(bugprone-suspicious-include)
+#include "mrcalc.cpp" //NOLINT(bugprone-suspicious-include,misc-header-include-cycle)
 
   + DataType::options();
 }
@@ -987,7 +987,7 @@ public:
 **********************************************************************/
 
 #define SECTION 2     // check_syntax off
-#include "mrcalc.cpp" // NOLINT(bugprone-suspicious-include)
+#include "mrcalc.cpp" // NOLINT(bugprone-suspicious-include,misc-header-include-cycle)
 
 /**********************************************************************
   MAIN BODY OF COMMAND:
@@ -1009,7 +1009,7 @@ void run() {
         n += 2;
 
 #define SECTION 3     // check_syntax off
-#include "mrcalc.cpp" // NOLINT(bugprone-suspicious-include)
+#include "mrcalc.cpp" // NOLINT(bugprone-suspicious-include,misc-header-include-cycle)
 
       else
         throw Exception(std::string("operation \"") + opt->id + "\" not yet implemented!");

--- a/cpp/cmd/mrcat.cpp
+++ b/cpp/cmd/mrcat.cpp
@@ -130,6 +130,9 @@ void run() {
       else
         write<uint64_t>(headers, axis, header_out);
       break;
+    default:
+      assert(false);
+      break;
     }
   } else {
     if (header_out.datatype().is_complex())

--- a/cpp/cmd/mrcat.cpp
+++ b/cpp/cmd/mrcat.cpp
@@ -14,13 +14,14 @@
  * For more details, see http://www.mrtrix.org/.
  */
 
+#include <cassert>
+#include <filesystem>
+
 #include "algo/loop.h"
 #include "command.h"
 #include "dwi/gradient.h"
 #include "image.h"
 #include "progressbar.h"
-
-#include <filesystem>
 
 using namespace MR;
 using namespace App;

--- a/cpp/cmd/mrconvert.cpp
+++ b/cpp/cmd/mrconvert.cpp
@@ -547,6 +547,7 @@ void run() {
         extract<uint64_t>(header_in, header_out, pos, output_path);
       break;
     case DataType::Undefined:
+    default:
       throw Exception("invalid output image data type");
       break;
     }

--- a/cpp/cmd/mrgrid.cpp
+++ b/cpp/cmd/mrgrid.cpp
@@ -424,7 +424,7 @@ void run() {
         try {
           delta = parse_ints<int>(opt[i][1]);
         } catch (Exception &E) {
-          Exception(E, "-axis " + str(axis) + ": can't parse delta specifier \"" + spec + "\"");
+          throw Exception(E, "-axis " + str(axis) + ": can't parse delta specifier \"" + spec + "\"");
         }
         if (delta.size() != 2)
           throw Exception("-axis " + str(axis) + ": can't parse delta specifier \"" + spec + "\"");

--- a/cpp/cmd/mrmath.cpp
+++ b/cpp/cmd/mrmath.cpp
@@ -19,9 +19,9 @@
 
 #include "algo/threaded_loop.h"
 #include "command.h"
-#include "debug.h"
 #include "dwi/gradient.h"
 #include "enum.h"
+#include "exception.h"
 #include "image.h"
 #include "image_helpers.h"
 #include "math/entropy.h"

--- a/cpp/cmd/mrmath.cpp
+++ b/cpp/cmd/mrmath.cpp
@@ -394,7 +394,8 @@ void run() {
       try {
         const auto DW_scheme = DWI::parse_DW_scheme(header_out);
         DWI::stash_DW_scheme(header_out, DW_scheme);
-      } catch (...) {
+      } catch (Exception &) {
+        DEBUG("No diffusion gradient table to stash");
       }
       DWI::clear_DW_scheme(header_out);
       Metadata::PhaseEncoding::clear_scheme(header_out.keyval());

--- a/cpp/cmd/mrmath.cpp
+++ b/cpp/cmd/mrmath.cpp
@@ -19,6 +19,7 @@
 
 #include "algo/threaded_loop.h"
 #include "command.h"
+#include "debug.h"
 #include "dwi/gradient.h"
 #include "enum.h"
 #include "image.h"

--- a/cpp/cmd/mrmetric.cpp
+++ b/cpp/cmd/mrmetric.cpp
@@ -290,7 +290,7 @@ void run() {
   Eigen::Matrix<value_type, Eigen::Dynamic, 1> sos = Eigen::Matrix<value_type, Eigen::Dynamic, 1>::Zero(volumes, 1);
   if (space == space_t::VOXEL) {
     INFO("per-voxel");
-    check_dimensions(input1, input2);
+    check_voxel_grids_match_in_scanner_space(input1, input2);
     if (!use_mask1 and !use_mask2)
       n_voxels = input1.size(0) * input1.size(1) * input1.size(2);
     evaluate_voxelwise_msq(input1, input2, mask1, mask2, dimensions, use_mask1, use_mask2, n_voxels, sos);

--- a/cpp/cmd/mrtransform.cpp
+++ b/cpp/cmd/mrtransform.cpp
@@ -22,6 +22,7 @@
 #include "algo/loop.h"
 #include "algo/threaded_copy.h"
 #include "command.h"
+#include "debug.h"
 #include "dwi/directions/predefined.h"
 #include "dwi/directions/validate.h"
 #include "dwi/gradient.h"

--- a/cpp/cmd/mrtransform.cpp
+++ b/cpp/cmd/mrtransform.cpp
@@ -510,6 +510,7 @@ void run() {
     try {
       grad = DWI::get_DW_scheme(input_header);
     } catch (Exception &) {
+      DEBUG("No valid diffusion gradient table found");
     }
     if (grad.rows()) {
       try {

--- a/cpp/cmd/mtnormalise.cpp
+++ b/cpp/cmd/mtnormalise.cpp
@@ -529,6 +529,7 @@ void run() {
     size_t iter = 0;
     ProgressBar progress("performing log-domain intensity normalisation", max_iter);
 
+    // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
     size_t outliers_changed = detect_outliers(3.0, data, field, balance_factors, weights);
 
     while (++iter <= max_iter) {

--- a/cpp/cmd/sh2metric.cpp
+++ b/cpp/cmd/sh2metric.cpp
@@ -95,6 +95,7 @@ const DWI::Directions::Set get_directions() {
     try {
       return DWI::Directions::Set(static_cast<std::string>(opt[0][0]));
     } catch (Exception &) {
+      DEBUG("Unable to import direction set interpreting \"" + opt[0][0] + "\" as filesystem path");
     }
     try {
       return DWI::Directions::Set(static_cast<size_t>(opt[0][0]));
@@ -168,7 +169,7 @@ void run_entropy() {
       assign_pos_of(pos).to(out);
       try {
         out.value() = static_cast<float>(shared->normalise(Math::Entropy::nats(concat_amps)));
-      } catch (Exception &) {
+      } catch (Exception &) { // NOLINT(bugprone-empty-catch)
         out.value() = std::numeric_limits<float>::quiet_NaN();
       }
       return true;

--- a/cpp/cmd/sh2peaks.cpp
+++ b/cpp/cmd/sh2peaks.cpp
@@ -206,10 +206,10 @@ public:
       ipeaks_vox.index(1) = item.pos[1];
       ipeaks_vox.index(2) = item.pos[2];
 
-      for (int i = 0; i < npeaks; i++) {
+      for (size_t i = 0; i < npeaks; i++) {
         Eigen::Vector3f p;
-        ipeaks_vox.index(3) = 3 * i;
-        for (int n = 0; n < 3; n++) {
+        ipeaks_vox.index(3) = static_cast<ssize_t>(3 * i);
+        for (size_t n = 0; n < 3; n++) {
           p[n] = ipeaks_vox.value();
           ipeaks_vox.index(3)++;
         }
@@ -239,9 +239,9 @@ public:
       std::partial_sort_copy(all_peaks.begin(), all_peaks.end(), peaks_out.begin(), peaks_out.end());
     }
 
-    int actual_npeaks = std::min(npeaks, static_cast<int>(all_peaks.size()));
+    const size_t actual_npeaks = std::min(npeaks, all_peaks.size());
     dirs_vox.index(3) = 0;
-    for (int n = 0; n < actual_npeaks; n++) {
+    for (size_t n = 0; n < actual_npeaks; n++) {
       dirs_vox.value() = peaks_out[n].a * peaks_out[n].v[0];
       dirs_vox.index(3)++;
       dirs_vox.value() = peaks_out[n].a * peaks_out[n].v[1];
@@ -249,7 +249,7 @@ public:
       dirs_vox.value() = peaks_out[n].a * peaks_out[n].v[2];
       dirs_vox.index(3)++;
     }
-    for (; dirs_vox.index(3) < 3 * npeaks; dirs_vox.index(3)++)
+    for (; dirs_vox.index(3) < static_cast<ssize_t>(3 * npeaks); dirs_vox.index(3)++)
       dirs_vox.value() = NaNF;
 
     return true;
@@ -258,7 +258,7 @@ public:
 private:
   Image<value_type> dirs_vox;
   Eigen::Matrix<value_type, Eigen::Dynamic, 2> dirs;
-  int lmax, npeaks;
+  size_t lmax, npeaks;
   std::vector<Direction> true_peaks;
   value_type threshold;
   std::vector<Direction> peaks_out;
@@ -306,7 +306,7 @@ void run() {
   if (dirs.cols() != 2)
     throw Exception("expecting 2 columns for search directions matrix");
 
-  int npeaks = get_option_value("num", default_npeaks);
+  size_t npeaks = get_option_value("num", default_npeaks);
 
   opt = get_options("direction");
   std::vector<Direction> true_peaks;
@@ -334,7 +334,7 @@ void run() {
     check_dimensions(SH_data, ipeaks_data, 0, 3);
     npeaks = ipeaks_data.size(3) / 3;
   }
-  header.size(3) = 3 * npeaks;
+  header.size(3) = static_cast<ssize_t>(3 * npeaks);
   auto peaks = Image<value_type>::create(argument[1], header);
 
   DataLoader loader(SH_data, mask_data);

--- a/cpp/cmd/tckconvert.cpp
+++ b/cpp/cmd/tckconvert.cpp
@@ -232,7 +232,7 @@ public:
         throw Exception("VTK Reader only supports BINARY input");
 
       if (sscanf(line.c_str(), "POINTS %d float", &number_of_points) == 1) {
-        points.resize(3 * number_of_points);
+        points.resize(3 * static_cast<size_t>(number_of_points));
         input.read(reinterpret_cast<char *>(points.data()),
                    3UL * static_cast<unsigned long>(number_of_points) * sizeof(float));
 
@@ -264,7 +264,9 @@ public:
       lineIdx++;
       for (int i = 0; i < count; i++) {
         int idx = lines[lineIdx];
-        Eigen::Vector3f f(points[idx * 3], points[idx * 3 + 1], points[idx * 3 + 2]);
+        Eigen::Vector3f f(points[static_cast<size_t>(idx) * 3],
+                          points[static_cast<size_t>(idx) * 3 + 1],
+                          points[static_cast<size_t>(idx) * 3 + 2]);
         tck.push_back(f);
         lineIdx++;
       }
@@ -428,7 +430,7 @@ public:
 
   bool operator()(const Streamline<float> &intck) {
     // Need at least 5 points, silently ignore...
-    if (intck.size() < static_cast<size_t>(increment * 3)) {
+    if (intck.size() < static_cast<size_t>(increment) * 3) {
       return true;
     }
 

--- a/cpp/cmd/tckedit.cpp
+++ b/cpp/cmd/tckedit.cpp
@@ -143,13 +143,15 @@ void run() {
     input_file_list.push_back(input_path);
 
     Properties p;
-    Reader<float>(input_path, p);
+    { Reader<float> reader(input_path, p); }
 
     for (const auto &i : p.comments) {
       bool present = false;
-      for (const auto &j : properties.comments)
-        if ((present = (i == j)))
+      for (const auto &j : properties.comments) {
+        present = (i == j);
+        if (present)
           break;
+      }
       if (!present)
         properties.comments.push_back(i);
     }

--- a/cpp/cmd/tckglobal.cpp
+++ b/cpp/cmd/tckglobal.cpp
@@ -212,9 +212,10 @@ void usage() {
 }
 // clang-format on
 
-template <typename T> class __copy_fod {
+namespace {
+template <typename T> class _copy_fod {
 public:
-  __copy_fod(const int lmax, const double weight, const bool apodise)
+  _copy_fod(const int lmax, const double weight, const bool apodise)
       : w(weight), a(apodise), apo(lmax), SH_in(Math::SH::NforL(lmax)), SH_out(SH_in.size()) {}
 
   void operator()(Image<T> &in, Image<T> &out) {
@@ -228,6 +229,7 @@ private:
   Math::SH::aPSF<T> apo;
   Eigen::Matrix<T, Eigen::Dynamic, 1> SH_in, SH_out;
 };
+} // namespace
 
 void run() {
 
@@ -363,7 +365,7 @@ void run() {
     INFO("Saving fODF image to file");
     header_out.size(3) = Math::SH::NforL(properties.Lmax);
     auto fODF = Image<float>::create(opt[0][0], header_out);
-    auto f = __copy_fod<float>(properties.Lmax, properties.weight, get_options("noapo").empty());
+    auto f = _copy_fod<float>(properties.Lmax, properties.weight, get_options("noapo").empty());
     ThreadedLoop(Eext->getTOD(), 0, 3).run(f, Eext->getTOD(), fODF);
   }
 

--- a/cpp/cmd/tckmap.cpp
+++ b/cpp/cmd/tckmap.cpp
@@ -575,13 +575,13 @@ void run() {
     writer.reset(make_writer(header, output_image_path, stat_vox, writer_dim::GREYSCALE));
     break;
   case writer_dim::DEC:
-    writer.reset(new MapWriter<float>(header, output_image_path, stat_vox, writer_dim::DEC));
+    writer = std::make_unique<MapWriter<float>>(header, output_image_path, stat_vox, writer_dim::DEC);
     break;
   case writer_dim::DIXEL:
     writer.reset(make_writer(header, output_image_path, stat_vox, writer_dim::DIXEL));
     break;
   case writer_dim::TOD:
-    writer.reset(new MapWriter<float>(header, output_image_path, stat_vox, writer_dim::TOD));
+    writer = std::make_unique<MapWriter<float>>(header, output_image_path, stat_vox, writer_dim::TOD);
     break;
   }
 

--- a/cpp/cmd/tckmap.cpp
+++ b/cpp/cmd/tckmap.cpp
@@ -572,16 +572,16 @@ void run() {
   case writer_dim::UNDEFINED:
     throw Exception("Invalid TWI writer image dimensionality");
   case writer_dim::GREYSCALE:
-    writer.reset(make_writer(header, argument[1], stat_vox, writer_dim::GREYSCALE));
+    writer.reset(make_writer(header, output_image_path, stat_vox, writer_dim::GREYSCALE));
     break;
   case writer_dim::DEC:
-    writer.reset(new MapWriter<float>(header, argument[1], stat_vox, writer_dim::DEC));
+    writer.reset(new MapWriter<float>(header, output_image_path, stat_vox, writer_dim::DEC));
     break;
   case writer_dim::DIXEL:
-    writer.reset(make_writer(header, argument[1], stat_vox, writer_dim::DIXEL));
+    writer.reset(make_writer(header, output_image_path, stat_vox, writer_dim::DIXEL));
     break;
   case writer_dim::TOD:
-    writer.reset(new MapWriter<float>(header, argument[1], stat_vox, writer_dim::TOD));
+    writer.reset(new MapWriter<float>(header, output_image_path, stat_vox, writer_dim::TOD));
     break;
   }
 

--- a/cpp/cmd/tcksample.cpp
+++ b/cpp/cmd/tcksample.cpp
@@ -238,7 +238,10 @@ private:
 
   template <class VectorType>
   value_type compute_statistic(const VectorType &data, const std::vector<value_type> &weights) const {
-    assert(statistic().has_value());
+    if (!statistic().has_value()) {
+      assert(false);
+      return std::numeric_limits<value_type>::quiet_NaN();
+    }
     switch (statistic().value()) {
     case Statistic::MEAN: {
       value_type integral = value_type(0);
@@ -284,8 +287,6 @@ private:
       return cast_to_nan ? std::numeric_limits<value_type>::quiet_NaN() : value;
     } break;
     }
-    assert(false);
-    return std::numeric_limits<value_type>::quiet_NaN();
   }
 };
 
@@ -320,6 +321,10 @@ protected:
   };
 
   value_type compute_statistic(std::vector<ValueLength> &data) const {
+    if (!statistic().has_value()) {
+      assert(false);
+      return std::numeric_limits<value_type>::quiet_NaN();
+    }
     if (data.empty())
       return std::numeric_limits<value_type>::quiet_NaN();
     switch (statistic().value()) {
@@ -376,8 +381,6 @@ protected:
       return cast_to_nan ? std::numeric_limits<value_type>::quiet_NaN() : maxvalue;
     }
     }
-    assert(false);
-    return std::numeric_limits<value_type>::quiet_NaN();
   }
 };
 

--- a/cpp/cmd/tcksample.cpp
+++ b/cpp/cmd/tcksample.cpp
@@ -242,6 +242,7 @@ private:
       assert(false);
       return std::numeric_limits<value_type>::quiet_NaN();
     }
+    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     switch (statistic().value()) {
     case Statistic::MEAN: {
       value_type integral = value_type(0);
@@ -330,6 +331,7 @@ protected:
     }
     if (data.empty())
       return std::numeric_limits<value_type>::quiet_NaN();
+    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     switch (statistic().value()) {
     case Statistic::MEAN: {
       value_type integral = value_type(0);

--- a/cpp/cmd/tcksample.cpp
+++ b/cpp/cmd/tcksample.cpp
@@ -286,6 +286,9 @@ private:
       }
       return cast_to_nan ? std::numeric_limits<value_type>::quiet_NaN() : value;
     } break;
+    default:
+      assert(false);
+      return std::numeric_limits<value_type>::quiet_NaN();
     }
   }
 };
@@ -380,6 +383,9 @@ protected:
       }
       return cast_to_nan ? std::numeric_limits<value_type>::quiet_NaN() : maxvalue;
     }
+    default:
+      assert(false);
+      return std::numeric_limits<value_type>::quiet_NaN();
     }
   }
 };

--- a/cpp/cmd/tcksift.cpp
+++ b/cpp/cmd/tcksift.cpp
@@ -126,7 +126,7 @@ void run() {
     opt = get_options("output_at_counts");
     if (!opt.empty()) {
       std::vector<uint32_t> counts = parse_ints<uint32_t>(opt[0][0]);
-      sifter.set_regular_outputs(counts, debug_path.value());
+      sifter.set_regular_outputs(counts, debug_path);
     }
 
     sifter.perform_filtering();

--- a/cpp/cmd/tensor2metric.cpp
+++ b/cpp/cmd/tensor2metric.cpp
@@ -14,6 +14,7 @@
  * For more details, see http://www.mrtrix.org/.
  */
 
+#include "eigen_plugins/eigen_plugins.h"
 #include <Eigen/Eigenvalues>
 
 #include "algo/threaded_copy.h"

--- a/cpp/cmd/transformcalc.cpp
+++ b/cpp/cmd/transformcalc.cpp
@@ -14,6 +14,12 @@
  * For more details, see http://www.mrtrix.org/.
  */
 
+#include "eigen_plugins/eigen_plugins.h"
+#include <Eigen/Geometry>
+#include <algorithm>
+#include <filesystem>
+#include <unsupported/Eigen/MatrixFunctions>
+
 #include "command.h"
 #include "enum.h"
 #include "file/key_value.h"
@@ -23,10 +29,6 @@
 #include "math/average_space.h"
 #include "math/math.h"
 #include "transform.h"
-#include <Eigen/Geometry>
-#include <algorithm>
-#include <filesystem>
-#include <unsupported/Eigen/MatrixFunctions>
 
 using namespace MR;
 using namespace App;

--- a/cpp/cmd/transformcompose.cpp
+++ b/cpp/cmd/transformcompose.cpp
@@ -163,6 +163,7 @@ void run() {
     output_header.ndim() = 4;
     output_header.size(3) = 3;
     output_header.datatype() = DataType::Float32;
+    output_header.datatype().set_byte_order_native();
 
     Image<float> output = Image<value_type>::create(output_path, output_header);
 

--- a/cpp/cmd/transformconvert.cpp
+++ b/cpp/cmd/transformconvert.cpp
@@ -14,6 +14,11 @@
  * For more details, see http://www.mrtrix.org/.
  */
 
+#include "eigen_plugins/eigen_plugins.h"
+#include <algorithm>
+#include <filesystem>
+#include <unsupported/Eigen/MatrixFunctions>
+
 #include "axes.h"
 #include "command.h"
 #include "enum.h"
@@ -22,9 +27,6 @@
 #include "file/nifti_utils.h"
 #include "image.h"
 #include "transform.h"
-#include <algorithm>
-#include <filesystem>
-#include <unsupported/Eigen/MatrixFunctions>
 
 using namespace MR;
 using namespace App;

--- a/cpp/cmd/tsfinfo.cpp
+++ b/cpp/cmd/tsfinfo.cpp
@@ -69,7 +69,7 @@ void run() {
     if (!properties.comments.empty()) {
       std::cout << "    Comments:             ";
       for (std::vector<std::string>::iterator i = properties.comments.begin(); i != properties.comments.end(); ++i)
-        std::cout << (i == properties.comments.begin() ? "" : "                       ") << *i << "\n";
+        std::cout << (i == properties.comments.begin() ? "" : "                          ") << *i << "\n";
     }
 
     for (std::multimap<std::string, std::string>::const_iterator i = properties.prior_rois.begin();

--- a/cpp/core/CMakeLists.txt
+++ b/cpp/core/CMakeLists.txt
@@ -19,6 +19,12 @@ if(NOT MRTRIX_HAVE_LGAMMA_R)
     message(STATUS "No lgamma_r() function found; statistical inference may have poorer multi-threading performance")
 endif()
 
+# Check for re-entrant strerror_r() for thread-safe errno string conversion
+check_symbol_exists(strerror_r "string.h" MRTRIX_HAVE_STRERROR_R)
+if(NOT MRTRIX_HAVE_STRERROR_R)
+    message(STATUS "No strerror_r() function found; falling back to mutex-protected strerror()")
+endif()
+
 file(GLOB_RECURSE HEADLESS_SOURCES *.h *.cpp)
 
 
@@ -96,6 +102,7 @@ endif()
 target_compile_definitions(mrtrix-core PUBLIC
     MRTRIX_BASE_VERSION="${MRTRIX_BASE_VERSION}"
     $<$<BOOL:${MRTRIX_HAVE_LGAMMA_R}>:MRTRIX_HAVE_LGAMMA_R>
+    $<$<BOOL:${MRTRIX_HAVE_STRERROR_R}>:MRTRIX_HAVE_STRERROR_R>
 )
 
 if(APPLE AND MRTRIX_HAVE_LGAMMA_R)

--- a/cpp/core/CMakeLists.txt
+++ b/cpp/core/CMakeLists.txt
@@ -117,7 +117,7 @@ else()
 endif()
 
 target_link_libraries(mrtrix-core PUBLIC
-    Eigen3::Eigen
+    mrtrix::eigen
     ZLIB::ZLIB
     fftw3::fftw
     mrtrix::common

--- a/cpp/core/adapter/base.h
+++ b/cpp/core/adapter/base.h
@@ -31,10 +31,12 @@ inline AdapterType<ImageType> make(const ImageType &parent, Args &&...args) {
 
 template <class AdapterType, class ImageType>
 class Base : public ImageBase<AdapterType, typename ImageType::value_type> {
+protected:
+  // NOLINTNEXTLINE(bugprone-crtp-constructor-accessibility)
+  Base(const ImageType &parent) : parent_(parent) {}
+
 public:
   using value_type = typename ImageType::value_type;
-
-  Base(const ImageType &parent) : parent_(parent) {}
 
   template <class U> const Base &operator=(const U &V) { return parent_ = V; }
 

--- a/cpp/core/adapter/neighbourhood3D.h
+++ b/cpp/core/adapter/neighbourhood3D.h
@@ -39,12 +39,8 @@ public:
     for (size_t i = 0; i < ndim(); ++i) {
       from_[i] = (iter_.index(i) - extent[i] < 0) ? 0 : iter_.index(i) - extent[i];
       size_[i] = (from_[i] + extent[i] >= original.size(i)) ? original.size(i) - from_[i] - 1 : extent[i];
-      assert(from_[n] + size_[n] < original.size(n));
+      assert(from_[i] + size_[i] < original.size(i));
     }
-
-    // for (size_t n = 0; n < ndim(); ++n)
-    //   if (from_[n] + size_[n] > original.size(n))
-    //     throw Exception ("FIXME: dimensions requested for NeighbourhoodCoord adapter are out of bounds!");
 
     for (size_t j = 0; j < 3; ++j)
       for (size_t i = 0; i < 3; ++i)

--- a/cpp/core/algo/histogram.cpp
+++ b/cpp/core/algo/histogram.cpp
@@ -64,6 +64,7 @@ void Calibrator::finalize(const size_t num_volumes, const bool is_integer) {
       //   histograms are generated for individual volumes
       // Need to adjust the bin width accordingly... kinda ugly hack
       // Will need to revisit if mrstats gets capability to compute statistics across all volumes rather than splitting
+      // NOLINTNEXTLINE(bugprone-integer-division)
       bin_width = 2.0 * get_iqr() * std::pow(static_cast<default_type>(data.size() / num_volumes), -1.0 / 3.0);
       std::vector<default_type>().swap(data); // No longer required; free the memory used
       // If the input data are integers, the bin width should also be an integer, to avoid getting

--- a/cpp/core/algo/min_max.h
+++ b/cpp/core/algo/min_max.h
@@ -22,11 +22,11 @@ namespace MR {
 
 //! \cond skip
 namespace {
-template <class ImageType> class __MinMax {
+template <class ImageType> class MinMax {
 public:
   using value_type = typename ImageType::value_type;
 
-  __MinMax(value_type &overall_min, value_type &overall_max)
+  MinMax(value_type &overall_min, value_type &overall_max)
       : overall_min(overall_min),
         overall_max(overall_max),
         min(std::numeric_limits<value_type>::infinity()),
@@ -34,7 +34,7 @@ public:
     overall_min = min;
     overall_max = max;
   }
-  ~__MinMax() {
+  ~MinMax() {
     std::lock_guard<std::mutex> lock(mutex);
     overall_min = std::min(overall_min, min);
     overall_max = std::max(overall_max, max);
@@ -66,9 +66,10 @@ public:
   value_type &overall_max;
   value_type min, max;
 
+private:
   static std::mutex mutex;
 };
-template <class ImageType> std::mutex __MinMax<ImageType>::mutex;
+template <class ImageType> std::mutex MinMax<ImageType>::mutex;
 } // namespace
 //! \endcond
 
@@ -79,7 +80,7 @@ inline void min_max(ImageType &in,
                     size_t from_axis = 0,
                     size_t to_axis = std::numeric_limits<size_t>::max()) {
   ThreadedLoop("finding min/max of \"" + shorten(in.name()) + "\"", in, from_axis, to_axis)
-      .run(__MinMax<ImageType>(min, max), in);
+      .run(MinMax<ImageType>(min, max), in);
 }
 
 template <class ImageType, class MaskType>
@@ -90,7 +91,7 @@ inline void min_max(ImageType &in,
                     size_t from_axis = 0,
                     size_t to_axis = std::numeric_limits<size_t>::max()) {
   ThreadedLoop("finding min/max of \"" + shorten(in.name()) + "\"", in, from_axis, to_axis)
-      .run(__MinMax<ImageType>(min, max), in, mask);
+      .run(MinMax<ImageType>(min, max), in, mask);
 }
 
 } // namespace MR

--- a/cpp/core/algo/random_loop.h
+++ b/cpp/core/algo/random_loop.h
@@ -23,6 +23,7 @@
 #include <algorithm> // std::shuffle
 #include <iterator>
 #include <numeric>
+#include <random>
 #include <unordered_set>
 
 namespace MR {
@@ -86,7 +87,7 @@ public:
                      const bool repeat = false,
                      const ssize_t &min_index = 0,
                      const ssize_t &max_index = std::numeric_limits<ssize_t>::max())
-      : image(in), repeat_(repeat), status(true), ax(axis), cnt(0), min_idx(min_index) {
+      : image(in), repeat_(repeat), status(true), ax(axis), cnt(0), min_idx(min_index), rng_{std::random_device{}()} {
     if (max_index < image.size(ax))
       range = max_index - min_idx + 1;
     else
@@ -104,8 +105,9 @@ public:
   }
 
   void set_next_index_no_repeat() {
+    std::uniform_int_distribution<ssize_t> dist{0, static_cast<ssize_t>(range) - 1};
     while (cnt < max_cnt) {
-      index = rand() % range + min_idx;
+      index = dist(rng_) + min_idx;
       if (!idx_done.count(index)) {
         idx_done.insert(index);
         break;
@@ -117,7 +119,7 @@ public:
   }
 
   void set_next_index_with_repeat() {
-    index = rand() % range + min_idx;
+    index = std::uniform_int_distribution<ssize_t>{0, static_cast<ssize_t>(range) - 1}(rng_) + min_idx;
     ++cnt;
     image.index(ax) = index;
   }
@@ -144,6 +146,7 @@ private:
   size_t max_cnt;
   ssize_t index;
   std::unordered_set<ssize_t> idx_done;
+  std::mt19937 rng_;
 };
 
 template <class ImageType, class IterType> class Iterator_loop {

--- a/cpp/core/algo/random_threaded_loop.h
+++ b/cpp/core/algo/random_threaded_loop.h
@@ -18,6 +18,7 @@
 
 #include "algo/iterator.h"
 #include "algo/loop.h"
+#include "algo/threaded_loop.h"
 #include "debug.h"
 #include "exception.h"
 #include "math/rng.h"

--- a/cpp/core/algo/stochastic_threaded_loop.h
+++ b/cpp/core/algo/stochastic_threaded_loop.h
@@ -18,6 +18,7 @@
 
 #include "algo/iterator.h"
 #include "algo/loop.h"
+#include "algo/threaded_loop.h"
 #include "debug.h"
 #include "math/rng.h"
 #include "thread.h"

--- a/cpp/core/algo/threaded_copy.h
+++ b/cpp/core/algo/threaded_copy.h
@@ -23,7 +23,7 @@ namespace MR {
 //! \cond skip
 namespace {
 
-struct __copy_func {
+struct _copy_func {
   template <class InputImageType, class OutputImageType>
   FORCE_INLINE void operator()(InputImageType &in, OutputImageType &out) const {
     out.value() = in.value();
@@ -39,7 +39,7 @@ inline void threaded_copy(InputImageType &source,
                           OutputImageType &destination,
                           const std::vector<size_t> &axes,
                           size_t num_axes_in_thread = 1) {
-  ThreadedLoop(source, axes, num_axes_in_thread).run(__copy_func(), source, destination);
+  ThreadedLoop(source, axes, num_axes_in_thread).run(_copy_func(), source, destination);
 }
 
 template <class InputImageType, class OutputImageType>
@@ -48,7 +48,7 @@ inline void threaded_copy(InputImageType &source,
                           size_t from_axis = 0,
                           size_t to_axis = std::numeric_limits<size_t>::max(),
                           size_t num_axes_in_thread = 1) {
-  ThreadedLoop(source, from_axis, to_axis, num_axes_in_thread).run(__copy_func(), source, destination);
+  ThreadedLoop(source, from_axis, to_axis, num_axes_in_thread).run(_copy_func(), source, destination);
 }
 
 template <class InputImageType, class OutputImageType>
@@ -57,7 +57,7 @@ inline void threaded_copy_with_progress_message(std::string_view message,
                                                 OutputImageType &destination,
                                                 const std::vector<size_t> &axes,
                                                 size_t num_axes_in_thread = 1) {
-  ThreadedLoop(message, source, axes, num_axes_in_thread).run(__copy_func(), source, destination);
+  ThreadedLoop(message, source, axes, num_axes_in_thread).run(_copy_func(), source, destination);
 }
 
 template <class InputImageType, class OutputImageType>
@@ -67,7 +67,7 @@ inline void threaded_copy_with_progress_message(std::string_view message,
                                                 size_t from_axis = 0,
                                                 size_t to_axis = std::numeric_limits<size_t>::max(),
                                                 size_t num_axes_in_thread = 1) {
-  ThreadedLoop(message, source, from_axis, to_axis, num_axes_in_thread).run(__copy_func(), source, destination);
+  ThreadedLoop(message, source, from_axis, to_axis, num_axes_in_thread).run(_copy_func(), source, destination);
 }
 
 template <class InputImageType, class OutputImageType>

--- a/cpp/core/algo/threaded_loop.h
+++ b/cpp/core/algo/threaded_loop.h
@@ -296,9 +296,9 @@ template <class Functor, class... ImageType> struct ThreadedLoopRunInner<0, Func
   }
 };
 
-inline void __manage_progress(...) {}
+inline void _manage_progress(...) {}
 template <class LoopType, class ThreadType>
-inline auto __manage_progress(const LoopType *loop, const ThreadType *threads)
+inline auto _manage_progress(const LoopType *loop, const ThreadType *threads)
     -> decltype((void)(&loop->progress), void()) {
   loop->progress.run_update_thread(*threads);
 }
@@ -359,7 +359,7 @@ template <class OuterLoopType> struct ThreadedLoopRunOuter {
     auto threads = Thread::run(Thread::multi(loop_thread), "loop threads");
 
     auto *loop = &(shared.lock()->loop);
-    __manage_progress(loop, &threads);
+    _manage_progress(loop, &threads);
     threads.wait();
   }
 

--- a/cpp/core/algo/threaded_loop.h
+++ b/cpp/core/algo/threaded_loop.h
@@ -22,6 +22,8 @@
 #include "mutexprotected.h"
 #include "thread.h"
 #include <tuple>
+#include <type_traits>
+#include <utility>
 
 namespace MR {
 
@@ -296,11 +298,16 @@ template <class Functor, class... ImageType> struct ThreadedLoopRunInner<0, Func
   }
 };
 
-inline void _manage_progress(...) {}
+//! Detect whether \a LoopType exposes a \c progress member to be updated during threaded execution.
+template <class LoopType, class = void> struct has_progress : std::false_type {};
+template <class LoopType>
+struct has_progress<LoopType, std::void_t<decltype(std::declval<const LoopType &>().progress)>> : std::true_type {};
+
+//! Spawn a progress-update thread for the duration of the loop, but only if \a loop carries a progress bar.
 template <class LoopType, class ThreadType>
-inline auto _manage_progress(const LoopType *loop, const ThreadType *threads)
-    -> decltype((void)(&loop->progress), void()) {
-  loop->progress.run_update_thread(*threads);
+inline void _manage_progress(const LoopType *loop, const ThreadType *threads) {
+  if constexpr (has_progress<LoopType>::value)
+    loop->progress.run_update_thread(*threads);
 }
 
 template <class OuterLoopType> struct ThreadedLoopRunOuter {

--- a/cpp/core/app.cpp
+++ b/cpp/core/app.cpp
@@ -59,7 +59,7 @@ const std::string core_reference =
     "NeuroImage, 2019, 202, 116137";                                                                          //
 
 // clang-format off
-OptionGroup __standard_options = OptionGroup("Standard options")
+OptionGroup _standard_options = OptionGroup("Standard options")
   + Option("info", "display information messages.")
   + Option("quiet",
            "do not display information messages or progress status; "
@@ -498,7 +498,7 @@ std::string Option::usage() const {
 std::string get_help_string(const bool format) {
   return help_head(format) + help_synopsis(format) + usage_syntax(format) + ARGUMENTS.syntax(format) +
          DESCRIPTION.syntax(format) + EXAMPLES.syntax(format) + OPTIONS.syntax(format) +
-         __standard_options.header(format) + __standard_options.contents(format) + __standard_options.footer(format) +
+         _standard_options.header(format) + _standard_options.contents(format) + _standard_options.footer(format) +
          help_tail(format);
 }
 
@@ -566,25 +566,25 @@ std::string full_usage() {
     for (size_t j = 0; j < OPTIONS[i].size(); ++j)
       s += OPTIONS[i][j].usage();
 
-  for (size_t i = 0; i < __standard_options.size(); ++i)
-    s += __standard_options[i].usage();
+  for (size_t i = 0; i < _standard_options.size(); ++i)
+    s += _standard_options[i].usage();
 
   return s;
 }
 
 std::string markdown_usage() {
   /*
-  help_head (format)
-  + help_synopsis (format)
-  + usage_syntax (format)
-  + ARGUMENTS.syntax (format)
-  + DESCRIPTION.syntax (format)
-  + EXAMPLES.syntax (format)
-  + OPTIONS.syntax (format)
-  + __standard_options.header (format)
-  + __standard_options.contents (format)
-  + __standard_options.footer (format)
-  + help_tail (format);
+    help_head (format)
+    + help_synopsis (format)
+    + usage_syntax (format)
+    + ARGUMENTS.syntax (format)
+    + DESCRIPTION.syntax (format)
+    + EXAMPLES.syntax (format)
+    + OPTIONS.syntax (format)
+    + _standard_options.header (format)
+    + _standard_options.contents (format)
+    + _standard_options.footer (format)
+    + help_tail (format);
   */
   std::string s = std::string("## Synopsis\n\n") + SYNOPSIS + "\n\n";
 
@@ -662,8 +662,8 @@ std::string markdown_usage() {
   }
 
   s += "#### Standard options\n\n";
-  for (size_t i = 0; i < __standard_options.size(); ++i)
-    s += format_option(__standard_options[i]);
+  for (size_t i = 0; i < _standard_options.size(); ++i)
+    s += format_option(_standard_options[i]);
 
   s += std::string("## References\n\n");
   for (size_t i = 0; i < REFERENCES.size(); ++i)
@@ -678,17 +678,17 @@ std::string markdown_usage() {
 
 std::string restructured_text_usage() {
   /*
-  help_head (format)
-  + help_synopsis (format)
-  + usage_syntax (format)
-  + ARGUMENTS.syntax (format)
-  + DESCRIPTION.syntax (format)
-  + EXAMPLES.syntax (format)
-  + OPTIONS.syntax (format)
-  + __standard_options.header (format)
-  + __standard_options.contents (format)
-  + __standard_options.footer (format)
-  + help_tail (format);
+    help_head (format)
+    + help_synopsis (format)
+    + usage_syntax (format)
+    + ARGUMENTS.syntax (format)
+    + DESCRIPTION.syntax (format)
+    + EXAMPLES.syntax (format)
+    + OPTIONS.syntax (format)
+    + _standard_options.header (format)
+    + _standard_options.contents (format)
+    + _standard_options.footer (format)
+    + help_tail (format);
   */
 
   std::string s = std::string("Synopsis\n--------\n\n") + SYNOPSIS + "\n\n";
@@ -792,8 +792,8 @@ std::string restructured_text_usage() {
   }
 
   s += "Standard options\n^^^^^^^^^^^^^^^^\n\n";
-  for (size_t i = 0; i < __standard_options.size(); ++i)
-    s += format_option(__standard_options[i]);
+  for (size_t i = 0; i < _standard_options.size(); ++i)
+    s += format_option(_standard_options[i]);
 
   s += std::string("References\n^^^^^^^^^^\n\n");
   for (size_t i = 0; i < REFERENCES.size(); ++i) {
@@ -822,7 +822,7 @@ const Option *match_option(std::string_view arg) {
 
   for (size_t i = 0; i < OPTIONS.size(); ++i)
     get_matches(candidates, OPTIONS[i], root);
-  get_matches(candidates, __standard_options, root);
+  get_matches(candidates, _standard_options, root);
 
   // no matches
   if (candidates.empty())

--- a/cpp/core/app.cpp
+++ b/cpp/core/app.cpp
@@ -24,6 +24,7 @@
 
 #include "app.h"
 #include "debug.h"
+#include "env.h"
 #include "executable_version.h"
 #include "file/config.h"
 #include "file/path.h"
@@ -110,7 +111,7 @@ std::vector<ParsedOption> option;
 // ENVVAR Set the default terminal verbosity. Default terminal verbosity
 // ENVVAR is 1. This has the same effect as the ``-quiet`` (0),
 // ENVVAR ``-info`` (2) or ``-debug`` (3) comand-line options.
-int log_level = getenv("MRTRIX_QUIET") ? 0 : (getenv("MRTRIX_LOGLEVEL") ? to<int>(getenv("MRTRIX_LOGLEVEL")) : 1);
+int log_level = MR::get_env("MRTRIX_QUIET").has_value() ? 0 : MR::get_env("MRTRIX_LOGLEVEL", 1);
 
 int exit_error_code = 0;
 bool fail_on_warn = false;
@@ -514,9 +515,9 @@ void print_help() {
     std::string help_string = get_help_string(1);
     FILE *file = popen(help_display_command.c_str(), "w");
     if (!file) {
-      INFO("error launching help display command \"" + help_display_command + "\": " + strerror(errno));
+      INFO("error launching help display command \"" + help_display_command + "\": " + MR::C_strerror(errno));
     } else if (fwrite(help_string.c_str(), 1, help_string.size(), file) != help_string.size()) {
-      INFO("error sending help page to display command \"" + help_display_command + "\": " + strerror(errno));
+      INFO("error sending help page to display command \"" + help_display_command + "\": " + MR::C_strerror(errno));
     }
 
     if (pclose(file) == 0)
@@ -1271,9 +1272,7 @@ void init(int cmdline_argc, const char *const *cmdline_argv) { // check_syntax o
   command_history_string += ")";
 
   std::locale::global(std::locale::classic());
-  std::setlocale(LC_ALL, "C");
-
-  srand(time(nullptr));
+  std::setlocale(LC_ALL, "C"); // NOLINT(concurrency-mt-unsafe)
 }
 
 std::vector<ParsedOption> get_options(std::string_view name) {

--- a/cpp/core/app.cpp
+++ b/cpp/core/app.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <algorithm>
+#include <cerrno>
 #include <clocale>
 #include <cstddef>
 #include <fcntl.h>
@@ -23,8 +24,10 @@
 #include <unistd.h>
 
 #include "app.h"
+#include "cmdline_option.h"
 #include "debug.h"
 #include "env.h"
+#include "exception.h"
 #include "executable_version.h"
 #include "file/config.h"
 #include "file/path.h"
@@ -59,7 +62,7 @@ const std::string core_reference =
     "NeuroImage, 2019, 202, 116137";                                                                          //
 
 // clang-format off
-OptionGroup _standard_options = OptionGroup("Standard options")
+const OptionGroup _standard_options = OptionGroup("Standard options")
   + Option("info", "display information messages.")
   + Option("quiet",
            "do not display information messages or progress status; "
@@ -498,7 +501,7 @@ std::string Option::usage() const {
 std::string get_help_string(const bool format) {
   return help_head(format) + help_synopsis(format) + usage_syntax(format) + ARGUMENTS.syntax(format) +
          DESCRIPTION.syntax(format) + EXAMPLES.syntax(format) + OPTIONS.syntax(format) +
-         _standard_options.header(format) + _standard_options.contents(format) + _standard_options.footer(format) +
+         _standard_options.header(format) + _standard_options.contents(format) + MR::App::OptionGroup::footer(format) +
          help_tail(format);
 }
 

--- a/cpp/core/app.h
+++ b/cpp/core/app.h
@@ -334,7 +334,7 @@ extern std::string SYNOPSIS;
 extern Description REFERENCES;
 
 //! the group of standard options for all commands
-extern OptionGroup __standard_options;
+extern OptionGroup _standard_options;
 
 //! return all command-line options matching \c name
 /*! This returns a vector of vectors, where each top-level entry

--- a/cpp/core/app.h
+++ b/cpp/core/app.h
@@ -334,7 +334,7 @@ extern std::string SYNOPSIS;
 extern Description REFERENCES;
 
 //! the group of standard options for all commands
-extern OptionGroup _standard_options;
+extern const OptionGroup _standard_options;
 
 //! return all command-line options matching \c name
 /*! This returns a vector of vectors, where each top-level entry

--- a/cpp/core/command.h
+++ b/cpp/core/command.h
@@ -21,9 +21,12 @@
 #endif
 
 #include <cstdio>
+#include <initializer_list>
+#include <optional>
 
 #include "app.h"
 #include "env.h"
+#include "exception.h"
 #include "executable_version.h"
 #include "mrtrix.h"
 #include "mrtrix_version.h"

--- a/cpp/core/command.h
+++ b/cpp/core/command.h
@@ -20,7 +20,10 @@
 #include <xmmintrin.h>
 #endif
 
+#include <cstdio>
+
 #include "app.h"
+#include "env.h"
 #include "executable_version.h"
 #include "mrtrix.h"
 #include "mrtrix_version.h"
@@ -35,22 +38,51 @@ void set_project_version();
 #ifdef MRTRIX_AS_R_LIBRARY
 
 extern "C" void R_main(int *cmdline_argc, char **cmdline_argv) { // check_syntax off
-#ifdef MRTRIX_PROJECT
-  ::MR::App::set_project_version();
-#endif
-  ::MR::App::DESCRIPTION.clear();
-  ::MR::App::ARGUMENTS.clear();
-  ::MR::App::OPTIONS.clear();
+  // Non-throwing [ERROR] line writer for the R-hosted entry point; routes via
+  // REprintf (R's stderr-equivalent channel) and mirrors the "<name>: [colour][ERROR]
+  // <msg>[reset]" layout produced by MR::cmdline_report_to_user_func. Uses only
+  // noexcept primitives so it is safe inside catch handlers
+  // (see bugprone-exception-escape). The "<name>: " prefix appears only once
+  // ::MR::App::init() has populated ::MR::App::NAME.
+  const auto fail = [](std::initializer_list<const char *> parts) noexcept { // check_syntax off
+    if (!::MR::App::NAME.empty())
+      REprintf("%s: ", ::MR::App::NAME.c_str());
+    if (::MR::App::terminal_use_colour)
+      REprintf("%s", "\033[01;31m");
+    REprintf("%s", "[ERROR] ");
+    for (const char *const p : parts) // check_syntax off
+      REprintf("%s", p);
+    if (::MR::App::terminal_use_colour)
+      REprintf("%s", "\033[0m");
+    REprintf("%s", "\n");
+  };
+
   try {
+#ifdef MRTRIX_PROJECT
+    ::MR::App::set_project_version();
+#endif
+    ::MR::App::DESCRIPTION.clear();
+    ::MR::App::ARGUMENTS.clear();
+    ::MR::App::OPTIONS.clear();
     usage();
     ::MR::App::verify_usage();
     ::MR::App::init(*cmdline_argc, cmdline_argv);
     ::MR::App::parse();
     run();
-  } catch (MR::Exception &E) {
-    E.display();
-    return;
   } catch (int retval) {
+    return;
+  } catch (MR::Exception &E) {
+    try {
+      E.display();
+    } catch (...) {
+      fail({"additional exception raised while displaying MR::Exception"});
+    }
+    return;
+  } catch (const std::exception &E) {
+    fail({"unhandled std::exception escaped from R_main: ", E.what()});
+    return;
+  } catch (...) { // NOLINT(bugprone-empty-catch)
+    fail({"unhandled non-std::exception escaped from R_main"});
     return;
   }
 }
@@ -68,14 +100,36 @@ extern "C" void R_usage(char **output) { // check_syntax off
 #else
 
 int main(int cmdline_argc, char **cmdline_argv) { // check_syntax off
+  // Non-throwing [ERROR] line writer; mirrors the "<name>: [colour][ERROR] <msg>[reset]"
+  // layout produced by MR::cmdline_report_to_user_func, but uses only noexcept
+  // primitives so it is safe to call from outside the main try block and from
+  // catch handlers (see bugprone-exception-escape). The "<name>: " prefix appears
+  // only once ::MR::App::init() has populated ::MR::App::NAME.
+  const auto fail = [](std::initializer_list<const char *> parts) noexcept { // check_syntax off
+    if (!::MR::App::NAME.empty()) {
+      std::fputs(::MR::App::NAME.c_str(), stderr);
+      std::fputs(": ", stderr);
+    }
+    if (::MR::App::terminal_use_colour)
+      std::fputs("\033[01;31m", stderr);
+    std::fputs("[ERROR] ", stderr);
+    for (const char *const p : parts) // check_syntax off
+      std::fputs(p, stderr);
+    if (::MR::App::terminal_use_colour)
+      std::fputs("\033[0m", stderr);
+    std::fputc('\n', stderr);
+  };
+
+  // Version mismatch is reported via the noexcept "fail" helper so the check
+  // can safely run before the main try block (see bugprone-exception-escape).
   if (MR::App::mrtrix_version != MR::App::mrtrix_executable_version) {
-    MR::Exception E("executable was compiled for a different version of the MRtrix3 library!");
-    E.push_back(std::string("  ") + MR::App::NAME + " version: " + MR::App::mrtrix_executable_version);
-    E.push_back(std::string("  library version: ") + MR::App::mrtrix_version);
-    E.push_back("You may need to erase files left over from prior MRtrix3 versions;");
-    E.push_back("eg. core/version.cpp; src/exec_version.cpp");
-    E.push_back(", and re-configure cmake");
-    throw E;
+    fail({"executable was compiled for a different version of the MRtrix3 library!"});
+    fail({"  executable version: ", MR::App::mrtrix_executable_version.c_str()});
+    fail({"  library version: ", MR::App::mrtrix_version.c_str()});
+    fail({"You may need to erase files left over from prior MRtrix3 versions;"});
+    fail({"eg. core/version.cpp; src/exec_version.cpp,"});
+    fail({"and re-configure cmake"});
+    return 1;
   }
 
 #ifdef FLUSH_TO_ZERO
@@ -87,10 +141,10 @@ int main(int cmdline_argc, char **cmdline_argv) { // check_syntax off
   mxcsr |= (1 << 6); // denormals-are-zero
   _mm_setcsr(mxcsr);
 #endif
-#ifdef MRTRIX_PROJECT
-  ::MR::App::set_project_version();
-#endif
   try {
+#ifdef MRTRIX_PROJECT
+    ::MR::App::set_project_version();
+#endif
     ::MR::App::init(cmdline_argc, cmdline_argv);
     usage();
     ::MR::App::verify_usage();
@@ -105,18 +159,28 @@ int main(int cmdline_argc, char **cmdline_argv) { // check_syntax off
     // ENVVAR if it is set. This can be used in the CI of wrapping code,
     // ENVVAR such as the automatically generated Pydra interfaces.
     // ENVVAR Note that it will have no effect for R interfaces
-    char *parse_only = std::getenv("MRTRIX_CLI_PARSE_ONLY"); // check_syntax off
-    if (parse_only && ::MR::to<bool>(parse_only)) {
+    const std::optional<std::string> parse_only = ::MR::get_env("MRTRIX_CLI_PARSE_ONLY");
+    if (parse_only.has_value() && ::MR::to<bool>(*parse_only)) {
       CONSOLE("Quitting after parsing command-line arguments successfully due to environment variable "
               "'MRTRIX_CLI_PARSE_ONLY'");
       return 0;
     }
     run();
-  } catch (::MR::Exception &E) {
-    E.display();
-    return 1;
   } catch (int retval) {
     return retval;
+  } catch (::MR::Exception &E) {
+    try {
+      E.display();
+    } catch (...) {
+      fail({"additional exception raised while displaying MR::Exception"});
+    }
+    return 1;
+  } catch (const std::exception &E) {
+    fail({"unhandled std::exception escaped from main: ", E.what()});
+    return 1;
+  } catch (...) { // NOLINT(bugprone-empty-catch)
+    fail({"unhandled non-std::exception escaped from main"});
+    return 1;
   }
   return ::MR::App::exit_error_code;
 }

--- a/cpp/core/connectome/connectome.h
+++ b/cpp/core/connectome/connectome.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "eigen_plugins/eigen_plugins.h"
 #include <Eigen/Dense>
 
 #include "app.h"

--- a/cpp/core/connectome/enhance.cpp
+++ b/cpp/core/connectome/enhance.cpp
@@ -65,7 +65,7 @@ void NBS::initialise(const node_t num_nodes) {
 
       const size_t index = mat2vec(row, column);
       std::vector<size_t> &vector = (*adjacency)[index];
-      vector.reserve(2 * (num_nodes - 1));
+      vector.reserve(2 * static_cast<size_t>(num_nodes - 1));
       // Should be able to expand from this edge to any other edge connected to either row or column
       for (node_t r = 0; r != num_nodes; ++r) {
         if (r != row)

--- a/cpp/core/debug.h
+++ b/cpp/core/debug.h
@@ -42,13 +42,13 @@ extern std::string NAME;
   {                                                                                                                    \
     Eigen::IOFormat fmt(Eigen::FullPrecision, 0, ", ", ",\n        ", "[", "]", "\nnp.array([", "])");                 \
     std::cerr << MR::App::NAME << " [" << __FILE__ << ": " << __LINE__ << "]: " << #variable << " = "                  \
-              << (variable.format(fmt)) << "\n";                                                                       \
+              << (variable).format(fmt) << "\n";                                                                       \
   }
 
 #define VEC(variable)                                                                                                  \
   {                                                                                                                    \
     std::cerr << MR::App::NAME << " [" << __FILE__ << ": " << __LINE__ << "]: " << #variable << " = ";                 \
-    for (ssize_t i = 0; i < variable.size(); ++i) {                                                                    \
+    for (ssize_t i = 0; i < (variable).size(); ++i) {                                                                  \
       std::cerr << str(variable(i)) << " ";                                                                            \
     }                                                                                                                  \
     std::cerr << std::endl;                                                                                            \

--- a/cpp/core/degibbs/unring3d.h
+++ b/cpp/core/degibbs/unring3d.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <cassert>
+
 #include "algo/threaded_loop.h"
 #include "axes.h"
 #include "degibbs/degibbs.h"

--- a/cpp/core/degibbs/unring3d.h
+++ b/cpp/core/degibbs/unring3d.h
@@ -173,8 +173,10 @@ inline std::vector<size_t> strides_for_axis(int axis) {
     return {1, 2, 0};
   case 2:
     return {2, 0, 1};
+  default:
+    assert(false);
+    return {};
   }
-  return {};
 }
 
 } // namespace

--- a/cpp/core/dwi/bootstrap.h
+++ b/cpp/core/dwi/bootstrap.h
@@ -16,7 +16,11 @@
 
 #pragma once
 
+#include <map>
+#include <vector>
+
 #include "adapter/base.h"
+#include "algo/loop.h"
 
 namespace MR::DWI {
 

--- a/cpp/core/dwi/directions/set.cpp
+++ b/cpp/core/dwi/directions/set.cpp
@@ -16,10 +16,10 @@
 
 #include "dwi/directions/set.h"
 
+#include "eigen_plugins/eigen_plugins.h"
+#include <Eigen/Dense>
 #include <list>
 #include <set>
-
-#include <Eigen/Dense>
 
 #include "math/rng.h"
 

--- a/cpp/core/dwi/directions/set.cpp
+++ b/cpp/core/dwi/directions/set.cpp
@@ -270,6 +270,9 @@ void Set::initialise_adjacency() {
           case 2:
             edge = std::make_pair(p->indices[2], p->indices[0]);
             break;
+          default:
+            assert(false);
+            break;
           }
           bool found = false;
           for (auto h = horizon.begin(); h != horizon.end(); ++h) {
@@ -331,6 +334,9 @@ void Set::initialise_adjacency() {
       case 5:
         from = vertices[current.indices[2]].index;
         to = vertices[current.indices[0]].index;
+        break;
+      default:
+        assert(false);
         break;
       }
       bool found = false;
@@ -440,6 +446,9 @@ void FastLookupSet::initialise() {
         break;
       case 3:
         el += el_grid_step;
+        break;
+      default:
+        assert(false);
         break;
       }
 

--- a/cpp/core/dwi/directions/set.h
+++ b/cpp/core/dwi/directions/set.h
@@ -18,6 +18,7 @@
 
 #include <cstdint>
 #include <filesystem>
+#include <utility>
 
 #include "dwi/directions/directions.h"
 #include "dwi/directions/predefined.h"

--- a/cpp/core/dwi/directions/set.h
+++ b/cpp/core/dwi/directions/set.h
@@ -139,7 +139,7 @@ public:
   FastLookupSet(const size_t d) : Set(d) { initialise(); }
 
   FastLookupSet(FastLookupSet &&that)
-      : Set(std::move(that)),
+      : Set(std::move(static_cast<Set &&>(that))),
         grid_lookup(std::move(that.grid_lookup)),
         num_az_grids(that.num_az_grids),
         num_el_grids(that.num_el_grids),

--- a/cpp/core/dwi/directions/validate.cpp
+++ b/cpp/core/dwi/directions/validate.cpp
@@ -16,6 +16,7 @@
 
 #include "dwi/directions/validate.h"
 
+#include "eigen_plugins/eigen_plugins.h"
 #include <Eigen/Dense>
 #include <cmath>
 #include <string>

--- a/cpp/core/dwi/directions/validate.cpp
+++ b/cpp/core/dwi/directions/validate.cpp
@@ -163,12 +163,14 @@ validate(const MatrixType &M, const std::filesystem::path &path, const bool perm
     throw Exception(e, "Direction file \"" + path.string() + "\" validation failed");
   }
 
+  // NOLINTNEXTLINE(bugprone-unused-local-non-trivial-variable)
   const std::string fmt = result.format == DirectionsFormat::Spherical   ? "spherical"
                           : result.format == DirectionsFormat::Cartesian ? "Cartesian"
                                                                          : "gradient table";
   DEBUG("Direction file \"" + path.string() + "\": " +                     //
         str(result.n_directions) + " direction(s) in " + fmt + " format"); //
   if (result.n_non_unit) {
+    // NOLINTNEXTLINE(bugprone-unused-local-non-trivial-variable)
     const std::string msg = "Direction file \"" + path.string() + "\": " +                 //
                             str(result.n_non_unit) + " direction(s) are not of unit norm"; //
     if (result.format == DirectionsFormat::Cartesian) {

--- a/cpp/core/dwi/sdeconv/msmt_csd.h
+++ b/cpp/core/dwi/sdeconv/msmt_csd.h
@@ -145,8 +145,7 @@ public:
       // TODO: is this just computing the Associated Legrendre polynomials...?
       Eigen::MatrixXd delta(1, 2);
       delta << 0, 0;
-      Eigen::MatrixXd DSH__ = Math::SH::init_transform(delta, maxlmax);
-      Eigen::VectorXd DSH_ = DSH__.row(0);
+      Eigen::VectorXd DSH_ = Math::SH::init_transform(delta, maxlmax).row(0);
       Eigen::VectorXd DSH(maxlmax / 2 + 1);
       size_t j = 0;
       for (ssize_t i = 0; i < DSH_.size(); i++)

--- a/cpp/core/dwi/sdeconv/msmt_csd.h
+++ b/cpp/core/dwi/sdeconv/msmt_csd.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <Eigen/Dense>
+
 #include "dwi/directions/predefined.h"
 #include "dwi/directions/validate.h"
 #include "dwi/gradient.h"

--- a/cpp/core/dwi/sdeconv/msmt_csd.h
+++ b/cpp/core/dwi/sdeconv/msmt_csd.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "eigen_plugins/eigen_plugins.h"
 #include <Eigen/Dense>
 
 #include "dwi/directions/predefined.h"

--- a/cpp/core/dwi/tractography/GT/gt.h
+++ b/cpp/core/dwi/tractography/GT/gt.h
@@ -16,13 +16,13 @@
 
 #pragma once
 
+#include "eigen_plugins/eigen_plugins.h"
+#include <Eigen/Dense>
 #include <array>
 #include <cassert>
 #include <fstream>
 #include <iostream>
 #include <mutex>
-
-#include <Eigen/Dense>
 
 #include "math/math.h"
 #include "progressbar.h"

--- a/cpp/core/dwi/tractography/GT/gt.h
+++ b/cpp/core/dwi/tractography/GT/gt.h
@@ -202,6 +202,9 @@ public:
     case 'c':
       n_acc[4] += i;
       break;
+    default:
+      assert(false);
+      break;
     }
   }
 

--- a/cpp/core/dwi/tractography/GT/gt.h
+++ b/cpp/core/dwi/tractography/GT/gt.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <array>
+#include <cassert>
 #include <fstream>
 #include <iostream>
 #include <mutex>

--- a/cpp/core/dwi/tractography/GT/spatiallock.h
+++ b/cpp/core/dwi/tractography/GT/spatiallock.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "eigen_plugins/eigen_plugins.h"
 #include <Eigen/Dense>
 #include <mutex>
 

--- a/cpp/core/dwi/tractography/SIFT/model.h
+++ b/cpp/core/dwi/tractography/SIFT/model.h
@@ -245,10 +245,11 @@ void Model<Fixel>::output_non_contributing_streamlines(const std::filesystem::pa
   ProgressBar progress("Writing non-contributing streamlines output file", contributions.size());
   track_t tck_counter = 0;
   while (reader(tck) && tck_counter < contributions.size()) {
-    if (contributions[tck_counter] && !contributions[tck_counter++]->get_total_contribution())
+    if (contributions[tck_counter] && !contributions[tck_counter]->get_total_contribution())
       writer(tck);
     else
       writer.skip();
+    ++tck_counter;
     ++progress;
   }
   reader.close();

--- a/cpp/core/dwi/tractography/SIFT2/tckfactor.cpp
+++ b/cpp/core/dwi/tractography/SIFT2/tckfactor.cpp
@@ -188,7 +188,7 @@ void TckFactor::estimate_factors() {
   const double init_cf = calc_cost_function();
   double cf_data = init_cf;
   double new_cf = init_cf;
-  double prev_cf = init_cf;
+  double prev_cf = NaN;
   double cf_reg = 0.0;
   const double required_cf_change = -min_cf_decrease_percentage * init_cf;
 

--- a/cpp/core/dwi/tractography/algorithms/calibrator.h
+++ b/cpp/core/dwi/tractography/algorithms/calibrator.h
@@ -64,9 +64,12 @@ template <class Method> void calibrate(Method &method) {
   const float max_angle = std::isfinite(method.S.max_angle_ho) ? method.S.max_angle_ho : method.S.max_angle_1o;
 
   std::vector<Pair> amps;
-  for (float incl = 0.0; incl < max_angle; incl += 0.001) {
+  // for (float incl = 0.0; incl < max_angle; incl += 0.001) {
+  const size_t incl_maxindex = static_cast<size_t>(std::floor(1000.0F * max_angle));
+  for (size_t incl_index = 0; incl_index <= incl_maxindex; ++incl_index) {
+    const float incl = 0.001F * incl_index;
     amps.push_back(Pair(incl, calibrate_func(incl)));
-    if (!std::isfinite(amps.back().amp) || amps.back().amp <= 0.0)
+    if (!std::isfinite(amps.back().amp) || amps.back().amp <= 0.0F)
       break;
   }
   float zero = amps.back().incl;

--- a/cpp/core/dwi/tractography/algorithms/fact.h
+++ b/cpp/core/dwi/tractography/algorithms/fact.h
@@ -136,7 +136,9 @@ protected:
     if (idx < 0)
       return (0.0);
 
-    d = {values[3 * idx], values[3 * idx + 1], values[3 * idx + 2]};
+    d = {values[3 * static_cast<size_t>(idx)],
+         values[3 * static_cast<size_t>(idx) + 1],
+         values[3 * static_cast<size_t>(idx) + 2]};
     d.normalize();
     if (max_dot < 0.0)
       d = -d;

--- a/cpp/core/dwi/tractography/algorithms/iFOD2.h
+++ b/cpp/core/dwi/tractography/algorithms/iFOD2.h
@@ -140,15 +140,15 @@ public:
   iFOD2(const Shared &shared)
       : MethodBase(shared),
         S(shared),
-        source(S.source, S.source_mask),
         mean_sample_num(0),
         num_sample_runs(0),
         num_truncations(0),
         max_truncation(0.0),
-        positions(S.num_samples),
         calib_positions(S.num_samples),
-        tangents(S.num_samples),
         calib_tangents(S.num_samples),
+        source(S.source, S.source_mask),
+        positions(S.num_samples),
+        tangents(S.num_samples),
         sample_idx(S.num_samples) {
     calibrate(*this);
   }
@@ -156,17 +156,17 @@ public:
   iFOD2(const iFOD2 &that)
       : MethodBase(that.S),
         S(that.S),
-        source(S.source, S.source_mask),
         calibrate_ratio(that.calibrate_ratio),
         mean_sample_num(0),
         num_sample_runs(0),
         num_truncations(0),
         max_truncation(0.0),
         calibrate_list(that.calibrate_list),
-        positions(S.num_samples),
         calib_positions(S.num_samples),
-        tangents(S.num_samples),
         calib_tangents(S.num_samples),
+        source(S.source, S.source_mask),
+        positions(S.num_samples),
+        tangents(S.num_samples),
         sample_idx(S.num_samples) {}
 
   ~iFOD2() {
@@ -315,20 +315,24 @@ public:
 
 private:
   const Shared &S;
-  Interpolator<Image<float>>::type source;
+
   float calibrate_ratio, half_log_prob0, last_half_log_probN, half_log_prob0_seed;
   size_t mean_sample_num, num_sample_runs, num_truncations;
   float max_truncation;
   std::vector<Eigen::Vector3f> calibrate_list;
+  std::vector<Eigen::Vector3f> calib_positions;
+  std::vector<Eigen::Vector3f> calib_tangents;
 
+protected:
+  Interpolator<Image<float>>::type source;
   // Store list of points in the currently-calculated arc
-  std::vector<Eigen::Vector3f> positions, calib_positions;
-  std::vector<Eigen::Vector3f> tangents, calib_tangents;
-
+  std::vector<Eigen::Vector3f> positions;
+  std::vector<Eigen::Vector3f> tangents;
   // Generate an arc only when required, and on the majority of next() calls, simply return the next point
   //   in the arc - more dense structural image sampling
   size_t sample_idx;
 
+private:
   FORCE_INLINE float FOD(const Eigen::Vector3f &direction) const {
     return (S.precomputer ? S.precomputer.value(values, direction) : Math::SH::value(values, direction, S.lmax));
   }

--- a/cpp/core/dwi/tractography/algorithms/nulldist.h
+++ b/cpp/core/dwi/tractography/algorithms/nulldist.h
@@ -85,28 +85,16 @@ public:
   public:
     Shared(const std::filesystem::path &diff_path, DWI::Tractography::Properties &property_set)
         : iFOD2::Shared(diff_path, property_set) {
-      set_cutoff(0.0f);
+      set_cutoff(0.0F);
       if (is_act())
         act().set_default_sgm_trunc(ACT::sgm_trunc_t::RANDOM);
       properties["method"] = "Nulldist2";
     }
   };
 
-  NullDist2(const Shared &shared)
-      : iFOD2(shared),
-        S(shared),
-        source(S.source, S.source_mask),
-        positions(S.num_samples),
-        tangents(S.num_samples),
-        sample_idx(S.num_samples) {}
+  NullDist2(const Shared &shared) : iFOD2(shared), S(shared) {}
 
-  NullDist2(const NullDist2 &that)
-      : iFOD2(that),
-        S(that.S),
-        source(S.source, S.source_mask),
-        positions(S.num_samples),
-        tangents(S.num_samples),
-        sample_idx(S.num_samples) {}
+  NullDist2(const NullDist2 &that) : iFOD2(that), S(that.S) {}
 
   bool init() override {
     if (!get_data(source))
@@ -135,24 +123,16 @@ public:
     return std::nullopt;
   }
 
-  void reverse_track() override {
-    sample_idx = S.num_samples;
-    MethodBase::reverse_track();
-  }
+  void reverse_track() override { iFOD2::reverse_track(); }
 
   void truncate_track(GeneratedTrack &tck, const size_t length_to_revert_from, const size_t revert_step) override {
     iFOD2::truncate_track(tck, length_to_revert_from, revert_step);
-    sample_idx = S.num_samples;
   }
 
   float get_metric(const Eigen::Vector3f &, const Eigen::Vector3f &) override { return uniform(rng); }
 
 protected:
   const Shared &S;
-  Interpolator<Image<float>>::type source;
-
-  std::vector<Eigen::Vector3f> positions, tangents;
-  size_t sample_idx;
 };
 
 } // namespace MR::DWI::Tractography::Algorithms

--- a/cpp/core/dwi/tractography/algorithms/tensor_det.h
+++ b/cpp/core/dwi/tractography/algorithms/tensor_det.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "eigen_plugins/eigen_plugins.h"
 // These lines are to silence deprecation warnings with Eigen & GCC v5
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"

--- a/cpp/core/dwi/tractography/connectome/exemplar.h
+++ b/cpp/core/dwi/tractography/connectome/exemplar.h
@@ -34,16 +34,16 @@ public:
            const size_t length,
            const NodePair &nodes,
            const std::pair<point_type, point_type> &COMs)
-      : Tractography::Streamline<float>(length, {0.0f, 0.0f, 0.0f}),
+      : Tractography::Streamline<float>(length, {0.0F, 0.0F, 0.0F}),
         nodes(nodes),
         node_COMs(COMs),
         is_finalized(false) {
     set_index(exemplar_index);
-    weight = 0.0f;
+    weight = 0.0F;
   }
 
   Exemplar(Exemplar &&that)
-      : Tractography::Streamline<float>(std::move(that)),
+      : Tractography::Streamline<float>(std::move(static_cast<Tractography::Streamline<float> &&>(that))),
         mutex(),
         nodes(that.nodes),
         node_COMs(that.node_COMs),

--- a/cpp/core/dwi/tractography/connectome/metric.h
+++ b/cpp/core/dwi/tractography/connectome/metric.h
@@ -72,10 +72,14 @@ public:
     else if (scale_by_invlength)
       result = (tck.size() > 1 ? (result / Tractography::length(tck)) : 0.0);
     if (scale_by_file) {
-      assert(file_values.has_value());
-      if (tck.get_index() >= static_cast<size_t>(file_values->size()))
-        throw Exception("File " + file_path->string() + " does not contain enough entries for this tractogram");
-      result *= (*file_values)[tck.get_index()];
+      if (file_values.has_value()) {
+        if (tck.get_index() >= static_cast<size_t>(file_values->size()))
+          throw Exception("File " + file_path->string() + " does not contain enough entries for this tractogram");
+        result *= (*file_values)[tck.get_index()];
+      } else {
+        assert(false);
+        result = std::numeric_limits<double>::signaling_NaN();
+      }
     }
     return result;
   }

--- a/cpp/core/dwi/tractography/connectome/metric.h
+++ b/cpp/core/dwi/tractography/connectome/metric.h
@@ -72,10 +72,10 @@ public:
     else if (scale_by_invlength)
       result = (tck.size() > 1 ? (result / Tractography::length(tck)) : 0.0);
     if (scale_by_file) {
-      if (file_values.has_value()) {
-        if (tck.get_index() >= static_cast<size_t>(file_values->size()))
-          throw Exception("File " + file_path->string() + " does not contain enough entries for this tractogram");
-        result *= (*file_values)[tck.get_index()];
+      if (by_file.has_value()) {
+        if (tck.get_index() >= static_cast<size_t>(by_file->values.size()))
+          throw Exception("File " + by_file->path.string() + " does not contain enough entries for this tractogram");
+        result *= by_file->values[tck.get_index()];
       } else {
         assert(false);
         result = std::numeric_limits<double>::signaling_NaN();
@@ -110,19 +110,22 @@ public:
   void set_scale_file(const std::filesystem::path &path, const bool i = true) {
     scale_by_file = i;
     if (!i) {
-      file_path.reset();
-      file_values.reset();
+      by_file.reset();
       return;
     }
-    file_path.emplace(path);
-    file_values.emplace(File::Matrix::load_vector(path));
+    by_file.emplace(path);
   }
 
 private:
   bool scale_by_length, scale_by_invlength, scale_by_invnodevol, scale_by_file;
   Eigen::VectorXd node_volumes;
-  std::optional<std::filesystem::path> file_path;
-  std::optional<Eigen::VectorXd> file_values;
+
+  struct ByFile {
+    std::filesystem::path path;
+    Eigen::VectorXd values;
+    ByFile(const std::filesystem::path &path) : path(path), values(File::Matrix::load_vector(path)) {}
+  };
+  std::optional<ByFile> by_file;
 };
 
 } // namespace MR::DWI::Tractography::Connectome

--- a/cpp/core/dwi/tractography/connectome/metric.h
+++ b/cpp/core/dwi/tractography/connectome/metric.h
@@ -16,10 +16,13 @@
 
 #pragma once
 
+#include <cstddef>
 #include <filesystem>
+#include <limits>
 #include <optional>
 
 #include "algo/loop.h"
+#include "exception.h"
 #include "file/matrix.h"
 #include "image.h"
 #include "interp/linear.h"

--- a/cpp/core/dwi/tractography/connectome/tck2nodes.cpp
+++ b/cpp/core/dwi/tractography/connectome/tck2nodes.cpp
@@ -102,7 +102,8 @@ node_t Tck2nodes_revsearch::select_node(const Tractography::Streamline<> &tck, I
       if (this_node)
         return this_node;
     }
-    if (max_dist && ((dist += (tck[index] - tck[index + step]).norm()) > max_dist))
+    dist += (tck[index] - tck[index + step]).norm();
+    if (max_dist != 0.0 && dist > max_dist)
       return 0;
   }
 

--- a/cpp/core/dwi/tractography/editing/editing.cpp
+++ b/cpp/core/dwi/tractography/editing/editing.cpp
@@ -16,6 +16,8 @@
 
 #include "dwi/tractography/editing/editing.h"
 
+#include "exception.h"
+
 namespace MR::DWI::Tractography::Editing {
 
 using namespace App;

--- a/cpp/core/dwi/tractography/editing/editing.cpp
+++ b/cpp/core/dwi/tractography/editing/editing.cpp
@@ -60,7 +60,8 @@ void load_properties(Tractography::Properties &properties) {
       try {
         const float maxlength = std::min(static_cast<float>(opt[0][0]), to<float>(properties["max_dist"]));
         properties["max_dist"] = str(maxlength);
-      } catch (...) {
+      } catch (Exception &) {
+        DEBUG("Corrupted pre-existing property field \"max_dist\"; applying user request as-is");
         properties["max_dist"] = static_cast<std::string>(opt[0][0]);
       }
     }
@@ -73,7 +74,8 @@ void load_properties(Tractography::Properties &properties) {
       try {
         const float minlength = std::max(static_cast<float>(opt[0][0]), to<float>(properties["min_dist"]));
         properties["min_dist"] = str(minlength);
-      } catch (...) {
+      } catch (Exception &) {
+        DEBUG("Corrupted pre-existing property field \"min_dist\"; applying user request as-is");
         properties["min_dist"] = static_cast<std::string>(opt[0][0]);
       }
     }

--- a/cpp/core/dwi/tractography/editing/worker.cpp
+++ b/cpp/core/dwi/tractography/editing/worker.cpp
@@ -16,6 +16,7 @@
 
 #include "dwi/tractography/editing/worker.h"
 
+#include "eigen_plugins/eigen_plugins.h"
 #include <Eigen/Dense>
 #include <cstddef>
 

--- a/cpp/core/dwi/tractography/editing/worker.cpp
+++ b/cpp/core/dwi/tractography/editing/worker.cpp
@@ -16,6 +16,11 @@
 
 #include "dwi/tractography/editing/worker.h"
 
+#include <Eigen/Dense>
+#include <cstddef>
+
+#include "exception.h"
+
 namespace MR::DWI::Tractography::Editing {
 
 bool Worker::operator()(Streamline<> &in, Streamline<> &out) const {
@@ -37,7 +42,7 @@ bool Worker::operator()(Streamline<> &in, Streamline<> &out) const {
 
       exclude = true;
 
-    } else if (include_visitation.size() || properties.exclude.size()) {
+    } else if (!include_visitation.empty() || !properties.exclude.empty()) {
 
       // Assign to ROIs
       include_visitation.reset();

--- a/cpp/core/dwi/tractography/editing/worker.cpp
+++ b/cpp/core/dwi/tractography/editing/worker.cpp
@@ -24,47 +24,47 @@ bool Worker::operator()(Streamline<> &in, Streamline<> &out) const {
   out.set_index(in.get_index());
   out.weight = in.weight;
 
-  // Need to track exclusion separately, since we may still need to apply
-  //   mask (or, more accurately, their inverse) afterwards if -inverse is specified
-  bool exclude = false;
+  // Need to track exclusion separately, since we may still need to apply mask
+  //   (or, more accurately, their inverse) afterwards if -inverse is specified
+  bool exclude = !thresholds(in);
 
-  if (!thresholds(in)) {
-    exclude = true;
-  } else if (include_visitation.size() || properties.exclude.size()) {
-
-    // Assign to ROIs
-    include_visitation.reset();
-
-    if (ends_only) {
-      for (size_t i = 0; i != 2; ++i) {
-        const Eigen::Vector3f &p(i ? in.back() : in.front());
-        include_visitation(p);
-        if (properties.exclude.contains(p)) {
-          exclude = true;
-          break;
-        }
-      }
-    } else {
-      for (const auto &p : in) {
-        include_visitation(p);
-        if (properties.exclude.contains(p)) {
-          exclude = true;
-          break;
-        }
-      }
-    }
-
-    // Make sure all of the include regions were visited
-    if (!include_visitation)
-      exclude = true;
-
-  } else if (inverse) {
-
+  if (!exclude) {
     // If no thresholds are specified, and no include / exclude ROIs are defined, then
     //   it's still possible that one or more masks have been provided;
     //   if this is the case, then we want to continue processing this streamline,
     //   regardless of whether or not -inverse has been specified
-    exclude = true;
+    if (include_visitation.empty() && properties.exclude.empty() && inverse) {
+
+      exclude = true;
+
+    } else if (include_visitation.size() || properties.exclude.size()) {
+
+      // Assign to ROIs
+      include_visitation.reset();
+
+      if (ends_only) {
+        for (size_t i = 0; i != 2; ++i) {
+          const Eigen::Vector3f &p(i ? in.back() : in.front());
+          include_visitation(p);
+          if (properties.exclude.contains(p)) {
+            exclude = true;
+            break;
+          }
+        }
+      } else {
+        for (const auto &p : in) {
+          include_visitation(p);
+          if (properties.exclude.contains(p)) {
+            exclude = true;
+            break;
+          }
+        }
+      }
+
+      // Make sure all of the include regions were visited
+      if (!include_visitation)
+        exclude = true;
+    }
   }
 
   // In default usage, pass the empty track down the queue if track is excluded
@@ -115,20 +115,22 @@ bool Worker::operator()(Streamline<> &in, Streamline<> &out) const {
 
 Worker::Thresholds::Thresholds(Tractography::Properties &properties)
     : max_length(std::numeric_limits<float>::infinity()),
-      min_length(0.0f),
+      min_length(0.0F),
       max_weight(std::numeric_limits<float>::infinity()),
-      min_weight(0.0f),
+      min_weight(0.0F),
       step_size(properties.get_stepsize()) {
   if (properties.find("max_dist") != properties.end()) {
     try {
       max_length = to<float>(properties["max_dist"]);
-    } catch (...) {
+    } catch (Exception &) {
+      WARN("Ignoring corrupt key-value \"max_dist\"");
     }
   }
   if (properties.find("min_dist") != properties.end()) {
     try {
       min_length = to<float>(properties["min_dist"]);
-    } catch (...) {
+    } catch (Exception &) {
+      WARN("Ignoring corrupt key-value \"min_dist\"");
     }
   }
 

--- a/cpp/core/dwi/tractography/file.h
+++ b/cpp/core/dwi/tractography/file.h
@@ -207,7 +207,7 @@ public:
     format_point(barrier(), x);
     out.write(reinterpret_cast<const char *>(&x[0]), sizeof(x)); // check_syntax off
     if (!out.good())
-      throw Exception("error writing tracks file \"" + path.string() + "\": " + strerror(errno));
+      throw Exception("error writing tracks file \"" + path.string() + "\": " + MR::C_strerror(errno));
     open_success = true;
 
     auto opt = App::get_options("tck_weights_out");
@@ -267,7 +267,7 @@ protected:
     File::OFStream out(weights_path, std::ios::in | std::ios::out | std::ios::binary | std::ios::ate);
     out << contents;
     if (!out.good())
-      throw Exception("error writing streamline weights file \"" + weights_path.string() + "\": " + strerror(errno));
+      throw Exception("error writing streamline weights file \"" + weights_path.string() + "\": " + MR::C_strerror(errno));
   }
 
   //! write track point data to file

--- a/cpp/core/dwi/tractography/file.h
+++ b/cpp/core/dwi/tractography/file.h
@@ -17,12 +17,14 @@
 #pragma once
 
 #include <array>
+#include <cerrno>
 #include <map>
 
 #include "app.h"
 #include "dwi/tractography/file_base.h"
 #include "dwi/tractography/properties.h"
 #include "dwi/tractography/streamline.h"
+#include "exception.h"
 #include "file/config.h"
 #include "file/key_value.h"
 #include "file/matrix.h"

--- a/cpp/core/dwi/tractography/file.h
+++ b/cpp/core/dwi/tractography/file.h
@@ -45,7 +45,7 @@ public:
 };
 
 //! A class to read streamlines data
-template <class ValueType = float> class Reader : public __ReaderBase__, public ReaderInterface<ValueType> {
+template <class ValueType = float> class Reader : public ReaderBase, public ReaderInterface<ValueType> {
 public:
   //! open the \c file for reading and load header into \c properties
   Reader(const std::filesystem::path &path, Properties &properties) {
@@ -106,9 +106,9 @@ public:
   }
 
 protected:
-  using __ReaderBase__::current_index;
-  using __ReaderBase__::dtype;
-  using __ReaderBase__::in;
+  using ReaderBase::current_index;
+  using ReaderBase::dtype;
+  using ReaderBase::in;
 
   Eigen::Matrix<ValueType, Eigen::Dynamic, 1> weights;
 
@@ -170,21 +170,21 @@ protected:
  * written at a time), the Writer class is more appropriate.
  * */
 template <class ValueType = float>
-class WriterUnbuffered : public __WriterBase__<ValueType>, public WriterInterface<ValueType> {
+class WriterUnbuffered : public WriterBase<ValueType>, public WriterInterface<ValueType> {
 public:
-  using __WriterBase__<ValueType>::count;
-  using __WriterBase__<ValueType>::total_count;
-  using __WriterBase__<ValueType>::path;
-  using __WriterBase__<ValueType>::dtype;
-  using __WriterBase__<ValueType>::create;
-  using __WriterBase__<ValueType>::verify_stream;
-  using __WriterBase__<ValueType>::update_counts;
-  using __WriterBase__<ValueType>::open_success;
+  using WriterBase<ValueType>::count;
+  using WriterBase<ValueType>::total_count;
+  using WriterBase<ValueType>::path;
+  using WriterBase<ValueType>::dtype;
+  using WriterBase<ValueType>::create;
+  using WriterBase<ValueType>::verify_stream;
+  using WriterBase<ValueType>::update_counts;
+  using WriterBase<ValueType>::open_success;
 
   using vector_type = Eigen::Matrix<ValueType, 3, 1>;
 
   //! create a new track file with the specified properties
-  WriterUnbuffered(const std::filesystem::path &path, const Properties &properties) : __WriterBase__<ValueType>(path) {
+  WriterUnbuffered(const std::filesystem::path &path, const Properties &properties) : WriterBase<ValueType>(file) {
 
     if (path.extension() != ".tck")
       throw Exception("output track files must use the .tck suffix");
@@ -310,8 +310,8 @@ protected:
  * */
 template <typename ValueType = float> class Writer : public WriterUnbuffered<ValueType> {
 public:
-  using __WriterBase__<ValueType>::count;
-  using __WriterBase__<ValueType>::total_count;
+  using WriterBase<ValueType>::count;
+  using WriterBase<ValueType>::total_count;
   using WriterUnbuffered<ValueType>::delimiter;
   using WriterUnbuffered<ValueType>::format_point;
   using WriterUnbuffered<ValueType>::weights_path;
@@ -338,7 +338,13 @@ public:
   Writer(const Writer &W) = delete;
 
   //! commits any remaining data to file
-  ~Writer() { commit(); }
+  ~Writer() {
+    try {
+      commit();
+    } catch (Exception &e) {
+      Exception(e, "Tractography file not properly finalised").display();
+    }
+  }
 
   //! append track to file
   bool operator()(const Streamline<ValueType> &tck) {

--- a/cpp/core/dwi/tractography/file.h
+++ b/cpp/core/dwi/tractography/file.h
@@ -184,7 +184,7 @@ public:
   using vector_type = Eigen::Matrix<ValueType, 3, 1>;
 
   //! create a new track file with the specified properties
-  WriterUnbuffered(const std::filesystem::path &path, const Properties &properties) : WriterBase<ValueType>(file) {
+  WriterUnbuffered(const std::filesystem::path &path, const Properties &properties) : WriterBase<ValueType>(path) {
 
     if (path.extension() != ".tck")
       throw Exception("output track files must use the .tck suffix");
@@ -267,7 +267,8 @@ protected:
     File::OFStream out(weights_path, std::ios::in | std::ios::out | std::ios::binary | std::ios::ate);
     out << contents;
     if (!out.good())
-      throw Exception("error writing streamline weights file \"" + weights_path.string() + "\": " + MR::C_strerror(errno));
+      throw Exception("error writing streamline weights file \"" + weights_path.string() + "\": " + //
+                      MR::C_strerror(errno));
   }
 
   //! write track point data to file

--- a/cpp/core/dwi/tractography/file_base.cpp
+++ b/cpp/core/dwi/tractography/file_base.cpp
@@ -16,6 +16,11 @@
 
 #include "dwi/tractography/file_base.h"
 
+#include <cerrno>
+#include <filesystem>
+#include <string_view>
+
+#include "dwi/tractography/properties.h"
 #include "exception.h"
 #include "file/path.h"
 

--- a/cpp/core/dwi/tractography/file_base.cpp
+++ b/cpp/core/dwi/tractography/file_base.cpp
@@ -19,7 +19,7 @@
 
 namespace MR::DWI::Tractography {
 
-void __ReaderBase__::open(const std::filesystem::path &file, std::string_view type, Properties &properties) {
+void ReaderBase::open(const std::filesystem::path &file, std::string_view type, Properties &properties) {
   properties.clear();
   dtype = DataType::Undefined;
 

--- a/cpp/core/dwi/tractography/file_base.cpp
+++ b/cpp/core/dwi/tractography/file_base.cpp
@@ -15,6 +15,8 @@
  */
 
 #include "dwi/tractography/file_base.h"
+
+#include "exception.h"
 #include "file/path.h"
 
 namespace MR::DWI::Tractography {

--- a/cpp/core/dwi/tractography/file_base.cpp
+++ b/cpp/core/dwi/tractography/file_base.cpp
@@ -80,7 +80,7 @@ void __ReaderBase__::open(const std::filesystem::path &file, std::string_view ty
 
   in.open(fname, std::ios::in | std::ios::binary);
   if (!in)
-    throw Exception("error opening " + type + " data file \"" + fname.string() + "\": " + strerror(errno));
+    throw Exception("error opening " + type + " data file \"" + fname.string() + "\": " + MR::C_strerror(errno));
   in.seekg(offset);
 }
 

--- a/cpp/core/dwi/tractography/file_base.h
+++ b/cpp/core/dwi/tractography/file_base.h
@@ -18,11 +18,13 @@
 
 #include <filesystem>
 #include <iomanip>
+#include <ios>
 #include <map>
 #include <set>
 #include <string_view>
 
 #include "dwi/tractography/properties.h"
+#include "exception.h"
 #include "file/key_value.h"
 #include "file/ofstream.h"
 #include "file/path.h"
@@ -66,7 +68,7 @@ public:
   ~WriterBase() noexcept {
     if (open_success) {
       try {
-        File::OFStream out(path, std::ios::in | std::ios::out | std::ios::binary);
+        File::OFStream out(path, std::ios_base::in | std::ios_base::out | std::ios_base::binary);
         update_counts(out);
       } catch (Exception &e) {
         e.display();

--- a/cpp/core/dwi/tractography/file_base.h
+++ b/cpp/core/dwi/tractography/file_base.h
@@ -20,6 +20,7 @@
 #include <iomanip>
 #include <map>
 #include <set>
+#include <string_view>
 
 #include "dwi/tractography/properties.h"
 #include "file/key_value.h"

--- a/cpp/core/dwi/tractography/file_base.h
+++ b/cpp/core/dwi/tractography/file_base.h
@@ -30,10 +30,10 @@
 namespace MR::DWI::Tractography {
 
 //! \cond skip
-class __ReaderBase__ {
+class ReaderBase {
 public:
-  __ReaderBase__() : current_index(0) {}
-  ~__ReaderBase__() {
+  ReaderBase() : current_index(0) {}
+  ~ReaderBase() {
     if (in.is_open())
       in.close();
   }
@@ -48,11 +48,11 @@ protected:
   uint64_t current_index;
 };
 
-template <typename ValueType = float> class __WriterBase__ {
+template <typename ValueType = float> class WriterBase {
 public:
   using value_type = ValueType;
 
-  __WriterBase__(const std::filesystem::path &path)
+  WriterBase(const std::filesystem::path &path)
       : count(0), total_count(0), path(path), dtype(DataType::from<ValueType>()), count_offset(0), open_success(false) {
     dtype.set_byte_order_native();
     if (dtype != DataType::Float32LE && dtype != DataType::Float32BE && dtype != DataType::Float64LE &&
@@ -62,10 +62,14 @@ public:
     App::check_overwrite(path);
   }
 
-  ~__WriterBase__() {
+  ~WriterBase() noexcept {
     if (open_success) {
-      File::OFStream out(path, std::ios::in | std::ios::out | std::ios::binary);
-      update_counts(out);
+      try {
+        File::OFStream out(path, std::ios::in | std::ios::out | std::ios::binary);
+        update_counts(out);
+      } catch (Exception &e) {
+        e.display();
+      }
     }
   }
 

--- a/cpp/core/dwi/tractography/file_base.h
+++ b/cpp/core/dwi/tractography/file_base.h
@@ -118,7 +118,7 @@ protected:
 
   void verify_stream(const File::OFStream &out) {
     if (!out.good())
-      throw Exception("error writing file \"" + path.string() + "\": " + strerror(errno));
+      throw Exception("error writing file \"" + path.string() + "\": " + MR::C_strerror(errno));
   }
 
   void update_counts(File::OFStream &out) {

--- a/cpp/core/dwi/tractography/mapping/mapper.cpp
+++ b/cpp/core/dwi/tractography/mapping/mapper.cpp
@@ -158,7 +158,7 @@ void TrackMapperTWI::set_factor(const Streamline<> &tck, SetVoxelExtras &out) co
   }
 
   if (contrast == contrast_t::SCALAR_MAP_COUNT)
-    out.factor = (out.factor ? 1.0 : 0.0);
+    out.factor = (out.factor != 0.0 ? 1.0 : 0.0);
 
   if (!std::isfinite(out.factor))
     out.factor = 0.0;

--- a/cpp/core/dwi/tractography/properties.cpp
+++ b/cpp/core/dwi/tractography/properties.cpp
@@ -16,6 +16,10 @@
 
 #include "dwi/tractography/properties.h"
 
+#include <cmath>
+
+#include "exception.h"
+
 namespace MR::DWI::Tractography {
 
 void Properties::set_timestamp() { (*this)["timestamp"] = str(Timer::current_time(), file_timestamp_precision); }

--- a/cpp/core/dwi/tractography/properties.cpp
+++ b/cpp/core/dwi/tractography/properties.cpp
@@ -49,7 +49,8 @@ float Properties::get_stepsize() const {
   if (it != KeyValues::end()) {
     try {
       return to<float>(it->second);
-    } catch (...) {
+    } catch (Exception &) {
+      DEBUG("Corrupt tractography property \"step_size\"; ignoring");
     }
   }
   return NaNF;
@@ -57,7 +58,7 @@ float Properties::get_stepsize() const {
 
 void Properties::compare_stepsize_rois() const {
   const float step_size = get_stepsize();
-  if (!std::isfinite(step_size) || !step_size)
+  if (!std::isfinite(step_size) || step_size == 0.0F)
     return;
 
   auto f = [](const ROISetBase &rois, std::string_view type, const float threshold) {

--- a/cpp/core/dwi/tractography/resampling/fixed_step_size.cpp
+++ b/cpp/core/dwi/tractography/resampling/fixed_step_size.cpp
@@ -63,7 +63,7 @@ bool FixedStepSize::operator()(const Streamline<> &in, Streamline<> &out) const 
         // Perform binary search
         point_type p_lower = temp[index], p, p_upper = temp[index + step];
         value_type mu_upper = value_type(1);
-        value_type mu = value_type(0.5) * (mu_lower + mu_upper);
+        value_type mu = std::numeric_limits<value_type>::quiet_NaN();
         do {
           mu = value_type(0.5) * (mu_lower + mu_upper);
           interp.set(mu);

--- a/cpp/core/dwi/tractography/resampling/resampling.h
+++ b/cpp/core/dwi/tractography/resampling/resampling.h
@@ -34,8 +34,10 @@ using point_type = typename Streamline<>::point_type;
 constexpr value_type hermite_tension = value_type(0.1);
 
 class Base {
-public:
+protected:
   Base() {}
+
+public:
   virtual ~Base() {}
 
   virtual Base *clone() const = 0;
@@ -44,6 +46,10 @@ public:
 };
 
 template <class Derived> class BaseCRTP : public Base {
+protected:
+  // NOLINTNEXTLINE(bugprone-crtp-constructor-accessibility)
+  BaseCRTP() = default;
+
 public:
   virtual Base *clone() const { return new Derived(static_cast<Derived const &>(*this)); }
 };

--- a/cpp/core/dwi/tractography/roi.h
+++ b/cpp/core/dwi/tractography/roi.h
@@ -205,6 +205,7 @@ public:
   IncludeROIVisitation(const IncludeROIVisitation &) = default;
   IncludeROIVisitation &operator=(const IncludeROIVisitation &) = delete;
 
+  bool empty() const { return unordered.empty() && ordered.empty(); }
   void reset() {
     visited.setZero();
     state.reset();

--- a/cpp/core/dwi/tractography/scalar_file.h
+++ b/cpp/core/dwi/tractography/scalar_file.h
@@ -146,7 +146,13 @@ public:
     current_offset = out.tellp();
   }
 
-  ~ScalarWriter() { commit(); }
+  ~ScalarWriter() {
+    try {
+      commit();
+    } catch (Exception &e) {
+      Exception(e, "Tractography scalar file not properly finalised").display();
+    }
+  }
 
   bool operator()(const TrackScalar<T> &tck_scalar) {
     if (buffer_size + tck_scalar.size() > buffer_capacity)

--- a/cpp/core/dwi/tractography/scalar_file.h
+++ b/cpp/core/dwi/tractography/scalar_file.h
@@ -28,7 +28,7 @@
 
 namespace MR::DWI::Tractography {
 
-template <typename T = float> class ScalarReader : public __ReaderBase__ {
+template <typename T = float> class ScalarReader : public ReaderBase {
 public:
   using value_type = T;
 
@@ -62,9 +62,9 @@ public:
   }
 
 protected:
-  using __ReaderBase__::current_index;
-  using __ReaderBase__::dtype;
-  using __ReaderBase__::in;
+  using ReaderBase::current_index;
+  using ReaderBase::dtype;
+  using ReaderBase::in;
 
   value_type get_next_scalar() {
     using namespace ByteOrder;
@@ -113,21 +113,21 @@ protected:
  * 16MB, and can be set in the config file using the
  * TrackWriterBufferSize field (in bytes).
  * */
-template <typename T = float> class ScalarWriter : public __WriterBase__<T> {
+template <typename T = float> class ScalarWriter : public WriterBase<T> {
 public:
   using value_type = T;
-  using __WriterBase__<T>::count;
-  using __WriterBase__<T>::count_offset;
-  using __WriterBase__<T>::total_count;
-  using __WriterBase__<T>::path;
-  using __WriterBase__<T>::dtype;
-  using __WriterBase__<T>::create;
-  using __WriterBase__<T>::update_counts;
-  using __WriterBase__<T>::verify_stream;
-  using __WriterBase__<T>::open_success;
+  using WriterBase<T>::count;
+  using WriterBase<T>::count_offset;
+  using WriterBase<T>::total_count;
+  using WriterBase<T>::path;
+  using WriterBase<T>::dtype;
+  using WriterBase<T>::create;
+  using WriterBase<T>::update_counts;
+  using WriterBase<T>::verify_stream;
+  using WriterBase<T>::open_success;
 
   ScalarWriter(const std::filesystem::path &path, const Properties &properties)
-      : __WriterBase__<T>(path),
+      : WriterBase<T>(path),
         buffer_capacity(File::Config::get_int("TrackWriterBufferSize", 16777216) / sizeof(value_type)),
         buffer(new value_type[buffer_capacity + 1]),
         buffer_size(0) {

--- a/cpp/core/dwi/tractography/seeding/list.cpp
+++ b/cpp/core/dwi/tractography/seeding/list.cpp
@@ -60,9 +60,11 @@ bool List::get_seed(Eigen::Vector3f &p, Eigen::Vector3f &d) {
     do {
       float incrementer = 0.0;
       const float sample = uniform(rng) * total_volume;
-      for (auto &i : seeders)
-        if ((incrementer += i->vol()) > sample)
+      for (auto &i : seeders) {
+        incrementer += i->vol();
+        if (incrementer > sample)
           return i->get_seed(p, d);
+      }
 
     } while (1);
     return false;

--- a/cpp/core/dwi/tractography/streamline.h
+++ b/cpp/core/dwi/tractography/streamline.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <limits>
+#include <utility>
 
 #include "types.h"
 

--- a/cpp/core/dwi/tractography/streamline.h
+++ b/cpp/core/dwi/tractography/streamline.h
@@ -81,15 +81,17 @@ public:
   Streamline &operator=(const Streamline &that) = default;
 
   Streamline(Streamline &&that)
-      : std::vector<point_type>(std::move(that)), DataIndex(std::move(that)), weight(that.weight) {
-    that.weight = 1.0f;
+      : std::vector<point_type>(std::move(static_cast<std::vector<point_type> &&>(that))),
+        DataIndex(std::move(static_cast<DataIndex &&>(that))),
+        weight(that.weight) {
+    that.weight = std::numeric_limits<float>::quiet_NaN();
   }
 
   Streamline(const std::vector<point_type> &tck) : std::vector<point_type>(tck), DataIndex(), weight(1.0) {}
 
   Streamline &operator=(Streamline &&that) {
-    std::vector<point_type>::operator=(std::move(that));
-    DataIndex::operator=(std::move(that));
+    std::vector<point_type>::operator=(std::move(static_cast<std::vector<point_type> &&>(that)));
+    DataIndex::operator=(std::move(static_cast<DataIndex &&>(that)));
     weight = that.weight;
     that.weight = 0.0f;
     return *this;

--- a/cpp/core/dwi/tractography/tracking/early_exit.h
+++ b/cpp/core/dwi/tractography/tracking/early_exit.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "eigen_plugins/eigen_plugins.h"
 #include <Eigen/Core>
 
 #if EIGEN_VERSION_AT_LEAST(3, 3, 0)

--- a/cpp/core/dwi/tractography/tracking/exec.h
+++ b/cpp/core/dwi/tractography/tracking/exec.h
@@ -417,8 +417,8 @@ private:
       if (method.act().fetch_tissue_data(i)) {
         const float wm = method.act().tissues().get_wm();
         max_value = std::max(max_value, wm);
-        if (((integral += (Math::pow2(wm) * S.internal_step_size())) > ACT::wm_pathintegral_threshold) &&
-            (max_value > ACT::wm_maxabs_threshold))
+        integral += Math::pow2(wm) * S.internal_step_size();
+        if ((integral > ACT::wm_pathintegral_threshold) && (max_value > ACT::wm_maxabs_threshold))
           return true;
       }
     }

--- a/cpp/core/dwi/tractography/tracking/shared.cpp
+++ b/cpp/core/dwi/tractography/tracking/shared.cpp
@@ -254,6 +254,7 @@ void SharedBase::add_termination(const term_t i, const Eigen::Vector3f &p) const
 #endif
 
 bool SharedBase::termination_relevant(const term_t i) const {
+  // NOLINTBEGIN(bugprone-branch-clone)
   switch (i) {
   case term_t::ENTER_CGM:
     return is_act();
@@ -280,10 +281,12 @@ bool SharedBase::termination_relevant(const term_t i) const {
   case term_t::TRAVERSE_ALL_INCLUDE:
     return stop_on_all_include;
   }
+  // NOLINTEND(bugprone-branch-clone)
   return false;
 }
 
 bool SharedBase::rejection_relevant(const reject_t i) const {
+  // NOLINTBEGIN(bugprone-branch-clone)
   switch (i) {
   case reject_t::INVALID_SEED:
     return true;
@@ -302,6 +305,7 @@ bool SharedBase::rejection_relevant(const reject_t i) const {
   case reject_t::ACT_FAILED_WM_REQUIREMENT:
     return is_act();
   }
+  // NOLINTEND(bugprone-branch-clone)
   return false;
 }
 

--- a/cpp/core/eigen_plugins/eigen_plugins.h
+++ b/cpp/core/eigen_plugins/eigen_plugins.h
@@ -14,14 +14,16 @@
  * For more details, see http://www.mrtrix.org/.
  */
 
-#pragma once
-
-#include "eigen_plugins/eigen_plugins.h"
-#include <Eigen/Dense>
-
-namespace MR::DWI::Directions {
-
-using index_type = unsigned int;
-using mask_type = Eigen::Array<bool, Eigen::Dynamic, 1>;
-
-} // namespace MR::DWI::Directions
+namespace MR::Helper {
+template <class ImageType> class ConstRow;
+template <class ImageType> class Row;
+} // namespace MR::Helper
+#define EIGEN_DENSEBASE_PLUGIN "eigen_plugins/dense_base.h"  // check_syntax off
+#define EIGEN_MATRIXBASE_PLUGIN "eigen_plugins/dense_base.h" // check_syntax off
+#define EIGEN_ARRAYBASE_PLUGIN "eigen_plugins/dense_base.h"  // check_syntax off
+#define EIGEN_MATRIX_PLUGIN "eigen_plugins/matrix.h"         // check_syntax off
+#define EIGEN_ARRAY_PLUGIN "eigen_plugins/array.h"           // check_syntax off
+#include <Eigen/Geometry>
+#ifdef EIGEN_HAS_OPENMP
+#undef EIGEN_HAS_OPENMP
+#endif

--- a/cpp/core/enum.h
+++ b/cpp/core/enum.h
@@ -118,12 +118,10 @@ public:
 
   size_t get(EnumType value) const noexcept {
     const auto index = magic_enum::enum_index(value);
-    if (index.has_value()) {
+    if (index.has_value())
       return counters[index.value()].value.load(std::memory_order_seq_cst);
-    } else {
-      assert(false);
-      return size_t(-1);
-    }
+    assert(false);
+    return size_t(-1);
   }
 
   size_t total() const noexcept {

--- a/cpp/core/enum.h
+++ b/cpp/core/enum.h
@@ -108,11 +108,22 @@ public:
   static constexpr size_t size() noexcept { return N; }
 
   void add(EnumType value, size_t increment = 1) const noexcept {
-    counters[*magic_enum::enum_index(value)].value.fetch_add(increment, std::memory_order_relaxed);
+    const auto index = magic_enum::enum_index(value);
+    if (index.has_value()) {
+      counters[index.value()].value.fetch_add(increment, std::memory_order_relaxed);
+    } else {
+      assert(false);
+    }
   }
 
   size_t get(EnumType value) const noexcept {
-    return counters[*magic_enum::enum_index(value)].value.load(std::memory_order_seq_cst);
+    const auto index = magic_enum::enum_index(value);
+    if (index.has_value()) {
+      return counters[index.value()].value.load(std::memory_order_seq_cst);
+    } else {
+      assert(false);
+      return size_t(-1);
+    }
   }
 
   size_t total() const noexcept {

--- a/cpp/core/env.h
+++ b/cpp/core/env.h
@@ -16,9 +16,11 @@
 
 #pragma once
 
+#include <cstdlib>
 #include <mutex>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <type_traits>
 
 #include "mrtrix.h"

--- a/cpp/core/env.h
+++ b/cpp/core/env.h
@@ -1,0 +1,64 @@
+/* Copyright (c) 2008-2026 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Covered Software is provided under this License on an "as is"
+ * basis, without warranty of any kind, either expressed, implied, or
+ * statutory, including, without limitation, warranties that the
+ * Covered Software is free of defects, merchantable, fit for a
+ * particular purpose or non-infringing.
+ * See the Mozilla Public License v. 2.0 for more details.
+ *
+ * For more details, see http://www.mrtrix.org/.
+ */
+
+#pragma once
+
+#include <mutex>
+#include <optional>
+#include <string>
+#include <type_traits>
+
+#include "mrtrix.h"
+
+namespace MR {
+
+/// \brief Thread-safe wrapper around \c std::getenv().
+/// \param name the name of the environment variable to query.
+/// \return the value of the environment variable,
+///   or an empty optional if the variable is not set.
+inline std::optional<std::string> get_env(std::string_view name) {
+  static std::mutex mutex;
+  const std::lock_guard<std::mutex> lock(mutex);
+  const char *const value = std::getenv(std::string(name).c_str()); // check_syntax off
+  if (value == nullptr)
+    return std::nullopt;
+  return std::string(value);
+}
+
+/// \brief Thread-safe wrapper around \c std::getenv() with a string default value.
+/// \param name the name of the environment variable to query.
+/// \param default_value the string to return if the variable is not set.
+/// \return the value of the environment variable if set,
+///   or \a default_value converted to \c std::string otherwise.
+inline std::string get_env(std::string_view name, std::string_view default_value) {
+  return get_env(name).value_or(std::string(default_value));
+}
+
+/// \brief Thread-safe wrapper around \c std::getenv() with a typed default value.
+///
+/// If the environment variable is set, its string value is converted to \c T via
+/// \c MR::to<T>().
+/// \param name the name of the environment variable to query.
+/// \param default_value the value to return if the variable is not set.
+/// \return the converted environment variable value if set,
+///   or \a default_value otherwise.
+template <typename T, typename = std::enable_if_t<!std::is_convertible_v<T, std::string_view>>>
+T get_env(std::string_view name, const T &default_value) {
+  const std::optional<std::string> value = get_env(name);
+  return value.has_value() ? to<T>(*value) : default_value;
+}
+
+} // namespace MR

--- a/cpp/core/env.h
+++ b/cpp/core/env.h
@@ -32,6 +32,7 @@ namespace MR {
 inline std::optional<std::string> get_env(std::string_view name) {
   static std::mutex mutex;
   const std::lock_guard<std::mutex> lock(mutex);
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
   const char *const value = std::getenv(std::string(name).c_str()); // check_syntax off
   if (value == nullptr)
     return std::nullopt;

--- a/cpp/core/exception.cpp
+++ b/cpp/core/exception.cpp
@@ -15,8 +15,10 @@
  */
 
 #include <array>
+#include <cerrno>
 #include <cstring>
 #include <mutex>
+#include <string>
 #include <string_view>
 #include <unordered_map>
 

--- a/cpp/core/exception.cpp
+++ b/cpp/core/exception.cpp
@@ -48,7 +48,7 @@ void display_exception_cmdline(const Exception &E, int log_level) {
       report_to_user_func(E.description[n], log_level);
 }
 
-bool __need_newline = false;
+bool _need_newline = false;
 
 void cmdline_report_to_user_func(std::string_view msg, int type) {
 
@@ -61,9 +61,9 @@ void cmdline_report_to_user_func(std::string_view msg, int type) {
   static const std::unordered_map<int, std::string> console_prefixes{
       {-1, ""}, {0, "[ERROR] "}, {1, "[WARNING] "}, {2, "[INFO] "}, {3, "[DEBUG] "}};
 
-  if (__need_newline) {
-    __print_stderr("\n");
-    __need_newline = false;
+  if (_need_newline) {
+    _print_stderr("\n");
+    _need_newline = false;
   }
 
   auto clamp = [](int t) {
@@ -72,10 +72,10 @@ void cmdline_report_to_user_func(std::string_view msg, int type) {
     return t + 1;
   };
 
-  __print_stderr(printf(colour_format_strings.at(App::terminal_use_colour ? type : -1).c_str(),
-                        App::NAME.c_str(),
-                        console_prefixes.at(type).c_str(),
-                        std::string(msg).c_str()));
+  _print_stderr(printf(colour_format_strings.at(App::terminal_use_colour ? type : -1).c_str(),
+                       App::NAME.c_str(),
+                       console_prefixes.at(type).c_str(),
+                       std::string(msg).c_str()));
   if (type == 1 && App::fail_on_warn)
     throw Exception("terminating due to request to fail on warning");
 }

--- a/cpp/core/exception.cpp
+++ b/cpp/core/exception.cpp
@@ -26,6 +26,7 @@
 #include "debug.h"
 #include "exception.h"
 #include "file/config.h"
+#include "mrtrix.h"
 
 #ifdef MRTRIX_AS_R_LIBRARY
 #include "wrap_r.h"
@@ -74,7 +75,7 @@ void cmdline_report_to_user_func(std::string_view msg, int type) {
     return t + 1;
   };
 
-  _print_stderr(printf(colour_format_strings.at(App::terminal_use_colour ? type : -1).c_str(),
+  _print_stderr(printf(colour_format_strings.at(App::terminal_use_colour ? type : -1),
                        App::NAME.c_str(),
                        console_prefixes.at(type).c_str(),
                        std::string(msg).c_str()));

--- a/cpp/core/exception.cpp
+++ b/cpp/core/exception.cpp
@@ -15,6 +15,8 @@
  */
 
 #include <array>
+#include <cstring>
+#include <mutex>
 #include <string_view>
 #include <unordered_map>
 
@@ -25,6 +27,17 @@
 
 #ifdef MRTRIX_AS_R_LIBRARY
 #include "wrap_r.h"
+#endif
+
+#ifdef MRTRIX_HAVE_STRERROR_R
+namespace {
+// Overloads resolve POSIX strerror_r (int return, fills buf) vs
+// GNU strerror_r (char* return, may point to a static string).
+std::string strerror_r_result(int /*errcode*/, const char *buf) { return std::string(buf); } // check_syntax off
+std::string strerror_r_result(const char *result, const char * /*buf*/) {                    // check_syntax off
+  return std::string(result);
+}
+} // namespace
 #endif
 
 namespace MR {
@@ -87,6 +100,21 @@ void (*Exception::display_func)(const Exception &E, int log_level) = display_exc
 void check_app_exit_code() {
   if (App::exit_error_code)
     throw Exception("Command performing delayed termination due to prior critical error");
+}
+
+std::string C_strerror(int errnum) {
+#if defined(MRTRIX_HAVE_STRERROR_R)
+  std::array<char, 256> buf = {};
+  return strerror_r_result(strerror_r(errnum, buf.data(), buf.size()), buf.data()); // check_syntax off
+#elif defined(MRTRIX_WINDOWS)
+  std::array<char, 256> buf = {};
+  strerror_s(buf.data(), buf.size(), errnum);
+  return std::string(buf.data()); // check_syntax off
+#else
+  static std::mutex mutex;
+  const std::lock_guard<std::mutex> lock(mutex);
+  return std::string(std::strerror(errnum)); // NOLINT(concurrency-mt-unsafe) check_syntax off
+#endif
 }
 
 } // namespace MR

--- a/cpp/core/exception.h
+++ b/cpp/core/exception.h
@@ -51,7 +51,7 @@ extern void (*print)(std::string_view msg);
 
 // for internal use only
 
-inline void __print_stderr(std::string_view text) {
+inline void _print_stderr(std::string_view text) {
 #ifdef MRTRIX_AS_R_LIBRARY
   REprintf(std::string(text).c_str());
 #else

--- a/cpp/core/exception.h
+++ b/cpp/core/exception.h
@@ -123,6 +123,11 @@ void display_exception_cmdline(const Exception &E, int log_level);
 void cmdline_print_func(std::string_view msg);
 void cmdline_report_to_user_func(std::string_view msg, int type);
 
+//! thread-safe alternative to strerror()
+/*! Uses strerror_r() when available; otherwise acquires a mutex before
+ * calling strerror(). Always returns the message as a std::string. */
+std::string C_strerror(int errnum);
+
 class LogLevelLatch {
 public:
   LogLevelLatch(const int new_level) : prev_level(App::log_level) { App::log_level = new_level; }

--- a/cpp/core/fetch_store.cpp
+++ b/cpp/core/fetch_store.cpp
@@ -14,6 +14,8 @@
  * For more details, see http://www.mrtrix.org/.
  */
 
+#include <Eigen/src/Core/arch/Default/Half.h>
+#include <cstddef>
 #include <cstdint>
 
 #include "datatype.h"

--- a/cpp/core/fetch_store.cpp
+++ b/cpp/core/fetch_store.cpp
@@ -14,6 +14,9 @@
  * For more details, see http://www.mrtrix.org/.
  */
 
+#include <cstdint>
+
+#include "datatype.h"
 #include "fetch_store.h"
 #include "types.h"
 

--- a/cpp/core/fetch_store.cpp
+++ b/cpp/core/fetch_store.cpp
@@ -14,12 +14,12 @@
  * For more details, see http://www.mrtrix.org/.
  */
 
-#include <Eigen/src/Core/arch/Default/Half.h>
 #include <cstddef>
 #include <cstdint>
 
 #include "datatype.h"
 #include "fetch_store.h"
+#include "half.h"
 #include "types.h"
 
 namespace MR {

--- a/cpp/core/fetch_store.cpp
+++ b/cpp/core/fetch_store.cpp
@@ -99,61 +99,61 @@ inline
 
 // for single-byte types:
 
-template <typename RAMType, typename DiskType> RAMType __fetch(const void *data, size_t i) {
+template <typename RAMType, typename DiskType> RAMType _fetch(const void *data, size_t i) {
   return round_func<RAMType>(Raw::fetch<DiskType>(data, i));
 }
 
-template <typename RAMType, typename DiskType> void __store(RAMType val, void *data, size_t i) {
+template <typename RAMType, typename DiskType> void _store(RAMType val, void *data, size_t i) {
   return Raw::store<DiskType>(round_func<DiskType>(val), data, i);
 }
 
 template <typename RAMType, typename DiskType>
-RAMType __fetch_scale(const void *data, size_t i, default_type offset, default_type scale) {
+RAMType _fetch_scale(const void *data, size_t i, default_type offset, default_type scale) {
   return round_func<RAMType>(scale_from_storage(Raw::fetch<DiskType>(data, i), offset, scale));
 }
 
 template <typename RAMType, typename DiskType>
-void __scale_store(RAMType val, void *data, size_t i, default_type offset, default_type scale) {
+void _scale_store(RAMType val, void *data, size_t i, default_type offset, default_type scale) {
   return Raw::store<DiskType>(round_func<DiskType>(scale_to_storage(val, offset, scale)), data, i);
 }
 
 // for little-endian multi-byte types:
 
-template <typename RAMType, typename DiskType> RAMType __fetch_LE(const void *data, size_t i) {
+template <typename RAMType, typename DiskType> RAMType _fetch_LE(const void *data, size_t i) {
   return round_func<RAMType>(Raw::fetch_LE<DiskType>(data, i));
 }
 
-template <typename RAMType, typename DiskType> void __store_LE(RAMType val, void *data, size_t i) {
+template <typename RAMType, typename DiskType> void _store_LE(RAMType val, void *data, size_t i) {
   return Raw::store_LE<DiskType>(round_func<DiskType>(val), data, i);
 }
 
 template <typename RAMType, typename DiskType>
-RAMType __fetch_scale_LE(const void *data, size_t i, default_type offset, default_type scale) {
+RAMType _fetch_scale_LE(const void *data, size_t i, default_type offset, default_type scale) {
   return round_func<RAMType>(scale_from_storage(Raw::fetch_LE<DiskType>(data, i), offset, scale));
 }
 
 template <typename RAMType, typename DiskType>
-void __scale_store_LE(RAMType val, void *data, size_t i, default_type offset, default_type scale) {
+void _scale_store_LE(RAMType val, void *data, size_t i, default_type offset, default_type scale) {
   return Raw::store_LE<DiskType>(round_func<DiskType>(scale_to_storage(val, offset, scale)), data, i);
 }
 
 // for big-endian multi-byte types:
 
-template <typename RAMType, typename DiskType> RAMType __fetch_BE(const void *data, size_t i) {
+template <typename RAMType, typename DiskType> RAMType _fetch_BE(const void *data, size_t i) {
   return round_func<RAMType>(Raw::fetch_BE<DiskType>(data, i));
 }
 
-template <typename RAMType, typename DiskType> void __store_BE(RAMType val, void *data, size_t i) {
+template <typename RAMType, typename DiskType> void _store_BE(RAMType val, void *data, size_t i) {
   return Raw::store_BE<DiskType>(round_func<DiskType>(val), data, i);
 }
 
 template <typename RAMType, typename DiskType>
-RAMType __fetch_scale_BE(const void *data, size_t i, default_type offset, default_type scale) {
+RAMType _fetch_scale_BE(const void *data, size_t i, default_type offset, default_type scale) {
   return round_func<RAMType>(scale_from_storage(Raw::fetch_BE<DiskType>(data, i), offset, scale));
 }
 
 template <typename RAMType, typename DiskType>
-void __scale_store_BE(RAMType val, void *data, size_t i, default_type offset, default_type scale) {
+void _scale_store_BE(RAMType val, void *data, size_t i, default_type offset, default_type scale) {
   return Raw::store_BE<DiskType>(round_func<DiskType>(scale_to_storage(val, offset, scale)), data, i);
 }
 
@@ -161,58 +161,58 @@ void __scale_store_BE(RAMType val, void *data, size_t i, default_type offset, de
 
 template <typename ValueType>
 typename std::enable_if<is_data_type<ValueType>::value, std::function<ValueType(const void *, size_t)>>::type
-__set_fetch_function(const DataType datatype) {
+_set_fetch_function(const DataType datatype) {
   switch (datatype()) {
   case DataType::Bit:
-    return __fetch<ValueType, bool>;
+    return _fetch<ValueType, bool>;
   case DataType::Int8:
-    return __fetch<ValueType, int8_t>;
+    return _fetch<ValueType, int8_t>;
   case DataType::UInt8:
-    return __fetch<ValueType, uint8_t>;
+    return _fetch<ValueType, uint8_t>;
   case DataType::Int16LE:
-    return __fetch_LE<ValueType, int16_t>;
+    return _fetch_LE<ValueType, int16_t>;
   case DataType::UInt16LE:
-    return __fetch_LE<ValueType, uint16_t>;
+    return _fetch_LE<ValueType, uint16_t>;
   case DataType::Int16BE:
-    return __fetch_BE<ValueType, int16_t>;
+    return _fetch_BE<ValueType, int16_t>;
   case DataType::UInt16BE:
-    return __fetch_BE<ValueType, uint16_t>;
+    return _fetch_BE<ValueType, uint16_t>;
   case DataType::Int32LE:
-    return __fetch_LE<ValueType, int32_t>;
+    return _fetch_LE<ValueType, int32_t>;
   case DataType::UInt32LE:
-    return __fetch_LE<ValueType, uint32_t>;
+    return _fetch_LE<ValueType, uint32_t>;
   case DataType::Int32BE:
-    return __fetch_BE<ValueType, int32_t>;
+    return _fetch_BE<ValueType, int32_t>;
   case DataType::UInt32BE:
-    return __fetch_BE<ValueType, uint32_t>;
+    return _fetch_BE<ValueType, uint32_t>;
   case DataType::Int64LE:
-    return __fetch_LE<ValueType, int64_t>;
+    return _fetch_LE<ValueType, int64_t>;
   case DataType::UInt64LE:
-    return __fetch_LE<ValueType, uint64_t>;
+    return _fetch_LE<ValueType, uint64_t>;
   case DataType::Int64BE:
-    return __fetch_BE<ValueType, int64_t>;
+    return _fetch_BE<ValueType, int64_t>;
   case DataType::UInt64BE:
-    return __fetch_BE<ValueType, uint64_t>;
+    return _fetch_BE<ValueType, uint64_t>;
   case DataType::Float16LE:
-    return __fetch_LE<ValueType, Eigen::half>;
+    return _fetch_LE<ValueType, Eigen::half>;
   case DataType::Float16BE:
-    return __fetch_BE<ValueType, Eigen::half>;
+    return _fetch_BE<ValueType, Eigen::half>;
   case DataType::Float32LE:
-    return __fetch_LE<ValueType, float>;
+    return _fetch_LE<ValueType, float>;
   case DataType::Float32BE:
-    return __fetch_BE<ValueType, float>;
+    return _fetch_BE<ValueType, float>;
   case DataType::Float64LE:
-    return __fetch_LE<ValueType, double>;
+    return _fetch_LE<ValueType, double>;
   case DataType::Float64BE:
-    return __fetch_BE<ValueType, double>;
+    return _fetch_BE<ValueType, double>;
   case DataType::CFloat32LE:
-    return __fetch_LE<ValueType, cfloat>;
+    return _fetch_LE<ValueType, cfloat>;
   case DataType::CFloat32BE:
-    return __fetch_BE<ValueType, cfloat>;
+    return _fetch_BE<ValueType, cfloat>;
   case DataType::CFloat64LE:
-    return __fetch_LE<ValueType, cdouble>;
+    return _fetch_LE<ValueType, cdouble>;
   case DataType::CFloat64BE:
-    return __fetch_BE<ValueType, cdouble>;
+    return _fetch_BE<ValueType, cdouble>;
   default:
     throw Exception("Unknown data type in request for fetch function");
   }
@@ -220,169 +220,169 @@ __set_fetch_function(const DataType datatype) {
 
 template <typename ValueType>
 typename std::enable_if<is_data_type<ValueType>::value, std::function<void(ValueType, void *, size_t)>>::type
-__set_store_function(const DataType datatype) {
+_set_store_function(const DataType datatype) {
   switch (datatype()) {
   case DataType::Bit:
-    return __store<ValueType, bool>;
+    return _store<ValueType, bool>;
   case DataType::Int8:
-    return __store<ValueType, int8_t>;
+    return _store<ValueType, int8_t>;
   case DataType::UInt8:
-    return __store<ValueType, uint8_t>;
+    return _store<ValueType, uint8_t>;
   case DataType::Int16LE:
-    return __store_LE<ValueType, int16_t>;
+    return _store_LE<ValueType, int16_t>;
   case DataType::UInt16LE:
-    return __store_LE<ValueType, uint16_t>;
+    return _store_LE<ValueType, uint16_t>;
   case DataType::Int16BE:
-    return __store_BE<ValueType, int16_t>;
+    return _store_BE<ValueType, int16_t>;
   case DataType::UInt16BE:
-    return __store_BE<ValueType, uint16_t>;
+    return _store_BE<ValueType, uint16_t>;
   case DataType::Int32LE:
-    return __store_LE<ValueType, int32_t>;
+    return _store_LE<ValueType, int32_t>;
   case DataType::UInt32LE:
-    return __store_LE<ValueType, uint32_t>;
+    return _store_LE<ValueType, uint32_t>;
   case DataType::Int32BE:
-    return __store_BE<ValueType, int32_t>;
+    return _store_BE<ValueType, int32_t>;
   case DataType::UInt32BE:
-    return __store_BE<ValueType, uint32_t>;
+    return _store_BE<ValueType, uint32_t>;
   case DataType::Int64LE:
-    return __store_LE<ValueType, int64_t>;
+    return _store_LE<ValueType, int64_t>;
   case DataType::UInt64LE:
-    return __store_LE<ValueType, uint64_t>;
+    return _store_LE<ValueType, uint64_t>;
   case DataType::Int64BE:
-    return __store_BE<ValueType, int64_t>;
+    return _store_BE<ValueType, int64_t>;
   case DataType::UInt64BE:
-    return __store_BE<ValueType, uint64_t>;
+    return _store_BE<ValueType, uint64_t>;
   case DataType::Float16LE:
-    return __store_LE<ValueType, Eigen::half>;
+    return _store_LE<ValueType, Eigen::half>;
   case DataType::Float16BE:
-    return __store_BE<ValueType, Eigen::half>;
+    return _store_BE<ValueType, Eigen::half>;
   case DataType::Float32LE:
-    return __store_LE<ValueType, float>;
+    return _store_LE<ValueType, float>;
   case DataType::Float32BE:
-    return __store_BE<ValueType, float>;
+    return _store_BE<ValueType, float>;
   case DataType::Float64LE:
-    return __store_LE<ValueType, double>;
+    return _store_LE<ValueType, double>;
   case DataType::Float64BE:
-    return __store_BE<ValueType, double>;
+    return _store_BE<ValueType, double>;
   case DataType::CFloat32LE:
-    return __store_LE<ValueType, cfloat>;
+    return _store_LE<ValueType, cfloat>;
   case DataType::CFloat32BE:
-    return __store_BE<ValueType, cfloat>;
+    return _store_BE<ValueType, cfloat>;
   case DataType::CFloat64LE:
-    return __store_LE<ValueType, cdouble>;
+    return _store_LE<ValueType, cdouble>;
   case DataType::CFloat64BE:
-    return __store_BE<ValueType, cdouble>;
+    return _store_BE<ValueType, cdouble>;
   default:
     throw Exception("Unknown data type in request for store function");
   }
 }
 
 template <typename ValueType>
-typename std::enable_if<is_data_type<ValueType>::value, void>::type __set_fetch_store_scale_functions(
-    std::function<ValueType(const void *, size_t, default_type, default_type)> &fetch_func,
-    std::function<void(ValueType, void *, size_t, default_type, default_type)> &store_func,
-    const DataType datatype) {
+typename std::enable_if<is_data_type<ValueType>::value, void>::type
+_set_fetch_store_scale_functions(std::function<ValueType(const void *, size_t, default_type, default_type)> &fetch_func,
+                                 std::function<void(ValueType, void *, size_t, default_type, default_type)> &store_func,
+                                 const DataType datatype) {
 
   switch (datatype()) {
   case DataType::Bit:
-    fetch_func = __fetch_scale<ValueType, bool>;
-    store_func = __scale_store<ValueType, bool>;
+    fetch_func = _fetch_scale<ValueType, bool>;
+    store_func = _scale_store<ValueType, bool>;
     return;
   case DataType::Int8:
-    fetch_func = __fetch_scale<ValueType, int8_t>;
-    store_func = __scale_store<ValueType, int8_t>;
+    fetch_func = _fetch_scale<ValueType, int8_t>;
+    store_func = _scale_store<ValueType, int8_t>;
     return;
   case DataType::UInt8:
-    fetch_func = __fetch_scale<ValueType, uint8_t>;
-    store_func = __scale_store<ValueType, uint8_t>;
+    fetch_func = _fetch_scale<ValueType, uint8_t>;
+    store_func = _scale_store<ValueType, uint8_t>;
     return;
   case DataType::Int16LE:
-    fetch_func = __fetch_scale_LE<ValueType, int16_t>;
-    store_func = __scale_store_LE<ValueType, int16_t>;
+    fetch_func = _fetch_scale_LE<ValueType, int16_t>;
+    store_func = _scale_store_LE<ValueType, int16_t>;
     return;
   case DataType::UInt16LE:
-    fetch_func = __fetch_scale_LE<ValueType, uint16_t>;
-    store_func = __scale_store_LE<ValueType, uint16_t>;
+    fetch_func = _fetch_scale_LE<ValueType, uint16_t>;
+    store_func = _scale_store_LE<ValueType, uint16_t>;
     return;
   case DataType::Int16BE:
-    fetch_func = __fetch_scale_BE<ValueType, int16_t>;
-    store_func = __scale_store_BE<ValueType, int16_t>;
+    fetch_func = _fetch_scale_BE<ValueType, int16_t>;
+    store_func = _scale_store_BE<ValueType, int16_t>;
     return;
   case DataType::UInt16BE:
-    fetch_func = __fetch_scale_BE<ValueType, uint16_t>;
-    store_func = __scale_store_BE<ValueType, uint16_t>;
+    fetch_func = _fetch_scale_BE<ValueType, uint16_t>;
+    store_func = _scale_store_BE<ValueType, uint16_t>;
     return;
   case DataType::Int32LE:
-    fetch_func = __fetch_scale_LE<ValueType, int32_t>;
-    store_func = __scale_store_LE<ValueType, int32_t>;
+    fetch_func = _fetch_scale_LE<ValueType, int32_t>;
+    store_func = _scale_store_LE<ValueType, int32_t>;
     return;
   case DataType::UInt32LE:
-    fetch_func = __fetch_scale_LE<ValueType, uint32_t>;
-    store_func = __scale_store_LE<ValueType, uint32_t>;
+    fetch_func = _fetch_scale_LE<ValueType, uint32_t>;
+    store_func = _scale_store_LE<ValueType, uint32_t>;
     return;
   case DataType::Int32BE:
-    fetch_func = __fetch_scale_BE<ValueType, int32_t>;
-    store_func = __scale_store_BE<ValueType, int32_t>;
+    fetch_func = _fetch_scale_BE<ValueType, int32_t>;
+    store_func = _scale_store_BE<ValueType, int32_t>;
     return;
   case DataType::UInt32BE:
-    fetch_func = __fetch_scale_BE<ValueType, uint32_t>;
-    store_func = __scale_store_BE<ValueType, uint32_t>;
+    fetch_func = _fetch_scale_BE<ValueType, uint32_t>;
+    store_func = _scale_store_BE<ValueType, uint32_t>;
     return;
   case DataType::Int64LE:
-    fetch_func = __fetch_scale_LE<ValueType, int64_t>;
-    store_func = __scale_store_LE<ValueType, int64_t>;
+    fetch_func = _fetch_scale_LE<ValueType, int64_t>;
+    store_func = _scale_store_LE<ValueType, int64_t>;
     return;
   case DataType::UInt64LE:
-    fetch_func = __fetch_scale_LE<ValueType, uint64_t>;
-    store_func = __scale_store_LE<ValueType, uint64_t>;
+    fetch_func = _fetch_scale_LE<ValueType, uint64_t>;
+    store_func = _scale_store_LE<ValueType, uint64_t>;
     return;
   case DataType::Int64BE:
-    fetch_func = __fetch_scale_BE<ValueType, int64_t>;
-    store_func = __scale_store_BE<ValueType, int64_t>;
+    fetch_func = _fetch_scale_BE<ValueType, int64_t>;
+    store_func = _scale_store_BE<ValueType, int64_t>;
     return;
   case DataType::UInt64BE:
-    fetch_func = __fetch_scale_BE<ValueType, uint64_t>;
-    store_func = __scale_store_BE<ValueType, uint64_t>;
+    fetch_func = _fetch_scale_BE<ValueType, uint64_t>;
+    store_func = _scale_store_BE<ValueType, uint64_t>;
     return;
   case DataType::Float16LE:
-    fetch_func = __fetch_scale_LE<ValueType, Eigen::half>;
-    store_func = __scale_store_LE<ValueType, Eigen::half>;
+    fetch_func = _fetch_scale_LE<ValueType, Eigen::half>;
+    store_func = _scale_store_LE<ValueType, Eigen::half>;
     return;
   case DataType::Float16BE:
-    fetch_func = __fetch_scale_BE<ValueType, Eigen::half>;
-    store_func = __scale_store_BE<ValueType, Eigen::half>;
+    fetch_func = _fetch_scale_BE<ValueType, Eigen::half>;
+    store_func = _scale_store_BE<ValueType, Eigen::half>;
     return;
   case DataType::Float32LE:
-    fetch_func = __fetch_scale_LE<ValueType, float>;
-    store_func = __scale_store_LE<ValueType, float>;
+    fetch_func = _fetch_scale_LE<ValueType, float>;
+    store_func = _scale_store_LE<ValueType, float>;
     return;
   case DataType::Float32BE:
-    fetch_func = __fetch_scale_BE<ValueType, float>;
-    store_func = __scale_store_BE<ValueType, float>;
+    fetch_func = _fetch_scale_BE<ValueType, float>;
+    store_func = _scale_store_BE<ValueType, float>;
     return;
   case DataType::Float64LE:
-    fetch_func = __fetch_scale_LE<ValueType, double>;
-    store_func = __scale_store_LE<ValueType, double>;
+    fetch_func = _fetch_scale_LE<ValueType, double>;
+    store_func = _scale_store_LE<ValueType, double>;
     return;
   case DataType::Float64BE:
-    fetch_func = __fetch_scale_BE<ValueType, double>;
-    store_func = __scale_store_BE<ValueType, double>;
+    fetch_func = _fetch_scale_BE<ValueType, double>;
+    store_func = _scale_store_BE<ValueType, double>;
     return;
   case DataType::CFloat32LE:
-    fetch_func = __fetch_scale_LE<ValueType, cfloat>;
-    store_func = __scale_store_LE<ValueType, cfloat>;
+    fetch_func = _fetch_scale_LE<ValueType, cfloat>;
+    store_func = _scale_store_LE<ValueType, cfloat>;
     return;
   case DataType::CFloat32BE:
-    fetch_func = __fetch_scale_BE<ValueType, cfloat>;
-    store_func = __scale_store_BE<ValueType, cfloat>;
+    fetch_func = _fetch_scale_BE<ValueType, cfloat>;
+    store_func = _scale_store_BE<ValueType, cfloat>;
     return;
   case DataType::CFloat64LE:
-    fetch_func = __fetch_scale_LE<ValueType, cdouble>;
-    store_func = __scale_store_LE<ValueType, cdouble>;
+    fetch_func = _fetch_scale_LE<ValueType, cdouble>;
+    store_func = _scale_store_LE<ValueType, cdouble>;
     return;
   case DataType::CFloat64BE:
-    fetch_func = __fetch_scale_BE<ValueType, cdouble>;
-    store_func = __scale_store_BE<ValueType, cdouble>;
+    fetch_func = _fetch_scale_BE<ValueType, cdouble>;
+    store_func = _scale_store_BE<ValueType, cdouble>;
     return;
   default:
     throw Exception("invalid data type in image header");
@@ -390,27 +390,29 @@ typename std::enable_if<is_data_type<ValueType>::value, void>::type __set_fetch_
 }
 
 // explicit instantiation of fetch/store methods for all types:
-#define __DEFINE_FETCH_STORE_FUNCTIONS_FOR_TYPE(ValueType)                                                             \
-  template std::function<ValueType(const void *, size_t)> __set_fetch_function<ValueType>(const DataType datatype);    \
-  template std::function<void(ValueType, void *, size_t)> __set_store_function<ValueType>(const DataType datatype);    \
-  template void __set_fetch_store_scale_functions<ValueType>(                                                          \
+#define DEFINE_FETCH_STORE_FUNCTIONS_FOR_TYPE(ValueType)                                                               \
+  template std::function<ValueType(const void *, size_t)> _set_fetch_function<ValueType>(const DataType datatype);     \
+  template std::function<void(ValueType, void *, size_t)> _set_store_function<ValueType>(const DataType datatype);     \
+  template void _set_fetch_store_scale_functions<ValueType>(                                                           \
       std::function<ValueType(const void *, size_t, default_type, default_type)> & fetch_func,                         \
       std::function<void(ValueType, void *, size_t, default_type, default_type)> & store_func,                         \
       const DataType datatype)
 
-__DEFINE_FETCH_STORE_FUNCTIONS_FOR_TYPE(bool);
-__DEFINE_FETCH_STORE_FUNCTIONS_FOR_TYPE(uint8_t);
-__DEFINE_FETCH_STORE_FUNCTIONS_FOR_TYPE(int8_t);
-__DEFINE_FETCH_STORE_FUNCTIONS_FOR_TYPE(uint16_t);
-__DEFINE_FETCH_STORE_FUNCTIONS_FOR_TYPE(int16_t);
-__DEFINE_FETCH_STORE_FUNCTIONS_FOR_TYPE(uint32_t);
-__DEFINE_FETCH_STORE_FUNCTIONS_FOR_TYPE(int32_t);
-__DEFINE_FETCH_STORE_FUNCTIONS_FOR_TYPE(uint64_t);
-__DEFINE_FETCH_STORE_FUNCTIONS_FOR_TYPE(int64_t);
-__DEFINE_FETCH_STORE_FUNCTIONS_FOR_TYPE(Eigen::half);
-__DEFINE_FETCH_STORE_FUNCTIONS_FOR_TYPE(float);
-__DEFINE_FETCH_STORE_FUNCTIONS_FOR_TYPE(double);
-__DEFINE_FETCH_STORE_FUNCTIONS_FOR_TYPE(cfloat);
-__DEFINE_FETCH_STORE_FUNCTIONS_FOR_TYPE(cdouble);
+DEFINE_FETCH_STORE_FUNCTIONS_FOR_TYPE(bool);
+DEFINE_FETCH_STORE_FUNCTIONS_FOR_TYPE(uint8_t);
+DEFINE_FETCH_STORE_FUNCTIONS_FOR_TYPE(int8_t);
+DEFINE_FETCH_STORE_FUNCTIONS_FOR_TYPE(uint16_t);
+DEFINE_FETCH_STORE_FUNCTIONS_FOR_TYPE(int16_t);
+DEFINE_FETCH_STORE_FUNCTIONS_FOR_TYPE(uint32_t);
+DEFINE_FETCH_STORE_FUNCTIONS_FOR_TYPE(int32_t);
+DEFINE_FETCH_STORE_FUNCTIONS_FOR_TYPE(uint64_t);
+DEFINE_FETCH_STORE_FUNCTIONS_FOR_TYPE(int64_t);
+DEFINE_FETCH_STORE_FUNCTIONS_FOR_TYPE(Eigen::half);
+DEFINE_FETCH_STORE_FUNCTIONS_FOR_TYPE(float);
+DEFINE_FETCH_STORE_FUNCTIONS_FOR_TYPE(double);
+DEFINE_FETCH_STORE_FUNCTIONS_FOR_TYPE(cfloat);
+DEFINE_FETCH_STORE_FUNCTIONS_FOR_TYPE(cdouble);
+
+#undef DEFINE_FETCH_STORE_FUNCTIONS_FOR_TYPE
 
 } // namespace MR

--- a/cpp/core/fetch_store.h
+++ b/cpp/core/fetch_store.h
@@ -23,28 +23,28 @@ namespace MR {
 
 template <typename ValueType>
 typename std::enable_if<!is_data_type<ValueType>::value, std::function<ValueType(const void *, size_t)>>::type
-__set_fetch_function(const DataType /*datatype*/) {}
+_set_fetch_function(const DataType /*datatype*/) {}
 template <typename ValueType>
 typename std::enable_if<is_data_type<ValueType>::value, std::function<ValueType(const void *, size_t)>>::type
-__set_fetch_function(const DataType datatype);
+_set_fetch_function(const DataType datatype);
 
 template <typename ValueType>
 typename std::enable_if<!is_data_type<ValueType>::value, std::function<void(ValueType, void *, size_t)>>::type
-__set_store_function(const DataType /*datatype*/) {}
+_set_store_function(const DataType /*datatype*/) {}
 template <typename ValueType>
 typename std::enable_if<is_data_type<ValueType>::value, std::function<void(ValueType, void *, size_t)>>::type
-__set_store_function(const DataType datatype);
+_set_store_function(const DataType datatype);
 
 template <typename ValueType>
-typename std::enable_if<!is_data_type<ValueType>::value, void>::type __set_fetch_store_scale_functions(
+typename std::enable_if<!is_data_type<ValueType>::value, void>::type _set_fetch_store_scale_functions(
     std::function<ValueType(const void *, size_t, default_type, default_type)> & /*fetch_func*/,
     std::function<void(ValueType, void *, size_t, default_type, default_type)> & /*store_func*/,
     const DataType /*datatype*/) {}
 
 template <typename ValueType>
-typename std::enable_if<is_data_type<ValueType>::value, void>::type __set_fetch_store_scale_functions(
-    std::function<ValueType(const void *, size_t, default_type, default_type)> &fetch_func,
-    std::function<void(ValueType, void *, size_t, default_type, default_type)> &store_func,
-    const DataType datatype);
+typename std::enable_if<is_data_type<ValueType>::value, void>::type
+_set_fetch_store_scale_functions(std::function<ValueType(const void *, size_t, default_type, default_type)> &fetch_func,
+                                 std::function<void(ValueType, void *, size_t, default_type, default_type)> &store_func,
+                                 const DataType datatype);
 
 } // namespace MR

--- a/cpp/core/file/config.cpp
+++ b/cpp/core/file/config.cpp
@@ -47,7 +47,8 @@ void Config::init() {
       while (kv.next()) {
         config[std::string(kv.key())] = std::string(kv.value());
       }
-    } catch (...) {
+    } catch (Exception &e) {
+      WARN("Error reading key-values from system config file \"" + sysconf_location + "\": " + e[0]);
     }
   } else {
     DEBUG(std::string("No config file found at \"") + sysconf_path.string() + "\"");
@@ -60,7 +61,8 @@ void Config::init() {
       while (kv.next()) {
         config[std::string(kv.key())] = std::string(kv.value());
       }
-    } catch (...) {
+    } catch (Exception &e) {
+      WARN("Error reading key-values from user config file \"" + home_path.string() + "\": " + e[0]);
     }
   } else {
     DEBUG("No config file found at \"" + home_path.string() + "\"");

--- a/cpp/core/file/config.cpp
+++ b/cpp/core/file/config.cpp
@@ -17,6 +17,7 @@
 #include "app.h"
 #include "debug.h"
 #include "env.h"
+#include "exception.h"
 #include "header.h"
 
 #include "file/config.h"

--- a/cpp/core/file/config.cpp
+++ b/cpp/core/file/config.cpp
@@ -16,6 +16,7 @@
 
 #include "app.h"
 #include "debug.h"
+#include "env.h"
 #include "header.h"
 
 #include "file/config.h"
@@ -36,9 +37,7 @@ const std::string Config::default_sys_config_file("/etc/" + file_basename);
 // ENVVAR the software to have different configurations, etc.
 
 void Config::init() {
-  const char *sysconf_location_env = getenv("MRTRIX_CONFIGFILE"); // check_syntax off
-  const std::string sysconf_location(sysconf_location_env == nullptr ? default_sys_config_file
-                                                                     : std::string(sysconf_location_env));
+  const std::string sysconf_location = MR::get_env("MRTRIX_CONFIGFILE", default_sys_config_file);
 
   std::filesystem::path sysconf_path(sysconf_location);
   if (std::filesystem::is_regular_file(sysconf_path)) {

--- a/cpp/core/file/copy.h
+++ b/cpp/core/file/copy.h
@@ -16,10 +16,11 @@
 
 #pragma once
 
+#include <filesystem>
+
 #include "exception.h"
 #include "file/mmap.h"
-#include "file/utils.h"
-#include <filesystem>
+#include "file/ofstream.h"
 
 namespace MR::File {
 
@@ -27,7 +28,8 @@ inline void copy(const std::filesystem::path &source, const std::filesystem::pat
   {
     DEBUG("copying file \"" + source.string() + "\" to \"" + destination.string() + "\"...");
     MMap input(source);
-    create(destination, input.size());
+    { File::OFStream out(destination); }
+    std::filesystem::resize_file(destination, input.size());
     MMap output(destination, true);
     ::memcpy(output.address(), input.address(), input.size());
   }

--- a/cpp/core/file/dicom/csa_entry.h
+++ b/cpp/core/file/dicom/csa_entry.h
@@ -22,6 +22,7 @@
 
 #include "datatype.h"
 #include "file/dicom/element.h"
+#include "mrtrix.h"
 #include "raw.h"
 #include "types.h"
 

--- a/cpp/core/file/dicom/csa_entry.h
+++ b/cpp/core/file/dicom/csa_entry.h
@@ -97,7 +97,8 @@ public:
     for (uint32_t m = 0; m < nitems; m++) {
       uint32_t length = Raw::fetch_LE<uint32_t>(p);
       if (length)
-        return to<int>(std::string(reinterpret_cast<const char *>(p) + 16, 4 * ((length + 3) / 4)));
+        return to<int>(
+            std::string(reinterpret_cast<const char *>(p) + 16, static_cast<size_t>(4 * ((length + 3) / 4))));
       p += 16 + 4 * ((length + 3) / 4);
     }
     return 0;
@@ -108,7 +109,8 @@ public:
     for (uint32_t m = 0; m < nitems; m++) {
       uint32_t length = Raw::fetch_LE<uint32_t>(p);
       if (length)
-        return to<default_type>(std::string(reinterpret_cast<const char *>(p) + 16, 4 * ((length + 3) / 4)));
+        return to<default_type>(
+            std::string(reinterpret_cast<const char *>(p) + 16, static_cast<size_t>(4 * ((length + 3) / 4))));
       p += 16 + 4 * ((length + 3) / 4);
     }
     return NaN;
@@ -120,8 +122,9 @@ public:
       DEBUG("CSA entry contains fewer items than expected - trailing entries will be set to NaN");
     for (uint32_t m = 0; m < std::min<size_t>(nitems, v.size()); m++) {
       uint32_t length = Raw::fetch_LE<uint32_t>(p);
-      v[m] =
-          length ? to<default_type>(std::string(reinterpret_cast<const char *>(p) + 16, 4 * ((length + 3) / 4))) : NaN;
+      v[m] = length ? to<default_type>(std::string(reinterpret_cast<const char *>(p) + 16,
+                                                   static_cast<size_t>(4 * ((length + 3) / 4))))
+                    : NaN;
       p += 16 + 4 * ((length + 3) / 4);
     }
     for (uint32_t m = nitems; m < v.size(); ++m)

--- a/cpp/core/file/dicom/element.cpp
+++ b/cpp/core/file/dicom/element.cpp
@@ -31,7 +31,7 @@ std::ostream &operator<<(std::ostream &stream, const Date &item) {
 std::ostream &operator<<(std::ostream &stream, const Time &item) {
   stream << std::setfill('0') << std::setw(2) << item.hour << ":" << std::setfill('0') << std::setw(2) << item.minute
          << ":" << std::setfill('0') << std::setw(2) << item.second;
-  if (item.fraction)
+  if (item.fraction != 0.0)
     stream << str(item.fraction, 6).substr(1);
   return stream;
 }
@@ -61,7 +61,7 @@ void Element::set(const std::filesystem::path &filepath, bool force_read, bool r
 
   next = fmap->address();
 
-  if (memcmp(next + 128, "DICM", 4)) {
+  if (memcmp(next + 128, "DICM", 4) != 0) {
     is_explicit = false;
     DEBUG("DICOM magic number not found in file \"" + fmap->path().string() + "\" - trying truncated format");
     if (!force_read)
@@ -73,9 +73,9 @@ void Element::set(const std::filesystem::path &filepath, bool force_read, bool r
 
   try {
     set_explicit_encoding();
-  } catch (Exception) {
-    throw Exception("\"" + fmap->path().string() + "\" is not a valid DICOM file");
+  } catch (Exception &e) {
     fmap.reset();
+    throw Exception(e, "\"" + fmap->path().string() + "\" is not a valid DICOM file");
   }
 }
 
@@ -225,8 +225,12 @@ bool Element::read() {
         INFO("unsupported DICOM transfer syntax: \"" + data_as_string + "\" in file \"" + fmap->path().string() + "\"");
       }
     } break;
+    default:
+      break;
     }
 
+    break;
+  default:
     break;
   }
 

--- a/cpp/core/file/dicom/element.cpp
+++ b/cpp/core/file/dicom/element.cpp
@@ -15,10 +15,12 @@
  */
 
 #include "file/dicom/element.h"
-#include "debug.h"
-#include "file/path.h"
 
 #include <iomanip>
+#include <string.h>
+
+#include "debug.h"
+#include "file/path.h"
 
 namespace MR::File::Dicom {
 

--- a/cpp/core/file/dicom/element.h
+++ b/cpp/core/file/dicom/element.h
@@ -88,7 +88,7 @@ public:
 
 class Element {
 public:
-  typedef enum Type { INVALID, INT, UINT, FLOAT, DATE, TIME, DATETIME, STRING, SEQ, OTHER } Type;
+  typedef enum Type : uint8_t { INVALID, INT, UINT, FLOAT, DATE, TIME, DATETIME, STRING, SEQ, OTHER } Type;
   static const std::unordered_map<Type, std::string> type_as_str;
 
   uint16_t group, element, VR;

--- a/cpp/core/file/dicom/element.h
+++ b/cpp/core/file/dicom/element.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <filesystem>
 #include <unordered_map>
 

--- a/cpp/core/file/dicom/element.h
+++ b/cpp/core/file/dicom/element.h
@@ -88,7 +88,7 @@ public:
 
 class Element {
 public:
-  typedef enum _Type { INVALID, INT, UINT, FLOAT, DATE, TIME, DATETIME, STRING, SEQ, OTHER } Type;
+  typedef enum Type { INVALID, INT, UINT, FLOAT, DATE, TIME, DATETIME, STRING, SEQ, OTHER } Type;
   static const std::unordered_map<Type, std::string> type_as_str;
 
   uint16_t group, element, VR;
@@ -114,7 +114,7 @@ public:
   }
 
   uint32_t tag() const {
-    union __DICOM_group_element_pair__ {
+    const union {
       uint16_t s[2]; // check_syntax off
       uint32_t i;
     } val = {{

--- a/cpp/core/file/dicom/image.cpp
+++ b/cpp/core/file/dicom/image.cpp
@@ -125,8 +125,9 @@ void Image::parse_item(Element &item) {
         G[2] = item.get_float(2, G[2]);
       }
     }
+    default:
+      return;
     }
-    return;
   case 0x0019U:
     switch (item.element) { // GE DW encoding info:
     case 0x10BBU:
@@ -150,8 +151,9 @@ void Image::parse_item(Element &item) {
       }
     }
       return;
+    default:
+      return;
     }
-    return;
   case 0x0020U:
     for (const auto &p : item.parents)
       if (p.group == 0x2005)
@@ -198,8 +200,9 @@ void Image::parse_item(Element &item) {
         if (frame_dim[n] < index[n])
           frame_dim[n] = index[n];
       return;
+    default:
+      return;
     }
-    return;
   case 0x0028U:
     switch (item.element) {
     case 0x0002U:
@@ -227,8 +230,9 @@ void Image::parse_item(Element &item) {
     case 0x1053U:
       scale_slope = item.get_float(0, scale_slope);
       return;
+    default:
+      return;
     }
-    return;
   case 0x0029U: // Siemens CSA entry
     if (item.element == 0x1010U || item.element == 0x1020U || item.element == 0x1110U || item.element == 0x1120U ||
         item.element == 0x1210U || item.element == 0x1220U) {
@@ -247,10 +251,12 @@ void Image::parse_item(Element &item) {
       bvalue = item.get_float(0, bvalue);
       return;
     case 0x1004:
+      // NOLINTNEXTLINE(bugprone-string-literal-with-embedded-nul)
       philips_orientation = item.get_string(0, "\0")[0];
       return;
+    default:
+      return;
     }
-    return;
   case 0x2005U: // Philips DW encoding info:
     switch (item.element) {
     case 0x10B0U:
@@ -265,8 +271,9 @@ void Image::parse_item(Element &item) {
     case 0x1413:
       grad_number = item.get_int()[0];
       return;
+    default:
+      return;
     }
-    return;
   case 0x7FE0U:
     if (item.element == 0x0010U) {
       data = item.offset(item.data);
@@ -288,7 +295,10 @@ void Image::parse_item(Element &item) {
           in_frames = true;
       }
       return;
+    default:
+      return;
     }
+  default:
     return;
   }
 }
@@ -563,10 +573,10 @@ Frame::get_DW_scheme(const std::vector<Frame *> &frames, const size_t nslices, c
     Eigen::Vector3d g = Eigen::Vector3d::Zero();
     double bvalue = frame.bvalue;
     if (bvalue < 0) {
-      bvalue = 0;
+      bvalue = 0.0;
       report_negative_bvalues = true;
     }
-    if (bvalue) {
+    if (bvalue != 0.0) {
       if (frame.G.allFinite()) {
         g[0] = -frame.G[0];
         g[1] = -frame.G[1];

--- a/cpp/core/file/dicom/mapper.cpp
+++ b/cpp/core/file/dicom/mapper.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 
+#include "env.h"
 #include "file/dicom/image.h"
 #include "file/dicom/mapper.h"
 #include "file/dicom/patient.h"
@@ -45,7 +46,7 @@ std::unique_ptr<MR::ImageIO::Base> dicom_to_mapper(MR::Header &H, std::vector<st
   // ENVVAR will normally have been modified from its initial value
   // ENVVAR (e.g. [ 0 0 0 1000 ] for a b=1000 acquisition) to b=0 due to
   // ENVVAR b-value scaling.
-  bool preserve_philips_iso = (getenv("MRTRIX_PRESERVE_PHILIPS_ISO") != nullptr);
+  const bool preserve_philips_iso = MR::get_env("MRTRIX_PRESERVE_PHILIPS_ISO").has_value();
 
   assert(series.size() > 0);
   std::unique_ptr<MR::ImageIO::Base> io_handler;

--- a/cpp/core/file/dicom/mapper.h
+++ b/cpp/core/file/dicom/mapper.h
@@ -16,6 +16,9 @@
 
 #pragma once
 
+#include <memory>
+#include <vector>
+
 #include "memory.h"
 
 namespace MR {

--- a/cpp/core/file/dicom/select_cmdline.cpp
+++ b/cpp/core/file/dicom/select_cmdline.cpp
@@ -20,6 +20,7 @@
 #include "file/dicom/series.h"
 #include "file/dicom/study.h"
 #include "file/dicom/tree.h"
+#include "mrtrix.h"
 
 namespace MR::File::Dicom {
 

--- a/cpp/core/file/dicom/select_cmdline.cpp
+++ b/cpp/core/file/dicom/select_cmdline.cpp
@@ -14,6 +14,7 @@
  * For more details, see http://www.mrtrix.org/.
  */
 
+#include "env.h"
 #include "file/dicom/image.h"
 #include "file/dicom/patient.h"
 #include "file/dicom/series.h"
@@ -31,35 +32,32 @@ std::vector<std::shared_ptr<Series>> select_cmdline(const Tree &tree) {
   // ENVVAR name: DICOM_PATIENT
   // ENVVAR when reading DICOM data, match the PatientName entry against
   // ENVVAR the string provided
-  const char *patient_env = getenv("DICOM_PATIENT"); // check_syntax off
-  const std::string patient_from_env(patient_env == nullptr ? "" : std::string(patient_env));
+  const auto patient_from_env = MR::get_env("DICOM_PATIENT");
 
   // ENVVAR name: DICOM_ID
   // ENVVAR when reading DICOM data, match the PatientID entry against
   // ENVVAR the string provided
-  const char *patid_env = getenv("DICOM_ID"); // check_syntax off
-  const std::string patid_from_env(patid_env == nullptr ? "" : std::string(patid_env));
+  const auto patid_from_env = MR::get_env("DICOM_ID");
 
   // ENVVAR name: DICOM_STUDY
   // ENVVAR when reading DICOM data, match the StudyName entry against
   // ENVVAR the string provided
-  const char *study_env = getenv("DICOM_STUDY"); // check_syntax off
-  const std::string study_from_env(study_env == nullptr ? "" : std::string(study_env));
+  const auto study_from_env = MR::get_env("DICOM_STUDY");
 
   // ENVVAR name: DICOM_SERIES
   // ENVVAR when reading DICOM data, match the SeriesName entry against
   // ENVVAR the string provided
-  const char *series_env = getenv("DICOM_SERIES"); // check_syntax off
-  const std::string series_from_env(series_env == nullptr ? "" : std::string(series_env));
+  const auto series_from_env = MR::get_env("DICOM_SERIES");
 
-  if (!patient_from_env.empty() || !patid_from_env.empty() || !study_from_env.empty() || !series_from_env.empty()) {
+  if (patient_from_env.has_value() || patid_from_env.has_value() || study_from_env.has_value() ||
+      series_from_env.has_value()) {
 
     // select using environment variables:
 
     std::vector<std::shared_ptr<Patient>> patient;
     for (size_t i = 0; i < tree.size(); i++) {
-      if ((patient_from_env.empty() || match(patient_from_env, tree[i]->name, true)) &&
-          (patid_from_env.empty() || match(patid_from_env, tree[i]->ID, true)))
+      if ((!patient_from_env.has_value() || match(patient_from_env.value(), tree[i]->name, true)) &&
+          (!patid_from_env.has_value() || match(patid_from_env.value(), tree[i]->ID, true)))
         patient.push_back(tree[i]);
     }
     if (patient.empty())
@@ -69,7 +67,7 @@ std::vector<std::shared_ptr<Series>> select_cmdline(const Tree &tree) {
 
     std::vector<std::shared_ptr<Study>> study;
     for (size_t i = 0; i < patient[0]->size(); i++) {
-      if (study_from_env.empty() || match(study_from_env, (*patient[0])[i]->name, true))
+      if (!study_from_env.has_value() || match(study_from_env.value(), (*patient[0])[i]->name, true))
         study.push_back((*patient[0])[i]);
     }
     if (study.empty())
@@ -78,7 +76,7 @@ std::vector<std::shared_ptr<Series>> select_cmdline(const Tree &tree) {
       throw Exception("too many matching studies in DICOM dataset \"" + tree.description + "\"");
 
     for (size_t i = 0; i < study[0]->size(); i++) {
-      if (series_from_env.empty() || match(series_from_env, (*study[0])[i]->name, true))
+      if (!series_from_env.has_value() || match(series_from_env.value(), (*study[0])[i]->name, true))
         series.push_back((*study[0])[i]);
     }
     if (series.empty())

--- a/cpp/core/file/dicom/tree.cpp
+++ b/cpp/core/file/dicom/tree.cpp
@@ -15,6 +15,10 @@
  */
 
 #include "file/dicom/tree.h"
+
+#include <cerrno>
+
+#include "exception.h"
 #include "file/dicom/element.h"
 #include "file/dicom/image.h"
 #include "file/dicom/patient.h"

--- a/cpp/core/file/dicom/tree.cpp
+++ b/cpp/core/file/dicom/tree.cpp
@@ -104,7 +104,8 @@ void Tree::read(const std::filesystem::path &path) {
   } else {
     try {
       read_file(path);
-    } catch (Exception) {
+    } catch (Exception &e) {
+      DEBUG("Error reading DICOM file \"" + path.string() + "\" (\"" + e[0] + "\"); ignored");
     }
   }
 

--- a/cpp/core/file/dicom/tree.cpp
+++ b/cpp/core/file/dicom/tree.cpp
@@ -58,7 +58,7 @@ void Tree::read_dir(const std::filesystem::path &dirpath, ProgressBar &progress)
       ++progress;
     }
   } catch (Exception &E) {
-    throw Exception(E, "error opening DICOM folder \"" + dirpath.string() + "\": " + strerror(errno));
+    throw Exception(E, "error opening DICOM folder \"" + dirpath.string() + "\": " + MR::C_strerror(errno));
   }
 }
 

--- a/cpp/core/file/gz.h
+++ b/cpp/core/file/gz.h
@@ -56,7 +56,7 @@ public:
 
     gz = gzopen(filepath.string().c_str(), std::string(mode).c_str());
     if (!gz)
-      throw Exception("error opening file \"" + filepath.string() + "\": " + strerror(errno));
+      throw Exception("error opening file \"" + filepath.string() + "\": " + MR::C_strerror(errno));
   }
 
   void close() {
@@ -153,9 +153,9 @@ protected:
 
   const std::string error() {
     int error_number;
-    const char *s = gzerror(gz, &error_number); // check_syntax off
+    const char *const s = gzerror(gz, &error_number); // check_syntax off
     if (error_number == Z_ERRNO)
-      s = strerror(errno);
+      return MR::C_strerror(errno);
     return std::string(s);
   }
 };

--- a/cpp/core/file/gz.h
+++ b/cpp/core/file/gz.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cassert>
+#include <cerrno>
 #include <cstdio>
 #include <cstring>
 #include <fcntl.h>
@@ -56,7 +57,7 @@ public:
 
     gz = gzopen(filepath.string().c_str(), std::string(mode).c_str());
     if (!gz)
-      throw Exception("error opening file \"" + filepath.string() + "\": " + MR::C_strerror(errno));
+      throw Exception("error opening file \"" + filepath.string() + "\": " + error());
   }
 
   void close() {

--- a/cpp/core/file/json_utils.cpp
+++ b/cpp/core/file/json_utils.cpp
@@ -169,7 +169,7 @@ template <typename T> bool attempt_scalar(const std::pair<std::string, std::stri
     const T temp = to<T>(kv.second);
     json[kv.first] = temp;
     return true;
-  } catch (...) {
+  } catch (Exception &) { // NOLINT(bugprone-empty-catch)
   }
   return false;
 }

--- a/cpp/core/file/key_value.cpp
+++ b/cpp/core/file/key_value.cpp
@@ -26,7 +26,7 @@ void Reader::open(const std::filesystem::path &file, std::string_view first_line
   DEBUG("reading key/value file \"" + file.string() + "\"...");
   in.open(file, std::ios::in | std::ios::binary);
   if (!in)
-    throw Exception("failed to open key/value file \"" + file.string() + "\": " + strerror(errno));
+    throw Exception("failed to open key/value file \"" + file.string() + "\": " + MR::C_strerror(errno));
   if (!first_line.empty()) {
     std::string sbuf;
     getline(in, sbuf);
@@ -44,7 +44,7 @@ bool Reader::next() {
     std::string sbuf;
     getline(in, sbuf);
     if (in.bad())
-      throw Exception("error reading key/value file \"" + filepath.string() + "\": " + strerror(errno));
+      throw Exception("error reading key/value file \"" + filepath.string() + "\": " + MR::C_strerror(errno));
 
     sbuf = strip(sbuf.substr(0, sbuf.find_first_of('#')));
     if (sbuf == "END") {

--- a/cpp/core/file/key_value.cpp
+++ b/cpp/core/file/key_value.cpp
@@ -15,9 +15,13 @@
  */
 
 #include "file/key_value.h"
-#include "app.h"
-#include "file/ofstream.h"
+
+#include <cerrno>
 #include <fstream>
+
+#include "app.h"
+#include "exception.h"
+#include "file/ofstream.h"
 
 namespace MR::File::KeyValue {
 

--- a/cpp/core/file/matrix.h
+++ b/cpp/core/file/matrix.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cerrno>
 #include <filesystem>
 #include <string>
 

--- a/cpp/core/file/matrix.h
+++ b/cpp/core/file/matrix.h
@@ -61,7 +61,7 @@ std::vector<std::vector<ValueType>> load_matrix_2D_vector(const std::filesystem:
                                                           std::vector<std::string> *comments = nullptr) {
   std::ifstream stream(filename.string().c_str(), std::ios_base::in | std::ios_base::binary);
   if (!stream)
-    throw Exception("Unable to open numerical data text file \"" + filename.string() + "\": " + strerror(errno));
+    throw Exception("Unable to open numerical data text file \"" + filename.string() + "\": " + MR::C_strerror(errno));
   std::vector<std::vector<ValueType>> V;
   std::string sbuf, cbuf;
   size_t hash;
@@ -97,7 +97,7 @@ std::vector<std::vector<ValueType>> load_matrix_2D_vector(const std::filesystem:
                         str(V.back().size()) + " columns)");
   }
   if (stream.bad())
-    throw Exception(strerror(errno));
+    throw Exception(MR::C_strerror(errno));
 
   if (!V.size())
     throw Exception("no data in matrix text file \"" + filename.string() + "\"");

--- a/cpp/core/file/mgh.h
+++ b/cpp/core/file/mgh.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <array>
+#include <cstddef>
 #include <iomanip>
 #include <sstream>
 
@@ -34,7 +35,7 @@ namespace MR::File::MGH {
 constexpr size_t header_size = 90;
 constexpr size_t data_offset = 284;
 constexpr size_t strlen = 1024;
-constexpr size_t matrix_strlen = 4 * 4 * 100;
+constexpr size_t matrix_strlen = static_cast<const size_t>(4 * 4 * 100);
 
 using tag_type = int32_t;
 constexpr tag_type tag_old_colortable = 1;
@@ -544,6 +545,7 @@ template <class Input> void read_other(Header &H, Input &in) {
     } while (!in.eof());
 
   } catch (int) {
+    DEBUG("No MGH \"other\" data found");
   }
 }
 
@@ -601,6 +603,9 @@ template <class Output> void write_header(const Header &H, Output &out) {
       break;
     case 2:
       c[2] = offset;
+      break;
+    default:
+      assert(false);
       break;
     }
   }

--- a/cpp/core/file/mgh.h
+++ b/cpp/core/file/mgh.h
@@ -17,10 +17,12 @@
 #pragma once
 
 #include <array>
+#include <cassert>
 #include <cstddef>
 #include <iomanip>
 #include <sstream>
 
+#include "exception.h"
 #include "file/gz.h"
 #include "file/nifti_utils.h"
 #include "header.h"

--- a/cpp/core/file/mmap.cpp
+++ b/cpp/core/file/mmap.cpp
@@ -147,7 +147,8 @@ MMap::MMap(const Entry &entry, bool readwrite, bool preload, std::optional<int64
         in.seekg(start, in.beg);
         in.read(reinterpret_cast<char *>(first), msize);
         if (!in.good())
-          throw Exception("error preloading contents of file \"" + Entry::path.string() + "\": " + MR::C_strerror(errno));
+          throw Exception("error preloading contents of file \"" + Entry::path.string() + "\": " + //
+                          MR::C_strerror(errno));                                                  //
       } else
         memset(first, 0, msize);
       DEBUG("file \"" + Entry::path.string() + "\" held in RAM at " + str(reinterpret_cast<void *>(first)) + "," + //

--- a/cpp/core/file/mmap.cpp
+++ b/cpp/core/file/mmap.cpp
@@ -46,15 +46,14 @@ namespace MR::File {
 MMap::MMap(const Entry &entry, bool readwrite, bool preload, std::optional<int64_t> mapped_size)
     : Entry(entry), addr(nullptr), first(nullptr), msize(0), readwrite(readwrite) {
 
-  const std::filesystem::path &file_path = Entry::path;
-  DEBUG("memory-mapping file \"" + file_path.string() + "\"...");
+  DEBUG("memory-mapping file \"" + Entry::path.string() + "\"...");
 
   try {
-    auto last_write = std::filesystem::last_write_time(file_path);
+    auto last_write = std::filesystem::last_write_time(Entry::path);
     auto sctp = std::chrono::time_point_cast<std::chrono::system_clock::duration>(
         last_write - std::filesystem::file_time_type::clock::now() + std::chrono::system_clock::now());
     mtime = std::chrono::system_clock::to_time_t(sctp);
-    const int64_t file_size = std::filesystem::file_size(file_path);
+    const int64_t file_size = std::filesystem::file_size(Entry::path);
     if (!mapped_size.has_value()) {
       msize = file_size - start;
     } else {
@@ -78,12 +77,12 @@ MMap::MMap(const Entry &entry, bool readwrite, bool preload, std::optional<int64
       const unsigned int code = GetDriveType(root_path.data());
       switch (code) {
       case 0: // DRIVE_UNKNOWN
-        DEBUG("cannot get filesystem information on file \"" + Entry::path.string() + "\": " + strerror(errno));
+        DEBUG("cannot get filesystem information on file \"" + Entry::path.string() + "\": " + MR::C_strerror(errno));
         DEBUG("  defaulting to delayed write-back");
         delayed_writeback = true;
         break;
       case 1: // DRIVE_NO_ROOT_DIR:
-        DEBUG("erroneous root path derived for file \"" + Entry::path.string() + "\": " + strerror(errno));
+        DEBUG("erroneous root path derived for file \"" + Entry::path.string() + "\": " + MR::C_strerror(errno));
         DEBUG("  defaulting to delayed write-back");
         delayed_writeback = true;
         break;
@@ -113,7 +112,7 @@ MMap::MMap(const Entry &entry, bool readwrite, bool preload, std::optional<int64
 #else
     struct statfs fsbuf;
     if (statfs(Entry::path.string().c_str(), &fsbuf)) {
-      DEBUG("cannot get filesystem information on file \"" + Entry::path.string() + "\": " + strerror(errno));
+      DEBUG("cannot get filesystem information on file \"" + Entry::path.string() + "\": " + MR::C_strerror(errno));
       DEBUG("  defaulting to delayed write-back");
       delayed_writeback = true;
     }
@@ -144,11 +143,11 @@ MMap::MMap(const Entry &entry, bool readwrite, bool preload, std::optional<int64
         CONSOLE("preloading contents of mapped file \"" + Entry::path.string() + "\"...");
         std::ifstream in(Entry::path, std::ios::in | std::ios::binary);
         if (!in)
-          throw Exception("failed to open file \"" + Entry::path.string() + "\": " + strerror(errno));
+          throw Exception("failed to open file \"" + Entry::path.string() + "\": " + MR::C_strerror(errno));
         in.seekg(start, in.beg);
         in.read(reinterpret_cast<char *>(first), msize);
         if (!in.good())
-          throw Exception("error preloading contents of file \"" + Entry::path.string() + "\": " + strerror(errno));
+          throw Exception("error preloading contents of file \"" + Entry::path.string() + "\": " + MR::C_strerror(errno));
       } else
         memset(first, 0, msize);
       DEBUG("file \"" + Entry::path.string() + "\" held in RAM at " + str(reinterpret_cast<void *>(first)) + "," + //
@@ -159,9 +158,9 @@ MMap::MMap(const Entry &entry, bool readwrite, bool preload, std::optional<int64
   }
 
   // use regular memory-mapping:
-
-  if ((fd = open(Entry::path.string().c_str(), (readwrite ? O_RDWR : O_RDONLY), 0666)) < 0)
-    throw Exception("error opening file \"" + Entry::path.string() + "\": " + strerror(errno));
+  fd = open(Entry::path.string().c_str(), (readwrite ? O_RDWR : O_RDONLY), 0666);
+  if (fd < 0)
+    throw Exception("error opening file \"" + Entry::path.string() + "\": " + MR::C_strerror(errno));
 
   try {
 #ifdef MRTRIX_WINDOWS
@@ -183,7 +182,7 @@ MMap::MMap(const Entry &entry, bool readwrite, bool preload, std::optional<int64
   } catch (...) {
     close(fd);
     addr = nullptr;
-    throw Exception("memory-mapping failed for file \"" + Entry::path.string() + "\": " + strerror(errno));
+    throw Exception("memory-mapping failed for file \"" + Entry::path.string() + "\": " + MR::C_strerror(errno));
   }
   first = addr + start;
   DEBUG("file \"" + Entry::path.string() + "\" mapped at " + str(reinterpret_cast<void *>(addr)) + "," + //
@@ -200,7 +199,7 @@ MMap::~MMap() {
 #else
     if (munmap(addr, msize))
 #endif
-      WARN("error unmapping file \"" + Entry::path.string() + "\": " + strerror(errno));
+      WARN("error unmapping file \"" + Entry::path.string() + "\": " + MR::C_strerror(errno));
     close(fd);
   } else {
     if (readwrite) {
@@ -212,7 +211,7 @@ MMap::~MMap() {
         if (!out.good())
           throw 1;
       } catch (...) {
-        FAIL("error writing back contents of file \"" + Entry::path.string() + "\": " + strerror(errno));
+        FAIL("error writing back contents of file \"" + Entry::path.string() + "\": " + MR::C_strerror(errno));
         App::exit_error_code = 1;
       }
     }

--- a/cpp/core/file/mmap.cpp
+++ b/cpp/core/file/mmap.cpp
@@ -15,8 +15,10 @@
  */
 
 #include <array>
+#include <cerrno>
 #include <cstddef>
 #include <fcntl.h>
+#include <filesystem>
 #include <unistd.h>
 #include <zlib.h>
 
@@ -34,12 +36,11 @@
 #endif
 
 #include "app.h"
+#include "exception.h"
 #include "file/config.h"
 #include "file/mmap.h"
 #include "file/ofstream.h"
 #include "file/path.h"
-
-#include "debug.h"
 
 namespace MR::File {
 

--- a/cpp/core/file/name_parser.cpp
+++ b/cpp/core/file/name_parser.cpp
@@ -51,9 +51,9 @@ void NameParser::parse(std::string_view specifier, size_t max_num_sequences) {
     while ((pos = basename.find_last_of(']')) < std::string::npos && num < max_num_sequences) {
       insert_str(basename.substr(pos + 1));
       basename = basename.substr(0, pos);
-      if ((pos = basename.find_last_of('[')) == std::string::npos)
+      pos = basename.find_last_of('[');
+      if (pos == std::string::npos)
         throw Exception("malformed image sequence specifier for image \"" + specifier + "\"");
-
       insert_seq(basename.substr(pos + 1));
       num++;
       basename = basename.substr(0, pos);
@@ -180,9 +180,10 @@ std::filesystem::path NameParser::get_next_match(std::vector<uint32_t> &indices,
   if (!folder)
     folder.emplace(folder_path.empty() ? std::filesystem::current_path() : folder_path);
 
-  while (*folder != std::filesystem::directory_iterator()) {
-    std::string fname = folder->operator*().path().filename().string();
-    ++(*folder);
+  assert(folder.has_value());
+  while (folder.value() != std::filesystem::directory_iterator()) {
+    const std::string fname = folder->operator*().path().filename().string();
+    ++folder.value();
 
     if (match(fname, indices)) {
       if (return_seq_index) {

--- a/cpp/core/file/nifti_utils.cpp
+++ b/cpp/core/file/nifti_utils.cpp
@@ -86,7 +86,8 @@ template <class NiftiHeader> size_t fetch(Header &H, const NiftiHeader &NH) {
   }
 
   bool is_nifti = true;
-  if (memcmp(NH.magic, Type<NiftiHeader>::magic1.data(), 4) && memcmp(NH.magic, Type<NiftiHeader>::magic2.data(), 4)) {
+  if (memcmp(NH.magic, Type<NiftiHeader>::magic1.data(), 4) != 0 &&
+      memcmp(NH.magic, Type<NiftiHeader>::magic2.data(), 4) != 0) {
     if (Type<NiftiHeader>::is_version2) {
       throw Exception("image \"" + H.path().string() + "\" is not in " + version + " format (invalid magic signature)");
     } else {
@@ -96,7 +97,7 @@ template <class NiftiHeader> size_t fetch(Header &H, const NiftiHeader &NH) {
   }
 
   if (Type<NiftiHeader>::is_version2) {
-    if (memcmp(NH.magic + 4, Type<NiftiHeader>::signature_extra.data(), 4))
+    if (memcmp(NH.magic + 4, Type<NiftiHeader>::signature_extra.data(), 4) != 0)
       WARN("possible file transfer corruption of file \"" + H.path().string() + "\" (invalid magic signature)");
   } else {
     std::string db_name(19, '\0');
@@ -672,8 +673,8 @@ template <int VERSION> std::unique_ptr<ImageIO::Base> read_gz(Header &H) {
     memset(io_handler.get()->header() + sizeof(NH), 0, sizeof(nifti1_extender));
     io_handler->files.push_back(File::Entry(static_cast<const Header &>(H).path(), data_offset));
     return io_handler;
-  } catch (...) {
-    return std::unique_ptr<ImageIO::Base>();
+  } catch (Exception &e) {
+    throw Exception(e, "Error reading compressed NIfTI image \"" + H.name() + "\"");
   }
 }
 

--- a/cpp/core/file/nifti_utils.cpp
+++ b/cpp/core/file/nifti_utils.cpp
@@ -86,8 +86,8 @@ template <class NiftiHeader> size_t fetch(Header &H, const NiftiHeader &NH) {
   }
 
   bool is_nifti = true;
-  if (memcmp(NH.magic, Type<NiftiHeader>::magic1.data(), 4) != 0 &&
-      memcmp(NH.magic, Type<NiftiHeader>::magic2.data(), 4) != 0) {
+  if (memcmp(&NH.magic[0], Type<NiftiHeader>::magic1.data(), 4) != 0 &&
+      memcmp(&NH.magic[0], Type<NiftiHeader>::magic2.data(), 4) != 0) {
     if (Type<NiftiHeader>::is_version2) {
       throw Exception("image \"" + H.path().string() + "\" is not in " + version + " format (invalid magic signature)");
     } else {
@@ -97,7 +97,7 @@ template <class NiftiHeader> size_t fetch(Header &H, const NiftiHeader &NH) {
   }
 
   if (Type<NiftiHeader>::is_version2) {
-    if (memcmp(NH.magic + 4, Type<NiftiHeader>::signature_extra.data(), 4) != 0)
+    if (memcmp(&NH.magic[4], Type<NiftiHeader>::signature_extra.data(), 4) != 0)
       WARN("possible file transfer corruption of file \"" + H.path().string() + "\" (invalid magic signature)");
   } else {
     std::string db_name(19, '\0');

--- a/cpp/core/file/npy.h
+++ b/cpp/core/file/npy.h
@@ -60,7 +60,7 @@ Eigen::Matrix<ValueType, Eigen::Dynamic, Eigen::Dynamic> load_matrix(const std::
   // Actually load the data
   const ssize_t cols = info.shape.size() == 2 ? info.shape[1] : 1;
   Eigen::Matrix<ValueType, Eigen::Dynamic, Eigen::Dynamic> data(info.shape[0], cols);
-  const std::function<ValueType(void *, size_t)> fetch_func(__set_fetch_function<ValueType>(info.data_type));
+  const std::function<ValueType(void *, size_t)> fetch_func(_set_fetch_function<ValueType>(info.data_type));
   size_t i = 0;
   if (info.column_major) {
     for (ssize_t col = 0; col != cols; ++col) {
@@ -93,7 +93,7 @@ template <class ContType> void save_vector(const ContType &data, const std::file
       out[i] = std::byte(data[i] ? 1 : 0);
     return;
   }
-  auto store_func = __set_store_function<ValueType>(info.data_type);
+  auto store_func = _set_store_function<ValueType>(info.data_type);
   for (ssize_t i = 0; i != static_cast<ssize_t>(data.size()); ++i)
     store_func(data[i], info.mmap->address(), i);
 }
@@ -111,7 +111,7 @@ template <class ContType> void save_matrix(const ContType &data, const std::file
       }
     return;
   }
-  auto store_func = __set_store_function<ValueType>(info.data_type);
+  auto store_func = _set_store_function<ValueType>(info.data_type);
   size_t i = 0;
   for (ssize_t col = 0; col != data.cols(); ++col)
     for (ssize_t row = 0; row != data.rows(); ++row) {

--- a/cpp/core/file/npy.h
+++ b/cpp/core/file/npy.h
@@ -18,6 +18,7 @@
 
 #include <array>
 #include <filesystem>
+#include <functional>
 #include <sstream>
 
 #include "datatype.h"

--- a/cpp/core/file/ofstream.cpp
+++ b/cpp/core/file/ofstream.cpp
@@ -36,7 +36,7 @@ void OFStream::open(const std::filesystem::path &path, const std::ios_base::open
 
   std::ofstream::open(path, mode);
   if (std::ofstream::operator!())
-    throw Exception("error opening output file \"" + path.string() + "\": " + std::strerror(errno));
+    throw Exception("error opening output file \"" + path.string() + "\": " + MR::C_strerror(errno));
 }
 
 } // namespace MR::File

--- a/cpp/core/file/ofstream.cpp
+++ b/cpp/core/file/ofstream.cpp
@@ -25,7 +25,7 @@
 namespace MR::File {
 
 void OFStream::open(const std::filesystem::path &path, const std::ios_base::openmode mode) {
-  if (!(mode & std::ios_base::app) && !(mode & std::ios_base::ate) && !(mode & std::ios_base::in)) {
+  if ((mode & std::ios_base::app) == 0 && (mode & std::ios_base::ate) == 0 && (mode & std::ios_base::in) == 0) {
     if (!File::is_tempfile(path)) {
       if (std::filesystem::exists(path)) {
         App::check_overwrite(path);

--- a/cpp/core/file/ofstream.cpp
+++ b/cpp/core/file/ofstream.cpp
@@ -16,6 +16,7 @@
 
 #include "file/ofstream.h"
 
+#include <cerrno>
 #include <filesystem>
 
 #include "app.h"

--- a/cpp/core/file/path.cpp
+++ b/cpp/core/file/path.cpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 
+#include "env.h"
 #include "exception.h"
 
 namespace MR::Path {
@@ -53,10 +54,10 @@ bool is_mrtrix_image(const std::filesystem::path &path) {
 const std::filesystem::path &home() {
   static std::filesystem::path result;
   if (result.empty()) {
-    const char *const home = getenv(home_env.c_str()); // check_syntax off
-    if (!home)
+    const std::optional<std::string> home = MR::get_env(home_env);
+    if (!home.has_value())
       throw Exception(home_env + " environment variable is not set!");
-    result = home;
+    result = home.value();
   }
   return result;
 }

--- a/cpp/core/file/path.cpp
+++ b/cpp/core/file/path.cpp
@@ -17,6 +17,7 @@
 #include "file/path.h"
 
 #include <algorithm>
+#include <optional>
 
 #include "env.h"
 #include "exception.h"

--- a/cpp/core/file/png.cpp
+++ b/cpp/core/file/png.cpp
@@ -165,7 +165,7 @@ Writer::Writer(const Header &H, const std::filesystem::path &path)
   outfile = fopen(Writer::filepath.string().c_str(), "wb");
   if (!outfile)
     throw Exception("Unable to open PNG file for writing for image \"" + path.string() + "\": " //
-                    + strerror(errno));                                                         //
+                    + MR::C_strerror(errno));                                                   //
   png_init_io(png_ptr, outfile);
   png_set_compression_level(png_ptr, Z_DEFAULT_COMPRESSION);
   switch (H.ndim()) {

--- a/cpp/core/file/png.cpp
+++ b/cpp/core/file/png.cpp
@@ -54,11 +54,13 @@ Reader::Reader(const std::filesystem::path &filepath)
     e.push_back("File signature: " + s.str());
     throw e;
   }
-  if (!(png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr))) {
+  png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
+  if (png_ptr == nullptr) {
     fclose(infile);
     throw Exception("Unable to allocate memory for PNG read structure for image \"" + filepath.string() + "\"");
   }
-  if (!(info_ptr = png_create_info_struct(png_ptr))) {
+  info_ptr = png_create_info_struct(png_ptr);
+  if (info_ptr == nullptr) {
     fclose(infile);
     png_destroy_read_struct(&png_ptr, nullptr, nullptr);
     throw Exception("Unable to allocate memory for PNG info structure for image \"" + filepath.string() + "\"");
@@ -132,9 +134,9 @@ void Reader::load(std::byte *image_data) {
     png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
     throw Exception("Fatal error reading PNG image");
   }
-  const int row_bytes = png_get_rowbytes(png_ptr, info_ptr);
+  const size_t row_bytes = static_cast<size_t>(png_get_rowbytes(png_ptr, info_ptr));
   png_bytepp row_pointers = new png_bytep[height];
-  for (png_uint_32 i = 0; i != height; ++i)
+  for (size_t i = 0; i != static_cast<size_t>(height); ++i)
     row_pointers[i] = reinterpret_cast<png_bytep>(image_data + i * row_bytes);
   png_read_image(png_ptr, row_pointers);
   delete[] row_pointers;
@@ -154,9 +156,11 @@ Writer::Writer(const Header &H, const std::filesystem::path &path)
       outfile(nullptr) {
   if (std::filesystem::exists(path) && !App::overwrite_files)
     throw Exception("output file \"" + path.string() + "\" already exists (use -force option to force overwrite)");
-  if (!(png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, this, &error_handler, nullptr)))
+  png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, this, &error_handler, nullptr);
+  if (png_ptr == nullptr)
     throw Exception("Unable to create PNG write structure for image \"" + path.string() + "\"");
-  if (!(info_ptr = png_create_info_struct(png_ptr)))
+  info_ptr = png_create_info_struct(png_ptr);
+  if (info_ptr == nullptr)
     throw Exception("Unable to create PNG info structure for image \"" + path.string() + "\"");
   if (setjmp(jmpbuf)) {
     png_destroy_write_struct(&png_ptr, &info_ptr);
@@ -207,9 +211,6 @@ Writer::Writer(const Header &H, const std::filesystem::path &path)
          "image will be scaled to integer representation assuming input data is in the range 0.0 - 1.0");
   }
   switch (data_type() & DataType::Type) {
-  case DataType::Undefined:
-    png_destroy_write_struct(&png_ptr, &info_ptr);
-    throw Exception("Undefined data type in image \"" + H.path().string() + "\" for PNG writer");
   case DataType::Bit:
     assert(false);
     break;
@@ -229,6 +230,11 @@ Writer::Writer(const Header &H, const std::filesystem::path &path)
     bit_depth = 16;
     multiplier = std::numeric_limits<uint16_t>::max();
     break;
+  case DataType::Undefined:
+    [[fallthrough]];
+  default:
+    png_destroy_write_struct(&png_ptr, &info_ptr);
+    throw Exception("Undefined data type in image \"" + H.path().string() + "\" for PNG writer");
   }
   // Detect cases where one axis has a size of 1, and hence represents the image plane
   //   being set via selection of a single slice rather than axis permutation
@@ -322,7 +328,8 @@ void Writer::save(std::byte *data) {
     std::byte *in_ptr = data;
     std::byte *out_ptr = scratch;
     const uint8_t channels = png_get_channels(png_ptr, info_ptr);
-    const size_t num_elements = channels * width * height;
+    const size_t num_elements =
+        static_cast<size_t>(channels) * static_cast<size_t>(width) * static_cast<size_t>(height);
     switch (bit_depth) {
     case 8:
       fill<uint8_t>(in_ptr, out_ptr, data_type, num_elements);

--- a/cpp/core/file/png.h
+++ b/cpp/core/file/png.h
@@ -88,7 +88,7 @@ template <typename T>
 void Writer::fill(std::byte *in_ptr, std::byte *out_ptr, const DataType data_type, const size_t num_elements) {
   std::function<default_type(const void *, size_t, default_type, default_type)> fetch_func;
   std::function<void(default_type, void *, size_t, default_type, default_type)> store_func;
-  __set_fetch_store_scale_functions<default_type>(fetch_func, store_func, data_type);
+  _set_fetch_store_scale_functions<default_type>(fetch_func, store_func, data_type);
   for (size_t i = 0; i != num_elements; ++i) {
     Raw::store_BE<T>(std::min(static_cast<default_type>(std::numeric_limits<T>::max()),                 //
                               std::max(0.0, std::round(multiplier * fetch_func(in_ptr, i, 0.0, 1.0)))), //

--- a/cpp/core/file/temp.cpp
+++ b/cpp/core/file/temp.cpp
@@ -17,6 +17,8 @@
 #include "file/temp.h"
 
 #include <fcntl.h>
+#include <filesystem>
+#include <optional>
 #include <random>
 #include <string>
 #include <sys/stat.h>

--- a/cpp/core/file/temp.cpp
+++ b/cpp/core/file/temp.cpp
@@ -17,11 +17,13 @@
 #include "file/temp.h"
 
 #include <fcntl.h>
+#include <random>
 #include <string>
 #include <sys/stat.h>
 #include <unistd.h>
 
 #include "app.h"
+#include "env.h"
 #include "exception.h"
 #include "file/config.h"
 #include "file/path.h"
@@ -71,8 +73,8 @@ std::filesystem::path _get_tmpfile_dir() {
 }
 
 const std::filesystem::path &tmpfile_dir() {
-  static const std::filesystem::path __tmpfile_dir{__get_tmpfile_dir()};
-  return __tmpfile_dir;
+  static const std::filesystem::path _tmpfile_dir{_get_tmpfile_dir()};
+  return _tmpfile_dir;
 }
 
 // CONF option: TmpFilePrefix
@@ -90,16 +92,16 @@ const std::filesystem::path &tmpfile_dir() {
 // ENVVAR the name  of temporary files (as used in Unix pipes) for a
 // ENVVAR single session, within a single script, or for a single command
 // ENVVAR without modifying the configuration file.
-std::string __get_tmpfile_prefix() {
-  const char *from_env = getenv("MRTRIX_TMPFILE_PREFIX"); // check_syntax off
-  if (from_env != nullptr)
-    return from_env;
+std::string _get_tmpfile_prefix() {
+  const std::optional<std::string> from_env = MR::get_env("MRTRIX_TMPFILE_PREFIX");
+  if (from_env.has_value())
+    return from_env.value();
   return File::Config::get("TmpFilePrefix", "mrtrix-tmp-");
 }
 
 std::string tmpfile_prefix() {
-  static const std::string __tmpfile_prefix = __get_tmpfile_prefix();
-  return __tmpfile_prefix;
+  static const std::string _tmpfile_prefix = _get_tmpfile_prefix();
+  return _tmpfile_prefix;
 }
 
 } // namespace
@@ -130,12 +132,12 @@ std::filesystem::path create_tempfile(int64_t size, std::string_view suffix) {
 
   if (fid < 0)
     throw Exception(std::string("error creating temporary file in directory \"" + tmpfile_dir().string() + "\": ") +
-                    strerror(errno));
+                    MR::C_strerror(errno));
 
   const int status = size == 0 ? 0 : ftruncate(fid, size);
   close(fid);
   if (status)
-    throw Exception("cannot resize file \"" + filepath.string() + "\": " + strerror(errno));
+    throw Exception("cannot resize file \"" + filepath.string() + "\": " + MR::C_strerror(errno));
 
   return filepath;
 }

--- a/cpp/core/file/temp.cpp
+++ b/cpp/core/file/temp.cpp
@@ -30,7 +30,9 @@ namespace MR::File {
 
 namespace {
 inline char random_char() {
-  const char c = rand() % 62;
+  thread_local std::mt19937 rng{std::random_device{}()};
+  thread_local std::uniform_int_distribution<int> dist{0, 61};
+  const char c = static_cast<const char>(dist(rng));
   if (c < 10)
     return c + 48;
   if (c < 36)
@@ -61,19 +63,11 @@ inline char random_char() {
 // ENVVAR temporary files (as used in Unix pipes) for a single session,
 // ENVVAR within a single script, or for a single command without
 // ENVVAR modifying the configuration  file.
-std::filesystem::path __get_tmpfile_dir() {
-  const char *from_env_mrtrix = getenv("MRTRIX_TMPFILE_DIR"); // check_syntax off
-  if (from_env_mrtrix != nullptr)
-    return std::string(from_env_mrtrix);
-
-  std::filesystem::path default_tmpdir = std::filesystem::temp_directory_path();
-
-  const char *from_env_general = getenv("TMPDIR"); // check_syntax off
-  if (from_env_general != nullptr)
-    default_tmpdir = std::filesystem::path(from_env_general);
-
-  const std::string from_config = File::Config::get("TmpFileDir");
-  return from_config.empty() ? default_tmpdir : std::filesystem::path(from_config);
+std::filesystem::path _get_tmpfile_dir() {
+  const std::optional<std::filesystem::path> from_env_mrtrix = MR::get_env("MRTRIX_TMPFILE_DIR");
+  if (from_env_mrtrix.has_value())
+    return from_env_mrtrix.value();
+  return {File::Config::get("TmpFileDir", MR::get_env("TMPDIR", std::filesystem::temp_directory_path().string()))};
 }
 
 const std::filesystem::path &tmpfile_dir() {

--- a/cpp/core/file/temp.h
+++ b/cpp/core/file/temp.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <filesystem>
 #include <string_view>
 

--- a/cpp/core/filter/demodulate.h
+++ b/cpp/core/filter/demodulate.h
@@ -160,8 +160,7 @@ public:
       // Determine direction and frequency of harmonic
       pos_type kspace_origin;
       for (ssize_t axis = 0; axis != 3; ++axis)
-        // Do integer division, then convert to floating-point
-        kspace_origin[axis] = axis_mask[axis] ? real_type((kspace.size(axis) - 1) / 2) : real_type(0);
+        kspace_origin[axis] = axis_mask[axis] ? static_cast<real_type>((kspace.size(axis) - 1) / 2) : real_type(0);
       const pos_type kspace_offset({axis_mask[0] ? (pos[0] - kspace_origin[0]) : real_type(0),
                                     axis_mask[1] ? (pos[1] - kspace_origin[1]) : real_type(0),
                                     axis_mask[2] ? (pos[2] - kspace_origin[2]) : real_type(0)});

--- a/cpp/core/filter/zclean.h
+++ b/cpp/core/filter/zclean.h
@@ -241,12 +241,8 @@ public:
         continue;
       float val = input.value();
       if (mask.value()) {
-        if (val < lo)
-          output.value() = val; // hack
-        else if (val > hi)
-          output.value() = hi;
-        else
-          output.value() = val;
+        // Includes hack for val < lo
+        output.value() = val > hi ? hi : val;
         continue;
       } else { // outside refined mask but inside initial mask
         if (keep_lower && val < lo)

--- a/cpp/core/fixel/filter/smooth.cpp
+++ b/cpp/core/fixel/filter/smooth.cpp
@@ -72,7 +72,8 @@ void Smooth::operator()(Image<float> &input, Image<float> &output) const {
   public:
     Source(const size_t N) : number(N), counter(0) {}
     bool operator()(size_t &fixel) {
-      if ((fixel = counter) == number)
+      fixel = counter;
+      if (fixel == number)
         return false;
       ++counter;
       return true;

--- a/cpp/core/fixel/matrix.cpp
+++ b/cpp/core/fixel/matrix.cpp
@@ -189,7 +189,6 @@ private:
 } // namespace
 
 #define FIXEL_MATRIX_GENERATE_SHARED                                                                                   \
-  const auto fixel_dir_path = index_image.path().parent_path();                                                        \
   auto directions_image = Fixel::find_directions_header(index_image.path().parent_path())                              \
                               .template get_image<default_type>(DirectIO{Stride::List{+2, +1}});                       \
   DWI::Tractography::Properties properties;                                                                            \

--- a/cpp/core/fixel/validate.cpp
+++ b/cpp/core/fixel/validate.cpp
@@ -67,7 +67,8 @@ void validate_directory(const std::filesystem::path &fixel_directory_path) {
                                         " but the index image contains " + str(total_nfixels)); //
     } catch (InvalidDirectoryException &) {
       throw;
-    } catch (...) {
+    } catch (Exception &e) {
+      DEBUG("Unable to open \"" + entry.path().string() + "\" as image; ignoring");
     }
   }
   if (!directions_found)
@@ -104,13 +105,17 @@ index_type validate_index_image(Image<index_type> index_image) {
   // Check whether this total number matches what is stored in the header
   try {
     const index_type nfixels_header = to<index_type>(index_image.keyval().at(n_fixels_key));
-    if (to<index_type>(index_image.keyval().at(n_fixels_key)) != total_nfixels) {
+    if (nfixels_header != total_nfixels) {
       WARN("Total number of fixels indicated in header of image \"" + index_image.name() + "\"" + //
            " (" + str(nfixels_header) + ")" +                                                     //
            " does not match that indicated in image data" +                                       //
            " (" + str(total_nfixels) + ")");                                                      //
     }
-  } catch (std::out_of_range &) {
+  } catch (std::out_of_range &e) {
+    DEBUG("Fixel count \"" + index_image.keyval().at(n_fixels_key) + "\"" + //
+          " in fixel index image \"" + index_image.name() + "\"" +          //
+          " out of integer range (error: \"" + str(e.what()) + "\");" +     //
+          " unable to compare to max fixel index in image (" + str(total_nfixels) + "\"");
   }
 
   // Verify that every fixel index in [0, total_nfixels) is covered

--- a/cpp/core/fixel/validate.cpp
+++ b/cpp/core/fixel/validate.cpp
@@ -17,13 +17,16 @@
 #include "fixel/validate.h"
 
 #include <limits>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include "algo/loop.h"
+#include "exception.h"
 #include "fixel/helpers.h"
 #include "image.h"
+#include "mrtrix.h"
 
 namespace MR::Fixel {
 

--- a/cpp/core/fixel/validate.h
+++ b/cpp/core/fixel/validate.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <filesystem>
+#include <limits>
 #include <optional>
 #include <string_view>
 

--- a/cpp/core/formats/list.h
+++ b/cpp/core/formats/list.h
@@ -18,6 +18,8 @@
 
 #include "header.h"
 
+// NOLINTBEGIN(bugprone-macro-parentheses)
+
 #define DECLARE_IMAGEFORMAT(format, desc)                                                                              \
   class format : public Base {                                                                                         \
   public:                                                                                                              \
@@ -26,6 +28,8 @@
     virtual bool check(Header &H, size_t num_axes) const;                                                              \
     virtual std::unique_ptr<ImageIO::Base> create(Header &H) const;                                                    \
   }
+
+// NOLINTEND(bugprone-macro-parentheses)
 
 //! Classes responsible for handling of specific image formats
 namespace MR::Formats {

--- a/cpp/core/formats/mri.cpp
+++ b/cpp/core/formats/mri.cpp
@@ -76,8 +76,9 @@ inline size_t char2order(char item, bool &forward) {
   case 'E':
     forward = false;
     return (3);
+  default:
+    return (std::numeric_limits<size_t>::max());
   }
-  return (std::numeric_limits<size_t>::max());
 }
 
 inline char order2char(size_t axis, bool forward) {
@@ -102,8 +103,9 @@ inline char order2char(size_t axis, bool forward) {
       return ('B');
     else
       return ('E');
+  default:
+    return ('\0');
   }
-  return ('\0');
 }
 
 inline uint32_t type(const std::byte *pos, bool is_BE) { return Raw::fetch_<uint32_t>(pos, is_BE); }
@@ -151,7 +153,7 @@ std::unique_ptr<ImageIO::Base> MRI::read(Header &H) const {
 
   File::MMap fmap(const_cast<const Header &>(H).path());
 
-  if (memcmp(fmap.address(), "MRI#", 4))
+  if (memcmp(fmap.address(), "MRI#", 4) != 0)
     throw Exception("file \"" + H.path().string() + "\" is not in MRI format (unrecognised magic number)");
 
   bool is_BE = false;

--- a/cpp/core/formats/mri.cpp
+++ b/cpp/core/formats/mri.cpp
@@ -15,6 +15,8 @@
  */
 
 #include <cstddef>
+#include <cstring>
+#include <limits>
 
 #include "file/config.h"
 #include "file/mmap.h"

--- a/cpp/core/formats/mrtrix_gz.cpp
+++ b/cpp/core/formats/mrtrix_gz.cpp
@@ -39,17 +39,16 @@ std::unique_ptr<ImageIO::Base> MRtrix_GZ::read(Header &H) const {
   zf.close();
 
   std::filesystem::path filepath;
-  size_t offset, write_offset;
+  size_t offset;
   get_mrtrix_file_path(H, "file", filepath, offset);
-  write_offset = offset;
   if (filepath != hpath)
     throw Exception("GZip-compressed MRtrix format images must have image data within the same file as the header");
 
   std::stringstream header;
   header << "mrtrix image\n";
   write_mrtrix_header(H, header);
-  write_offset = header.str().size() + size_t(24);
-  write_offset += ((4 - (offset % 4)) % 4);
+  size_t write_offset = header.str().size() + size_t(24);
+  write_offset += ((4 - (write_offset % 4)) % 4);
   header << "file: . " << write_offset << "\nEND\n";
 
   std::unique_ptr<ImageIO::GZ> io_handler(new ImageIO::GZ(H, write_offset));

--- a/cpp/core/formats/par.cpp
+++ b/cpp/core/formats/par.cpp
@@ -120,7 +120,7 @@ std::unique_ptr<ImageIO::Base> PAR::read(Header &H) const {
 
   std::ifstream in(hpath, std::ios::binary);
   if (!in)
-    throw Exception("error opening PAR/REC header \"" + H.path().string() + "\": " + strerror(errno));
+    throw Exception("error opening PAR/REC header \"" + H.path().string() + "\": " + MR::C_strerror(errno));
 
   float version = NaNF;
   ParCols cols;

--- a/cpp/core/formats/par.cpp
+++ b/cpp/core/formats/par.cpp
@@ -22,6 +22,7 @@
 #include <tuple>
 
 #include "dwi/gradient.h"
+#include "exception.h"
 #include "file/config.h"
 #include "file/mmap.h"
 #include "file/ofstream.h"

--- a/cpp/core/formats/png.cpp
+++ b/cpp/core/formats/png.cpp
@@ -92,11 +92,9 @@ std::unique_ptr<ImageIO::Base> PNG::read(Header &H) const {
     }
     break;
   case 2:
-    H.datatype() = DataType::UInt8;
-    break;
+    [[fallthrough]];
   case 4:
-    H.datatype() = DataType::UInt8;
-    break;
+    [[fallthrough]];
   case 8:
     H.datatype() = DataType::UInt8;
     break;

--- a/cpp/core/formats/xds.cpp
+++ b/cpp/core/formats/xds.cpp
@@ -37,7 +37,7 @@ std::unique_ptr<ImageIO::Base> XDS::read(Header &H) const {
 
   std::ifstream in(hdr_path);
   if (!in)
-    throw Exception("error reading header file \"" + hdr_path.string() + "\": " + strerror(errno));
+    throw Exception("error reading header file \"" + hdr_path.string() + "\": " + MR::C_strerror(errno));
   std::array<int, 3> dim{};
   in >> dim[0] >> dim[1] >> dim[2] >> BE;
   H.size(0) = dim[1];

--- a/cpp/core/formats/xds.cpp
+++ b/cpp/core/formats/xds.cpp
@@ -15,7 +15,9 @@
  */
 
 #include <array>
+#include <cerrno>
 
+#include "exception.h"
 #include "file/entry.h"
 #include "file/ofstream.h"
 #include "file/path.h"

--- a/cpp/core/gpu/gpu.cpp
+++ b/cpp/core/gpu/gpu.cpp
@@ -17,6 +17,7 @@
 #include "gpu.h"
 #include "adapter/extract.h"
 #include "algo/threaded_copy.h"
+#include "env.h"
 #include "exception.h"
 #include "image_helpers.h"
 #include "match_variant.h"
@@ -196,13 +197,12 @@ std::future<Slang::ComPtr<slang::IGlobalSession>> request_slang_global_session_a
 }
 
 std::optional<uint32_t> parse_gpu_adapter_index_env() {
-  // NOLINTNEXTLINE(concurrency-mt-unsafe)
-  const char *gpu_id_env = std::getenv("MRTRIX_GPU_ID"); // check_syntax off
-  if (gpu_id_env == nullptr) {
+  const std::optional<std::string> gpu_id_env = MR::get_env("MRTRIX_GPU_ID");
+  if (!gpu_id_env.has_value()) {
     return std::nullopt;
   }
 
-  const std::string_view gpu_id_string = gpu_id_env;
+  const std::string_view gpu_id_string = *gpu_id_env;
   uint32_t gpu_id = 0;
   const auto [parsed_to, parse_error] =
       std::from_chars(gpu_id_string.data(), gpu_id_string.data() + gpu_id_string.size(), gpu_id);
@@ -298,9 +298,8 @@ ComputeContext::ComputeContext() : m_slang_session_info(std::make_unique<SlangSe
 
     // On MacOS, MRTRIX_GPU_DEBUG_TRACE can be enabled together with METAL_CAPTURE_ENABLED=1 and DAWN_TRACE_FILE_BASE to
     // produce a GPU trace that can be opened in Xcode for profile and debugging.
-    // NOLINTNEXTLINE(concurrency-mt-unsafe)
-    const char *dawn_gpu_debug_env = std::getenv("MRTRIX_GPU_DEBUG_TRACE"); // check_syntax off
-    if (dawn_gpu_debug_env != nullptr && std::string(dawn_gpu_debug_env) == "1") {
+    const std::optional<std::string> dawn_gpu_debug_env = MR::get_env("MRTRIX_GPU_DEBUG_TRACE");
+    if (dawn_gpu_debug_env.has_value() && *dawn_gpu_debug_env == "1") {
       dawn_toggles.emplace_back("dump_shaders");
       dawn_toggles.emplace_back("disable_symbol_renaming");
     }

--- a/cpp/core/half.h
+++ b/cpp/core/half.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "eigen_plugins/eigen_plugins.h"
 #include <Eigen/Core>
 #include <type_traits>
 

--- a/cpp/core/half.h
+++ b/cpp/core/half.h
@@ -16,6 +16,9 @@
 
 #pragma once
 
+#include <Eigen/Core>
+#include <type_traits>
+
 namespace std {
 template <> struct is_fundamental<Eigen::half> : std::true_type {};
 template <> struct is_floating_point<Eigen::half> : std::true_type {};

--- a/cpp/core/header.cpp
+++ b/cpp/core/header.cpp
@@ -150,7 +150,8 @@ Header Header::open(const std::filesystem::path &image_path) {
     H.path() = list[item_index].name();
 
     for (; *format_handler; format_handler++) {
-      if ((H.io = (*format_handler)->read(H)))
+      H.io = (*format_handler)->read(H);
+      if (static_cast<bool>(H.io))
         break;
     }
 
@@ -194,7 +195,8 @@ Header Header::open(const std::filesystem::path &image_path) {
             std::unique_ptr<ImageIO::Base> io_handler;
             header.path() = list[++item_index].name();
             header.keyval().clear();
-            if (!(io_handler = (*format_handler)->read(header)))
+            io_handler = (*format_handler)->read(header);
+            if (io_handler == nullptr)
               throw Exception("image specifier contains mixed format files");
             assert(io_handler);
             template_header.check(header);
@@ -878,11 +880,11 @@ concatenate(const std::vector<Header> &headers, const size_t axis_to_concat, con
       Eigen::MatrixXd extra_pe;
       try {
         extra_dw = DWI::parse_DW_scheme(H);
-      } catch (Exception &) {
+      } catch (Exception &) { // NOLINT(bugprone-empty-catch)
       }
       try {
         extra_pe = Metadata::PhaseEncoding::get_scheme(H);
-      } catch (Exception &) {
+      } catch (Exception &) { // NOLINT(bugprone-empty-catch)
       }
 
       switch (dwscheme_manip) {

--- a/cpp/core/header.h
+++ b/cpp/core/header.h
@@ -101,8 +101,8 @@ public:
         keyval_(H.keyval_),
         format_(H.format_),
         datatype_(H.datatype_),
-        offset_(datatype().is_integer() ? H.offset_ : 0.0),
-        scale_(datatype().is_integer() ? H.scale_ : 1.0),
+        offset_(H.datatype_.is_integer() ? H.offset_ : 0.0),
+        scale_(H.datatype_.is_integer() ? H.scale_ : 1.0),
         realignment_(H.realignment_) {}
 
   //! copy constructor from type of class derived from Header

--- a/cpp/core/image.h
+++ b/cpp/core/image.h
@@ -383,13 +383,19 @@ template <typename ValueType> Image<ValueType>::Buffer::~Buffer() {
     return;
   if (!ram.has_value())
     return;
-  auto local_data = std::move(ram->data);
-  // Construct a temporary shared_ptr with a no-op deleter so that Image can be
-  // used as a write destination without triggering a second deletion of this.
-  std::shared_ptr<Buffer> self(this, [](Buffer *) {});
-  TmpImage<ValueType> src = {*this, local_data.get(), std::vector<ssize_t>(ndim(), 0), ram->strides, ram->offset};
-  Image<ValueType> dest(self);
-  threaded_copy_with_progress_message("writing back direct IO buffer for \"" + name() + "\"", src, dest);
+  try {
+    auto local_data = std::move(ram->data);
+    // Construct a temporary shared_ptr with a no-op deleter so that Image can be
+    // used as a write destination without triggering a second deletion of this.
+    std::shared_ptr<Buffer> self(this, [](Buffer *) {});
+    TmpImage<ValueType> src = {*this, local_data.get(), std::vector<ssize_t>(ndim(), 0), ram->strides, ram->offset};
+    Image<ValueType> dest(self);
+    threaded_copy_with_progress_message("writing back direct IO buffer for \"" + name() + "\"", src, dest);
+  } catch (Exception &e) {
+    Exception(e, "Error during writeback of image \"" + name() + "\"; image may be corrupt").display();
+  } catch (std::exception &e) {
+    WARN("Error during writeback of image \"" + name() + "\"---" + e.what() + "---image may be corrupt");
+  }
 }
 
 template <typename ValueType>

--- a/cpp/core/image.h
+++ b/cpp/core/image.h
@@ -231,7 +231,7 @@ protected:
   std::function<ValueType(const void *, size_t, default_type, default_type)> fetch_func;
   std::function<void(ValueType, void *, size_t, default_type, default_type)> store_func;
 
-  void set_fetch_store_functions() { __set_fetch_store_scale_functions(fetch_func, store_func, datatype()); }
+  void set_fetch_store_functions() { _set_fetch_store_scale_functions(fetch_func, store_func, datatype()); }
 };
 
 //! \cond skip
@@ -351,9 +351,8 @@ Image<ValueType> Header::get_image(std::optional<DirectIO> direct_io, bool read_
   // direct-IO preload completes before the shared_ptr is published. After this
   // point, Buffer::ram is immutable until destruction (writeback).
   auto raw = std::make_unique<typename Image<ValueType>::Buffer>(*this, read_write_if_existing, std::move(direct_io));
-  Stride::List image_strides;
-  if (raw->ram.has_value())
-    image_strides = raw->ram->strides;
+  // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+  const Stride::List image_strides = raw->ram.has_value() ? raw->ram->strides : Stride::List();
   std::shared_ptr<typename Image<ValueType>::Buffer> buffer(std::move(raw));
   return Image<ValueType>(buffer, image_strides);
 }
@@ -438,7 +437,7 @@ std::filesystem::path Image<ValueType>::dump_to_mrtrix_file(const std::filesyste
 }
 
 template <class ImageType>
-std::filesystem::path __save_generic(ImageType &x, const std::filesystem::path &filepath, bool use_multi_threading) {
+std::filesystem::path _save_generic(ImageType &x, const std::filesystem::path &filepath, bool use_multi_threading) {
   auto out = Image<typename ImageType::value_type>::create(filepath, x);
   if (use_multi_threading)
     threaded_copy(x, out);
@@ -454,7 +453,7 @@ template <class ImageType>
 typename std::enable_if<is_adapter_type<typename std::remove_reference<ImageType>::type>::value,
                         std::filesystem::path>::type
 save(ImageType &&x, const std::filesystem::path &filepath, bool use_multi_threading = true) {
-  return __save_generic(x, filepath, use_multi_threading);
+  return _save_generic(x, filepath, use_multi_threading);
 }
 
 //! save contents of an existing image to file (for debugging only)
@@ -464,15 +463,16 @@ typename std::enable_if<is_pure_image<typename std::remove_reference<ImageType>:
 save(ImageType &&x, const std::filesystem::path &filepath, bool use_multi_threading = true) {
   try {
     return x.dump_to_mrtrix_file(filepath);
-  } catch (...) {
+  } catch (Exception &) {
+    return _save_generic(x, filename, use_multi_threading);
   }
-  return __save_generic(x, filepath, use_multi_threading);
 }
 
 //! display the contents of an image in MRView (for debugging only)
 template <class ImageType> typename enable_if_image_type<ImageType, void>::type display(ImageType &x) {
   const std::filesystem::path filepath = save(x, "-");
   CONSOLE("displaying image \"" + filepath.string() + "\"");
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
   if (system(("bash -c \"mrview " + filepath.string() + "\"").c_str()))
     WARN(std::string("error invoking viewer: ") + MR::C_strerror(errno));
 }

--- a/cpp/core/image.h
+++ b/cpp/core/image.h
@@ -464,7 +464,7 @@ save(ImageType &&x, const std::filesystem::path &filepath, bool use_multi_thread
   try {
     return x.dump_to_mrtrix_file(filepath);
   } catch (Exception &) {
-    return _save_generic(x, filename, use_multi_threading);
+    return _save_generic(x, filepath, use_multi_threading);
   }
 }
 

--- a/cpp/core/image.h
+++ b/cpp/core/image.h
@@ -18,6 +18,7 @@
 
 #define IMAGE_H
 
+#include <cerrno>
 #include <cstddef>
 #include <functional>
 #include <optional>
@@ -28,6 +29,7 @@
 #include "algo/threaded_copy.h"
 #include "debug.h"
 #include "directio.h"
+#include "exception.h"
 #include "fetch_store.h"
 #include "file/ofstream.h"
 #include "file/temp.h"

--- a/cpp/core/image.h
+++ b/cpp/core/image.h
@@ -427,7 +427,7 @@ std::filesystem::path Image<ValueType>::dump_to_mrtrix_file(const std::filesyste
   out.seekp(offset, out.beg);
   out.write((const char *)data_pointer, data_size);
   if (!out.good())
-    throw Exception("error writing back contents of file \"" + data_path.string() + "\": " + strerror(errno));
+    throw Exception("error writing back contents of file \"" + data_path.string() + "\": " + MR::C_strerror(errno));
   out.close();
 
   // If data_size exceeds some threshold, ostream artificially increases the file size beyond that required at close()
@@ -474,7 +474,7 @@ template <class ImageType> typename enable_if_image_type<ImageType, void>::type 
   const std::filesystem::path filepath = save(x, "-");
   CONSOLE("displaying image \"" + filepath.string() + "\"");
   if (system(("bash -c \"mrview " + filepath.string() + "\"").c_str()))
-    WARN(std::string("error invoking viewer: ") + strerror(errno));
+    WARN(std::string("error invoking viewer: ") + MR::C_strerror(errno));
 }
 // Explicit instantiations in image.cpp:
 extern template MR::Image<bool>::Buffer::~Buffer();

--- a/cpp/core/image_diff.h
+++ b/cpp/core/image_diff.h
@@ -127,25 +127,17 @@ inline void check_keyvals(const HeaderType1 &in1, const HeaderType2 &in2) {
     while (it2 != in2.keyval().end() && reserved.find(it2->first) != reserved.end())
       ++it2;
 
-    if (it1 == in1.keyval().end() || it2 == in2.keyval().end())
+    if (it1 == in1.keyval().end() && it2 == in2.keyval().end())
       break;
 
-    if (it1 == in1.keyval().end()) {
-      errors.push_back("Key \"" + it2->first + "\" in image \"" + in2.name() + "\" not present in \"" + in1.name() +
-                       "\"");
+    if (it1 == in1.keyval().end() || (it2 != in2.keyval().end() && it1->first > it2->first)) {
+      errors.push_back("Key \"" + it2->first + "\" in image \"" + in2.name() + "\"" + //
+                       " not present in \"" + in1.name() + "\"");                     //
       ++it2;
-    } else if (it2 == in2.keyval().end()) {
-      errors.push_back("Key \"" + it1->first + "\" in image \"" + in1.name() + "\" not present in \"" + in2.name() +
-                       "\"");
+    } else if (it2 == in2.keyval().end() || (it1 != in1.keyval().end() && it1->first < it2->first)) {
+      errors.push_back("Key \"" + it1->first + "\" in image \"" + in1.name() + "\"" + //
+                       " not present in \"" + in2.name() + "\"");                     //
       ++it1;
-    } else if (it1->first < it2->first) {
-      errors.push_back("Key \"" + it1->first + "\" in image \"" + in1.name() + "\" not present in \"" + in2.name() +
-                       "\"");
-      ++it1;
-    } else if (it1->first > it2->first) {
-      errors.push_back("Key \"" + it2->first + "\" in image \"" + in2.name() + "\" not present in \"" + in1.name() +
-                       "\"");
-      ++it2;
     } else {
       if (it1->second != it2->second)
         errors.push_back("Key \"" + it1->first + "\" has different values between images");

--- a/cpp/core/image_helpers.h
+++ b/cpp/core/image_helpers.h
@@ -271,6 +271,11 @@ template <class HeaderType> inline int64_t voxel_count(const HeaderType &in, con
   return fp;
 }
 
+// Disable warning:
+//   this presumably gets called on a pointer type
+//   due to DWI::Fixel_map<> providing a pointer as the image datatype;
+//   this will eventually get obviated (#2644 / #2657)
+// NOLINTNEXTLINE(bugprone-sizeof-expression)
 template <typename ValueType> inline int64_t footprint(int64_t count) { return count * sizeof(ValueType); }
 
 template <> inline int64_t footprint<bool>(int64_t count) { return (count + 7) / 8; }

--- a/cpp/core/image_helpers.h
+++ b/cpp/core/image_helpers.h
@@ -16,9 +16,13 @@
 
 #pragma once
 
+#include <sys/types.h>
+#include <tuple>
+
 #include "apply.h"
 #include "datatype.h"
 #include "debug.h"
+#include "types.h"
 
 namespace MR {
 

--- a/cpp/core/image_helpers.h
+++ b/cpp/core/image_helpers.h
@@ -25,82 +25,82 @@ namespace MR {
 //! \cond skip
 namespace {
 
-template <class AxesType> FORCE_INLINE auto __ndim(const AxesType &axes) -> decltype(axes.size(), size_t()) {
+template <class AxesType> FORCE_INLINE auto _ndim(const AxesType &axes) -> decltype(axes.size(), size_t()) {
   return axes.size();
 }
 
-template <class AxesType> FORCE_INLINE auto __ndim(const AxesType &axes) -> decltype(axes.ndim(), size_t()) {
+template <class AxesType> FORCE_INLINE auto _ndim(const AxesType &axes) -> decltype(axes.ndim(), size_t()) {
   return axes.ndim();
 }
 
 template <class AxesType>
-FORCE_INLINE auto __get_index(const AxesType &axes, size_t axis) -> decltype(axes.size(), ssize_t()) {
+FORCE_INLINE auto _get_index(const AxesType &axes, size_t axis) -> decltype(axes.size(), ssize_t()) {
   return axes[axis];
 }
 
 template <class AxesType>
-FORCE_INLINE auto __get_index(const AxesType &axes, size_t axis) -> decltype(axes.ndim(), ssize_t()) {
+FORCE_INLINE auto _get_index(const AxesType &axes, size_t axis) -> decltype(axes.ndim(), ssize_t()) {
   return axes.index(axis);
 }
 
 template <class AxesType>
-FORCE_INLINE auto __set_index(AxesType &axes, size_t axis, ssize_t index) -> decltype(axes.size(), void()) {
+FORCE_INLINE auto _set_index(AxesType &axes, size_t axis, ssize_t index) -> decltype(axes.size(), void()) {
   axes[axis] = index;
 }
 
 template <class AxesType>
-FORCE_INLINE auto __set_index(AxesType &axes, size_t axis, ssize_t index) -> decltype(axes.ndim(), void()) {
+FORCE_INLINE auto _set_index(AxesType &axes, size_t axis, ssize_t index) -> decltype(axes.ndim(), void()) {
   axes.index(axis) = index;
 }
 
-template <class... DestImageType> struct __assign {
-  __assign(size_t axis, ssize_t index) : axis(axis), index(index) {}
+template <class... DestImageType> struct _assign {
+  _assign(size_t axis, ssize_t index) : axis(axis), index(index) {}
   const size_t axis;
   const ssize_t index;
-  template <class ImageType> FORCE_INLINE void operator()(ImageType &x) { __set_index(x, axis, index); }
+  template <class ImageType> FORCE_INLINE void operator()(ImageType &x) { _set_index(x, axis, index); }
 };
 
-template <class... DestImageType> struct __assign<std::tuple<DestImageType...>> {
-  __assign(size_t axis, ssize_t index) : axis(axis), index(index) {}
+template <class... DestImageType> struct _assign<std::tuple<DestImageType...>> {
+  _assign(size_t axis, ssize_t index) : axis(axis), index(index) {}
   const size_t axis;
   const ssize_t index;
   template <class ImageType> FORCE_INLINE void operator()(ImageType &x) {
-    MR::apply_for_each(__assign<DestImageType...>(axis, index), x);
+    MR::apply_for_each(_assign<DestImageType...>(axis, index), x);
   }
 };
 
-template <class... DestImageType> struct __max_axis {
-  __max_axis(size_t &axis) : axis(axis) {}
+template <class... DestImageType> struct _max_axis {
+  _max_axis(size_t &axis) : axis(axis) {}
   size_t &axis;
   template <class ImageType> FORCE_INLINE void operator()(ImageType &x) {
-    if (axis > __ndim(x))
-      axis = __ndim(x);
+    if (axis > _ndim(x))
+      axis = _ndim(x);
   }
 };
 
-template <class... DestImageType> struct __max_axis<std::tuple<DestImageType...>> {
-  __max_axis(size_t &axis) : axis(axis) {}
+template <class... DestImageType> struct _max_axis<std::tuple<DestImageType...>> {
+  _max_axis(size_t &axis) : axis(axis) {}
   size_t &axis;
   template <class ImageType> FORCE_INLINE void operator()(ImageType &x) {
-    MR::apply_for_each(__max_axis<DestImageType...>(axis), x);
+    MR::apply_for_each(_max_axis<DestImageType...>(axis), x);
   }
 };
 
-template <class ImageType> struct __assign_pos_axis_range {
+template <class ImageType> struct _assign_pos_axis_range {
   template <class... DestImageType> FORCE_INLINE void to(DestImageType &...dest) const {
     size_t last_axis = to_axis;
-    MR::apply_for_each(__max_axis<DestImageType...>(last_axis), std::tie(ref, dest...));
+    MR::apply_for_each(_max_axis<DestImageType...>(last_axis), std::tie(ref, dest...));
     for (size_t n = from_axis; n < last_axis; ++n)
-      MR::apply_for_each(__assign<DestImageType...>(n, __get_index(ref, n)), std::tie(dest...));
+      MR::apply_for_each(_assign<DestImageType...>(n, _get_index(ref, n)), std::tie(dest...));
   }
   const ImageType &ref;
   const size_t from_axis, to_axis;
 };
 
-template <class ImageType, typename IntType> struct __assign_pos_axes {
+template <class ImageType, typename IntType> struct _assign_pos_axes {
   template <class... DestImageType> FORCE_INLINE void to(DestImageType &...dest) const {
     for (auto a : axes)
-      MR::apply_for_each(__assign<DestImageType...>(a, __get_index(ref, a)), std::tie(dest...));
+      MR::apply_for_each(_assign<DestImageType...>(a, _get_index(ref, a)), std::tie(dest...));
   }
   const ImageType &ref;
   const std::vector<IntType> axes;
@@ -165,7 +165,7 @@ template <class ImageType> struct is_adapter_type {
  * index(size_t) methods) or VectorType objects (i.e. with size() &
  * operator[](size_t) methods). */
 template <class ImageType>
-FORCE_INLINE __assign_pos_axis_range<ImageType>
+FORCE_INLINE _assign_pos_axis_range<ImageType>
 assign_pos_of(const ImageType &reference, size_t from_axis = 0, size_t to_axis = std::numeric_limits<size_t>::max()) {
   return {reference, from_axis, to_axis};
 }
@@ -181,14 +181,14 @@ assign_pos_of(const ImageType &reference, size_t from_axis = 0, size_t to_axis =
  * index(size_t) methods) or VectorType objects (i.e. with size() &
  * operator[](size_t) methods). */
 template <class ImageType, typename IntType>
-FORCE_INLINE __assign_pos_axes<ImageType, IntType> assign_pos_of(const ImageType &reference,
-                                                                 const std::vector<IntType> &axes) {
+FORCE_INLINE _assign_pos_axes<ImageType, IntType> assign_pos_of(const ImageType &reference,
+                                                                const std::vector<IntType> &axes) {
   return {reference, axes};
 }
 
 template <class ImageType, typename IntType>
-FORCE_INLINE __assign_pos_axes<ImageType, IntType> assign_pos_of(const ImageType &reference,
-                                                                 const std::vector<IntType> &&axes) {
+FORCE_INLINE _assign_pos_axes<ImageType, IntType> assign_pos_of(const ImageType &reference,
+                                                                const std::vector<IntType> &&axes) {
   return assign_pos_of(reference, axes);
 }
 
@@ -577,6 +577,7 @@ public:
       image.value() = other.image.value();
   }
 
+// NOLINTBEGIN
 #define MRTRIX_OP(ARG)                                                                                                 \
   template <class OtherImageType> FORCE_INLINE void operator ARG(ConstRow<OtherImageType> &&other) {                   \
     assert(image.size(axis) == other.image.size(other.axis));                                                          \
@@ -588,11 +589,16 @@ public:
   MRTRIX_OP(+=);
   MRTRIX_OP(-=);
 #undef MRTRIX_OP
+  // NOLINTEND
 };
 
 } // namespace Helper
 
 template <class Derived, typename ValueType> class ImageBase {
+protected:
+  // NOLINTNEXTLINE(bugprone-crtp-constructor-accessibility)
+  ImageBase() = default;
+
 public:
   using value_type = ValueType;
 

--- a/cpp/core/image_io/default.cpp
+++ b/cpp/core/image_io/default.cpp
@@ -57,7 +57,7 @@ void Default::unload(const Header &header) {
         out.seekp(files[n].start, out.beg);
         out.write(reinterpret_cast<const char *>(addresses[0].get() + n * bytes_per_segment), bytes_per_segment);
         if (!out.good())
-          throw Exception("error writing back contents of file \"" + files[n].path.string() + "\": " + strerror(errno));
+          throw Exception("error writing back contents of file \"" + files[n].path.string() + "\": " + MR::C_strerror(errno));
       }
     }
   } else {

--- a/cpp/core/image_io/default.cpp
+++ b/cpp/core/image_io/default.cpp
@@ -57,7 +57,8 @@ void Default::unload(const Header &header) {
         out.seekp(files[n].start, out.beg);
         out.write(reinterpret_cast<const char *>(addresses[0].get() + n * bytes_per_segment), bytes_per_segment);
         if (!out.good())
-          throw Exception("error writing back contents of file \"" + files[n].path.string() + "\": " + MR::C_strerror(errno));
+          throw Exception("error writing back contents of file \"" + files[n].path.string() + "\": " + //
+                          MR::C_strerror(errno));                                                      //
       }
     }
   } else {

--- a/cpp/core/image_io/default.cpp
+++ b/cpp/core/image_io/default.cpp
@@ -14,6 +14,7 @@
  * For more details, see http://www.mrtrix.org/.
  */
 
+#include <cerrno>
 #include <cstddef>
 #include <limits>
 

--- a/cpp/core/image_io/default.cpp
+++ b/cpp/core/image_io/default.cpp
@@ -18,6 +18,7 @@
 #include <limits>
 
 #include "app.h"
+#include "exception.h"
 #include "file/ofstream.h"
 #include "header.h"
 #include "image_io/default.h"

--- a/cpp/core/image_io/mosaic.h
+++ b/cpp/core/image_io/mosaic.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "file/mmap.h"
+#include "header.h"
 #include "image_io/base.h"
 
 namespace MR::ImageIO {

--- a/cpp/core/image_io/pipe.cpp
+++ b/cpp/core/image_io/pipe.cpp
@@ -17,6 +17,7 @@
 #include <limits>
 #include <unistd.h>
 
+#include "env.h"
 #include "header.h"
 #include "image_io/pipe.h"
 #include "signal_handler.h"
@@ -53,10 +54,7 @@ void Pipe::unload(const Header &) {
 // ENVVAR it is necessary to retain the temp files until all
 // ENVVAR the piped commands are executed.
 namespace {
-bool preserve_tmpfile() {
-  const char *const MRTRIX_PRESERVE_TMPFILE = getenv("MRTRIX_PRESERVE_TMPFILE"); // check_syntax off
-  return (MRTRIX_PRESERVE_TMPFILE != nullptr && to<bool>(std::string(MRTRIX_PRESERVE_TMPFILE)));
-}
+bool preserve_tmpfile() { return MR::get_env("MRTRIX_PRESERVE_TMPFILE", false); }
 } // namespace
 bool Pipe::delete_piped_images = !preserve_tmpfile();
 

--- a/cpp/core/math/SH.h
+++ b/cpp/core/math/SH.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <string>
 
 #include "exception.h"
@@ -43,7 +44,7 @@ inline size_t NforL(int lmax) { return (lmax + 1) * (lmax + 2) / 2; }
 inline size_t index(int l, int m) { return l * (l + 1) / 2 + m; }
 
 //! same as NforL(), but consider only non-negative orders \e m
-inline size_t NforL_mpos(int lmax) { return (lmax / 2 + 1) * (lmax / 2 + 1); }
+inline size_t NforL_mpos(int lmax) { return (static_cast<size_t>(lmax) / 2 + 1) * (static_cast<size_t>(lmax) / 2 + 1); }
 
 //! same as index(), but consider only non-negative orders \e m
 inline size_t index_mpos(int l, int m) { return l * l / 4 + m; }
@@ -331,7 +332,7 @@ template <class MatrixType1, class VectorType2> inline MatrixType1 &sconv_mat(Ma
 }
 
 namespace {
-template <typename> struct __dummy {
+template <typename> struct _dummy {
   using type = int;
 };
 } // namespace

--- a/cpp/core/math/ZSH.h
+++ b/cpp/core/math/ZSH.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <Eigen/Dense>
+#include <cstddef>
 
 #include "math/SH.h"
 #include "math/least_squares.h"
@@ -38,7 +39,7 @@ inline size_t NforL(int lmax) { return (1 + lmax / 2); }
 inline size_t index(int l) { return (l / 2); }
 
 //! returns the largest \e lmax given \a N parameters
-inline size_t LforN(int N) { return (2 * (N - 1)); }
+inline size_t LforN(int N) { return (static_cast<size_t>(2 * (N - 1))); }
 
 //! form the ZSH->amplitudes matrix for a set of inclination angles
 /*! This computes the matrix \a ZSHT mapping zonal spherical harmonic

--- a/cpp/core/math/ZSH.h
+++ b/cpp/core/math/ZSH.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "eigen_plugins/eigen_plugins.h"
 #include <Eigen/Dense>
 #include <cstddef>
 

--- a/cpp/core/math/average_space.h
+++ b/cpp/core/math/average_space.h
@@ -16,12 +16,14 @@
 
 #pragma once
 
-#include "debug.h"
-#include "image.h"
-#include "transform.h"
+#include "eigen_plugins/eigen_plugins.h"
 #include <Eigen/Geometry>
 #include <Eigen/SVD>
 #include <unsupported/Eigen/MatrixFunctions>
+
+#include "debug.h"
+#include "image.h"
+#include "transform.h"
 
 namespace MR::Math {
 double matrix_average(std::vector<Eigen::MatrixXd> const &mat_in, Eigen::MatrixXd &mat_avg, bool verbose = false);

--- a/cpp/core/math/bessel.h
+++ b/cpp/core/math/bessel.h
@@ -16,9 +16,9 @@
 
 #pragma once
 
-#include <limits>
-
+#include "eigen_plugins/eigen_plugins.h"
 #include <Eigen/Dense>
+#include <limits>
 
 #include "math/chebyshev.h"
 

--- a/cpp/core/math/betainc.h
+++ b/cpp/core/math/betainc.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #ifdef MRTRIX_HAVE_EIGEN_UNSUPPORTED_SPECIAL_FUNCTIONS
+#include "eigen_plugins/eigen_plugins.h"
 #include <unsupported/Eigen/SpecialFunctions>
 #endif
 

--- a/cpp/core/math/condition_number.h
+++ b/cpp/core/math/condition_number.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "eigen_plugins/eigen_plugins.h"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include <Eigen/SVD>

--- a/cpp/core/math/constrained_least_squares.h
+++ b/cpp/core/math/constrained_least_squares.h
@@ -16,10 +16,11 @@
 
 #pragma once
 
-#include "math/math.h"
+#include "eigen_plugins/eigen_plugins.h"
+#include <Eigen/Cholesky>
 #include <set>
 
-#include <Eigen/Cholesky>
+#include "math/math.h"
 
 // #define DEBUG_ICLS
 

--- a/cpp/core/math/constrained_least_squares.h
+++ b/cpp/core/math/constrained_least_squares.h
@@ -17,9 +17,11 @@
 #pragma once
 
 #include "eigen_plugins/eigen_plugins.h"
+
 #include <Eigen/Cholesky>
 #include <set>
 
+#include "exception.h"
 #include "math/math.h"
 
 // #define DEBUG_ICLS

--- a/cpp/core/math/entropy.h
+++ b/cpp/core/math/entropy.h
@@ -21,6 +21,7 @@
 #include <cmath>
 #include <type_traits>
 
+#include "exception.h"
 #include "math/math.h"
 #include "types.h"
 

--- a/cpp/core/math/entropy.h
+++ b/cpp/core/math/entropy.h
@@ -16,11 +16,13 @@
 
 #pragma once
 
-#include "math/math.h"
-#include "types.h"
+#include "eigen_plugins/eigen_plugins.h"
 #include <Eigen/Dense>
 #include <cmath>
 #include <type_traits>
+
+#include "math/math.h"
+#include "types.h"
 
 namespace MR::Math::Entropy {
 

--- a/cpp/core/math/gaussian.h
+++ b/cpp/core/math/gaussian.h
@@ -16,8 +16,9 @@
 
 #pragma once
 
+#include <vector>
+
 #include "math/math.h"
-#include "math/vector.h"
 
 namespace MR::Math::Gaussian {
 

--- a/cpp/core/math/gradient_descent.h
+++ b/cpp/core/math/gradient_descent.h
@@ -19,6 +19,7 @@
 #include <limits>
 
 #include "math/math.h"
+#include "mrtrix.h"
 
 namespace MR::Math {
 

--- a/cpp/core/math/least_squares.h
+++ b/cpp/core/math/least_squares.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "eigen_plugins/eigen_plugins.h"
 #include <Eigen/Cholesky>
 
 #include "types.h"

--- a/cpp/core/math/math.h
+++ b/cpp/core/math/math.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "eigen_plugins/eigen_plugins.h"
 #include <Eigen/Core>
 #include <cmath>
 #include <cstdlib>

--- a/cpp/core/math/rician.h
+++ b/cpp/core/math/rician.h
@@ -16,9 +16,10 @@
 
 #pragma once
 
+#include <vector>
+
 #include "math/bessel.h"
 #include "math/math.h"
-#include "math/vector.h"
 
 namespace MR::Math::Rician {
 

--- a/cpp/core/math/rng.h
+++ b/cpp/core/math/rng.h
@@ -23,6 +23,7 @@
 
 #include <mutex>
 
+#include "env.h"
 #include "mrtrix.h"
 
 namespace MR::Math {
@@ -70,9 +71,9 @@ private:
     // ENVVAR setting the :envvar:`MRTRIX_NTHREADS` environment variable to zero).
     // ENVVAR Multi-threading introduces randomness in the order of execution, which
     // ENVVAR will generally also affect the reproducibility of results.
-    const char *from_env = getenv("MRTRIX_RNG_SEED"); // check_syntax off
-    if (from_env)
-      return to<std::mt19937::result_type>(from_env);
+    const std::optional<std::string> from_env = MR::get_env("MRTRIX_RNG_SEED");
+    if (from_env.has_value())
+      return to<std::mt19937::result_type>(*from_env);
 
     std::random_device rd;
     return rd();

--- a/cpp/core/math/rng.h
+++ b/cpp/core/math/rng.h
@@ -16,12 +16,13 @@
 
 #pragma once
 
+#include <mutex>
+#include <optional>
 #include <random>
+#include <string>
 #ifdef MRTRIX_WINDOWS
 #include <sys/time.h>
 #endif
-
-#include <mutex>
 
 #include "env.h"
 #include "mrtrix.h"

--- a/cpp/core/math/sech.h
+++ b/cpp/core/math/sech.h
@@ -16,8 +16,9 @@
 
 #pragma once
 
+#include <vector>
+
 #include "math/math.h"
-#include "math/vector.h"
 
 namespace MR::Math::Sech {
 
@@ -76,7 +77,7 @@ template <typename T> inline T lnP(const int N, const T *measured, const T *actu
 }
 
 template <typename T>
-inline T lnP(const Math::Vector<T> &measured, const Math::Vector<T> &actual, const T one_over_noise_squared) {
+inline T lnP(const std::vector<T> &measured, const std::vector<T> &actual, const T one_over_noise_squared) {
   assert(one_over_noise_squared > 0.0);
   assert(measured.size() == actual.size());
 
@@ -126,10 +127,10 @@ inline T lnP(const int N, const T *measured, const T *actual, const T one_over_n
 }
 
 template <typename T>
-inline T lnP(const Math::Vector<T> &measured,
-             const Math::Vector<T> &actual,
+inline T lnP(const std::vector<T> &measured,
+             const std::vector<T> &actual,
              const T one_over_noise_squared,
-             Math::Vector<T> &dP_dactual,
+             std::vector<T> &dP_dactual,
              T &dP_dN) {
   assert(one_over_noise_squared > 0.0);
   assert(measured.size() == actual.size());

--- a/cpp/core/math/sphere.h
+++ b/cpp/core/math/sphere.h
@@ -17,7 +17,7 @@
 #pragma once
 
 #include "eigen_plugins/eigen_plugins.h"
-#include <Eigen/Core>
+#include <Eigen/Dense>
 #include <cmath>
 #include <sys/types.h>
 #include <type_traits>

--- a/cpp/core/math/sphere.h
+++ b/cpp/core/math/sphere.h
@@ -16,11 +16,11 @@
 
 #pragma once
 
+#include "eigen_plugins/eigen_plugins.h"
+#include <Eigen/Core>
 #include <cmath>
 #include <sys/types.h>
 #include <type_traits>
-
-#include <Eigen/Core>
 
 #include "math/math.h"
 

--- a/cpp/core/math/stats/shuffle.cpp
+++ b/cpp/core/math/stats/shuffle.cpp
@@ -99,25 +99,12 @@ Shuffler::Shuffler(const index_type num_rows, const bool is_nonstationarity, std
     : rows(num_rows),
       nshuffles(is_nonstationarity ? default_numshuffles_nonstationarity : default_numshuffles_nulldist),
       counter(0) {
+
   using namespace App;
-  auto opt = get_options("errors");
-  error_t error_types = error_t::EE;
-  if (!opt.empty()) {
-    switch (static_cast<MR::App::ParsedArgument::IntType>(opt[0][0])) {
-    case 0:
-      error_types = error_t::EE;
-      break;
-    case 1:
-      error_types = error_t::ISE;
-      break;
-    case 2:
-      error_types = error_t::BOTH;
-      break;
-    }
-  }
+  const error_t error_types = get_option_choice<error_t>("errors", error_t::EE);
 
   bool nshuffles_explicit = false;
-  opt = get_options(is_nonstationarity ? "nshuffles_nonstationarity" : "nshuffles");
+  auto opt = get_options(is_nonstationarity ? "nshuffles_nonstationarity" : "nshuffles");
   if (!opt.empty()) {
     nshuffles = opt[0][0];
     nshuffles_explicit = true;

--- a/cpp/core/math/stats/typedefs.h
+++ b/cpp/core/math/stats/typedefs.h
@@ -16,9 +16,10 @@
 
 #pragma once
 
-#include "types.h"
-
+#include "eigen_plugins/eigen_plugins.h"
 #include <Eigen/Dense>
+
+#include "types.h"
 
 namespace MR::Math::Stats {
 

--- a/cpp/core/metadata/bids.h
+++ b/cpp/core/metadata/bids.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "eigen_plugins/eigen_plugins.h"
 #include <Eigen/Dense>
 #include <string>
 

--- a/cpp/core/metadata/phase_encoding.cpp
+++ b/cpp/core/metadata/phase_encoding.cpp
@@ -238,16 +238,15 @@ void transform_for_image_load(KeyValues &keyval, const Header &H) {
     return;
   }
   switch (H.realignment().state()) {
-  case MR::Header::Realignment::State::Unknown:
-    assert(false);
-    return;
   case MR::Header::Realignment::State::Disabled:
-    return;
+    [[fallthrough]];
   case MR::Header::Realignment::State::Identity:
     return;
   case MR::Header::Realignment::State::Applied:
     set_scheme(keyval, transform_for_image_load(pe_scheme, H));
     return;
+  case MR::Header::Realignment::State::Unknown:
+    [[fallthrough]];
   default:
     assert(false);
     return;

--- a/cpp/core/metadata/phase_encoding.cpp
+++ b/cpp/core/metadata/phase_encoding.cpp
@@ -344,7 +344,7 @@ void export_commandline(const Header &header) {
   auto check = [&](const scheme_type &m) -> const scheme_type & {
     if (m.rows() == 0)
       throw Exception("no phase-encoding information found within image \"" + header.name() + "\"");
-    return m;
+    return m; // NOLINT(bugprone-return-const-ref-from-parameter)
   };
 
   auto scheme = parse_scheme(header.keyval(), header);

--- a/cpp/core/metadata/phase_encoding.h
+++ b/cpp/core/metadata/phase_encoding.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "eigen_plugins/eigen_plugins.h"
 #include <Eigen/Dense>
 #include <array>
 #include <filesystem>

--- a/cpp/core/metadata/slice_encoding.cpp
+++ b/cpp/core/metadata/slice_encoding.cpp
@@ -31,15 +31,14 @@ void transform_for_image_load(KeyValues &keyval, const Header &header) {
   auto slice_timing_it = keyval.find("SliceTiming");
   if (!(slice_encoding_it == keyval.end() && slice_timing_it == keyval.end())) {
     switch (header.realignment().state()) {
-    case MR::Header::Realignment::State::Unknown:
-      assert(false);
-      return;
     case MR::Header::Realignment::State::Disabled:
-      return;
+      [[fallthrough]];
     case MR::Header::Realignment::State::Identity:
       return;
     case MR::Header::Realignment::State::Applied:
       break;
+    case MR::Header::Realignment::State::Unknown:
+      [[fallthrough]];
     default:
       assert(false);
       return;

--- a/cpp/core/min_mem_array.h
+++ b/cpp/core/min_mem_array.h
@@ -138,6 +138,8 @@ public:
   }
 
   Min_mem_array<T> &operator=(const Min_mem_array<T> &that) {
+    if (this == &that)
+      return (*this);
     n = that.n;
     if (d)
       delete[] d;

--- a/cpp/core/mrtrix.cpp
+++ b/cpp/core/mrtrix.cpp
@@ -99,7 +99,8 @@ namespace {
 
 // from https://www.geeksforgeeks.org/wildcard-character-matching/
 
-inline bool __match(std::string_view first, std::string_view second) {
+// NOLINTNEXTLINE(misc-no-recursion)
+inline bool _match(std::string_view first, std::string_view second) {
   // If we reach at the end of both strings, we are done
   if (first.empty() && second.empty())
     return true;
@@ -113,13 +114,13 @@ inline bool __match(std::string_view first, std::string_view second) {
   // If the first string contains '?', or current characters
   // of both strings match
   if (first[0] == '?' || first[0] == second[0])
-    return __match(first.substr(1), second.substr(1));
+    return _match(first.substr(1), second.substr(1));
 
   // If there is *, then there are two possibilities
   // a) We consider current character of second string
   // b) We ignore current character of second string.
   if (first[0] == '*')
-    return __match(first.substr(1), second) || __match(first, second.substr(1));
+    return _match(first.substr(1), second) || _match(first, second.substr(1));
 
   return false;
 }
@@ -128,9 +129,9 @@ inline bool __match(std::string_view first, std::string_view second) {
 
 bool match(std::string_view pattern, std::string_view text, bool ignore_case) {
   if (ignore_case)
-    return __match(lowercase(pattern), lowercase(text));
+    return _match(lowercase(pattern), lowercase(text));
   else
-    return __match(pattern, text);
+    return _match(pattern, text);
 }
 
 std::istream &getline(std::istream &stream, std::string &string) {
@@ -229,7 +230,7 @@ bool is_dash(std::string_view arg) {
   return nbytes != 0 && nbytes == arg.size();
 }
 
-bool starts_with_dash(std::string_view arg) { return dash_bytes(arg.data()) != 0U; }
+bool starts_with_dash(std::string_view arg) { return dash_bytes(arg) != 0U; }
 
 std::string without_leading_dash(std::string_view arg) {
   std::string result(arg);

--- a/cpp/core/mrtrix.h
+++ b/cpp/core/mrtrix.h
@@ -213,7 +213,7 @@ template <> inline cfloat to<cfloat>(std::string_view string) {
       second.push_back('1');
     try {
       candidates.push_back(cfloat{to<float>(first), to<float>(second)});
-    } catch (Exception &) {
+    } catch (Exception &) { // NOLINT(bugprone-empty-catch)
     }
   }
 
@@ -270,7 +270,7 @@ template <> inline cdouble to<cdouble>(std::string_view string) {
       second.push_back('1');
     try {
       candidates.push_back(cdouble{to<double>(first), to<double>(second)});
-    } catch (Exception &) {
+    } catch (Exception &) { // NOLINT(bugprone-empty-catch)
     }
   }
 

--- a/cpp/core/ordered_thread_queue.h
+++ b/cpp/core/ordered_thread_queue.h
@@ -23,26 +23,26 @@ namespace MR::Thread {
 
 namespace {
 
-template <class Item> class __Ordered {
+template <class Item> class Ordered {
 public:
-  __Ordered() = default;
-  __Ordered(const Item &item) : item(item) {}
+  Ordered() : index(-1) {}
+  Ordered(const Item &item) : item(item), index(-1) {}
 
   Item item;
-  size_t index;
+  ssize_t index;
 };
 
 struct CompareItems {
-  template <class Item> bool operator()(const __Ordered<Item> *a, const __Ordered<Item> *b) const {
+  template <class Item> bool operator()(const Ordered<Item> *a, const Ordered<Item> *b) const {
     return a->index < b->index;
   }
 };
 
 template <class JobType> struct job_is_single_threaded : std::true_type {};
-template <class JobType> struct job_is_single_threaded<__Multi<JobType>> : std::false_type {};
+template <class JobType> struct job_is_single_threaded<Multi<JobType>> : std::false_type {};
 
-template <class Item> struct __batch_size<__Ordered<__Batch<Item>>> {
-  __batch_size(const __Ordered<__Batch<Item>> &item) : n(item.item.num) {}
+template <class Item> struct _batch_size<Ordered<Batch<Item>>> {
+  _batch_size(const Ordered<Batch<Item>> &item) : n(item.item.num) {}
   operator size_t() const { return n; }
   const size_t n;
 };
@@ -51,28 +51,28 @@ template <class Item> struct __batch_size<__Ordered<__Batch<Item>>> {
  *        Source/Pipe/Sink for UNBATCHED ordered queue                 *
  ***********************************************************************/
 
-template <class Item> struct Type<__Ordered<Item>> {
+template <class Item> struct Type<Ordered<Item>> {
   using item = Item;
-  using queue = Queue<__Ordered<Item>>;
+  using queue = Queue<Ordered<Item>>;
   using reader = typename queue::Reader;
   using writer = typename queue::Writer;
   using read_item = typename reader::Item;
   using write_item = typename writer::Item;
 };
 
-template <class Item, class Functor> struct __Source<__Ordered<Item>, Functor> {
+template <class Item, class Functor> struct SourceWrapper<Ordered<Item>, Functor> {
 
-  using queued_t = __Ordered<Item>;
+  using queued_t = Ordered<Item>;
   using queue_t = typename Type<queued_t>::queue;
   using writer_t = typename Type<queued_t>::writer;
-  using functor_t = typename __job<Functor>::member_type;
+  using functor_t = typename _job<Functor>::member_type;
 
   writer_t writer;
   functor_t func;
   size_t batch_size;
 
-  __Source(queue_t &queue, Functor &functor, const queued_t &item)
-      : writer(queue), func(__job<Functor>::functor(functor)), batch_size(__batch_size<queued_t>(item)) {}
+  SourceWrapper(queue_t &queue, Functor &functor, const queued_t &item)
+      : writer(queue), func(_job<Functor>::functor(functor)), batch_size(_batch_size<queued_t>(item)) {}
 
   void execute() {
     size_t count = 0;
@@ -85,26 +85,26 @@ template <class Item, class Functor> struct __Source<__Ordered<Item>, Functor> {
   }
 };
 
-template <class Item1, class Functor, class Item2> struct __Pipe<__Ordered<Item1>, Functor, __Ordered<Item2>> {
+template <class Item1, class Functor, class Item2> struct PipeWrapper<Ordered<Item1>, Functor, Ordered<Item2>> {
 
-  using queued1_t = __Ordered<Item1>;
-  using queued2_t = __Ordered<Item2>;
+  using queued1_t = Ordered<Item1>;
+  using queued2_t = Ordered<Item2>;
   using queue1_t = typename Type<queued1_t>::queue;
   using queue2_t = typename Type<queued2_t>::queue;
   using reader_t = typename Type<queued1_t>::reader;
   using writer_t = typename Type<queued2_t>::writer;
-  using functor_t = typename __job<Functor>::member_type;
+  using functor_t = typename _job<Functor>::member_type;
 
   reader_t reader;
   writer_t writer;
   functor_t func;
   const size_t batch_size;
 
-  __Pipe(queue1_t &queue_in, Functor &functor, queue2_t &queue_out, const queued2_t &item2)
+  PipeWrapper(queue1_t &queue_in, Functor &functor, queue2_t &queue_out, const queued2_t &item2)
       : reader(queue_in),
         writer(queue_out),
-        func(__job<Functor>::functor(functor)),
-        batch_size(__batch_size<queued2_t>(item2)) {}
+        func(_job<Functor>::functor(functor)),
+        batch_size(_batch_size<queued2_t>(item2)) {}
 
   void execute() {
     auto in = reader.placeholder();
@@ -112,29 +112,31 @@ template <class Item1, class Functor, class Item2> struct __Pipe<__Ordered<Item1
     while (in.read()) {
       if (!func(in->item, out->item))
         break;
+      assert(in->index >= 0);
       out->index = in->index;
       out.write();
     }
   }
 };
 
-template <class Item, class Functor> struct __Sink<__Ordered<Item>, Functor> {
+template <class Item, class Functor> struct SinkWrapper<Ordered<Item>, Functor> {
 
-  using queued_t = __Ordered<Item>;
+  using queued_t = Ordered<Item>;
   using queue_t = typename Type<queued_t>::queue;
   using reader_t = typename Type<queued_t>::reader;
-  using functor_t = typename __job<Functor>::member_type;
+  using functor_t = typename _job<Functor>::member_type;
 
   reader_t reader;
   functor_t func;
 
-  __Sink(queue_t &queue, Functor &functor) : reader(queue), func(__job<Functor>::functor(functor)) {}
+  SinkWrapper(queue_t &queue, Functor &functor) : reader(queue), func(_job<Functor>::functor(functor)) {}
 
   void execute() {
     size_t expected = 0;
     auto in = reader.placeholder();
     std::set<queued_t *, CompareItems> buffer;
     while (in.read()) {
+      assert(in->index >= 0);
       if (in->index > expected) {
         buffer.emplace(in.stash());
         continue;
@@ -157,29 +159,29 @@ template <class Item, class Functor> struct __Sink<__Ordered<Item>, Functor> {
  *        Source/Pipe/Sink for BATCHED ordered queue                 *
  ***********************************************************************/
 
-template <class Item> struct Type<__Ordered<__Batch<Item>>> {
+template <class Item> struct Type<Ordered<Batch<Item>>> {
   using item = Item;
-  using queue = Queue<__Ordered<std::vector<Item>>>;
+  using queue = Queue<Ordered<std::vector<Item>>>;
   using reader = typename queue::Reader;
   using writer = typename queue::Writer;
   using read_item = typename reader::Item;
   using write_item = typename writer::Item;
 };
 
-template <class Item, class Functor> struct __Source<__Ordered<__Batch<Item>>, Functor> {
+template <class Item, class Functor> struct SourceWrapper<Ordered<Batch<Item>>, Functor> {
 
-  using queued_t = __Ordered<std::vector<Item>>;
-  using passed_t = __Ordered<__Batch<Item>>;
+  using queued_t = Ordered<std::vector<Item>>;
+  using passed_t = Ordered<Batch<Item>>;
   using queue_t = typename Type<queued_t>::queue;
   using writer_t = typename Type<queued_t>::writer;
-  using functor_t = typename __job<Functor>::member_type;
+  using functor_t = typename _job<Functor>::member_type;
 
   writer_t writer;
   functor_t func;
   size_t batch_size;
 
-  __Source(queue_t &queue, Functor &functor, const passed_t &item)
-      : writer(queue), func(__job<Functor>::functor(functor)), batch_size(__batch_size<passed_t>(item)) {}
+  SourceWrapper(queue_t &queue, Functor &functor, const passed_t &item)
+      : writer(queue), func(_job<Functor>::functor(functor)), batch_size(_batch_size<passed_t>(item)) {}
 
   void execute() {
     size_t count = 0;
@@ -200,27 +202,27 @@ template <class Item, class Functor> struct __Source<__Ordered<__Batch<Item>>, F
 };
 
 template <class Item1, class Functor, class Item2>
-struct __Pipe<__Ordered<__Batch<Item1>>, Functor, __Ordered<__Batch<Item2>>> {
+struct PipeWrapper<Ordered<Batch<Item1>>, Functor, Ordered<Batch<Item2>>> {
 
-  using queued1_t = __Ordered<std::vector<Item1>>;
-  using queued2_t = __Ordered<std::vector<Item2>>;
-  using passed2_t = __Ordered<__Batch<Item2>>;
+  using queued1_t = Ordered<std::vector<Item1>>;
+  using queued2_t = Ordered<std::vector<Item2>>;
+  using passed2_t = Ordered<Batch<Item2>>;
   using queue1_t = typename Type<queued1_t>::queue;
   using queue2_t = typename Type<queued2_t>::queue;
   using reader_t = typename Type<queued1_t>::reader;
   using writer_t = typename Type<queued2_t>::writer;
-  using functor_t = typename __job<Functor>::member_type;
+  using functor_t = typename _job<Functor>::member_type;
 
   reader_t reader;
   writer_t writer;
   functor_t func;
   const size_t batch_size;
 
-  __Pipe(queue1_t &queue_in, Functor &functor, queue2_t &queue_out, const passed2_t &item2)
+  PipeWrapper(queue1_t &queue_in, Functor &functor, queue2_t &queue_out, const passed2_t &item2)
       : reader(queue_in),
         writer(queue_out),
-        func(__job<Functor>::functor(functor)),
-        batch_size(__batch_size<passed2_t>(item2)) {}
+        func(_job<Functor>::functor(functor)),
+        batch_size(_batch_size<passed2_t>(item2)) {}
 
   void execute() {
     auto in = reader.placeholder();
@@ -233,6 +235,7 @@ struct __Pipe<__Ordered<__Batch<Item1>>, Functor, __Ordered<__Batch<Item2>>> {
           ++k;
       }
       out->item.resize(k);
+      assert(in->index >= 0);
       out->index = in->index;
       if (!out.write())
         return;
@@ -240,23 +243,24 @@ struct __Pipe<__Ordered<__Batch<Item1>>, Functor, __Ordered<__Batch<Item2>>> {
   }
 };
 
-template <class Item, class Functor> struct __Sink<__Ordered<__Batch<Item>>, Functor> {
+template <class Item, class Functor> struct SinkWrapper<Ordered<Batch<Item>>, Functor> {
 
-  using queued_t = __Ordered<std::vector<Item>>;
+  using queued_t = Ordered<std::vector<Item>>;
   using queue_t = typename Type<queued_t>::queue;
   using reader_t = typename Type<queued_t>::reader;
-  using functor_t = typename __job<Functor>::member_type;
+  using functor_t = typename _job<Functor>::member_type;
 
   reader_t reader;
   functor_t func;
 
-  __Sink(queue_t &queue, Functor &functor) : reader(queue), func(__job<Functor>::functor(functor)) {}
+  SinkWrapper(queue_t &queue, Functor &functor) : reader(queue), func(_job<Functor>::functor(functor)) {}
 
   void execute() {
     size_t expected = 0;
     auto in = reader.placeholder();
     std::set<queued_t *, CompareItems> buffer;
     while (in.read()) {
+      assert(in->index >= 0);
       if (in->index > expected) {
         buffer.emplace(in.stash());
         continue;
@@ -289,11 +293,15 @@ inline void run_ordered_queue(Source &&source,
   static_assert(job_is_single_threaded<Source>::value && job_is_single_threaded<Sink>::value,
                 "run_ordered_queue can only run with single-threaded source & sink");
 
-  if (__batch_size<Item1>(item1) != __batch_size<Item2>(item2))
+  if (_batch_size<Item1>(item1) != _batch_size<Item2>(item2))
     throw Exception("Thread::run_ordered_queue must be run with matching batch sizes across all stages");
 
-  run_queue(
-      std::move(source), __Ordered<Item1>(item1), std::move(pipe), __Ordered<Item2>(item2), std::move(sink), capacity);
+  run_queue(std::forward<Source>(source),
+            Ordered<Item1>(item1),
+            std::forward<Pipe>(pipe),
+            Ordered<Item2>(item2),
+            std::forward<Sink>(sink),
+            capacity);
 }
 
 template <class Source, class Item1, class Pipe1, class Item2, class Pipe2, class Item3, class Sink>
@@ -308,17 +316,16 @@ inline void run_ordered_queue(Source &&source,
   static_assert(job_is_single_threaded<Source>::value && job_is_single_threaded<Sink>::value,
                 "run_ordered_queue can only run with single-threaded source & sink");
 
-  if (__batch_size<Item1>(item1) != __batch_size<Item2>(item2) ||
-      __batch_size<Item1>(item1) != __batch_size<Item3>(item3))
+  if (_batch_size<Item1>(item1) != _batch_size<Item2>(item2) || _batch_size<Item1>(item1) != _batch_size<Item3>(item3))
     throw Exception("Thread::run_ordered_queue must be run with matching batch sizes across all stages");
 
-  run_queue(std::move(source),
-            __Ordered<Item1>(item1),
-            std::move(pipe1),
-            __Ordered<Item2>(item2),
-            std::move(pipe2),
-            __Ordered<Item3>(item3),
-            std::move(sink),
+  run_queue(std::forward<Source>(source),
+            Ordered<Item1>(item1),
+            std::forward<Pipe1>(pipe1),
+            Ordered<Item2>(item2),
+            std::forward<Pipe2>(pipe2),
+            Ordered<Item3>(item3),
+            std::forward<Sink>(sink),
             capacity);
 }
 

--- a/cpp/core/ordered_thread_queue.h
+++ b/cpp/core/ordered_thread_queue.h
@@ -22,6 +22,7 @@
 #include <type_traits>
 #include <vector>
 
+#include "thread.h"
 #include "thread_queue.h"
 
 namespace MR::Thread {

--- a/cpp/core/ordered_thread_queue.h
+++ b/cpp/core/ordered_thread_queue.h
@@ -16,8 +16,13 @@
 
 #pragma once
 
-#include "thread_queue.h"
+#include <cassert>
 #include <set>
+#include <sys/types.h>
+#include <type_traits>
+#include <vector>
+
+#include "thread_queue.h"
 
 namespace MR::Thread {
 

--- a/cpp/core/progressbar.cpp
+++ b/cpp/core/progressbar.cpp
@@ -30,7 +30,7 @@
 
 namespace MR {
 
-extern bool __need_newline;
+extern bool _need_newline;
 
 namespace {
 
@@ -42,27 +42,27 @@ void display_func_multithreaded(const ProgressBar &p) {
 }
 
 void display_func_terminal(const ProgressBar &p) {
-  __need_newline = true;
+  _need_newline = true;
   if (p.show_percent())
-    __print_stderr(printf(WRAP_OFF_CODE "\r%s: [%3" PRI_SIZET "%%] %s%s" CLEAR_LINE_CODE WRAP_ON_CODE,
-                          App::NAME.c_str(),
-                          p.value(),
-                          p.text_cstr(),
-                          p.ellipsis_cstr()));
+    _print_stderr(printf(WRAP_OFF_CODE "\r%s: [%3" PRI_SIZET "%%] %s%s" CLEAR_LINE_CODE WRAP_ON_CODE,
+                         App::NAME.c_str(),
+                         p.value(),
+                         p.text_cstr(),
+                         p.ellipsis_cstr()));
   else
-    __print_stderr(printf(WRAP_OFF_CODE "\r%s: [%s] %s%s" CLEAR_LINE_CODE WRAP_ON_CODE,
-                          App::NAME.c_str(),
-                          busy[p.value() % busy.size()].c_str(),
-                          p.text_cstr(),
-                          p.ellipsis_cstr()));
+    _print_stderr(printf(WRAP_OFF_CODE "\r%s: [%s] %s%s" CLEAR_LINE_CODE WRAP_ON_CODE,
+                         App::NAME.c_str(),
+                         busy.at(p.value() % busy.size()).c_str(),
+                         p.text_cstr(),
+                         p.ellipsis_cstr()));
 }
 
 void done_func_terminal(const ProgressBar &p) {
   if (p.show_percent())
-    __print_stderr(printf("\r%s: [100%%] %s" CLEAR_LINE_CODE "\n", App::NAME.c_str(), p.text_cstr()));
+    _print_stderr(printf("\r%s: [100%%] %s" CLEAR_LINE_CODE "\n", App::NAME.c_str(), p.text_cstr()));
   else
-    __print_stderr(printf("\r%s: [done] %s" CLEAR_LINE_CODE "\n", App::NAME.c_str(), p.text_cstr()));
-  __need_newline = false;
+    _print_stderr(printf("\r%s: [done] %s" CLEAR_LINE_CODE "\n", App::NAME.c_str(), p.text_cstr()));
+  _need_newline = false;
 }
 
 void display_func_redirect(const ProgressBar &p) {
@@ -70,20 +70,20 @@ void display_func_redirect(const ProgressBar &p) {
   static size_t next_update_at = 0;
   // need to update whole line since text may have changed:
   if (p.text_has_been_modified()) {
-    __need_newline = false;
+    _need_newline = false;
     if (p.value() == 0 && p.count() == 0)
       count = next_update_at = 0;
     if (count++ == next_update_at) {
       if (p.show_percent()) {
-        __print_stderr(
+        _print_stderr(
             printf("%s: [%3" PRI_SIZET "%%] %s%s\n", App::NAME.c_str(), p.value(), p.text_cstr(), p.ellipsis_cstr()));
         ;
       } else {
-        __print_stderr(printf("%s: [%s] %s%s\n",
-                              App::NAME.c_str(),
-                              busy[p.value() % busy.size()].c_str(),
-                              p.text_cstr(),
-                              p.ellipsis_cstr()));
+        _print_stderr(printf("%s: [%s] %s%s\n",
+                             App::NAME.c_str(),
+                             busy.at(p.value() % busy.size()).c_str(),
+                             p.text_cstr(),
+                             p.ellipsis_cstr()));
       }
       if (next_update_at)
         next_update_at *= 2;
@@ -93,23 +93,23 @@ void display_func_redirect(const ProgressBar &p) {
   }
   // text is static - can simply append to the current line:
   else {
-    __need_newline = true;
+    _need_newline = true;
     if (p.show_percent()) {
       if (p.first_time) {
         p.first_time = false;
-        __print_stderr(printf("%s: %s%s [", App::NAME.c_str(), p.text_cstr(), p.ellipsis_cstr()));
+        _print_stderr(printf("%s: %s%s [", App::NAME.c_str(), p.text_cstr(), p.ellipsis_cstr()));
         ;
       } else
         while (p.last_value < p.value()) {
-          __print_stderr(printf("="));
+          _print_stderr(printf("="));
           p.last_value += 2;
         }
     } else {
       if (p.value() == 0) {
-        __print_stderr(printf("%s: %s%s ", App::NAME.c_str(), p.text_cstr(), p.ellipsis_cstr()));
+        _print_stderr(printf("%s: %s%s ", App::NAME.c_str(), p.text_cstr(), p.ellipsis_cstr()));
         ;
       } else if (!(p.value() & (p.value() - 1))) {
-        __print_stderr(".");
+        _print_stderr(".");
       }
     }
   }
@@ -118,18 +118,18 @@ void display_func_redirect(const ProgressBar &p) {
 void done_func_redirect(const ProgressBar &p) {
   if (p.text_has_been_modified()) {
     if (p.show_percent()) {
-      __print_stderr(printf("%s: [100%%] %s\n", App::NAME.c_str(), p.text_cstr()));
+      _print_stderr(printf("%s: [100%%] %s\n", App::NAME.c_str(), p.text_cstr()));
       ;
     } else {
-      __print_stderr(printf("%s: [done] %s\n", App::NAME.c_str(), p.text_cstr()));
+      _print_stderr(printf("%s: [done] %s\n", App::NAME.c_str(), p.text_cstr()));
     }
   } else {
     if (p.show_percent())
-      __print_stderr(printf("]\n"));
+      _print_stderr(printf("]\n"));
     else
-      __print_stderr(printf("done\n"));
+      _print_stderr(printf("done\n"));
   }
-  __need_newline = false;
+  _need_newline = false;
 }
 
 } // namespace

--- a/cpp/core/progressbar.cpp
+++ b/cpp/core/progressbar.cpp
@@ -22,6 +22,8 @@
 #include <utility>
 
 #include "app.h"
+#include "exception.h"
+#include "mrtrix.h"
 
 // MSYS2 supports VT100, and file redirection is handled explicitly so this can be used globally
 #define CLEAR_LINE_CODE "\033[0K" // check_syntax off

--- a/cpp/core/progressbar.h
+++ b/cpp/core/progressbar.h
@@ -87,7 +87,7 @@ public:
 
   FORCE_INLINE size_t value() const { return _value; }
   FORCE_INLINE size_t count() const { return current_val; }
-  FORCE_INLINE bool show_percent() const { return _multiplier; }
+  FORCE_INLINE bool show_percent() const { return _multiplier != 0.0F; }
   FORCE_INLINE bool text_has_been_modified() const { return _text_has_been_modified; }
   FORCE_INLINE std::string_view text() const { return _text; }
   FORCE_INLINE std::string_view ellipsis() const { return _ellipsis; }
@@ -204,7 +204,7 @@ template <class TextFunc> FORCE_INLINE void ProgressBar::update(TextFunc &&text_
     return;
   const std::unique_lock<std::mutex> lock(mutex);
   const double time = timer.elapsed();
-  if (increment && _multiplier && ++current_val >= next_percent) {
+  if (increment && _multiplier != 0.0F && ++current_val >= next_percent) {
     set_text(text_func());
     _ellipsis.clear();
     _value = std::round(current_val / _multiplier);
@@ -216,7 +216,7 @@ template <class TextFunc> FORCE_INLINE void ProgressBar::update(TextFunc &&text_
   if (time >= next_time) {
     set_text(text_func());
     _ellipsis.clear();
-    if (_multiplier)
+    if (_multiplier != 0.0F)
       next_time = time + busy_interval;
     else {
       _value = time / busy_interval;
@@ -232,19 +232,19 @@ FORCE_INLINE void ProgressBar::operator++() {
   if (!show)
     return;
   const std::unique_lock<std::mutex> lock(mutex);
-  if (_multiplier) {
-    if (++current_val >= next_percent) {
-      _value = std::round(current_val / _multiplier);
-      next_percent = std::ceil((_value + 1) * _multiplier);
-      display_now();
-    }
-  } else {
+  if (_multiplier == 0.0F) {
     double time = timer.elapsed();
     if (time >= next_time) {
       _value = time / busy_interval;
       do {
         next_time += busy_interval;
       } while (next_time <= time);
+      display_now();
+    }
+  } else {
+    if (++current_val >= next_percent) {
+      _value = static_cast<size_t>(std::round(current_val / _multiplier));
+      next_percent = static_cast<size_t>(std::ceil((_value + 1) * _multiplier));
       display_now();
     }
   }

--- a/cpp/core/progressbar.h
+++ b/cpp/core/progressbar.h
@@ -243,8 +243,8 @@ FORCE_INLINE void ProgressBar::operator++() {
     }
   } else {
     if (++current_val >= next_percent) {
-      _value = static_cast<size_t>(std::round(current_val / _multiplier));
-      next_percent = static_cast<size_t>(std::ceil((_value + 1) * _multiplier));
+      _value = static_cast<size_t>(std::round(static_cast<float>(current_val) / _multiplier));
+      next_percent = static_cast<size_t>(std::ceil(static_cast<float>(_value + 1) * _multiplier));
       display_now();
     }
   }

--- a/cpp/core/raw.h
+++ b/cpp/core/raw.h
@@ -118,7 +118,7 @@ template <typename ValueType> inline ValueType fetch_(const void *address, bool 
   return ByteOrder::swap(*as<ValueType>(address), is_big_endian);
 }
 
-template <typename ValueType> inline ValueType fetch__native(const void *address) { return *as<ValueType>(address); }
+template <typename ValueType> inline ValueType fetch_native(const void *address) { return *as<ValueType>(address); }
 
 // PUT at pointer:
 template <typename ValueType> inline void store_LE(const ValueType value, void *address) {

--- a/cpp/core/registration/linear.h
+++ b/cpp/core/registration/linear.h
@@ -483,11 +483,14 @@ public:
       const default_type beta(MR::File::Config::get_float("RegGdConvergenceSlopeSmooth", 0.1));
       if ((beta < 0.0f) || (beta > 1.0f))
         throw Exception("config file option RegGdConvergenceSlopeSmooth has to be in the range: [0...1]");
-      size_t buffer_len(MR::File::Config::get_float("RegGdConvergenceBufferLen", 4));
+      // CONF option: RegGdConvergenceBufferLen
+      // CONF default: 4
+      // CONF Linear registration: gradient descent convergence buffer length.
+      size_t buffer_len(MR::File::Config::get_int("RegGdConvergenceBufferLen", 4));
       // CONF option: RegGdConvergenceMinIter
       // CONF default: 10
       // CONF Linear registration: minimum number of iterations until convergence check is activated.
-      size_t min_iter(MR::File::Config::get_float("RegGdConvergenceMinIter", 10));
+      size_t min_iter(MR::File::Config::get_int("RegGdConvergenceMinIter", 10));
       transform.get_gradient_descent_updator()->set_convergence_check(
           slope_threshold, alpha, beta, buffer_len, min_iter);
 

--- a/cpp/core/registration/metric/cc_helper.h
+++ b/cpp/core/registration/metric/cc_helper.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "algo/loop.h"
 #include "algo/neighbourhooditerator.h"
 #include "debug.h"
 #include "image_helpers.h"

--- a/cpp/core/registration/metric/demons.h
+++ b/cpp/core/registration/metric/demons.h
@@ -19,6 +19,7 @@
 #include <mutex>
 
 #include "adapter/gradient3D.h"
+#include "image.h"
 #include "image_helpers.h"
 
 namespace MR::Registration::Metric {

--- a/cpp/core/registration/metric/demons_cc.h
+++ b/cpp/core/registration/metric/demons_cc.h
@@ -19,6 +19,7 @@
 #include <mutex>
 
 #include "adapter/gradient3D.h"
+#include "image.h"
 #include "image_helpers.h"
 
 namespace MR::Registration::Metric {

--- a/cpp/core/registration/metric/linear_base.h
+++ b/cpp/core/registration/metric/linear_base.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "eigen_plugins/eigen_plugins.h"
 #include <Eigen/Dense>
 
 #include "image.h"

--- a/cpp/core/registration/metric/linear_base.h
+++ b/cpp/core/registration/metric/linear_base.h
@@ -16,6 +16,11 @@
 
 #pragma once
 
+#include <Eigen/Dense>
+
+#include "image.h"
+#include "types.h"
+
 namespace MR::Registration::Metric {
 
 class LinearBase {

--- a/cpp/core/registration/metric/local_cross_correlation.h
+++ b/cpp/core/registration/metric/local_cross_correlation.h
@@ -21,6 +21,7 @@
 #include "algo/neighbourhooditerator.h"
 #include "algo/threaded_loop.h"
 #include "filter/reslice.h"
+#include "interp/linear.h"
 #include "transform.h"
 
 namespace MR::Registration::Metric {

--- a/cpp/core/registration/metric/robust_estimators.h
+++ b/cpp/core/registration/metric/robust_estimators.h
@@ -18,7 +18,6 @@
 
 #include <Eigen/Dense>
 #include <cmath>
-#include <cstdint>
 
 #include "types.h"
 

--- a/cpp/core/registration/metric/robust_estimators.h
+++ b/cpp/core/registration/metric/robust_estimators.h
@@ -16,6 +16,12 @@
 
 #pragma once
 
+#include <Eigen/Dense>
+#include <cmath>
+#include <cstdint>
+
+#include "types.h"
+
 namespace MR::Math {
 template <typename T> inline int sgn(T val) { return (T(0) < val) - (val < T(0)); }
 } // namespace MR::Math

--- a/cpp/core/registration/metric/robust_estimators.h
+++ b/cpp/core/registration/metric/robust_estimators.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "eigen_plugins/eigen_plugins.h"
 #include <Eigen/Dense>
 #include <cmath>
 

--- a/cpp/core/registration/transform/affine.cpp
+++ b/cpp/core/registration/transform/affine.cpp
@@ -15,10 +15,14 @@
  */
 
 #include "registration/transform/affine.h"
+
+#include "eigen_plugins/eigen_plugins.h"
+#include <iterator>
+#include <unsupported/Eigen/MatrixFunctions>
+
 #include "math/gradient_descent.h"
 #include "math/math.h"
 #include "math/median.h"
-#include <iterator>
 
 namespace MR {
 using namespace MR::Math;

--- a/cpp/core/registration/transform/base.cpp
+++ b/cpp/core/registration/transform/base.cpp
@@ -15,6 +15,9 @@
  */
 #include "registration/transform/base.h"
 
+#include "eigen_plugins/eigen_plugins.h"
+#include <unsupported/Eigen/MatrixFunctions> // Eigen::MatrixBase::sqrt()
+
 namespace MR::Registration::Transform {
 
 Base::Base(size_t number_of_parameters)

--- a/cpp/core/registration/transform/base.h
+++ b/cpp/core/registration/transform/base.h
@@ -16,13 +16,15 @@
 
 #pragma once
 
+#include "eigen_plugins/eigen_plugins.h"
+#include <Eigen/Geometry> // Eigen::Translation
+#include <Eigen/SVD>
+#include <unsupported/Eigen/MatrixFunctions> // Eigen::MatrixBase::sqrt()
+
 #include "datatype.h" // debug
 #include "file/config.h"
 #include "registration/transform/convergence_check.h"
 #include "types.h"
-#include <Eigen/Geometry> // Eigen::Translation
-#include <Eigen/SVD>
-#include <unsupported/Eigen/MatrixFunctions> // Eigen::MatrixBase::sqrt()
 
 namespace MR::Registration::Transform {
 template <class ValueType>

--- a/cpp/core/registration/transform/base.h
+++ b/cpp/core/registration/transform/base.h
@@ -18,8 +18,6 @@
 
 #include "eigen_plugins/eigen_plugins.h"
 #include <Eigen/Geometry> // Eigen::Translation
-#include <Eigen/SVD>
-#include <unsupported/Eigen/MatrixFunctions> // Eigen::MatrixBase::sqrt()
 
 #include "datatype.h" // debug
 #include "file/config.h"

--- a/cpp/core/registration/transform/initialiser_helpers.cpp
+++ b/cpp/core/registration/transform/initialiser_helpers.cpp
@@ -14,10 +14,7 @@
  * For more details, see http://www.mrtrix.org/.
  */
 
-#include "registration/transform/initialiser_helpers.h"
-#include "registration/multi_contrast.h"
-#include "registration/multi_resolution_lmax.h"
-#include "registration/transform/search.h"
+#include "eigen_plugins/eigen_plugins.h"
 #include <Eigen/Dense>
 #include <Eigen/Eigenvalues>
 #include <Eigen/Geometry>
@@ -25,6 +22,10 @@
 #include "algo/loop.h"
 #include "algo/threaded_loop.h"
 #include "debug.h"
+#include "registration/multi_contrast.h"
+#include "registration/multi_resolution_lmax.h"
+#include "registration/transform/initialiser_helpers.h"
+#include "registration/transform/search.h"
 // #define DEBUG_INIT
 
 namespace MR::Registration::Transform::Init {

--- a/cpp/core/registration/transform/initialiser_helpers.cpp
+++ b/cpp/core/registration/transform/initialiser_helpers.cpp
@@ -15,15 +15,16 @@
  */
 
 #include "eigen_plugins/eigen_plugins.h"
+
 #include <Eigen/Dense>
 #include <Eigen/Eigenvalues>
 #include <Eigen/Geometry>
+#include <algorithm>
 
 #include "algo/loop.h"
 #include "algo/threaded_loop.h"
 #include "debug.h"
 #include "registration/multi_contrast.h"
-#include "registration/multi_resolution_lmax.h"
 #include "registration/transform/initialiser_helpers.h"
 #include "registration/transform/search.h"
 // #define DEBUG_INIT

--- a/cpp/core/registration/transform/initialiser_helpers.h
+++ b/cpp/core/registration/transform/initialiser_helpers.h
@@ -16,14 +16,16 @@
 
 #pragma once
 
+#include "eigen_plugins/eigen_plugins.h"
+#include <Eigen/Geometry>
+#include <algorithm>
+
 #include "image.h"
 #include "math/SH.h"
 #include "math/math.h"
 #include "registration/multi_contrast.h"
 #include "registration/transform/base.h"
 #include "transform.h"
-#include <Eigen/Geometry>
-#include <algorithm>
 
 namespace MR::Registration::Transform::Init {
 template <class ImageType, class ValueType>

--- a/cpp/core/registration/transform/initialiser_helpers.h
+++ b/cpp/core/registration/transform/initialiser_helpers.h
@@ -18,7 +18,7 @@
 
 #include "eigen_plugins/eigen_plugins.h"
 #include <Eigen/Geometry>
-#include <algorithm>
+#include <vector>
 
 #include "image.h"
 #include "math/SH.h"

--- a/cpp/core/registration/transform/rigid.cpp
+++ b/cpp/core/registration/transform/rigid.cpp
@@ -15,13 +15,17 @@
  */
 
 #include "registration/transform/rigid.h"
+
+#include "eigen_plugins/eigen_plugins.h"
+#include <algorithm> // std::min_element
+#include <deque>
+#include <iterator>
+#include <unsupported/Eigen/MatrixFunctions>
+
 #include "debug.h"
 #include "math/gradient_descent.h"
 #include "math/math.h"
 #include "math/median.h"
-#include <algorithm> // std::min_element
-#include <deque>
-#include <iterator>
 
 namespace MR {
 using namespace MR::Math;

--- a/cpp/core/registration/transform/search.h
+++ b/cpp/core/registration/transform/search.h
@@ -22,7 +22,6 @@
 #include <iostream>
 
 #include "adapter/reslice.h"
-#include "debug.h"
 #include "filter/resize.h"
 #include "filter/reslice.h"
 #include "image.h"

--- a/cpp/core/registration/transform/search.h
+++ b/cpp/core/registration/transform/search.h
@@ -16,18 +16,16 @@
 
 #pragma once
 
+#include "eigen_plugins/eigen_plugins.h"
 #include <Eigen/Eigen>
 #include <Eigen/Geometry>
 #include <iostream>
 
-#include "debug.h"
-#include "image.h"
-#include "progressbar.h"
-#include "types.h"
-
 #include "adapter/reslice.h"
+#include "debug.h"
 #include "filter/resize.h"
 #include "filter/reslice.h"
+#include "image.h"
 #include "interp/cubic.h"
 #include "interp/linear.h"
 #include "interp/nearest.h"
@@ -36,6 +34,7 @@
 #include "math/math.h"
 #include "math/median.h"
 #include "math/rng.h"
+#include "progressbar.h"
 #include "registration/metric/mean_squared.h"
 #include "registration/metric/params.h"
 // #include "registration/metric/local_cross_correlation.h"
@@ -43,6 +42,7 @@
 #include "registration/metric/thread_kernel.h"
 #include "registration/transform/initialiser.h"
 #include "registration/transform/rigid.h"
+#include "types.h"
 
 namespace MR::Registration::RotationSearch {
 

--- a/cpp/core/registration/warp/helpers.h
+++ b/cpp/core/registration/warp/helpers.h
@@ -16,11 +16,19 @@
 
 #pragma once
 
+#include <string>
+#include <string_view>
+
+#include "exception.h"
+#include "mrtrix.h"
+#include "types.h"
+
 namespace MR::Registration::Warp {
 
-template <class InputWarpType> transform_type parse_linear_transform(InputWarpType &input_warps, std::string name) {
+template <class InputWarpType>
+transform_type parse_linear_transform(InputWarpType &input_warps, std::string_view name) {
   transform_type linear;
-  const auto it = input_warps.keyval().find(name);
+  const auto it = input_warps.keyval().find(std::string(name));
   if (it != input_warps.keyval().end()) {
     const auto lines = split_lines(it->second);
     if (lines.size() != 3)

--- a/cpp/core/signal_handler.cpp
+++ b/cpp/core/signal_handler.cpp
@@ -81,7 +81,7 @@ void handler(int i) noexcept {
     char str[256]; // check_syntax off
     str[255] = '\0';
     snprintf(str, 255, "\n%s: [SYSTEM FATAL CODE: %s (%d)] %s\n", App::NAME.c_str(), sig, i, msg);
-    std::ignore = write(STDERR_FILENO, str, strnlen(str, 256));
+    std::ignore = write(STDERR_FILENO, &str[0], strnlen(&str[0], 256));
     std::_Exit(i);
   }
 }

--- a/cpp/core/signal_handler.cpp
+++ b/cpp/core/signal_handler.cpp
@@ -21,6 +21,7 @@
 #include <filesystem>
 #include <iostream>
 #include <signal.h>
+#include <tuple>
 #include <unistd.h>
 #include <vector>
 
@@ -61,13 +62,13 @@ void handler(int i) noexcept {
     const char *msg = nullptr; // check_syntax off
     switch (i) {
 
-#define __SIGNAL(SIG, MSG)                                                                                             \
+#define MRTRIX_MANIP_SIGNAL(SIG, MSG)                                                                                  \
   case SIG:                                                                                                            \
     sig = #SIG;                                                                                                        \
     msg = MSG;                                                                                                         \
     break;
 #include "signals.h"
-#undef __SIGNAL
+#undef MRTRIX_MANIP_SIGNAL
 
     default:
       sig = "UNKNOWN";
@@ -80,10 +81,8 @@ void handler(int i) noexcept {
     char str[256]; // check_syntax off
     str[255] = '\0';
     snprintf(str, 255, "\n%s: [SYSTEM FATAL CODE: %s (%d)] %s\n", App::NAME.c_str(), sig, i, msg);
-    if (write(STDERR_FILENO, str, strnlen(str, 256)) == 0)
-      std::_Exit(i);
-    else
-      std::_Exit(i);
+    std::ignore = write(STDERR_FILENO, str, strnlen(str, 256));
+    std::_Exit(i);
   }
 }
 
@@ -103,7 +102,7 @@ void init() {
 
 #ifdef MRTRIX_WINDOWS
     // Use signal() rather than sigaction() for Windows, as the latter is not supported
-#define __SIGNAL(SIG, MSG) signal(SIG, handler)
+#define MRTRIX_MANIP_SIGNAL(SIG, MSG) signal(SIG, handler)
 #else
   // Construct the signal structure
   struct sigaction act;
@@ -111,10 +110,10 @@ void init() {
   // Since we're _Exit()-ing for any of these signals, block them all
   sigfillset(&act.sa_mask);
   act.sa_flags = 0;
-#define __SIGNAL(SIG, MSG) sigaction(SIG, &act, nullptr)
+#define MRTRIX_MANIP_SIGNAL(SIG, MSG) sigaction(SIG, &act, nullptr)
 #endif
-
 #include "signals.h"
+#undef MRTRIX_MANIP_SIGNAL
 }
 
 void on_signal(cleanup_function_type func) {

--- a/cpp/core/signal_handler.cpp
+++ b/cpp/core/signal_handler.cpp
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "app.h"
+#include "env.h"
 #include "file/path.h"
 
 #ifdef MRTRIX_WINDOWS
@@ -97,7 +98,7 @@ void init() {
   // ENVVAR Note however that this prevents the
   // ENVVAR deletion of temporary files when the command terminates
   // ENVVAR abnormally.
-  if (getenv("MRTRIX_NOSIGNALS"))
+  if (MR::get_env("MRTRIX_NOSIGNALS").has_value())
     return;
 
 #ifdef MRTRIX_WINDOWS

--- a/cpp/core/signals.h
+++ b/cpp/core/signals.h
@@ -15,44 +15,44 @@
  */
 
 #ifdef SIGALRM
-__SIGNAL(SIGALRM, "Timer expiration");
+MRTRIX_MANIP_SIGNAL(SIGALRM, "Timer expiration");
 #endif
 #ifdef SIGBUS
-__SIGNAL(SIGBUS, "Bus error: Accessing invalid address (out of storage space?)");
+MRTRIX_MANIP_SIGNAL(SIGBUS, "Bus error: Accessing invalid address (out of storage space?)");
 #endif
 #ifdef SIGFPE
-__SIGNAL(SIGFPE, "Floating-point arithmetic exception");
+MRTRIX_MANIP_SIGNAL(SIGFPE, "Floating-point arithmetic exception");
 #endif
 #ifdef SIGHUP
-__SIGNAL(SIGHUP, "Disconnection of terminal");
+MRTRIX_MANIP_SIGNAL(SIGHUP, "Disconnection of terminal");
 #endif
 #ifdef SIGILL // Note: Not generated under Windows
-__SIGNAL(SIGILL, "Illegal instruction (corrupt binary command file?)");
+MRTRIX_MANIP_SIGNAL(SIGILL, "Illegal instruction (corrupt binary command file?)");
 #endif
 #ifdef SIGINT // Note: Not supported for any Win32 application
-__SIGNAL(SIGINT, "Program manually interrupted by terminal");
+MRTRIX_MANIP_SIGNAL(SIGINT, "Program manually interrupted by terminal");
 #endif
 #ifdef SIGPIPE
-__SIGNAL(SIGPIPE, "Nothing on receiving end of pipe");
+MRTRIX_MANIP_SIGNAL(SIGPIPE, "Nothing on receiving end of pipe");
 #endif
 #ifdef SIGPWR
-__SIGNAL(SIGPWR, "Power failure restart");
+MRTRIX_MANIP_SIGNAL(SIGPWR, "Power failure restart");
 #endif
 #ifdef SIGQUIT
-__SIGNAL(SIGQUIT, "Received terminal quit signal");
+MRTRIX_MANIP_SIGNAL(SIGQUIT, "Received terminal quit signal");
 #endif
 #ifdef SIGSEGV
-__SIGNAL(SIGSEGV, "Segmentation fault: Invalid memory access");
+MRTRIX_MANIP_SIGNAL(SIGSEGV, "Segmentation fault: Invalid memory access");
 #endif
 #ifdef SIGSYS
-__SIGNAL(SIGSYS, "Bad system call");
+MRTRIX_MANIP_SIGNAL(SIGSYS, "Bad system call");
 #endif
 #ifdef SIGTERM // Note: Not generated under Windows
-__SIGNAL(SIGTERM, "Terminated by kill command");
+MRTRIX_MANIP_SIGNAL(SIGTERM, "Terminated by kill command");
 #endif
 #ifdef SIGXCPU
-__SIGNAL(SIGXCPU, "CPU time limit exceeded");
+MRTRIX_MANIP_SIGNAL(SIGXCPU, "CPU time limit exceeded");
 #endif
 #ifdef SIGXFSZ
-__SIGNAL(SIGXFSZ, "File size limit exceeded");
+MRTRIX_MANIP_SIGNAL(SIGXFSZ, "File size limit exceeded");
 #endif

--- a/cpp/core/stats.h
+++ b/cpp/core/stats.h
@@ -67,7 +67,7 @@ public:
         if (fields[n] == "mean")
           std::cout << str(mean) << " ";
         else if (fields[n] == "median")
-          std::cout << (!values.empty() ? str(Math::median(values)) : "N/A") << " ";
+          std::cout << (values.empty() ? "N/A" : str(Math::median(values))) << " ";
         else if (fields[n] == "std")
           std::cout << (count > 1 ? str(std) : "N/A") << " ";
         else if (fields[n] == "std_rv")

--- a/cpp/core/stats.h
+++ b/cpp/core/stats.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "math/median.h"
+#include "mrtrix.h"
 
 #include <iomanip>
 #include <vector>

--- a/cpp/core/stride.cpp
+++ b/cpp/core/stride.cpp
@@ -70,7 +70,7 @@ List &sanitise(List &current, const List &desired, const std::vector<ssize_t> &d
   return current;
 }
 
-List __from_command_line(const List &current) {
+List _from_command_line(const List &current) {
   List strides;
   auto opt = App::get_options("strides");
   if (opt.empty())

--- a/cpp/core/stride.h
+++ b/cpp/core/stride.h
@@ -333,11 +333,11 @@ template <class HeaderType> inline List contiguous_along_spatial_axes(const Head
   return strides;
 }
 
-List __from_command_line(const List &current);
+List _from_command_line(const List &current);
 
 template <class HeaderType>
 inline void set_from_command_line(HeaderType &header, const List &default_strides = List()) {
-  auto cmdline_strides = __from_command_line(get(header));
+  auto cmdline_strides = _from_command_line(get(header));
   if (cmdline_strides.size())
     set(header, cmdline_strides);
   else if (!default_strides.empty())

--- a/cpp/core/surface/algo/image2mesh.h
+++ b/cpp/core/surface/algo/image2mesh.h
@@ -16,17 +16,16 @@
 
 #pragma once
 
+#include "eigen_plugins/eigen_plugins.h"
+#include <Eigen/Dense>
 #include <array>
 #include <map>
 
-#include <Eigen/Dense>
-
 #include "image_helpers.h"
-#include "transform.h"
-#include "types.h"
-
 #include "surface/mesh.h"
 #include "surface/types.h"
+#include "transform.h"
+#include "types.h"
 
 namespace MR::Surface::Algo {
 

--- a/cpp/core/surface/algo/mesh2image.cpp
+++ b/cpp/core/surface/algo/mesh2image.cpp
@@ -302,8 +302,8 @@ void mesh2image(const Mesh &mesh_realspace, Image<float> &image) {
             fill_value = vox_mesh_t::OUTSIDE;
           } else if (!corner_count) {
             fill_value = vox_mesh_t::INSIDE;
-          } else if (sum_sum_distances) {
-            fill_value = sum_sum_distances < 0.0f ? vox_mesh_t::INSIDE : vox_mesh_t::OUTSIDE;
+          } else if (sum_sum_distances != 0.0F) {
+            fill_value = sum_sum_distances < 0.0F ? vox_mesh_t::INSIDE : vox_mesh_t::OUTSIDE;
           } else {
             Exception e("Internal error: fundamental ambiguity in voxel-based segmentation of surface");
             e.push_back("Fill region size: " + str(to_fill.size()));

--- a/cpp/core/surface/freesurfer.cpp
+++ b/cpp/core/surface/freesurfer.cpp
@@ -72,10 +72,10 @@ void read_annot(const std::filesystem::path &path, label_vector_type &labels, Co
 
     const int32_t version = -num_entries;
     if (version != 2)
-      throw Exception("Error reading FreeSurfer annotation file \"" + path.filename().string() +
-                      "\": Unsupported file version (" + str(version) + ")");
+      throw Exception("Error reading FreeSurfer annotation file \"" + path.filename().string() + "\": " + //
+                      " unsupported file version (" + str(version) + ")");                                //
 
-    num_entries = get_BE<int32_t>(in);
+    get_BE<int32_t>(in);
     const int32_t orig_lut_name_length = get_BE<int32_t>(in);
     std::unique_ptr<char[]> orig_lut_name(new char[orig_lut_name_length]);
     in.read(orig_lut_name.get(), orig_lut_name_length);

--- a/cpp/core/surface/mesh.cpp
+++ b/cpp/core/surface/mesh.cpp
@@ -463,14 +463,10 @@ void Mesh::load_obj(const std::filesystem::path &path) {
       std::array<float, 4> values{};
       sscanf(data.c_str(), "%f %f %f %f", &values[0], &values[1], &values[2], &values[3]);
       vertices.push_back(Vertex(values[0], values[1], values[2]));
-    } else if (prefix == "vt") {
-      // Texture data; do nothing
     } else if (prefix == "vn") {
       std::array<float, 3> values{};
       sscanf(data.c_str(), "%f %f %f", &values[0], &values[1], &values[2]);
       normals.push_back(Vertex(values[0], values[1], values[2]));
-    } else if (prefix == "vp") {
-      // Parameter space vertices; do nothing
     } else if (prefix == "f") {
       // Parse face information
       // Need to handle:
@@ -549,7 +545,10 @@ void Mesh::load_obj(const std::filesystem::path &path) {
         object = data;
       else
         throw Exception("Multiple objects in input OBJ file");
-    } // Do nothing for all other prefixes
+    }
+    // Do nothing for all other prefixes, including:
+    // "vt": Texture data
+    // "vp": Parameter space vertices
   }
 
   if (!object.empty())

--- a/cpp/core/surface/mesh_multi.cpp
+++ b/cpp/core/surface/mesh_multi.cpp
@@ -59,14 +59,6 @@ void MeshMulti::load(const std::filesystem::path &path) {
       std::array<float, 4> values{};
       sscanf(data.c_str(), "%f %f %f %f", &values[0], &values[1], &values[2], &values[3]);
       vertices.push_back(Vertex(values[0], values[1], values[2]));
-    } else if (prefix == "vt") {
-    } else if (prefix == "vn") {
-      // if (index < 0)
-      //   throw Exception ("Malformed OBJ file; vertex normal outside object (line " + str(counter) + ")");
-      // float values[3];
-      // sscanf (data.c_str(), "%f %f %f", &values[0], &values[1], &values[2]);
-      // normals.push_back (Vertex (values[0], values[1], values[2]));
-    } else if (prefix == "vp") {
     } else if (prefix == "f") {
       if (index < 0)
         throw Exception("Malformed OBJ file: face outside object (line " + str(counter) + ")");
@@ -122,7 +114,6 @@ void MeshMulti::load(const std::filesystem::path &path) {
         std::vector<uint32_t> temp{face_data[0].vertex, face_data[1].vertex, face_data[2].vertex, face_data[3].vertex};
         quads.push_back(Quad(temp));
       }
-    } else if (prefix == "g") {
     } else if (prefix == "o") {
       // This is where this function differs from the standard OBJ load
       // Allow multiple objects; in fact explicitly expect them
@@ -132,9 +123,13 @@ void MeshMulti::load(const std::filesystem::path &path) {
         temp.load(std::move(vertices), std::move(triangles), std::move(quads));
         temp.set_name(!object.empty() ? object : str(index - 1));
         push_back(temp);
+        vertices.clear();
+        triangles.clear();
+        quads.clear();
       }
       object = data;
     }
+    // Unused prefixes: "vt", "vn", "vp", "g"
   }
 
   if (!vertices.empty()) {

--- a/cpp/core/surface/scalar.h
+++ b/cpp/core/surface/scalar.h
@@ -30,12 +30,12 @@ public:
 
   Scalar(const Scalar &that) = default;
 
-  Scalar(Scalar &&that) : Base(std::move(that)), name(std::move(that.name)) {}
+  Scalar(Scalar &&that) : Base(std::move(static_cast<Base &&>(that))), name(std::move(that.name)) {}
 
   Scalar() {}
 
   Scalar &operator=(Scalar &&that) {
-    Base::operator=(std::move(that));
+    Base::operator=(std::move(static_cast<Base &&>(that)));
     name = std::move(that.name);
     return *this;
   }

--- a/cpp/core/thread.cpp
+++ b/cpp/core/thread.cpp
@@ -110,7 +110,7 @@ void Backend::thread_report_to_user_func(std::string_view msg, int type) {
   previous_report_to_user_func(msg, type);
 }
 
-Backend *Backend::backend = nullptr;
+std::unique_ptr<Backend> Backend::backend = nullptr;
 std::mutex Backend::mutex;
 
 } // namespace MR::Thread

--- a/cpp/core/thread.cpp
+++ b/cpp/core/thread.cpp
@@ -15,11 +15,16 @@
  */
 
 #include <atomic>
+#include <memory>
+#include <optional>
+#include <stddef.h>
+#include <string>
 #include <thread>
 
 #include "app.h"
 #include "env.h"
 #include "file/config.h"
+#include "mrtrix.h"
 #include "thread.h"
 #include "thread_queue.h"
 

--- a/cpp/core/thread.cpp
+++ b/cpp/core/thread.cpp
@@ -27,20 +27,20 @@ namespace MR::Thread {
 
 namespace {
 
-size_t __number_of_threads = 0;
-nthreads_t __nthreads_type = nthreads_t::UNINITIALISED;
+size_t _number_of_threads = 0;
+nthreads_t _nthreads_type = nthreads_t::UNINITIALISED;
 
 } // namespace
 
 size_t number_of_threads() {
-  if (__nthreads_type != nthreads_t::UNINITIALISED)
-    return __number_of_threads;
+  if (_nthreads_type != nthreads_t::UNINITIALISED)
+    return _number_of_threads;
 
   auto opt = App::get_options("nthreads");
   if (!opt.empty()) {
-    __number_of_threads = opt[0][0];
-    __nthreads_type = nthreads_t::EXPLICIT;
-    return __number_of_threads;
+    _number_of_threads = opt[0][0];
+    _nthreads_type = nthreads_t::EXPLICIT;
+    return _number_of_threads;
   }
 
   // ENVVAR name: MRTRIX_NTHREADS
@@ -61,24 +61,24 @@ size_t number_of_threads() {
   if (!File::Config::get("NumberOfThreads").empty()) {
     const int i = File::Config::get_int("NumberOfThreads", -1);
     if (i >= 0) {
-      __number_of_threads = i;
-      __nthreads_type = nthreads_t::EXPLICIT;
-      return __number_of_threads;
+      _number_of_threads = i;
+      _nthreads_type = nthreads_t::EXPLICIT;
+      return _number_of_threads;
     }
   }
-  __number_of_threads = std::thread::hardware_concurrency();
-  __nthreads_type = nthreads_t::IMPLICIT;
-  return __number_of_threads;
+  _number_of_threads = std::thread::hardware_concurrency();
+  _nthreads_type = nthreads_t::IMPLICIT;
+  return _number_of_threads;
 }
 
-nthreads_t type_nthreads() { return __nthreads_type; }
+nthreads_t type_nthreads() { return _nthreads_type; }
 
-size_t threads_to_execute() { return (__Backend::valid() ? 0 : number_of_threads()); }
+size_t threads_to_execute() { return (Backend::valid() ? 0 : number_of_threads()); }
 
-void (*__Backend::previous_print_func)(std::string_view msg) = nullptr;
-void (*__Backend::previous_report_to_user_func)(std::string_view msg, int type) = nullptr;
+void (*Backend::previous_print_func)(std::string_view msg) = nullptr;
+void (*Backend::previous_report_to_user_func)(std::string_view msg, int type) = nullptr;
 
-__Backend::__Backend() : refcount(0) {
+Backend::Backend() : refcount(0) {
   DEBUG("initialising threads...");
 
   std::atomic<uint8_t> a;
@@ -95,22 +95,22 @@ __Backend::__Backend() : refcount(0) {
   report_to_user_func = thread_report_to_user_func;
 }
 
-__Backend::~__Backend() {
+Backend::~Backend() {
   print = previous_print_func;
   report_to_user_func = previous_report_to_user_func;
 }
 
-void __Backend::thread_print_func(std::string_view msg) {
+void Backend::thread_print_func(std::string_view msg) {
   std::lock_guard<std::mutex> lock(mutex);
   previous_print_func(msg);
 }
 
-void __Backend::thread_report_to_user_func(std::string_view msg, int type) {
+void Backend::thread_report_to_user_func(std::string_view msg, int type) {
   std::lock_guard<std::mutex> lock(mutex);
   previous_report_to_user_func(msg, type);
 }
 
-__Backend *__Backend::backend = nullptr;
-std::mutex __Backend::mutex;
+Backend *Backend::backend = nullptr;
+std::mutex Backend::mutex;
 
 } // namespace MR::Thread

--- a/cpp/core/thread.cpp
+++ b/cpp/core/thread.cpp
@@ -18,6 +18,7 @@
 #include <thread>
 
 #include "app.h"
+#include "env.h"
 #include "file/config.h"
 #include "thread.h"
 #include "thread_queue.h"
@@ -47,11 +48,11 @@ size_t number_of_threads() {
   // ENVVAR This overrides the automatically determined number, or the
   // ENVVAR :option:`NumberOfThreads` setting in the configuration file, but
   // ENVVAR will be overridden by the ENVVAR ``-nthreads`` command-line option.
-  const char *from_env = getenv("MRTRIX_NTHREADS"); // check_syntax off
-  if (from_env) {
-    __number_of_threads = to<size_t>(from_env);
-    __nthreads_type = nthreads_t::EXPLICIT;
-    return __number_of_threads;
+  const std::optional<std::string> from_env = MR::get_env("MRTRIX_NTHREADS");
+  if (from_env.has_value()) {
+    _number_of_threads = to<size_t>(*from_env);
+    _nthreads_type = nthreads_t::EXPLICIT;
+    return _number_of_threads;
   }
 
   // CONF option: NumberOfThreads

--- a/cpp/core/thread.h
+++ b/cpp/core/thread.h
@@ -20,6 +20,7 @@
 #include <memory>
 #include <mutex>
 #include <thread>
+#include <type_traits>
 
 #include "debug.h"
 #include "exception.h"

--- a/cpp/core/thread.h
+++ b/cpp/core/thread.h
@@ -105,11 +105,16 @@ protected:
 class _single_thread : public _thread_base {
 public:
   _single_thread(const _single_thread &) = delete;
-  _single_thread(_single_thread &&) = default;
+  //_single_thread(_single_thread &&) = default;
+  _single_thread(_single_thread &&) = delete;
+  // Note: the functor is borrowed by reference (only its address is passed to std::async),
+  //   never owned; this is what guarantees single-threaded execution incurs no functor copy.
+  //   An lvalue reference (rather than a forwarding reference) suffices because _run<>::operator()
+  //   always supplies an lvalue, and forwarding would defeat the zero-copy intent.
   template <class Functor,
             typename =
                 typename std::enable_if<!std::is_same<typename std::decay<Functor>::type, _single_thread>::value>::type>
-  _single_thread(Functor &&functor, std::string_view name = "unnamed") : _thread_base(name) {
+  _single_thread(Functor &functor, std::string_view name = "unnamed") : _thread_base(name) {
     DEBUG(std::string("launching thread \"") + name + "\"...");
     using F = typename std::remove_reference<Functor>::type;
     thread = std::async(std::launch::async, &F::execute, &functor);

--- a/cpp/core/thread.h
+++ b/cpp/core/thread.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <future>
+#include <memory>
 #include <mutex>
 #include <thread>
 
@@ -62,19 +63,17 @@ public:
   static void register_thread() {
     std::lock_guard<std::mutex> lock(mutex);
     if (!backend)
-      backend = new Backend;
+      backend = std::make_unique<Backend>();
     ++backend->refcount;
   }
   static void unregister_thread() {
     assert(backend);
     std::lock_guard<std::mutex> lock(mutex);
-    if (!(--backend->refcount)) {
-      delete backend;
-      backend = nullptr;
-    }
+    if (--backend->refcount == 0)
+      backend.reset();
   }
 
-  static bool valid() { return backend; }
+  static bool valid() { return backend != nullptr; }
 
   static void thread_print_func(std::string_view msg);
   static void thread_report_to_user_func(std::string_view msg, int type);
@@ -85,7 +84,7 @@ public:
 protected:
   size_t refcount;
 
-  static Backend *backend;
+  static std::unique_ptr<Backend> backend;
   static std::mutex mutex;
 };
 
@@ -110,8 +109,7 @@ public:
             typename =
                 typename std::enable_if<!std::is_same<typename std::decay<Functor>::type, _single_thread>::value>::type>
   _single_thread(Functor &&functor, std::string_view name = "unnamed") : _thread_base(name) {
-    const std::string msg = std::string("launching thread \"") + name + "\"...";
-    DEBUG(msg);
+    DEBUG(std::string("launching thread \"") + name + "\"...");
     using F = typename std::remove_reference<Functor>::type;
     thread = std::async(std::launch::async, &F::execute, &functor);
   }

--- a/cpp/core/thread.h
+++ b/cpp/core/thread.h
@@ -54,15 +54,15 @@
 
 namespace MR::Thread {
 
-class __Backend {
+class Backend {
 public:
-  __Backend();
-  ~__Backend();
+  Backend();
+  ~Backend();
 
   static void register_thread() {
     std::lock_guard<std::mutex> lock(mutex);
     if (!backend)
-      backend = new __Backend;
+      backend = new Backend;
     ++backend->refcount;
   }
   static void unregister_thread() {
@@ -85,33 +85,36 @@ public:
 protected:
   size_t refcount;
 
-  static __Backend *backend;
+  static Backend *backend;
   static std::mutex mutex;
 };
 
 namespace {
 
-class __thread_base {
+class _thread_base {
 public:
-  __thread_base(std::string_view name = "unnamed") : name(name) { __Backend::register_thread(); }
-  __thread_base(const __thread_base &) = delete;
-  __thread_base(__thread_base &&) = default;
-  ~__thread_base() { __Backend::unregister_thread(); }
+  _thread_base(std::string_view name = "unnamed") : name(name) { Backend::register_thread(); }
+  _thread_base(const _thread_base &) = delete;
+  _thread_base(_thread_base &&) = default;
+  ~_thread_base() { Backend::unregister_thread(); }
 
 protected:
   const std::string name;
 };
 
-class __single_thread : public __thread_base {
+class _single_thread : public _thread_base {
 public:
-  template <class Functor> __single_thread(Functor &&functor, std::string_view name = "unnamed") : __thread_base(name) {
+  _single_thread(const _single_thread &) = delete;
+  _single_thread(_single_thread &&) = default;
+  template <class Functor,
+            typename =
+                typename std::enable_if<!std::is_same<typename std::decay<Functor>::type, _single_thread>::value>::type>
+  _single_thread(Functor &&functor, std::string_view name = "unnamed") : _thread_base(name) {
     const std::string msg = std::string("launching thread \"") + name + "\"...";
     DEBUG(msg);
     using F = typename std::remove_reference<Functor>::type;
     thread = std::async(std::launch::async, &F::execute, &functor);
   }
-  __single_thread(const __single_thread &) = delete;
-  __single_thread(__single_thread &&) = default;
 
   bool finished() const { return thread.wait_for(std::chrono::microseconds(0)) == std::future_status::ready; }
 
@@ -121,7 +124,7 @@ public:
     DEBUG("thread \"" + name + "\" completed OK");
   }
 
-  ~__single_thread() {
+  ~_single_thread() {
     if (thread.valid()) {
       try {
         wait();
@@ -135,10 +138,10 @@ protected:
   std::future<void> thread;
 };
 
-template <class Functor> class __multi_thread : public __thread_base {
+template <class Functor> class _multi_thread : public _thread_base {
 public:
-  __multi_thread(Functor &functor, size_t nthreads, std::string_view name = "unnamed")
-      : __thread_base(name), functors((nthreads > 0 ? nthreads - 1 : 0), functor) {
+  _multi_thread(Functor &functor, size_t nthreads, std::string_view name = "unnamed")
+      : _thread_base(name), functors((nthreads > 0 ? nthreads - 1 : 0), functor) {
     DEBUG("launching " + str(nthreads) + " threads \"" + name + "\"...");
     using F = typename std::remove_reference<Functor>::type;
     threads.reserve(nthreads);
@@ -147,8 +150,8 @@ public:
     threads.push_back(std::async(std::launch::async, &F::execute, &functor));
   }
 
-  __multi_thread(const __multi_thread &) = delete;
-  __multi_thread(__multi_thread &&) = default;
+  _multi_thread(const _multi_thread &) = delete;
+  _multi_thread(_multi_thread &&) = default;
 
   void wait() noexcept(false) {
     DEBUG("waiting for completion of threads \"" + name + "\"...");
@@ -182,7 +185,7 @@ public:
     return false;
   }
 
-  ~__multi_thread() {
+  ~_multi_thread() {
     if (any_valid()) {
       try {
         wait();
@@ -197,10 +200,10 @@ protected:
   std::vector<typename std::remove_reference<Functor>::type> functors;
 };
 
-template <class Functor> class __Multi {
+template <class Functor> class Multi {
 public:
-  __Multi(Functor &object, size_t number) : functor(object), num(number) {}
-  __Multi(__Multi &&m) = default;
+  Multi(Functor &object, size_t number) : functor(object), num(number) {}
+  Multi(Multi &&m) = default;
   template <class X> bool operator()(const X &) {
     assert(0);
     return false;
@@ -217,16 +220,16 @@ public:
   size_t num;
 };
 
-template <class Functor> class __run {
+template <class Functor> class _run {
 public:
-  using type = __single_thread;
+  using type = _single_thread;
   type operator()(Functor &functor, std::string_view name) { return {functor, name}; }
 };
 
-template <class Functor> class __run<__Multi<Functor>> {
+template <class Functor> class _run<Multi<Functor>> {
 public:
-  using type = __multi_thread<Functor>;
-  type operator()(__Multi<Functor> &functor, std::string_view name) { return {functor.functor, functor.num, name}; }
+  using type = _multi_thread<Functor>;
+  type operator()(Multi<Functor> &functor, std::string_view name) { return {functor.functor, functor.num, name}; }
 };
 
 } // namespace
@@ -272,8 +275,8 @@ size_t threads_to_execute();
  * \sa Thread::run()
  * \sa Thread::run_queue() */
 template <class Functor>
-inline __Multi<typename std::remove_reference<Functor>::type> multi(Functor &&functor,
-                                                                    size_t nthreads = threads_to_execute()) {
+inline Multi<typename std::remove_reference<Functor>::type> multi(Functor &&functor,
+                                                                  size_t nthreads = threads_to_execute()) {
   return {functor, nthreads};
 }
 
@@ -357,9 +360,8 @@ inline __Multi<typename std::remove_reference<Functor>::type> multi(Functor &&fu
  *
  * \sa Thread::multi()
  */
-template <class Functor>
-inline typename __run<Functor>::type run(Functor &&functor, std::string_view name = "unnamed") {
-  return __run<typename std::remove_reference<Functor>::type>()(functor, name);
+template <class Functor> inline typename _run<Functor>::type run(Functor &&functor, std::string_view name = "unnamed") {
+  return _run<typename std::remove_reference<Functor>::type>()(functor, name);
 }
 
 /** @} */

--- a/cpp/core/thread_queue.h
+++ b/cpp/core/thread_queue.h
@@ -579,7 +579,7 @@ template <class Item> struct Batch {
 };
 
 template <class Item> struct _batch_size {
-  _batch_size(const Item &) {}
+  _batch_size(const Item & /*unused*/) {}
   operator size_t() const { return 0; }
 };
 template <class Item> struct _batch_size<Batch<Item>> {
@@ -754,7 +754,7 @@ template <class Item, class Functor> struct SinkWrapper {
  * that the items \a object be processed in batches of \a number items
  * (defaults to default_batchsize).
  * \sa Thread::run_queue() */
-template <class Item> inline Batch<Item> batch(const Item &, size_t number = default_batchsize) {
+template <class Item> inline Batch<Item> batch(const Item & /*unused*/, size_t number = default_batchsize) {
   return Batch<Item>(number);
 }
 

--- a/cpp/core/thread_queue.h
+++ b/cpp/core/thread_queue.h
@@ -32,7 +32,7 @@ constexpr ssize_t default_batchsize = 128;
 namespace {
 
 // to get multi/single job/functor seamlessly:
-template <class X> class __job {
+template <class X> class _job {
 public:
   using type = typename std::remove_reference<X>::type;
   using member_type = typename std::remove_reference<X>::type &;
@@ -41,14 +41,14 @@ public:
   template <class SingleFunctor> static SingleFunctor &get(X & /*f*/, SingleFunctor &functor) { return functor; }
 };
 
-template <class X> class __job<__Multi<X>> {
+template <class X> class _job<Multi<X>> {
 public:
   using type = typename std::remove_reference<X>::type;
   using member_type = typename std::remove_reference<X>::type;
-  static X &functor(__Multi<X> &job) { return job.functor; }
+  static X &functor(Multi<X> &job) { return job.functor; }
 
-  template <class SingleFunctor> static __Multi<SingleFunctor> get(__Multi<X> &f, SingleFunctor &functor) {
-    return __Multi<SingleFunctor>(functor, f.num);
+  template <class SingleFunctor> static Multi<SingleFunctor> get(Multi<X> &f, SingleFunctor &functor) {
+    return Multi<SingleFunctor>(functor, f.num);
   }
 };
 
@@ -573,17 +573,17 @@ namespace {
 /********************************************************************
  * convenience Functor classes for use in Thread::run_queue()
  ********************************************************************/
-template <class Item> struct __Batch {
-  __Batch(size_t number) : num(number) {}
+template <class Item> struct Batch {
+  Batch(size_t number) : num(number) {}
   size_t num;
 };
 
-template <class Item> struct __batch_size {
-  __batch_size(const Item &) {}
+template <class Item> struct _batch_size {
+  _batch_size(const Item &) {}
   operator size_t() const { return 0; }
 };
-template <class Item> struct __batch_size<__Batch<Item>> {
-  __batch_size(const __Batch<Item> &item) : n(item.num) {}
+template <class Item> struct _batch_size<Batch<Item>> {
+  _batch_size(const Batch<Item> &item) : n(item.num) {}
   operator size_t() const { return n; }
   const size_t n;
 };
@@ -600,7 +600,7 @@ template <class Item> struct Type {
   using write_item = typename writer::Item;
 };
 
-template <class Item> struct Type<__Batch<Item>> {
+template <class Item> struct Type<Batch<Item>> {
   using item = Item;
   using queue = Queue<std::vector<Item>>;
   using reader = typename queue::Reader;
@@ -616,8 +616,8 @@ template <class Item> struct FetchItem {
   typename Type<Item>::read_item in;
 };
 
-template <class Item> struct FetchItem<__Batch<Item>> {
-  FetchItem(typename Type<__Batch<Item>>::reader &in) : in(in.placeholder()), n(0) {}
+template <class Item> struct FetchItem<Batch<Item>> {
+  FetchItem(typename Type<Batch<Item>>::reader &in) : in(in.placeholder()), n(0) {}
   bool read() {
     if (!in)
       return in.read();
@@ -630,7 +630,7 @@ template <class Item> struct FetchItem<__Batch<Item>> {
     return true;
   }
   Item &value() { return (*in)[n]; }
-  typename Type<__Batch<Item>>::read_item in;
+  typename Type<Batch<Item>>::read_item in;
   size_t n;
 };
 
@@ -642,8 +642,8 @@ template <class Item> struct StoreItem {
   typename Type<Item>::write_item out;
 };
 
-template <class Item> struct StoreItem<__Batch<Item>> {
-  StoreItem(size_t batch_size, typename Type<__Batch<Item>>::writer &item)
+template <class Item> struct StoreItem<Batch<Item>> {
+  StoreItem(size_t batch_size, typename Type<Batch<Item>>::writer &item)
       : out(item.placeholder()), batch_size(batch_size), n(0) {
     out->resize(batch_size);
   }
@@ -664,23 +664,23 @@ template <class Item> struct StoreItem<__Batch<Item>> {
       out.write();
     }
   }
-  typename Type<__Batch<Item>>::write_item out;
+  typename Type<Batch<Item>>::write_item out;
   const size_t batch_size;
   size_t n;
 };
 
-template <class Item, class Functor> struct __Source {
+template <class Item, class Functor> struct SourceWrapper {
   using item_t = typename Type<Item>::item;
   using queue_t = typename Type<Item>::queue;
   using writer_t = typename Type<Item>::writer;
-  using functor_t = typename __job<Functor>::member_type;
+  using functor_t = typename _job<Functor>::member_type;
 
   writer_t writer;
   functor_t func;
   size_t batch_size;
 
-  __Source(queue_t &queue, Functor &functor, const Item &item)
-      : writer(queue), func(__job<Functor>::functor(functor)), batch_size(__batch_size<Item>(item)) {}
+  SourceWrapper(queue_t &queue, Functor &functor, const Item &item)
+      : writer(queue), func(_job<Functor>::functor(functor)), batch_size(_batch_size<Item>(item)) {}
 
   void execute() {
     auto out = StoreItem<Item>(batch_size, writer);
@@ -692,25 +692,25 @@ template <class Item, class Functor> struct __Source {
   }
 };
 
-template <class Item1, class Functor, class Item2> struct __Pipe {
+template <class Item1, class Functor, class Item2> struct PipeWrapper {
   using item1_t = typename Type<Item1>::item;
   using item2_t = typename Type<Item2>::item;
   using queue1_t = typename Type<Item1>::queue;
   using queue2_t = typename Type<Item2>::queue;
   using reader_t = typename Type<Item1>::reader;
   using writer_t = typename Type<Item2>::writer;
-  using functor_t = typename __job<Functor>::member_type;
+  using functor_t = typename _job<Functor>::member_type;
 
   reader_t reader;
   writer_t writer;
   functor_t func;
   const size_t batch_size;
 
-  __Pipe(queue1_t &queue_in, Functor &functor, queue2_t &queue_out, const Item2 &item2)
+  PipeWrapper(queue1_t &queue_in, Functor &functor, queue2_t &queue_out, const Item2 &item2)
       : reader(queue_in),
         writer(queue_out),
-        func(__job<Functor>::functor(functor)),
-        batch_size(__batch_size<Item2>(item2)) {}
+        func(_job<Functor>::functor(functor)),
+        batch_size(_batch_size<Item2>(item2)) {}
 
   void execute() {
     auto in = FetchItem<Item1>(reader);
@@ -725,16 +725,16 @@ template <class Item1, class Functor, class Item2> struct __Pipe {
   }
 };
 
-template <class Item, class Functor> struct __Sink {
+template <class Item, class Functor> struct SinkWrapper {
   using item_t = typename Type<Item>::item;
   using queue_t = typename Type<Item>::queue;
   using reader_t = typename Type<Item>::reader;
-  using functor_t = typename __job<Functor>::member_type;
+  using functor_t = typename _job<Functor>::member_type;
 
   reader_t reader;
   functor_t func;
 
-  __Sink(queue_t &queue, Functor &functor) : reader(queue), func(__job<Functor>::functor(functor)) {}
+  SinkWrapper(queue_t &queue, Functor &functor) : reader(queue), func(_job<Functor>::functor(functor)) {}
 
   void execute() {
     auto in = FetchItem<Item>(reader);
@@ -754,8 +754,8 @@ template <class Item, class Functor> struct __Sink {
  * that the items \a object be processed in batches of \a number items
  * (defaults to default_batchsize).
  * \sa Thread::run_queue() */
-template <class Item> inline __Batch<Item> batch(const Item &, size_t number = default_batchsize) {
-  return __Batch<Item>(number);
+template <class Item> inline Batch<Item> batch(const Item &, size_t number = default_batchsize) {
+  return Batch<Item>(number);
 }
 
 //! convenience function to set up and run a 2-stage multi-threaded pipeline.
@@ -943,18 +943,18 @@ template <class Source, class Item, class Sink>
 inline void run_queue(Source &&source, const Item &item, Sink &&sink, size_t capacity = default_queue_capacity) {
   if (threads_to_execute() == 0) {
     typename Type<Item>::item item;
-    while (__job<Source>::functor(source)(item))
-      if (!__job<Sink>::functor(sink)(item))
+    while (_job<Source>::functor(source)(item))
+      if (!_job<Sink>::functor(sink)(item))
         return;
     return;
   }
 
   typename Type<Item>::queue queue("source->sink", capacity);
-  __Source<Item, Source> source_functor(queue, source, item);
-  __Sink<Item, Sink> sink_functor(queue, sink);
+  SourceWrapper<Item, Source> source_functor(queue, source, item);
+  SinkWrapper<Item, Sink> sink_functor(queue, sink);
 
-  auto t1 = run(__job<Source>::get(source, source_functor), "source");
-  auto t2 = run(__job<Sink>::get(sink, sink_functor), "sink");
+  auto t1 = run(_job<Source>::get(source, source_functor), "source");
+  auto t2 = run(_job<Sink>::get(sink, sink_functor), "sink");
 
   t1.wait();
   t2.wait();
@@ -1016,9 +1016,9 @@ inline void run_queue(Source &&source,
   if (threads_to_execute() == 0) {
     typename Type<Item1>::item item1;
     typename Type<Item2>::item item2;
-    while (__job<Source>::functor(source)(item1)) {
-      if (__job<Pipe>::functor(pipe)(item1, item2))
-        if (!__job<Sink>::functor(sink)(item2))
+    while (_job<Source>::functor(source)(item1)) {
+      if (_job<Pipe>::functor(pipe)(item1, item2))
+        if (!_job<Sink>::functor(sink)(item2))
           return;
     }
     return;
@@ -1027,13 +1027,13 @@ inline void run_queue(Source &&source,
   typename Type<Item1>::queue queue1("source->pipe", capacity);
   typename Type<Item2>::queue queue2("pipe->sink", capacity);
 
-  __Source<Item1, Source> source_functor(queue1, source, item1);
-  __Pipe<Item1, Pipe, Item2> pipe_functor(queue1, pipe, queue2, item2);
-  __Sink<Item2, Sink> sink_functor(queue2, sink);
+  SourceWrapper<Item1, Source> source_functor(queue1, source, item1);
+  PipeWrapper<Item1, Pipe, Item2> pipe_functor(queue1, pipe, queue2, item2);
+  SinkWrapper<Item2, Sink> sink_functor(queue2, sink);
 
-  auto t1 = run(__job<Source>::get(source, source_functor), "source");
-  auto t2 = run(__job<Pipe>::get(pipe, pipe_functor), "pipe");
-  auto t3 = run(__job<Sink>::get(sink, sink_functor), "sink");
+  auto t1 = run(_job<Source>::get(source, source_functor), "source");
+  auto t2 = run(_job<Pipe>::get(pipe, pipe_functor), "pipe");
+  auto t3 = run(_job<Sink>::get(sink, sink_functor), "sink");
 
   t1.wait();
   t2.wait();
@@ -1058,10 +1058,10 @@ inline void run_queue(Source &&source,
     typename Type<Item1>::item item1;
     typename Type<Item2>::item item2;
     typename Type<Item3>::item item3;
-    while (__job<Source>::functor(source)(item1)) {
-      if (__job<Pipe1>::functor(pipe1)(item1, item2))
-        if (__job<Pipe2>::functor(pipe2)(item2, item3))
-          if (!__job<Sink>::functor(sink)(item3))
+    while (_job<Source>::functor(source)(item1)) {
+      if (_job<Pipe1>::functor(pipe1)(item1, item2))
+        if (_job<Pipe2>::functor(pipe2)(item2, item3))
+          if (!_job<Sink>::functor(sink)(item3))
             return;
     }
     return;
@@ -1071,15 +1071,15 @@ inline void run_queue(Source &&source,
   typename Type<Item2>::queue queue2("pipe->pipe", capacity);
   typename Type<Item3>::queue queue3("pipe->sink", capacity);
 
-  __Source<Item1, Source> source_functor(queue1, source, item1);
-  __Pipe<Item1, Pipe1, Item2> pipe1_functor(queue1, pipe1, queue2, item2);
-  __Pipe<Item2, Pipe2, Item3> pipe2_functor(queue2, pipe2, queue3, item3);
-  __Sink<Item3, Sink> sink_functor(queue3, sink);
+  SourceWrapper<Item1, Source> source_functor(queue1, source, item1);
+  PipeWrapper<Item1, Pipe1, Item2> pipe1_functor(queue1, pipe1, queue2, item2);
+  PipeWrapper<Item2, Pipe2, Item3> pipe2_functor(queue2, pipe2, queue3, item3);
+  SinkWrapper<Item3, Sink> sink_functor(queue3, sink);
 
-  auto t1 = run(__job<Source>::get(source, source_functor), "source");
-  auto t2 = run(__job<Pipe1>::get(pipe1, pipe1_functor), "pipe1");
-  auto t3 = run(__job<Pipe2>::get(pipe2, pipe2_functor), "pipe2");
-  auto t4 = run(__job<Sink>::get(sink, sink_functor), "sink");
+  auto t1 = run(_job<Source>::get(source, source_functor), "source");
+  auto t2 = run(_job<Pipe1>::get(pipe1, pipe1_functor), "pipe1");
+  auto t3 = run(_job<Pipe2>::get(pipe2, pipe2_functor), "pipe2");
+  auto t4 = run(_job<Sink>::get(sink, sink_functor), "sink");
 
   t1.wait();
   t2.wait();

--- a/cpp/core/types.h
+++ b/cpp/core/types.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include "eigen_plugins/eigen_plugins.h"
+#include <Eigen/Geometry>
 #include <cinttypes>
 #include <complex>
 #include <cstddef>
@@ -33,20 +35,6 @@
 #endif
 #else
 #define PRI_SIZET "zu" // check_syntax off
-#endif
-
-namespace MR::Helper {
-template <class ImageType> class ConstRow;
-template <class ImageType> class Row;
-} // namespace MR::Helper
-#define EIGEN_DENSEBASE_PLUGIN "eigen_plugins/dense_base.h"  // check_syntax off
-#define EIGEN_MATRIXBASE_PLUGIN "eigen_plugins/dense_base.h" // check_syntax off
-#define EIGEN_ARRAYBASE_PLUGIN "eigen_plugins/dense_base.h"  // check_syntax off
-#define EIGEN_MATRIX_PLUGIN "eigen_plugins/matrix.h"         // check_syntax off
-#define EIGEN_ARRAY_PLUGIN "eigen_plugins/array.h"           // check_syntax off
-#include <Eigen/Geometry>
-#ifdef EIGEN_HAS_OPENMP
-#undef EIGEN_HAS_OPENMP
 #endif
 
 /*! \defgroup VLA Variable-length array macros

--- a/cpp/core/types.h
+++ b/cpp/core/types.h
@@ -18,6 +18,7 @@
 
 #include "eigen_plugins/eigen_plugins.h"
 #include <Eigen/Geometry>
+#include <array>
 #include <cinttypes>
 #include <complex>
 #include <cstddef>

--- a/cpp/gui/dialog/file.cpp
+++ b/cpp/gui/dialog/file.cpp
@@ -40,7 +40,6 @@ input_dirpath(QWidget *parent, std::string_view caption, std::optional<std::file
       QFileDialog::ShowDirsOnly | FILE_DIALOG_OPTIONS);
 
   FileDialogReturn result;
-  std::string new_folder;
   if (!qstring.isEmpty()) {
     result.single_selection = std::filesystem::path(qstring.toUtf8().data());
     result.last_directory = result.single_selection;
@@ -116,8 +115,8 @@ const FileDialogReturn output_filepath(QWidget *parent,
 
   QString selection;
   if (start_directory.has_value()) {
-    selection = suggested_name.has_value() ? qstr(start_directory.value().string())
-                                           : qstr((start_directory.value() / suggested_name.value()).string());
+    selection = suggested_name.has_value() ? qstr((start_directory.value() / suggested_name.value()).string())
+                                           : qstr(start_directory.value().string());
   } else if (suggested_name.has_value()) {
     selection = qstr(suggested_name->string());
   }

--- a/cpp/gui/dwi/render_frame.cpp
+++ b/cpp/gui/dwi/render_frame.cpp
@@ -103,10 +103,11 @@ void RenderFrame::initializeGL() {
   axes_VB.bind(gl::ARRAY_BUFFER);
   axes_VAO.bind();
   gl::EnableVertexAttribArray(0);
-  gl::VertexAttribPointer(0, 3, gl::FLOAT, gl::FALSE_, 6 * sizeof(GLfloat), (void *)0);
+  gl::VertexAttribPointer(0, 3, gl::FLOAT, gl::FALSE_, 6 * sizeof(GLfloat), nullptr);
 
   gl::EnableVertexAttribArray(1);
-  gl::VertexAttribPointer(1, 3, gl::FLOAT, gl::FALSE_, 6 * sizeof(GLfloat), (void *)(3 * sizeof(GLfloat)));
+  gl::VertexAttribPointer(
+      1, 3, gl::FLOAT, gl::FALSE_, 6 * sizeof(GLfloat), reinterpret_cast<void *>(3 * sizeof(GLfloat)));
 
   const std::array<GLfloat, 36> axis_data = {-1.0, -1.0, -1.0, 1.0, 0.0, 0.0, 1.0,  -1.0, -1.0, 1.0, 0.0, 0.0,  //
                                              -1.0, -1.0, -1.0, 0.0, 1.0, 0.0, -1.0, 1.0,  -1.0, 0.0, 1.0, 0.0,  //

--- a/cpp/gui/dwi/render_frame.cpp
+++ b/cpp/gui/dwi/render_frame.cpp
@@ -347,7 +347,8 @@ void RenderFrame::screenshot(int oversampling, const std::filesystem::path &imag
   screenshot_path = image_path;
   OS = oversampling;
   OS_x = OS_y = 0;
-  framebuffer.reset(new GLubyte[3 * projection.width() * projection.height()]);
+  framebuffer.reset(
+      new GLubyte[3 * static_cast<size_t>(projection.width()) * static_cast<size_t>(projection.height())]);
   pix.reset(new QImage(OS * projection.width(), OS * projection.height(), QImage::Format_RGB32));
   update();
 }
@@ -362,7 +363,8 @@ void RenderFrame::snapshot() {
   for (int j = 0; j < projection.height(); j++) {
     int j2 = projection.height() - j - 1;
     for (int i = 0; i < projection.width(); i++) {
-      GLubyte *p = framebuffer.get() + 3 * (i + projection.width() * j);
+      GLubyte *p = framebuffer.get() +
+                   3 * (static_cast<size_t>(i) + static_cast<size_t>(projection.width()) * static_cast<size_t>(j));
       pix->setPixel(start_i + i, start_j + j2, qRgb(p[0], p[1], p[2]));
     }
   }

--- a/cpp/gui/dwi/render_frame.cpp
+++ b/cpp/gui/dwi/render_frame.cpp
@@ -347,8 +347,8 @@ void RenderFrame::screenshot(int oversampling, const std::filesystem::path &imag
   screenshot_path = image_path;
   OS = oversampling;
   OS_x = OS_y = 0;
-  framebuffer.reset(
-      new GLubyte[3 * static_cast<size_t>(projection.width()) * static_cast<size_t>(projection.height())]);
+  framebuffer = std::make_unique<GLubyte[]>(3 * static_cast<size_t>(projection.width()) *
+                                            static_cast<size_t>(projection.height()));
   pix.reset(new QImage(OS * projection.width(), OS * projection.height(), QImage::Format_RGB32));
   update();
 }
@@ -364,7 +364,7 @@ void RenderFrame::snapshot() {
     int j2 = projection.height() - j - 1;
     for (int i = 0; i < projection.width(); i++) {
       GLubyte *p = framebuffer.get() +
-                   3 * (static_cast<size_t>(i) + static_cast<size_t>(projection.width()) * static_cast<size_t>(j));
+                   3 * (static_cast<size_t>(i) + (static_cast<size_t>(projection.width()) * static_cast<size_t>(j)));
       pix->setPixel(start_i + i, start_j + j2, qRgb(p[0], p[1], p[2]));
     }
   }

--- a/cpp/gui/dwi/renderer.cpp
+++ b/cpp/gui/dwi/renderer.cpp
@@ -14,7 +14,9 @@
  * For more details, see http://www.mrtrix.org/.
  */
 
+#include <array>
 #include <map>
+#include <vector>
 
 #include "dwi/renderer.h"
 #include "gui.h"

--- a/cpp/gui/dwi/renderer.cpp
+++ b/cpp/gui/dwi/renderer.cpp
@@ -312,11 +312,11 @@ void Renderer::SH::initGL() {
 
   half_sphere.vertex_buffer.bind(gl::ARRAY_BUFFER);
   gl::EnableVertexAttribArray(0);
-  gl::VertexAttribPointer(0, 3, gl::FLOAT, gl::FALSE_, sizeof(Shapes::HalfSphere::Vertex), (void *)0);
+  gl::VertexAttribPointer(0, 3, gl::FLOAT, gl::FALSE_, sizeof(Shapes::HalfSphere::Vertex), nullptr);
 
   surface_buffer.bind(gl::ARRAY_BUFFER);
   gl::EnableVertexAttribArray(1);
-  gl::VertexAttribPointer(1, 3, gl::FLOAT, gl::FALSE_, 3 * sizeof(GLfloat), (void *)0);
+  gl::VertexAttribPointer(1, 3, gl::FLOAT, gl::FALSE_, 3 * sizeof(GLfloat), nullptr);
 
   half_sphere.index_buffer.bind();
   GL_CHECK_ERROR;
@@ -331,7 +331,7 @@ void Renderer::SH::bind() {
 void Renderer::SH::set_data(const vector_t &r_del_daz, int /*buffer_ID*/) const {
   surface_buffer.bind(gl::ARRAY_BUFFER);
   gl::BufferData(gl::ARRAY_BUFFER, r_del_daz.size() * sizeof(float), &r_del_daz[0], gl::STREAM_DRAW);
-  gl::VertexAttribPointer(1, 3, gl::FLOAT, gl::FALSE_, 3 * sizeof(GLfloat), (void *)0);
+  gl::VertexAttribPointer(1, 3, gl::FLOAT, gl::FALSE_, 3 * sizeof(GLfloat), nullptr);
 }
 
 void Renderer::SH::update_mesh(const size_t lod, const int lmax) {
@@ -422,7 +422,7 @@ void Renderer::Tensor::initGL() {
 
   half_sphere.vertex_buffer.bind(gl::ARRAY_BUFFER);
   gl::EnableVertexAttribArray(0);
-  gl::VertexAttribPointer(0, 3, gl::FLOAT, gl::FALSE_, sizeof(Shapes::HalfSphere::Vertex), (void *)0);
+  gl::VertexAttribPointer(0, 3, gl::FLOAT, gl::FALSE_, sizeof(Shapes::HalfSphere::Vertex), nullptr);
 
   half_sphere.index_buffer.bind();
   GL_CHECK_ERROR;
@@ -491,11 +491,11 @@ void Renderer::Dixel::initGL() {
 
   vertex_buffer.bind(gl::ARRAY_BUFFER);
   gl::EnableVertexAttribArray(0);
-  gl::VertexAttribPointer(0, 3, gl::FLOAT, gl::FALSE_, 3 * sizeof(GLfloat), (void *)0);
+  gl::VertexAttribPointer(0, 3, gl::FLOAT, gl::FALSE_, 3 * sizeof(GLfloat), nullptr);
 
   value_buffer.bind(gl::ARRAY_BUFFER);
   gl::EnableVertexAttribArray(1);
-  gl::VertexAttribPointer(1, 1, gl::FLOAT, gl::FALSE_, sizeof(GLfloat), (void *)0);
+  gl::VertexAttribPointer(1, 1, gl::FLOAT, gl::FALSE_, sizeof(GLfloat), nullptr);
   GL_CHECK_ERROR;
 }
 
@@ -512,7 +512,7 @@ void Renderer::Dixel::set_data(const vector_t &data, int /*buffer_ID*/) const {
   VAO.bind();
   value_buffer.bind(gl::ARRAY_BUFFER);
   gl::BufferData(gl::ARRAY_BUFFER, vertex_count * sizeof(GLfloat), &data[0], gl::STREAM_DRAW);
-  gl::VertexAttribPointer(1, 1, gl::FLOAT, gl::FALSE_, sizeof(GLfloat), (void *)0);
+  gl::VertexAttribPointer(1, 1, gl::FLOAT, gl::FALSE_, sizeof(GLfloat), nullptr);
   GL_CHECK_ERROR;
 }
 
@@ -564,7 +564,7 @@ void Renderer::Dixel::update_dixels(const MR::DWI::Directions::Set &dirs) {
   VAO.bind();
   vertex_buffer.bind(gl::ARRAY_BUFFER);
   gl::BufferData(gl::ARRAY_BUFFER, dirs.size() * sizeof(Eigen::Vector3f), &directions_data[0], gl::STATIC_DRAW);
-  gl::VertexAttribPointer(0, 3, gl::FLOAT, gl::FALSE_, 3 * sizeof(GLfloat), (void *)0);
+  gl::VertexAttribPointer(0, 3, gl::FLOAT, gl::FALSE_, 3 * sizeof(GLfloat), nullptr);
   index_buffer.bind();
   gl::BufferData(
       gl::ELEMENT_ARRAY_BUFFER, indices_data.size() * sizeof(std::array<GLint, 3>), &indices_data[0], gl::STATIC_DRAW);

--- a/cpp/gui/dwi/renderer.h
+++ b/cpp/gui/dwi/renderer.h
@@ -19,7 +19,6 @@
 #include "eigen_plugins/eigen_plugins.h"
 #include <Eigen/Eigenvalues>
 #include <QOpenGLWidget>
-#include <array>
 
 #include "dwi/directions/set.h"
 #include "gui.h"

--- a/cpp/gui/dwi/renderer.h
+++ b/cpp/gui/dwi/renderer.h
@@ -16,10 +16,10 @@
 
 #pragma once
 
-#include <array>
-
+#include "eigen_plugins/eigen_plugins.h"
 #include <Eigen/Eigenvalues>
 #include <QOpenGLWidget>
+#include <array>
 
 #include "dwi/directions/set.h"
 #include "gui.h"

--- a/cpp/gui/dwi/renderer.h
+++ b/cpp/gui/dwi/renderer.h
@@ -114,7 +114,7 @@ protected:
   void half_draw() const {
     const GLuint num_indices =
         (mode == mode_t::SH ? sh.num_indices() : (mode == mode_t::TENSOR ? tensor.num_indices() : dixel.num_indices()));
-    gl::DrawElements(gl::TRIANGLES, num_indices, gl::UNSIGNED_INT, (void *)0);
+    gl::DrawElements(gl::TRIANGLES, num_indices, gl::UNSIGNED_INT, nullptr);
   }
 
 private:

--- a/cpp/gui/gui.cpp
+++ b/cpp/gui/gui.cpp
@@ -31,7 +31,7 @@ App::App(int &cmdline_argc, char **cmdline_argv) : QApplication(cmdline_argc, cm
 
   QLocale::setDefault(QLocale::c());
   std::locale::global(std::locale::classic());
-  std::setlocale(LC_ALL, "C");
+  std::setlocale(LC_ALL, "C"); // NOLINT(concurrency-mt-unsafe)
 
   setAttribute(Qt::AA_DontCreateNativeWidgetSiblings);
 

--- a/cpp/gui/mrview/colourbars.cpp
+++ b/cpp/gui/mrview/colourbars.cpp
@@ -131,7 +131,7 @@ void ColourBars::render(size_t colourmap,
     VAO.bind();
 
     gl::EnableVertexAttribArray(0);
-    gl::VertexAttribPointer(0, 3, gl::FLOAT, gl::FALSE_, 0, (void *)0);
+    gl::VertexAttribPointer(0, 3, gl::FLOAT, gl::FALSE_, 0, nullptr);
   } else {
     VB.bind(gl::ARRAY_BUFFER);
     VAO.bind();

--- a/cpp/gui/mrview/gui_image.cpp
+++ b/cpp/gui/mrview/gui_image.cpp
@@ -431,7 +431,7 @@ template <typename ValueType> inline void Image::copy_texture_3D() {
     using MR::Image<cfloat>::buffer;
 
     WithType(const MR::Image<cfloat> &source) : MR::Image<cfloat>(source) {
-      __set_fetch_store_scale_functions(fetch_func, store_func, buffer->datatype());
+      _set_fetch_store_scale_functions(fetch_func, store_func, buffer->datatype());
     }
     FORCE_INLINE ValueType value() const {
       ssize_t nseg = data_offset / buffer->get_io()->segment_size();
@@ -619,15 +619,9 @@ inline bool Image::volume_unchanged() {
 
 inline bool Image::format_unchanged() {
   std::string cmap_name = ColourMap::maps[colourmap].name;
-
-  if (cmap_name == "RGB" && format != gl::RGB)
-    return false;
-  else if (cmap_name == "Complex" && format != gl::RG)
-    return false;
-  else if (format != gl::RED)
-    return false;
-
-  return true;
+  return !((cmap_name == "RGB" && format != gl::RGB) ||    //
+           (cmap_name == "Complex" && format != gl::RG) || //
+           format != gl::RED);                             //
 }
 
 } // namespace MR::GUI::MRView

--- a/cpp/gui/mrview/mode/base.cpp
+++ b/cpp/gui/mrview/mode/base.cpp
@@ -72,7 +72,7 @@ void Base::paintGL() {
       // Draw additional labels from tools
       QList<QAction *> tools = window().tools()->actions();
       for (size_t i = 0, line_num = 4, N = tools.size(); i < N; ++i) {
-        Tool::Dock *dock = dynamic_cast<Tool::__Action__ *>(tools[i])->dock;
+        Tool::Dock *dock = dynamic_cast<Tool::ActionWrapper *>(tools[i])->dock;
         if (dock)
           line_num += dock->tool->draw_tool_labels(LeftEdge | BottomEdge, line_num, projection);
       }
@@ -98,7 +98,7 @@ void Base::paintGL() {
       QList<QAction *> tools = window().tools()->actions();
       size_t num_tool_colourbars = 0;
       for (size_t i = 0, N = tools.size(); i < N; ++i) {
-        Tool::Dock *dock = dynamic_cast<Tool::__Action__ *>(tools[i])->dock;
+        Tool::Dock *dock = dynamic_cast<Tool::ActionWrapper *>(tools[i])->dock;
         if (dock)
           num_tool_colourbars += dock->tool->visible_number_colourbars();
       }
@@ -106,7 +106,7 @@ void Base::paintGL() {
       colourbar_renderer.begin(&projection, window().tools_colourbar_position, num_tool_colourbars);
 
       for (size_t i = 0, N = tools.size(); i < N; ++i) {
-        Tool::Dock *dock = dynamic_cast<Tool::__Action__ *>(tools[i])->dock;
+        Tool::Dock *dock = dynamic_cast<Tool::ActionWrapper *>(tools[i])->dock;
         if (dock)
           dock->tool->draw_colourbars();
       }
@@ -245,14 +245,16 @@ Eigen::Quaternionf Base::get_rotate_rotation(const ModelViewProjection &proj) co
   if (dpos.x() == 0 && dpos.y() == 0)
     return Eigen::Quaternionf(NaNF, NaNF, NaNF, NaNF);
 
-  Eigen::Vector3f x1(window().mouse_position().x() - proj.x_position() - proj.width() / 2,
-                     window().mouse_position().y() - proj.y_position() - proj.height() / 2,
-                     0.0);
+  Eigen::Vector3f x1(static_cast<float>(window().mouse_position().x() - proj.x_position()) -
+                         (0.5F * static_cast<float>(proj.width())),
+                     static_cast<float>(window().mouse_position().y() - proj.y_position()) -
+                         (0.5F * static_cast<float>(proj.height())),
+                     0.0F);
 
   if (x1.norm() < 16.0f)
     return Eigen::Quaternionf(NaNF, NaNF, NaNF, NaNF);
 
-  Eigen::Vector3f x0(dpos.x() - x1[0], dpos.y() - x1[1], 0.0);
+  Eigen::Vector3f x0(static_cast<float>(dpos.x()) - x1[0], static_cast<float>(dpos.y()) - x1[1], 0.0F);
 
   x1.normalize();
   x0.normalize();

--- a/cpp/gui/mrview/mode/base.cpp
+++ b/cpp/gui/mrview/mode/base.cpp
@@ -15,7 +15,9 @@
  */
 
 #include "mrview/mode/base.h"
+
 #include "file/config.h"
+#include "opengl/gl_core_3_3.h"
 #include "opengl/glutils.h"
 
 namespace MR::GUI::MRView::Mode {

--- a/cpp/gui/mrview/mode/base.h
+++ b/cpp/gui/mrview/mode/base.h
@@ -147,7 +147,7 @@ public:
   void render_tools(const Projection &projection, bool is_3D = false, int axis = 0, int slice = 0) {
     QList<QAction *> tools = window().tools()->actions();
     for (int i = 0; i < tools.size(); ++i) {
-      Tool::Dock *dock = dynamic_cast<Tool::__Action__ *>(tools[i])->dock;
+      Tool::Dock *dock = dynamic_cast<Tool::ActionWrapper *>(tools[i])->dock;
       if (dock) {
         GL::assert_context_is_current();
         dock->tool->draw(projection, is_3D, axis, slice);
@@ -202,9 +202,12 @@ protected:
 };
 
 //! \cond skip
-class __Action__ : public QAction {
+class ActionWrapper : public QAction {
 public:
-  __Action__(QActionGroup *parent, const char *const name, const char *const description, int index) // check_syntax off
+  ActionWrapper(QActionGroup *parent,
+                const char *const name,        // check_syntax off
+                const char *const description, // check_syntax off
+                int index)
       : QAction(name, parent) {
     setCheckable(true);
     setShortcut(tr(std::string("F" + str(index)).c_str()));
@@ -215,10 +218,10 @@ public:
 };
 //! \endcond
 
-template <class T> class Action : public __Action__ {
+template <class T> class Action : public ActionWrapper {
 public:
   Action(QActionGroup *parent, const char *const name, const char *const description, int index) // check_syntax off
-      : __Action__(parent, name, description, index) {}
+      : ActionWrapper(parent, name, description, index) {}
 
   virtual Base *create() const { return new T; }
 };

--- a/cpp/gui/mrview/mode/lightbox.cpp
+++ b/cpp/gui/mrview/mode/lightbox.cpp
@@ -193,7 +193,7 @@ void LightBox::draw_grid() {
     frame_VAO.bind();
 
     gl::EnableVertexAttribArray(0);
-    gl::VertexAttribPointer(0, 2, gl::FLOAT, gl::FALSE_, 0, (void *)0);
+    gl::VertexAttribPointer(0, 2, gl::FLOAT, gl::FALSE_, 0, nullptr);
 
     GLfloat data[num_points];
 

--- a/cpp/gui/mrview/mode/lightbox.cpp
+++ b/cpp/gui/mrview/mode/lightbox.cpp
@@ -16,6 +16,8 @@
 
 #include "mrview/mode/lightbox.h"
 
+#include "opengl/gl_core_3_3.h"
+
 namespace MR::GUI::MRView::Mode {
 
 bool LightBox::show_grid_lines = true;

--- a/cpp/gui/mrview/mode/lightbox.cpp
+++ b/cpp/gui/mrview/mode/lightbox.cpp
@@ -32,7 +32,7 @@ LightBox::LightBox() : frames_dirty(true) {
   Image *img = image();
 
   if (!img || prev_image_path != img->header().path())
-    image_changed_event();
+    LightBox::image_changed_event();
   else {
     set_volume_increment(volume_increment);
     set_slice_increment(slice_focus_increment);

--- a/cpp/gui/mrview/mode/ortho.cpp
+++ b/cpp/gui/mrview/mode/ortho.cpp
@@ -18,6 +18,7 @@
 
 #include "cursor.h"
 #include "mrtrix.h"
+#include "opengl/gl_core_3_3.h"
 
 namespace MR::GUI::MRView::Mode {
 

--- a/cpp/gui/mrview/mode/ortho.cpp
+++ b/cpp/gui/mrview/mode/ortho.cpp
@@ -86,7 +86,7 @@ void Ortho::paint(Projection &projection) {
     frame_VAO.bind();
 
     gl::EnableVertexAttribArray(0);
-    gl::VertexAttribPointer(0, 2, gl::FLOAT, gl::FALSE_, 0, (void *)0);
+    gl::VertexAttribPointer(0, 2, gl::FLOAT, gl::FALSE_, 0, nullptr);
 
     static const std::array<GLfloat, 8> data = {-1.0F, 0.0F, 1.0F, 0.0F, 0.0F, -1.0F, 0.0F, 1.0F};
     static const std::array<GLfloat, 8> data_row = {

--- a/cpp/gui/mrview/mode/volume.cpp
+++ b/cpp/gui/mrview/mode/volume.cpp
@@ -346,7 +346,7 @@ void Volume::paint(Projection &projection) {
     volume_VI.bind(gl::ELEMENT_ARRAY_BUFFER);
 
     gl::EnableVertexAttribArray(0);
-    gl::VertexAttribPointer(0, 3, gl::BYTE, gl::FALSE_, 4 * sizeof(GLbyte), (void *)0);
+    gl::VertexAttribPointer(0, 3, gl::BYTE, gl::FALSE_, 4 * sizeof(GLbyte), nullptr);
 
     static const std::array<GLbyte, 32> vertices = {                                                 //
                                                     0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 1, 0,  //

--- a/cpp/gui/mrview/mode/volume.cpp
+++ b/cpp/gui/mrview/mode/volume.cpp
@@ -487,7 +487,7 @@ void Volume::paint(Projection &projection) {
 }
 
 inline Tool::View *Volume::get_view_tool() const {
-  Tool::Dock *dock = dynamic_cast<Tool::__Action__ *>(window().tools()->actions()[0])->dock;
+  Tool::Dock *dock = dynamic_cast<Tool::ActionWrapper *>(window().tools()->actions()[0])->dock;
   if (!dock)
     return nullptr;
   return dynamic_cast<Tool::View *>(dock->tool);

--- a/cpp/gui/mrview/mode/volume.cpp
+++ b/cpp/gui/mrview/mode/volume.cpp
@@ -19,6 +19,7 @@
 #include "mrview/adjust_button.h"
 #include "mrview/tool/base.h"
 #include "mrview/tool/view.h"
+#include "opengl/gl_core_3_3.h"
 #include "opengl/lighting.h"
 
 namespace MR::GUI::MRView::Mode {

--- a/cpp/gui/mrview/sync/interprocesscommunicator.cpp
+++ b/cpp/gui/mrview/sync/interprocesscommunicator.cpp
@@ -96,8 +96,9 @@ InterprocessCommunicator::InterprocessCommunicator() : QObject(0) {
  * with our id as the argument
  */
 void InterprocessCommunicator::OnNewIncomingConnection() {
-  // TODO Possible memory leak here
-  LocalSocketReader *lsr = new LocalSocketReader(receiver->nextPendingConnection());
+  // Parent the reader to this communicator so that Qt's object-ownership model
+  // reclaims it when this object is destroyed, rather than leaking the allocation.
+  LocalSocketReader *lsr = new LocalSocketReader(receiver->nextPendingConnection(), this);
   connect(lsr,
           SIGNAL(DataReceived(std::vector<std::shared_ptr<QByteArray>>)),
           this,

--- a/cpp/gui/mrview/sync/interprocesscommunicator.cpp
+++ b/cpp/gui/mrview/sync/interprocesscommunicator.cpp
@@ -96,6 +96,7 @@ InterprocessCommunicator::InterprocessCommunicator() : QObject(0) {
  * with our id as the argument
  */
 void InterprocessCommunicator::OnNewIncomingConnection() {
+  // TODO Possible memory leak here
   LocalSocketReader *lsr = new LocalSocketReader(receiver->nextPendingConnection());
   connect(lsr,
           SIGNAL(DataReceived(std::vector<std::shared_ptr<QByteArray>>)),

--- a/cpp/gui/mrview/sync/interprocesscommunicator.cpp
+++ b/cpp/gui/mrview/sync/interprocesscommunicator.cpp
@@ -95,6 +95,8 @@ InterprocessCommunicator::InterprocessCommunicator() : QObject(0) {
  * Fires when another process tries to set up a connection from them --> us. I.e. when another MRView calls TryConnectTo
  * with our id as the argument
  */
+// clang-analyzer does not model Qt parent/child ownership, so it false-positives here.
+// NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks)
 void InterprocessCommunicator::OnNewIncomingConnection() {
   // Parent the reader to this communicator so that Qt's object-ownership model
   // reclaims it when this object is destroyed, rather than leaking the allocation.
@@ -104,6 +106,7 @@ void InterprocessCommunicator::OnNewIncomingConnection() {
           this,
           SLOT(OnDataReceived(std::vector<std::shared_ptr<QByteArray>>)));
 }
+// NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)
 
 /**
  * Tries to set an outgoing connection to the specified ID (another process), and tells that process what our id is, so

--- a/cpp/gui/mrview/sync/localsocketreader.cpp
+++ b/cpp/gui/mrview/sync/localsocketreader.cpp
@@ -18,7 +18,7 @@
 #include "exception.h"
 
 namespace MR::GUI::MRView::Sync {
-LocalSocketReader::LocalSocketReader(QLocalSocket *mySocket) : QObject(0) {
+LocalSocketReader::LocalSocketReader(QLocalSocket *mySocket, QObject *parent) : QObject(parent) {
   socket = mySocket;
   QObject::connect(socket, SIGNAL(readyRead()), this, SLOT(OnDataReceived()));
 }

--- a/cpp/gui/mrview/sync/localsocketreader.h
+++ b/cpp/gui/mrview/sync/localsocketreader.h
@@ -30,7 +30,7 @@ class LocalSocketReader : public QObject {
   Q_OBJECT
 
 public:
-  LocalSocketReader(QLocalSocket *mySocket);
+  LocalSocketReader(QLocalSocket *mySocket, QObject *parent = nullptr);
 
 signals:
   void DataReceived(std::vector<std::shared_ptr<QByteArray>> dat); // emits every message currently available

--- a/cpp/gui/mrview/tool/base.cpp
+++ b/cpp/gui/mrview/tool/base.cpp
@@ -24,7 +24,7 @@ void Dock::closeEvent(QCloseEvent *) {
   tool->close_event();
 }
 
-void __Action__::visibility_slot(bool) { setChecked(dock->isVisible()); }
+void ActionWrapper::visibility_slot(bool) { setChecked(dock->isVisible()); }
 
 Base::Base(Dock *parent) : QFrame(parent) {
   QFont f = font();

--- a/cpp/gui/mrview/tool/base.h
+++ b/cpp/gui/mrview/tool/base.h
@@ -162,7 +162,10 @@ public:
     setStatusTip(tr(std::string(description).c_str()));
   }
 
-  virtual ~ActionWrapper() { delete dock; }
+  ~ActionWrapper() override {
+    delete dock;
+    dock = nullptr;
+  }
 
   virtual Dock *create(bool floating) = 0;
   Dock *dock;

--- a/cpp/gui/mrview/tool/base.h
+++ b/cpp/gui/mrview/tool/base.h
@@ -16,8 +16,11 @@
 
 #pragma once
 
-#include "file/config.h"
+#include <qaction.h>
+#include <qactiongroup.h>
+#include <string_view>
 
+#include "file/config.h"
 #include "mrview/window.h"
 #include "projection.h"
 
@@ -186,7 +189,7 @@ template <class T> Dock *create(const QString &text, bool floating) {
 template <class T> class Action : public ActionWrapper {
 public:
   Action(QActionGroup *parent, std::string_view name, std::string_view description, int index)
-      : ActionWrapper(parent, std::string(name).c_str(), std::string(description).c_str(), index) {}
+      : ActionWrapper(parent, name, description, index) {}
 
   virtual Dock *create(bool floating) {
     dock = Tool::create<T>(this->text(), floating);

--- a/cpp/gui/mrview/tool/base.h
+++ b/cpp/gui/mrview/tool/base.h
@@ -21,9 +21,6 @@
 #include "mrview/window.h"
 #include "projection.h"
 
-#define __STR__(x) #x
-#define __STR(x) __STR__(x)
-
 namespace MR::App {
 class OptionList;
 class Options;
@@ -155,17 +152,17 @@ public:
 
 inline Dock::~Dock() { delete tool; }
 
-class __Action__ : public QAction {
+class ActionWrapper : public QAction {
   Q_OBJECT
 public:
-  __Action__(QActionGroup *parent, std::string_view name, std::string_view description, int index)
+  ActionWrapper(QActionGroup *parent, std::string_view name, std::string_view description, int index)
       : QAction(std::string(name).c_str(), parent), dock(nullptr) {
     setCheckable(true);
     setShortcut(tr(std::string("Ctrl+F" + str(index)).c_str()));
     setStatusTip(tr(std::string(description).c_str()));
   }
 
-  virtual ~__Action__() { delete dock; }
+  virtual ~ActionWrapper() { delete dock; }
 
   virtual Dock *create(bool floating) = 0;
   Dock *dock;
@@ -183,10 +180,10 @@ template <class T> Dock *create(const QString &text, bool floating) {
   return dock;
 }
 
-template <class T> class Action : public __Action__ {
+template <class T> class Action : public ActionWrapper {
 public:
   Action(QActionGroup *parent, std::string_view name, std::string_view description, int index)
-      : __Action__(parent, std::string(name).c_str(), std::string(description).c_str(), index) {}
+      : ActionWrapper(parent, std::string(name).c_str(), std::string(description).c_str(), index) {}
 
   virtual Dock *create(bool floating) {
     dock = Tool::create<T>(this->text(), floating);

--- a/cpp/gui/mrview/tool/connectome/connectome.cpp
+++ b/cpp/gui/mrview/tool/connectome/connectome.cpp
@@ -742,27 +742,27 @@ Connectome::Connectome(Dock *parent)
   cube_VAO.bind();
   cube.vertex_buffer.bind(gl::ARRAY_BUFFER);
   gl::EnableVertexAttribArray(0);
-  gl::VertexAttribPointer(0, 3, gl::FLOAT, gl::FALSE_, 0, (void *)(0));
+  gl::VertexAttribPointer(0, 3, gl::FLOAT, gl::FALSE_, 0, nullptr);
   cube.normals_buffer.bind(gl::ARRAY_BUFFER);
   gl::EnableVertexAttribArray(1);
-  gl::VertexAttribPointer(1, 3, gl::FLOAT, gl::FALSE_, 0, (void *)(0));
+  gl::VertexAttribPointer(1, 3, gl::FLOAT, gl::FALSE_, 0, nullptr);
 
   cylinder.LOD(4);
   cylinder_VAO.gen();
   cylinder_VAO.bind();
   cylinder.vertex_buffer.bind(gl::ARRAY_BUFFER);
   gl::EnableVertexAttribArray(0);
-  gl::VertexAttribPointer(0, 3, gl::FLOAT, gl::FALSE_, 0, (void *)(0));
+  gl::VertexAttribPointer(0, 3, gl::FLOAT, gl::FALSE_, 0, nullptr);
   cylinder.normal_buffer.bind(gl::ARRAY_BUFFER);
   gl::EnableVertexAttribArray(1);
-  gl::VertexAttribPointer(1, 3, gl::FLOAT, gl::FALSE_, 0, (void *)(0));
+  gl::VertexAttribPointer(1, 3, gl::FLOAT, gl::FALSE_, 0, nullptr);
 
   sphere.LOD(4);
   sphere_VAO.gen();
   sphere_VAO.bind();
   sphere.vertex_buffer.bind(gl::ARRAY_BUFFER);
   gl::EnableVertexAttribArray(0);
-  gl::VertexAttribPointer(0, 3, gl::FLOAT, gl::FALSE_, 0, (void *)(0));
+  gl::VertexAttribPointer(0, 3, gl::FLOAT, gl::FALSE_, 0, nullptr);
 
   Edge::set_streamtube_LOD(3);
 
@@ -2729,22 +2729,22 @@ void Connectome::draw_nodes(const Projection &projection) {
               gl::CullFace(gl::FRONT);
               gl::Uniform1f(specular_ID,
                             (1.0 - node_alpha_given_selection(it->second) * node_fixed_alpha) * lighting.specular);
-              gl::DrawElements(gl::TRIANGLES, sphere.num_indices, gl::UNSIGNED_INT, (void *)0);
+              gl::DrawElements(gl::TRIANGLES, sphere.num_indices, gl::UNSIGNED_INT, nullptr);
               gl::CullFace(gl::BACK);
               gl::Uniform1f(specular_ID, lighting.specular);
             }
-            gl::DrawElements(gl::TRIANGLES, sphere.num_indices, gl::UNSIGNED_INT, (void *)0);
+            gl::DrawElements(gl::TRIANGLES, sphere.num_indices, gl::UNSIGNED_INT, nullptr);
             break;
           case node_geometry_t::CUBE:
             if (alpha) {
               gl::CullFace(gl::FRONT);
               gl::Uniform1f(specular_ID,
                             (1.0 - node_alpha_given_selection(it->second) * node_fixed_alpha) * lighting.specular);
-              gl::DrawElements(gl::TRIANGLES, cube.num_indices, gl::UNSIGNED_INT, (void *)0);
+              gl::DrawElements(gl::TRIANGLES, cube.num_indices, gl::UNSIGNED_INT, nullptr);
               gl::CullFace(gl::BACK);
               gl::Uniform1f(specular_ID, lighting.specular);
             }
-            gl::DrawElements(gl::TRIANGLES, cube.num_indices, gl::UNSIGNED_INT, (void *)0);
+            gl::DrawElements(gl::TRIANGLES, cube.num_indices, gl::UNSIGNED_INT, nullptr);
             break;
           case node_geometry_t::OVERLAY:
             assert(0);
@@ -2879,11 +2879,11 @@ void Connectome::draw_edges(const Projection &projection) {
           if (alpha) {
             gl::CullFace(gl::FRONT);
             gl::Uniform1f(specular_ID, (1.0 - edge_alpha_given_selection(edge) * edge_fixed_alpha) * lighting.specular);
-            gl::DrawElements(gl::TRIANGLES, cylinder.num_indices, gl::UNSIGNED_INT, (void *)0);
+            gl::DrawElements(gl::TRIANGLES, cylinder.num_indices, gl::UNSIGNED_INT, nullptr);
             gl::CullFace(gl::BACK);
             gl::Uniform1f(specular_ID, lighting.specular);
           }
-          gl::DrawElements(gl::TRIANGLES, cylinder.num_indices, gl::UNSIGNED_INT, (void *)0);
+          gl::DrawElements(gl::TRIANGLES, cylinder.num_indices, gl::UNSIGNED_INT, nullptr);
           break;
         case edge_geometry_t::STREAMLINE:
           gl::LineWidth(calc_line_width(edge_size_given_selection(edge) * edge_size_scale_factor,

--- a/cpp/gui/mrview/tool/connectome/connectome.cpp
+++ b/cpp/gui/mrview/tool/connectome/connectome.cpp
@@ -1048,9 +1048,9 @@ void Connectome::node_visibility_selection_slot(int index) {
         node_visibility_combobox->setCurrentIndex(3);
         return;
       case node_visibility_t::VECTOR_FILE:
-        node_visibility_combobox->setCurrentIndex(6);
-        return;
+        [[fallthrough]];
       case node_visibility_t::MATRIX_FILE:
+        // Selects newly added element in combobox with name of imported file
         node_visibility_combobox->setCurrentIndex(6);
         return;
       }
@@ -1083,9 +1083,9 @@ void Connectome::node_visibility_selection_slot(int index) {
         node_visibility_combobox->setCurrentIndex(3);
         return;
       case node_visibility_t::VECTOR_FILE:
-        node_visibility_combobox->setCurrentIndex(6);
-        return;
+        [[fallthrough]];
       case node_visibility_t::MATRIX_FILE:
+        // Selects newly added element in combobox with name of imported file
         node_visibility_combobox->setCurrentIndex(6);
         return;
       }
@@ -1119,7 +1119,8 @@ void Connectome::node_visibility_selection_slot(int index) {
                                     node_values_from_file_visibility.get_mean(),
                                     node_values_from_file_visibility.get_max());
     break;
-  case 6:
+  default:
+    assert(false);
     return;
   }
   calculate_node_visibility();
@@ -1216,6 +1217,9 @@ void Connectome::node_geometry_selection_slot(int index) {
       node_geometry_overlay_interp_checkbox->setVisible(false);
     }
     break;
+  default:
+    assert(false);
+    return;
   }
   if (node_visibility == node_visibility_t::NONE)
     node_visibility_warning_icon->setVisible(true);
@@ -1314,9 +1318,9 @@ void Connectome::node_colour_selection_slot(int index) {
         node_colour_combobox->setCurrentIndex(3);
         return;
       case node_colour_t::VECTOR_FILE:
-        node_colour_combobox->setCurrentIndex(6);
-        return;
+        [[fallthrough]];
       case node_colour_t::MATRIX_FILE:
+        // Selects newly added element in combobox with name of imported file
         node_colour_combobox->setCurrentIndex(6);
         return;
       }
@@ -1351,9 +1355,9 @@ void Connectome::node_colour_selection_slot(int index) {
         node_colour_combobox->setCurrentIndex(3);
         return;
       case node_colour_t::VECTOR_FILE:
-        node_colour_combobox->setCurrentIndex(6);
-        return;
+        [[fallthrough]];
       case node_colour_t::MATRIX_FILE:
+        // Selects newly added element in combobox with name of imported file
         node_colour_combobox->setCurrentIndex(6);
         return;
       }
@@ -1395,7 +1399,8 @@ void Connectome::node_colour_selection_slot(int index) {
                                 node_values_from_file_colour.get_mean(),
                                 node_values_from_file_colour.get_max());
     break;
-  case 6:
+  default:
+    assert(false);
     return;
   }
   if (node_visibility == node_visibility_t::NONE)
@@ -1480,9 +1485,9 @@ void Connectome::node_size_selection_slot(int index) {
         node_size_combobox->setCurrentIndex(2);
         return;
       case node_size_t::VECTOR_FILE:
-        node_size_combobox->setCurrentIndex(5);
-        return;
+        [[fallthrough]];
       case node_size_t::MATRIX_FILE:
+        // Selects newly added element in combobox with name of imported file
         node_size_combobox->setCurrentIndex(5);
         return;
       }
@@ -1513,9 +1518,9 @@ void Connectome::node_size_selection_slot(int index) {
         node_size_combobox->setCurrentIndex(2);
         return;
       case node_size_t::VECTOR_FILE:
-        node_size_combobox->setCurrentIndex(5);
-        return;
+        [[fallthrough]];
       case node_size_t::MATRIX_FILE:
+        // Selects newly added element in combobox with name of imported file
         node_size_combobox->setCurrentIndex(5);
         return;
       }
@@ -1556,7 +1561,8 @@ void Connectome::node_size_selection_slot(int index) {
                               node_values_from_file_size.get_max());
     node_size_invert_checkbox->setChecked(false);
     break;
-  case 5:
+  default:
+    assert(false);
     return;
   }
   if (node_visibility == node_visibility_t::NONE)
@@ -1640,9 +1646,9 @@ void Connectome::node_alpha_selection_slot(int index) {
         node_alpha_combobox->setCurrentIndex(2);
         return;
       case node_alpha_t::VECTOR_FILE:
-        node_alpha_combobox->setCurrentIndex(5);
-        return;
+        [[fallthrough]];
       case node_alpha_t::MATRIX_FILE:
+        // Selects newly added element in combobox with name of imported file
         node_alpha_combobox->setCurrentIndex(5);
         return;
       }
@@ -1673,9 +1679,9 @@ void Connectome::node_alpha_selection_slot(int index) {
         node_alpha_combobox->setCurrentIndex(2);
         return;
       case node_alpha_t::VECTOR_FILE:
-        node_alpha_combobox->setCurrentIndex(5);
-        return;
+        [[fallthrough]];
       case node_alpha_t::MATRIX_FILE:
+        // Selects newly added element in combobox with name of imported file
         node_alpha_combobox->setCurrentIndex(5);
         return;
       }
@@ -1716,7 +1722,8 @@ void Connectome::node_alpha_selection_slot(int index) {
                                node_values_from_file_alpha.get_max());
     node_alpha_invert_checkbox->setChecked(false);
     break;
-  case 5:
+  default:
+    assert(false);
     return;
   }
   if (node_visibility == node_visibility_t::NONE)
@@ -1924,7 +1931,10 @@ void Connectome::edge_visibility_selection_slot(int index) {
                                     edge_values_from_file_visibility.get_mean(),
                                     edge_values_from_file_visibility.get_max());
     break;
-  case 5:
+  case 4:
+    return;
+  default:
+    assert(false);
     return;
   }
   calculate_edge_visibility();
@@ -1996,6 +2006,9 @@ void Connectome::edge_geometry_selection_slot(int index) {
       edge_geometry_line_smooth_checkbox->setVisible(true);
     }
     break;
+  default:
+    assert(false);
+    return;
   }
   if (edge_visibility == edge_visibility_t::NONE)
     edge_visibility_warning_icon->setVisible(true);
@@ -2073,7 +2086,8 @@ void Connectome::edge_colour_selection_slot(int index) {
                                 edge_values_from_file_colour.get_mean(),
                                 edge_values_from_file_colour.get_max());
     break;
-  case 4:
+  default:
+    assert(false);
     return;
   }
   if (edge_visibility == edge_visibility_t::NONE)
@@ -2135,7 +2149,8 @@ void Connectome::edge_size_selection_slot(int index) {
                               edge_values_from_file_size.get_mean(),
                               edge_values_from_file_size.get_max());
     break;
-  case 3:
+  default:
+    assert(false);
     return;
   }
   if (edge_visibility == edge_visibility_t::NONE)
@@ -2198,7 +2213,8 @@ void Connectome::edge_alpha_selection_slot(int index) {
                                edge_values_from_file_alpha.get_max());
     edge_alpha_invert_checkbox->setChecked(false);
     break;
-  case 3:
+  default:
+    assert(false);
     return;
   }
   if (edge_visibility == edge_visibility_t::NONE)

--- a/cpp/gui/mrview/tool/connectome/edge.cpp
+++ b/cpp/gui/mrview/tool/connectome/edge.cpp
@@ -114,10 +114,10 @@ Edge::Line::Line(const Edge &parent) {
   vertex_array_object.bind();
   vertex_buffer.bind(gl::ARRAY_BUFFER);
   gl::EnableVertexAttribArray(0);
-  gl::VertexAttribPointer(0, 3, gl::FLOAT, gl::FALSE_, 0, (void *)(0));
+  gl::VertexAttribPointer(0, 3, gl::FLOAT, gl::FALSE_, 0, nullptr);
   tangent_buffer.bind(gl::ARRAY_BUFFER);
   gl::EnableVertexAttribArray(1);
-  gl::VertexAttribPointer(1, 3, gl::FLOAT, gl::FALSE_, 0, (void *)(0));
+  gl::VertexAttribPointer(1, 3, gl::FLOAT, gl::FALSE_, 0, nullptr);
   GL::assert_context_is_current();
 }
 
@@ -184,10 +184,10 @@ Edge::Streamline::Streamline(const Exemplar &data) {
   vertex_array_object.bind();
   vertex_buffer.bind(gl::ARRAY_BUFFER);
   gl::EnableVertexAttribArray(0);
-  gl::VertexAttribPointer(0, 3, gl::FLOAT, gl::FALSE_, 0, (void *)(0));
+  gl::VertexAttribPointer(0, 3, gl::FLOAT, gl::FALSE_, 0, nullptr);
   tangent_buffer.bind(gl::ARRAY_BUFFER);
   gl::EnableVertexAttribArray(1);
-  gl::VertexAttribPointer(1, 3, gl::FLOAT, gl::FALSE_, 0, (void *)(0));
+  gl::VertexAttribPointer(1, 3, gl::FLOAT, gl::FALSE_, 0, nullptr);
   GL::assert_context_is_current();
 }
 
@@ -262,13 +262,13 @@ Edge::Streamtube::Streamtube(const Exemplar &data) : count(data.vertices.size())
   vertex_array_object.bind();
   vertex_buffer.bind(gl::ARRAY_BUFFER);
   gl::EnableVertexAttribArray(0);
-  gl::VertexAttribPointer(0, 3, gl::FLOAT, gl::FALSE_, 0, (void *)(0));
+  gl::VertexAttribPointer(0, 3, gl::FLOAT, gl::FALSE_, 0, nullptr);
   tangent_buffer.bind(gl::ARRAY_BUFFER);
   gl::EnableVertexAttribArray(1);
-  gl::VertexAttribPointer(1, 3, gl::FLOAT, gl::FALSE_, 0, (void *)(0));
+  gl::VertexAttribPointer(1, 3, gl::FLOAT, gl::FALSE_, 0, nullptr);
   normal_buffer.bind(gl::ARRAY_BUFFER);
   gl::EnableVertexAttribArray(2);
-  gl::VertexAttribPointer(2, 3, gl::FLOAT, gl::FALSE_, 0, (void *)(0));
+  gl::VertexAttribPointer(2, 3, gl::FLOAT, gl::FALSE_, 0, nullptr);
   GL::assert_context_is_current();
 }
 

--- a/cpp/gui/mrview/tool/connectome/edge.cpp
+++ b/cpp/gui/mrview/tool/connectome/edge.cpp
@@ -22,6 +22,7 @@
 #include "dwi/tractography/properties.h"
 #include "dwi/tractography/streamline.h"
 #include "mrview/tool/connectome/connectome.h"
+#include "opengl/gl_core_3_3.h"
 
 namespace MR::GUI::MRView::Tool {
 

--- a/cpp/gui/mrview/tool/connectome/file_data_vector.cpp
+++ b/cpp/gui/mrview/tool/connectome/file_data_vector.cpp
@@ -18,6 +18,7 @@
 
 #include <filesystem>
 #include <limits>
+#include <utility>
 
 #include "file/matrix.h"
 #include "gui.h"
@@ -30,7 +31,7 @@ FileDataVector::FileDataVector(const FileDataVector &V)
     : base_t(V), name(V.name), min(V.min), mean(V.mean), max(V.max) {}
 
 FileDataVector::FileDataVector(FileDataVector &&V)
-    : base_t(std::move(static_cast<base_t &&>(V))), name(V.name), min(V.min), mean(V.mean), max(V.max) {
+    : base_t(std::move(static_cast<base_t &&>(V))), name(std::move(V.name)), min(V.min), mean(V.mean), max(V.max) {
   V.name.clear();
   V.min = V.mean = V.max = NaNF;
 }

--- a/cpp/gui/mrview/tool/connectome/file_data_vector.cpp
+++ b/cpp/gui/mrview/tool/connectome/file_data_vector.cpp
@@ -30,7 +30,7 @@ FileDataVector::FileDataVector(const FileDataVector &V)
     : base_t(V), name(V.name), min(V.min), mean(V.mean), max(V.max) {}
 
 FileDataVector::FileDataVector(FileDataVector &&V)
-    : base_t(std::move(V)), name(V.name), min(V.min), mean(V.mean), max(V.max) {
+    : base_t(std::move(static_cast<base_t &&>(V))), name(V.name), min(V.min), mean(V.mean), max(V.max) {
   V.name.clear();
   V.min = V.mean = V.max = NaNF;
 }
@@ -53,7 +53,7 @@ FileDataVector &FileDataVector::operator=(const FileDataVector &that) {
   return *this;
 }
 FileDataVector &FileDataVector::operator=(FileDataVector &&that) {
-  base_t::operator=(std::move(that));
+  base_t::operator=(std::move(static_cast<base_t &&>(that)));
   name = that.name;
   min = that.min;
   mean = that.mean;

--- a/cpp/gui/mrview/tool/connectome/node.cpp
+++ b/cpp/gui/mrview/tool/connectome/node.cpp
@@ -73,10 +73,10 @@ Node::Mesh::Mesh(MR::Surface::Mesh &in) : count(3 * in.num_triangles()) {
   vertex_array_object.bind();
   vertex_buffer.bind(gl::ARRAY_BUFFER);
   gl::EnableVertexAttribArray(0);
-  gl::VertexAttribPointer(0, 3, gl::FLOAT, gl::FALSE_, 0, (void *)(0));
+  gl::VertexAttribPointer(0, 3, gl::FLOAT, gl::FALSE_, 0, nullptr);
   normal_buffer.bind(gl::ARRAY_BUFFER);
   gl::EnableVertexAttribArray(1);
-  gl::VertexAttribPointer(1, 3, gl::FLOAT, gl::FALSE_, 0, (void *)(0));
+  gl::VertexAttribPointer(1, 3, gl::FLOAT, gl::FALSE_, 0, nullptr);
 
   std::vector<unsigned int> indices;
   indices.reserve(3 * in.num_triangles());
@@ -125,7 +125,7 @@ void Node::Mesh::render() const {
   normal_buffer.bind(gl::ARRAY_BUFFER);
   vertex_array_object.bind();
   index_buffer.bind();
-  gl::DrawElements(gl::TRIANGLES, count, gl::UNSIGNED_INT, (void *)0);
+  gl::DrawElements(gl::TRIANGLES, count, gl::UNSIGNED_INT, nullptr);
   GL::assert_context_is_current();
 }
 

--- a/cpp/gui/mrview/tool/connectome/node.cpp
+++ b/cpp/gui/mrview/tool/connectome/node.cpp
@@ -19,6 +19,7 @@
 
 #include "exception.h"
 #include "mrview/window.h"
+#include "opengl/gl_core_3_3.h"
 #include "types.h"
 
 namespace MR::GUI::MRView::Tool {

--- a/cpp/gui/mrview/tool/connectome/node.cpp
+++ b/cpp/gui/mrview/tool/connectome/node.cpp
@@ -46,7 +46,7 @@ Node::Mesh::Mesh(MR::Surface::Mesh &in) : count(3 * in.num_triangles()) {
   GL::assert_context_is_current();
 
   std::vector<float> vertices;
-  vertices.reserve(3 * in.num_vertices());
+  vertices.reserve(3 * static_cast<size_t>(in.num_vertices()));
   for (size_t v = 0; v != in.num_vertices(); ++v) {
     for (size_t axis = 0; axis != 3; ++axis)
       vertices.push_back(in.vert(v)[axis]);
@@ -59,7 +59,7 @@ Node::Mesh::Mesh(MR::Surface::Mesh &in) : count(3 * in.num_triangles()) {
   if (!in.have_normals())
     in.calculate_normals();
   std::vector<float> normals;
-  normals.reserve(3 * in.num_vertices());
+  normals.reserve(3 * static_cast<size_t>(in.num_vertices()));
   for (size_t n = 0; n != in.num_vertices(); ++n) {
     for (size_t axis = 0; axis != 3; ++axis)
       normals.push_back(in.norm(n)[axis]);

--- a/cpp/gui/mrview/tool/fixel/base_fixel.cpp
+++ b/cpp/gui/mrview/tool/fixel/base_fixel.cpp
@@ -23,8 +23,8 @@ BaseFixel::BaseFixel(const std::filesystem::path &filepath, Fixel &fixel_tool)
       slice_fixel_indices(3),
       slice_fixel_sizes(3),
       slice_fixel_counts(3),
-      colour_type(Direction),
-      scale_type(Unity),
+      colour_type(FixelColourType::Direction),
+      scale_type(FixelScaleType::Unity),
       colour_type_index(0),
       scale_type_index(0),
       threshold_type_index(0),
@@ -92,9 +92,9 @@ std::string BaseFixel::Shader::geometry_shader_source(const Displayable &object)
                        "uniform float line_thickness;\n";
 
   switch (color_type) {
-  case Direction:
+  case FixelColourType::Direction:
     break;
-  case CValue:
+  case FixelColourType::Value:
     source += "uniform float offset, scale;\n";
     break;
   }
@@ -113,17 +113,17 @@ std::string BaseFixel::Shader::geometry_shader_source(const Displayable &object)
     source += "  if (v_threshold[0] > upper || isnan(v_threshold[0])) return;\n";
 
   switch (scale_type) {
-  case Unity:
+  case FixelScaleType::Unity:
     source += "  vec4 line_offset = length_mult * vec4 (v_dir[0], 0);\n";
     break;
-  case Value:
+  case FixelScaleType::Value:
     source += "  if (isnan(v_scale[0])) return;\n"
               "  vec4 line_offset = length_mult * v_scale[0] * vec4 (v_dir[0], 0);\n";
     break;
   }
 
   switch (color_type) {
-  case CValue:
+  case FixelColourType::Value:
     if (!ColourMap::maps[colourmap].special) {
       source += "  if (isnan(v_colour[0])) return;\n"
                 "  float amplitude = clamp (";
@@ -133,7 +133,7 @@ std::string BaseFixel::Shader::geometry_shader_source(const Displayable &object)
     }
     source += std::string("  vec3 color;\n") + ColourMap::maps[colourmap].glsl_mapping + "  fColour = color;\n";
     break;
-  case Direction:
+  case FixelColourType::Direction:
     source += "  fColour = normalize (abs (v_dir[0]));\n";
     break;
   default:
@@ -338,9 +338,9 @@ void BaseFixel::update_interp_image_buffer(const Projection &projection,
       for (const GLsizei index : voxel_indices) {
         regular_grid_buffer_pos.push_back(scanner_pos);
         regular_grid_buffer_dir.push_back(dir_buffer_store[index]);
-        if (scale_type == Value)
+        if (scale_type == FixelScaleType::Value)
           regular_grid_buffer_val.push_back(val_buffer[index]);
-        if (colour_type == CValue)
+        if (colour_type == FixelColourType::Value)
           regular_grid_buffer_colour.push_back(col_buffer[index]);
         if (has_val)
           regular_grid_buffer_threshold.push_back(threshold_buffer[index]);
@@ -372,7 +372,7 @@ void BaseFixel::update_interp_image_buffer(const Projection &projection,
   gl::VertexAttribPointer(1, 3, gl::FLOAT, gl::FALSE_, 0, (void *)0);
 
   // fixel values
-  if (scale_type == Value) {
+  if (scale_type == FixelScaleType::Value) {
     regular_grid_val_buffer.bind(gl::ARRAY_BUFFER);
     gl::BufferData(gl::ARRAY_BUFFER,
                    regular_grid_buffer_val.size() * sizeof(float),
@@ -383,7 +383,7 @@ void BaseFixel::update_interp_image_buffer(const Projection &projection,
   }
 
   // fixel colours
-  if (colour_type == CValue) {
+  if (colour_type == FixelColourType::Value) {
     regular_grid_colour_buffer.bind(gl::ARRAY_BUFFER);
     gl::BufferData(gl::ARRAY_BUFFER,
                    regular_grid_buffer_colour.size() * sizeof(float),
@@ -522,7 +522,7 @@ void BaseFixel::reload_values_buffer() {
   GL::Context::Grab context;
   GL::assert_context_is_current();
 
-  if (scale_type == Unity)
+  if (scale_type == FixelScaleType::Unity)
     return;
 
   const auto &fixel_val = current_fixel_value_state();
@@ -543,7 +543,7 @@ void BaseFixel::reload_colours_buffer() {
   GL::Context::Grab context;
   GL::assert_context_is_current();
 
-  if (colour_type == Direction)
+  if (colour_type == FixelColourType::Direction)
     return;
 
   const auto &fixel_val = current_fixel_colour_state();

--- a/cpp/gui/mrview/tool/fixel/base_fixel.cpp
+++ b/cpp/gui/mrview/tool/fixel/base_fixel.cpp
@@ -16,6 +16,8 @@
 
 #include "mrview/tool/fixel/base_fixel.h"
 
+#include "mrview/tool/fixel/vector_structs.h"
+
 namespace MR::GUI::MRView::Tool {
 BaseFixel::BaseFixel(const std::filesystem::path &filepath, Fixel &fixel_tool)
     : Displayable(filepath),
@@ -237,7 +239,7 @@ void BaseFixel::render(const Projection &projection) {
       rebuild_element_index_buffer();
     element_index_buffer.bind(gl::ELEMENT_ARRAY_BUFFER);
     if (!element_indices.empty())
-      gl::DrawElements(gl::POINTS, static_cast<GLsizei>(element_indices.size()), gl::UNSIGNED_INT, (void *)0);
+      gl::DrawElements(gl::POINTS, static_cast<GLsizei>(element_indices.size()), gl::UNSIGNED_INT, nullptr);
   } else {
     request_update_interp_image_buffer(projection);
     if (GLsizei points_count = regular_grid_buffer_pos.size())
@@ -360,7 +362,7 @@ void BaseFixel::update_interp_image_buffer(const Projection &projection,
                  &regular_grid_buffer_pos[0],
                  gl::DYNAMIC_DRAW);
   gl::EnableVertexAttribArray(0);
-  gl::VertexAttribPointer(0, 3, gl::FLOAT, gl::FALSE_, 0, (void *)0);
+  gl::VertexAttribPointer(0, 3, gl::FLOAT, gl::FALSE_, 0, nullptr);
 
   // fixel directions
   regular_grid_dir_buffer.bind(gl::ARRAY_BUFFER);
@@ -369,7 +371,7 @@ void BaseFixel::update_interp_image_buffer(const Projection &projection,
                  &regular_grid_buffer_dir[0],
                  gl::DYNAMIC_DRAW);
   gl::EnableVertexAttribArray(1);
-  gl::VertexAttribPointer(1, 3, gl::FLOAT, gl::FALSE_, 0, (void *)0);
+  gl::VertexAttribPointer(1, 3, gl::FLOAT, gl::FALSE_, 0, nullptr);
 
   // fixel values
   if (scale_type == FixelScaleType::Value) {
@@ -379,7 +381,7 @@ void BaseFixel::update_interp_image_buffer(const Projection &projection,
                    &regular_grid_buffer_val[0],
                    gl::DYNAMIC_DRAW);
     gl::EnableVertexAttribArray(2);
-    gl::VertexAttribPointer(2, 1, gl::FLOAT, gl::FALSE_, 0, (void *)0);
+    gl::VertexAttribPointer(2, 1, gl::FLOAT, gl::FALSE_, 0, nullptr);
   }
 
   // fixel colours
@@ -390,7 +392,7 @@ void BaseFixel::update_interp_image_buffer(const Projection &projection,
                    &regular_grid_buffer_colour[0],
                    gl::DYNAMIC_DRAW);
     gl::EnableVertexAttribArray(3);
-    gl::VertexAttribPointer(3, 1, gl::FLOAT, gl::FALSE_, 0, (void *)0);
+    gl::VertexAttribPointer(3, 1, gl::FLOAT, gl::FALSE_, 0, nullptr);
   }
 
   // fixel threshold
@@ -401,7 +403,7 @@ void BaseFixel::update_interp_image_buffer(const Projection &projection,
                    &regular_grid_buffer_threshold[0],
                    gl::DYNAMIC_DRAW);
     gl::EnableVertexAttribArray(4);
-    gl::VertexAttribPointer(4, 1, gl::FLOAT, gl::FALSE_, 0, (void *)0);
+    gl::VertexAttribPointer(4, 1, gl::FLOAT, gl::FALSE_, 0, nullptr);
   }
 
   GL::assert_context_is_current();
@@ -453,7 +455,7 @@ void BaseFixel::load_image(const std::filesystem::path &filepath) {
   gl::BufferData(
       gl::ARRAY_BUFFER, pos_buffer_store.size() * sizeof(Eigen::Vector3f), &(pos_buffer_store[0][0]), gl::STATIC_DRAW);
   gl::EnableVertexAttribArray(0);
-  gl::VertexAttribPointer(0, 3, gl::FLOAT, gl::FALSE_, 0, (void *)0);
+  gl::VertexAttribPointer(0, 3, gl::FLOAT, gl::FALSE_, 0, nullptr);
 
   rebuild_element_index_buffer();
   element_indices_dirty = false;
@@ -513,7 +515,7 @@ void BaseFixel::reload_directions_buffer() {
   gl::BufferData(
       gl::ARRAY_BUFFER, dir_buffer_store.size() * sizeof(Eigen::Vector3f), &(dir_buffer_store)[0][0], gl::STATIC_DRAW);
   gl::EnableVertexAttribArray(1);
-  gl::VertexAttribPointer(1, 3, gl::FLOAT, gl::FALSE_, 0, (void *)0);
+  gl::VertexAttribPointer(1, 3, gl::FLOAT, gl::FALSE_, 0, nullptr);
 
   GL::assert_context_is_current();
 }
@@ -534,7 +536,7 @@ void BaseFixel::reload_values_buffer() {
   value_buffer.bind(gl::ARRAY_BUFFER);
   gl::BufferData(gl::ARRAY_BUFFER, val_buffer.size() * sizeof(float), &(val_buffer)[0], gl::STATIC_DRAW);
   gl::EnableVertexAttribArray(2);
-  gl::VertexAttribPointer(2, 1, gl::FLOAT, gl::FALSE_, 0, (void *)0);
+  gl::VertexAttribPointer(2, 1, gl::FLOAT, gl::FALSE_, 0, nullptr);
 
   GL::assert_context_is_current();
 }
@@ -555,7 +557,7 @@ void BaseFixel::reload_colours_buffer() {
   colour_buffer.bind(gl::ARRAY_BUFFER);
   gl::BufferData(gl::ARRAY_BUFFER, val_buffer.size() * sizeof(float), &(val_buffer)[0], gl::STATIC_DRAW);
   gl::EnableVertexAttribArray(3);
-  gl::VertexAttribPointer(3, 1, gl::FLOAT, gl::FALSE_, 0, (void *)0);
+  gl::VertexAttribPointer(3, 1, gl::FLOAT, gl::FALSE_, 0, nullptr);
 
   GL::assert_context_is_current();
 }
@@ -573,7 +575,7 @@ void BaseFixel::reload_threshold_buffer() {
   threshold_buffer.bind(gl::ARRAY_BUFFER);
   gl::BufferData(gl::ARRAY_BUFFER, val_buffer.size() * sizeof(float), &(val_buffer)[0], gl::STATIC_DRAW);
   gl::EnableVertexAttribArray(4);
-  gl::VertexAttribPointer(4, 1, gl::FLOAT, gl::FALSE_, 0, (void *)0);
+  gl::VertexAttribPointer(4, 1, gl::FLOAT, gl::FALSE_, 0, nullptr);
 
   GL::assert_context_is_current();
 }

--- a/cpp/gui/mrview/tool/fixel/base_fixel.cpp
+++ b/cpp/gui/mrview/tool/fixel/base_fixel.cpp
@@ -17,6 +17,7 @@
 #include "mrview/tool/fixel/base_fixel.h"
 
 #include "mrview/tool/fixel/vector_structs.h"
+#include "opengl/gl_core_3_3.h"
 
 namespace MR::GUI::MRView::Tool {
 BaseFixel::BaseFixel(const std::filesystem::path &filepath, Fixel &fixel_tool)

--- a/cpp/gui/mrview/tool/fixel/base_fixel.h
+++ b/cpp/gui/mrview/tool/fixel/base_fixel.h
@@ -42,7 +42,11 @@ public:
 
   class Shader : public Displayable::Shader {
   public:
-    Shader() : do_crop_to_slice(false), bidirectional(false), color_type(Direction), scale_type(Value) {}
+    Shader()
+        : do_crop_to_slice(false),
+          bidirectional(false),
+          color_type(FixelColourType::Direction),
+          scale_type(FixelScaleType::Value) {}
     std::string vertex_shader_source(const Displayable &) override;
     std::string geometry_shader_source(const Displayable &) override;
     std::string fragment_shader_source(const Displayable &) override;
@@ -58,7 +62,7 @@ public:
   void render(const Projection &projection);
 
   void request_render_colourbar(DisplayableVisitor &visitor) override {
-    if (colour_type == CValue && show_colour_bar)
+    if (colour_type == FixelColourType::Value && show_colour_bar)
       visitor.render_fixel_colourbar(*this);
   }
 
@@ -85,7 +89,7 @@ public:
   void set_scale_type_index(size_t index) {
     if (index != scale_type_index) {
       scale_type_index = index;
-      scale_type = index == 0 ? Unity : Value;
+      scale_type = index == 0 ? FixelScaleType::Unity : FixelScaleType::Value;
       value_buffer_dirty = true;
     }
   }
@@ -95,7 +99,7 @@ public:
   void set_threshold_type_index(size_t index) {
     if (index != threshold_type_index) {
       threshold_type_index = index;
-      if (colour_type == CValue) {
+      if (colour_type == FixelColourType::Value) {
         lessthan = get_threshold_lower();
         greaterthan = get_threshold_upper();
       }
@@ -113,14 +117,14 @@ public:
 
     if (index != colour_type_index) {
       colour_type_index = index;
-      colour_type = index == 0 ? Direction : CValue;
+      colour_type = index == 0 ? FixelColourType::Direction : FixelColourType::Value;
       colour_buffer_dirty = true;
     }
 
     auto &new_fixel_val = current_fixel_colour_state();
     value_min = new_fixel_val.value_min;
     value_max = new_fixel_val.value_max;
-    if (colour_type == CValue) {
+    if (colour_type == FixelColourType::Value) {
       lessthan = get_threshold_lower();
       greaterthan = get_threshold_upper();
     }
@@ -140,7 +144,7 @@ public:
   void set_threshold_lower(float value) {
     FixelValue &fixel_threshold = current_fixel_threshold_state();
     fixel_threshold.lessthan = value;
-    if (colour_type == CValue)
+    if (colour_type == FixelColourType::Value)
       lessthan = get_threshold_lower();
   }
 
@@ -155,7 +159,7 @@ public:
   void set_threshold_upper(float value) {
     FixelValue &fixel_threshold = current_fixel_threshold_state();
     fixel_threshold.greaterthan = value;
-    if (colour_type == CValue)
+    if (colour_type == FixelColourType::Value)
       greaterthan = get_threshold_upper();
   }
 

--- a/cpp/gui/mrview/tool/fixel/fixel.cpp
+++ b/cpp/gui/mrview/tool/fixel/fixel.cpp
@@ -443,12 +443,12 @@ void Fixel::update_gui_colour_controls(bool reload_colour_types) {
   const FixelColourType colour_type = first_fixel->get_colour_type();
 
   colour_combobox->setCurrentIndex(first_fixel->get_colour_type_index());
-  colourmap_option_group->setEnabled(colour_type == CValue);
+  colourmap_option_group->setEnabled(colour_type == FixelColourType::Value);
 
-  max_value->setEnabled(colour_type == CValue);
-  min_value->setEnabled(colour_type == CValue);
+  max_value->setEnabled(colour_type == FixelColourType::Value);
+  min_value->setEnabled(colour_type == FixelColourType::Value);
 
-  if (colour_type == CValue) {
+  if (colour_type == FixelColourType::Value) {
     min_value->setRate(first_fixel->scaling_rate());
     max_value->setRate(first_fixel->scaling_rate());
     min_value->setValue(first_fixel->scaling_min());

--- a/cpp/gui/mrview/tool/fixel/vector_structs.h
+++ b/cpp/gui/mrview/tool/fixel/vector_structs.h
@@ -16,10 +16,15 @@
 
 #pragma once
 
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
 namespace MR::GUI::MRView::Tool {
 
-enum FixelColourType { Direction, CValue };
-enum FixelScaleType { Unity, Value };
+enum class FixelColourType { Direction, Value };
+enum class FixelScaleType { Unity, Value };
 
 struct FixelValue {
   bool loaded = false;

--- a/cpp/gui/mrview/tool/fixel/vector_structs.h
+++ b/cpp/gui/mrview/tool/fixel/vector_structs.h
@@ -23,8 +23,8 @@
 
 namespace MR::GUI::MRView::Tool {
 
-enum class FixelColourType { Direction, Value };
-enum class FixelScaleType { Unity, Value };
+enum class FixelColourType : uint8_t { Direction, Value };
+enum class FixelScaleType : uint8_t { Unity, Value };
 
 struct FixelValue {
   bool loaded = false;

--- a/cpp/gui/mrview/tool/odf/item.cpp
+++ b/cpp/gui/mrview/tool/odf/item.cpp
@@ -41,15 +41,15 @@ ODF_Item::ODF_Item(
       throw Exception("No shell data");
     dixel->set_shell(dixel->shells->count() - 1);
     DEBUG("Image " + image.header().path().string() + " initialised as dixel ODF using DW scheme");
-  } catch (...) {
+  } catch (Exception &) {
     try {
       dixel->set_header();
       DEBUG("Image " + image.header().path().string() + " initialised as dixel ODF using header directions field");
-    } catch (...) {
+    } catch (Exception &) {
       try {
         dixel->set_internal(image.header().size(3));
         DEBUG("Image " + image.header().path().string() + " initialised as dixel ODF using internal direction set");
-      } catch (...) {
+      } catch (Exception &) {
         DEBUG("Image " + image.header().path().string() + " left uninitialised in ODF tool");
       }
     }
@@ -70,7 +70,7 @@ ODF_Item::DixelPlugin::DixelPlugin(const MR::Header &H) : dir_type(dir_t::NONE),
     grad = MR::DWI::get_DW_scheme(H);
     shells.reset(new MR::DWI::Shells(grad));
     shell_index = shells->count() - 1;
-  } catch (...) {
+  } catch (Exception &) { // NOLINT(bugprone-empty-catch)
   }
   auto entry = H.keyval().find("directions");
   if (entry != H.keyval().end()) {

--- a/cpp/gui/mrview/tool/odf/odf.cpp
+++ b/cpp/gui/mrview/tool/odf/odf.cpp
@@ -612,7 +612,7 @@ void ODF::dirs_slot() {
       }
       settings->dixel->set_from_file(load_paths.single_selection);
       current_folder = load_paths.last_directory;
-      break;
+    } break;
     default:
       assert(false);
       return;

--- a/cpp/gui/mrview/tool/odf/odf.cpp
+++ b/cpp/gui/mrview/tool/odf/odf.cpp
@@ -603,7 +603,7 @@ void ODF::dirs_slot() {
       if (preview)
         preview->render_frame->clear_dixels();
       break;
-    case 4: // From file
+    case 4: { // From file
       auto load_paths =
           Dialog::File::input_filepath(this, "Select directions file", "Text files (*.txt)", current_folder);
       if (load_paths.empty()) {
@@ -613,6 +613,9 @@ void ODF::dirs_slot() {
       settings->dixel->set_from_file(load_paths.single_selection);
       current_folder = load_paths.last_directory;
       break;
+    default:
+      assert(false);
+      return;
     }
     shell_selector->setEnabled(dir_type == 0 && settings->dixel->shells && settings->dixel->shells->count() > 1);
     if (dir_type == 3) {

--- a/cpp/gui/mrview/tool/overlay.cpp
+++ b/cpp/gui/mrview/tool/overlay.cpp
@@ -410,7 +410,7 @@ void Overlay::onSetVolumeIndex() {
 
   for (int i = 0; i < volume_index_layout->count(); ++i) {
     auto *box = dynamic_cast<SpinBox *>(volume_index_layout->itemAt(i)->widget());
-    if (overlay->header().ndim() <= static_cast<size_t>(i + 3))
+    if (overlay->header().ndim() <= static_cast<size_t>(i) + 3)
       break;
     overlay->image.index(i + 3) = box->value();
   }

--- a/cpp/gui/mrview/tool/roi_editor/roi.cpp
+++ b/cpp/gui/mrview/tool/roi_editor/roi.cpp
@@ -14,14 +14,15 @@
  * For more details, see http://www.mrtrix.org/.
  */
 
-#include <string>
-
-#include "mrview/qthelpers.h"
 #include "mrview/tool/roi_editor/roi.h"
+
+#include <string>
 
 #include "cursor.h"
 #include "dialog/file.h"
 #include "header.h"
+#include "mrview/qthelpers.h"
+#include "opengl/gl_core_3_3.h"
 #include "projection.h"
 
 namespace MR::GUI::MRView::Tool {

--- a/cpp/gui/mrview/tool/roi_editor/roi.cpp
+++ b/cpp/gui/mrview/tool/roi_editor/roi.cpp
@@ -311,7 +311,7 @@ void ROI::save(ROI_Item *roi) {
     GL::assert_context_is_current();
     roi->texture().bind();
     gl::PixelStorei(gl::PACK_ALIGNMENT, 1);
-    gl::GetTexImage(gl::TEXTURE_3D, 0, gl::RED_INTEGER, gl::UNSIGNED_BYTE, (void *)(&data[0]));
+    gl::GetTexImage(gl::TEXTURE_3D, 0, gl::RED_INTEGER, gl::UNSIGNED_BYTE, static_cast<void *>(&data[0]));
     GL::assert_context_is_current();
   }
 

--- a/cpp/gui/mrview/tool/roi_editor/undoentry.cpp
+++ b/cpp/gui/mrview/tool/roi_editor/undoentry.cpp
@@ -14,12 +14,14 @@
  * For more details, see http://www.mrtrix.org/.
  */
 
+#include "mrview/tool/roi_editor/undoentry.h"
+
 #include <limits>
 #include <stddef.h>
 
 #include "mrview/tool/roi_editor/item.h"
-#include "mrview/tool/roi_editor/undoentry.h"
 #include "mrview/window.h"
+#include "opengl/gl_core_3_3.h"
 
 namespace MR::GUI::MRView::Tool {
 

--- a/cpp/gui/mrview/tool/roi_editor/undoentry.cpp
+++ b/cpp/gui/mrview/tool/roi_editor/undoentry.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <limits>
+#include <stddef.h>
 
 #include "mrview/tool/roi_editor/item.h"
 #include "mrview/tool/roi_editor/undoentry.h"
@@ -53,7 +54,7 @@ ROI_UndoEntry::Shared::Shared() : count(1) {
   vertex_array_object.bind();
 
   gl::EnableVertexAttribArray(0);
-  gl::VertexAttribIPointer(0, 3, gl::INT, 3 * sizeof(GLint), (void *)0);
+  gl::VertexAttribIPointer(0, 3, gl::INT, 3 * sizeof(GLint), nullptr);
 
   static const std::array<GLint, 12> vertices = {
       -1,
@@ -149,7 +150,7 @@ ROI_UndoEntry::ROI_UndoEntry(ROI_Item &roi, int current_axis, int current_slice)
   tex.bind();
   gl::PixelStorei(gl::PACK_ALIGNMENT, 1);
 
-  gl::GetTexImage(gl::TEXTURE_2D, 0, gl::RED, gl::UNSIGNED_BYTE, (void *)(&before[0]));
+  gl::GetTexImage(gl::TEXTURE_2D, 0, gl::RED, gl::UNSIGNED_BYTE, static_cast<void *>(&before[0]));
   after = before;
   GL_CHECK_ERROR;
   GL::assert_context_is_current();
@@ -229,7 +230,7 @@ void ROI_UndoEntry::draw_line(ROI_Item &roi,
                     size[2],
                     gl::RED_INTEGER,
                     gl::UNSIGNED_BYTE,
-                    (void *)(&after[0]));
+                    static_cast<void *>(&after[0]));
   GL::assert_context_is_current();
 }
 
@@ -293,7 +294,7 @@ void ROI_UndoEntry::draw_thick_line(ROI_Item &roi,
                     size[2],
                     gl::RED_INTEGER,
                     gl::UNSIGNED_BYTE,
-                    (void *)(&after[0]));
+                    static_cast<void *>(&after[0]));
   GL::assert_context_is_current();
 }
 
@@ -338,7 +339,7 @@ void ROI_UndoEntry::draw_circle(ROI_Item &roi,
                     size[2],
                     gl::RED_INTEGER,
                     gl::UNSIGNED_BYTE,
-                    (void *)(&after[0]));
+                    static_cast<void *>(&after[0]));
   GL::assert_context_is_current();
 }
 
@@ -383,7 +384,7 @@ void ROI_UndoEntry::draw_rectangle(ROI_Item &roi,
                     size[2],
                     gl::RED_INTEGER,
                     gl::UNSIGNED_BYTE,
-                    (void *)(&after[0]));
+                    static_cast<void *>(&after[0]));
   GL::assert_context_is_current();
 }
 
@@ -450,7 +451,7 @@ void ROI_UndoEntry::draw_fill(ROI_Item &roi, const Eigen::Vector3f &pos, const b
                     size[2],
                     gl::RED_INTEGER,
                     gl::UNSIGNED_BYTE,
-                    (void *)(&after[0]));
+                    static_cast<void *>(&after[0]));
   GL::assert_context_is_current();
 }
 
@@ -468,7 +469,7 @@ void ROI_UndoEntry::undo(ROI_Item &roi) {
                     size[2],
                     gl::RED_INTEGER,
                     gl::UNSIGNED_BYTE,
-                    (void *)(&before[0]));
+                    static_cast<void *>(&before[0]));
   GL::assert_context_is_current();
 }
 
@@ -486,7 +487,7 @@ void ROI_UndoEntry::redo(ROI_Item &roi) {
                     size[2],
                     gl::RED_INTEGER,
                     gl::UNSIGNED_BYTE,
-                    (void *)(&after[0]));
+                    static_cast<void *>(&after[0]));
   GL::assert_context_is_current();
 }
 
@@ -505,7 +506,7 @@ void ROI_UndoEntry::copy(ROI_Item &roi, ROI_UndoEntry &source) {
                     size[2],
                     gl::RED_INTEGER,
                     gl::UNSIGNED_BYTE,
-                    (void *)(&after[0]));
+                    static_cast<void *>(&after[0]));
   GL::assert_context_is_current();
 }
 

--- a/cpp/gui/mrview/tool/roi_editor/undoentry.cpp
+++ b/cpp/gui/mrview/tool/roi_editor/undoentry.cpp
@@ -145,7 +145,7 @@ ROI_UndoEntry::ROI_UndoEntry(ROI_Item &roi, int current_axis, int current_slice)
   GL_CHECK_ERROR;
 
   // retrieve texture contents to main memory:
-  before.resize(tex_size[0] * tex_size[1]);
+  before.resize(static_cast<size_t>(tex_size[0]) * static_cast<size_t>(tex_size[1]));
   tex.bind();
   gl::PixelStorei(gl::PACK_ALIGNMENT, 1);
 
@@ -420,6 +420,9 @@ void ROI_UndoEntry::draw_fill(ROI_Item &roi, const Eigen::Vector3f &pos, const b
         break;
       case 3:
         adj[slice_axes[1]] += 1;
+        break;
+      default:
+        assert(false);
         break;
       }
       if (adj[0] >= 0 && adj[0] < static_cast<int>(roi.header().size(0)) && adj[1] >= 0 &&

--- a/cpp/gui/mrview/tool/screen_capture.cpp
+++ b/cpp/gui/mrview/tool/screen_capture.cpp
@@ -14,6 +14,7 @@
  * For more details, see http://www.mrtrix.org/.
  */
 
+#include "eigen_plugins/eigen_plugins.h"
 #include <Eigen/Geometry>
 #include <filesystem>
 

--- a/cpp/gui/mrview/tool/screen_capture.cpp
+++ b/cpp/gui/mrview/tool/screen_capture.cpp
@@ -373,7 +373,7 @@ void Capture::run(bool with_capture) {
       break;
     }
     case TranslationType::Scanner:
-      break;
+      [[fallthrough]];
     default:
       break;
     }

--- a/cpp/gui/mrview/tool/tractography/tractogram.cpp
+++ b/cpp/gui/mrview/tool/tractography/tractogram.cpp
@@ -459,18 +459,23 @@ inline void Tractogram::render_streamlines() {
       case TrackColourType::Ends:
         gl::BindBuffer(gl::ARRAY_BUFFER, colour_buffers[buf]);
         gl::EnableVertexAttribArray(3);
-        gl::VertexAttribPointer(3,
-                                3,
-                                gl::FLOAT,
-                                gl::FALSE_,
-                                static_cast<unsigned long>(3 * sample_stride) * sizeof(float),
-                                (void *)(static_cast<unsigned long>(3 * sample_stride) * sizeof(float)));
+        gl::VertexAttribPointer(
+            3,
+            3,
+            gl::FLOAT,
+            gl::FALSE_,
+            static_cast<GLsizei>(3 * static_cast<unsigned long>(sample_stride) * sizeof(float)),
+            reinterpret_cast<void *>(3 * static_cast<unsigned long>(sample_stride) * sizeof(float)));
         break;
       case TrackColourType::ScalarFile:
         gl::BindBuffer(gl::ARRAY_BUFFER, intensity_scalar_buffers[buf]);
         gl::EnableVertexAttribArray(3);
-        gl::VertexAttribPointer(
-            3, 1, gl::FLOAT, gl::FALSE_, sample_stride * sizeof(float), (void *)(sample_stride * sizeof(float)));
+        gl::VertexAttribPointer(3,
+                                1,
+                                gl::FLOAT,
+                                gl::FALSE_,
+                                static_cast<GLsizei>(sample_stride * sizeof(float)),
+                                reinterpret_cast<void *>(sample_stride * sizeof(float)));
         break;
       default:
         break;
@@ -479,8 +484,12 @@ inline void Tractogram::render_streamlines() {
       if (threshold_type == TrackThresholdType::SeparateFile) {
         gl::BindBuffer(gl::ARRAY_BUFFER, threshold_scalar_buffers[buf]);
         gl::EnableVertexAttribArray(4);
-        gl::VertexAttribPointer(
-            4, 1, gl::FLOAT, gl::FALSE_, sample_stride * sizeof(float), (void *)(sample_stride * sizeof(float)));
+        gl::VertexAttribPointer(4,
+                                1,
+                                gl::FLOAT,
+                                gl::FALSE_,
+                                static_cast<GLsizei>(sample_stride * sizeof(float)),
+                                reinterpret_cast<void *>(sample_stride * sizeof(float)));
       }
 
       gl::BindBuffer(gl::ARRAY_BUFFER, vertex_buffers[buf]);
@@ -489,18 +498,22 @@ inline void Tractogram::render_streamlines() {
                               3,
                               gl::FLOAT,
                               gl::FALSE_,
-                              static_cast<unsigned long>(3 * sample_stride) * sizeof(float),
-                              (void *)(static_cast<unsigned long>(3 * sample_stride) * sizeof(float)));
+                              static_cast<GLsizei>(3 * static_cast<unsigned long>(sample_stride) * sizeof(float)),
+                              reinterpret_cast<void *>(3 * static_cast<unsigned long>(sample_stride) * sizeof(float)));
       gl::EnableVertexAttribArray(1);
-      gl::VertexAttribPointer(
-          1, 3, gl::FLOAT, gl::FALSE_, static_cast<unsigned long>(3 * sample_stride) * sizeof(float), (void *)0);
+      gl::VertexAttribPointer(1,
+                              3,
+                              gl::FLOAT,
+                              gl::FALSE_,
+                              static_cast<GLsizei>(3 * static_cast<unsigned long>(sample_stride) * sizeof(float)),
+                              nullptr);
       gl::EnableVertexAttribArray(2);
       gl::VertexAttribPointer(2,
                               3,
                               gl::FLOAT,
                               gl::FALSE_,
-                              static_cast<unsigned long>(3 * sample_stride) * sizeof(float),
-                              (void *)(static_cast<unsigned long>(6 * sample_stride) * sizeof(float)));
+                              static_cast<GLsizei>(3 * static_cast<unsigned long>(sample_stride) * sizeof(float)),
+                              reinterpret_cast<void *>(6 * static_cast<unsigned long>(sample_stride) * sizeof(float)));
 
       for (size_t j = 0, M = track_sizes[buf].size(); j < M; ++j) {
         track_sizes[buf][j] = static_cast<GLint>(

--- a/cpp/gui/mrview/tool/tractography/tractogram.cpp
+++ b/cpp/gui/mrview/tool/tractography/tractogram.cpp
@@ -16,6 +16,7 @@
 
 #include "mrview/tool/tractography/tractogram.h"
 
+#include <cstddef>
 #include <cstdint>
 
 #include "dwi/tractography/file.h"
@@ -244,8 +245,7 @@ std::string Tractogram::Shader::fragment_shader_source(const Displayable &displa
     source += using_geom ? "  colour = abs (normalize (g_tangent));\n" : "  colour = abs (normalize (v_tangent));\n";
     break;
   case TrackColourType::ScalarFile:
-    source += using_geom ? "  colour = fColour;\n" : "  colour = v_colour;\n";
-    break;
+    [[fallthrough]];
   case TrackColourType::Ends:
     source += using_geom ? "  colour = fColour;\n" : "  colour = v_colour;\n";
     break;
@@ -463,8 +463,8 @@ inline void Tractogram::render_streamlines() {
                                 3,
                                 gl::FLOAT,
                                 gl::FALSE_,
-                                3 * sample_stride * sizeof(float),
-                                (void *)(3 * sample_stride * sizeof(float)));
+                                static_cast<unsigned long>(3 * sample_stride) * sizeof(float),
+                                (void *)(static_cast<unsigned long>(3 * sample_stride) * sizeof(float)));
         break;
       case TrackColourType::ScalarFile:
         gl::BindBuffer(gl::ARRAY_BUFFER, intensity_scalar_buffers[buf]);
@@ -485,13 +485,22 @@ inline void Tractogram::render_streamlines() {
 
       gl::BindBuffer(gl::ARRAY_BUFFER, vertex_buffers[buf]);
       gl::EnableVertexAttribArray(0);
-      gl::VertexAttribPointer(
-          0, 3, gl::FLOAT, gl::FALSE_, 3 * sample_stride * sizeof(float), (void *)(3 * sample_stride * sizeof(float)));
+      gl::VertexAttribPointer(0,
+                              3,
+                              gl::FLOAT,
+                              gl::FALSE_,
+                              static_cast<unsigned long>(3 * sample_stride) * sizeof(float),
+                              (void *)(static_cast<unsigned long>(3 * sample_stride) * sizeof(float)));
       gl::EnableVertexAttribArray(1);
-      gl::VertexAttribPointer(1, 3, gl::FLOAT, gl::FALSE_, 3 * sample_stride * sizeof(float), (void *)0);
-      gl::EnableVertexAttribArray(2);
       gl::VertexAttribPointer(
-          2, 3, gl::FLOAT, gl::FALSE_, 3 * sample_stride * sizeof(float), (void *)(6 * sample_stride * sizeof(float)));
+          1, 3, gl::FLOAT, gl::FALSE_, static_cast<unsigned long>(3 * sample_stride) * sizeof(float), (void *)0);
+      gl::EnableVertexAttribArray(2);
+      gl::VertexAttribPointer(2,
+                              3,
+                              gl::FLOAT,
+                              gl::FALSE_,
+                              static_cast<unsigned long>(3 * sample_stride) * sizeof(float),
+                              (void *)(static_cast<unsigned long>(6 * sample_stride) * sizeof(float)));
 
       for (size_t j = 0, M = track_sizes[buf].size(); j < M; ++j) {
         track_sizes[buf][j] = static_cast<GLint>(
@@ -629,7 +638,7 @@ void Tractogram::load_end_colours() {
       const size_t tck_length = original_track_sizes[buffer_index][buffer_tck_counter];
 
       // Includes pre- and post-padding to coincide with tracks buffer
-      for (size_t i = 0; i != tck_length + (2 * track_padding); ++i)
+      for (size_t i = 0; i != tck_length + static_cast<size_t>(2 * track_padding); ++i)
         buffer.push_back(colour);
     }
     load_end_colours_onto_GPU(buffer);

--- a/cpp/gui/mrview/tool/tractography/tractogram.cpp
+++ b/cpp/gui/mrview/tool/tractography/tractogram.cpp
@@ -26,6 +26,7 @@
 #include "file/matrix.h"
 #include "mrview/mode/base.h"
 #include "mrview/window.h"
+#include "opengl/gl_core_3_3.h"
 #include "opengl/lighting.h"
 #include "progressbar.h"
 #include "projection.h"

--- a/cpp/gui/mrview/tool/view.cpp
+++ b/cpp/gui/mrview/tool/view.cpp
@@ -16,6 +16,9 @@
 
 #include "mrview/tool/view.h"
 
+#include <cstdint>
+
+#include "exception.h"
 #include "math/math.h"
 #include "mrtrix.h"
 #include "mrview/adjust_button.h"
@@ -484,7 +487,8 @@ void View::onVolumeIndexChanged() {
 
   for (int i = 0; i < volume_index_layout->count(); ++i) {
     auto *box = dynamic_cast<SpinBox *>(volume_index_layout->itemAt(i)->widget());
-    box->setValue(image.ndim() > static_cast<size_t>(i) + 3 ? image.index(static_cast<ssize_t>(i) + 3) : 0);
+    box->setValue(image.ndim() > static_cast<size_t>(i) + 3 ? static_cast<int>(image.index(static_cast<ssize_t>(i) + 3))
+                                                            : int(0));
   }
 }
 

--- a/cpp/gui/mrview/tool/view.cpp
+++ b/cpp/gui/mrview/tool/view.cpp
@@ -484,7 +484,7 @@ void View::onVolumeIndexChanged() {
 
   for (int i = 0; i < volume_index_layout->count(); ++i) {
     auto *box = dynamic_cast<SpinBox *>(volume_index_layout->itemAt(i)->widget());
-    box->setValue(image.ndim() > static_cast<size_t>(i + 3) ? image.index(i + 3) : 0);
+    box->setValue(image.ndim() > static_cast<size_t>(i) + 3 ? image.index(static_cast<ssize_t>(i) + 3) : 0);
   }
 }
 
@@ -589,7 +589,8 @@ void View::onSetFocus() {
   try {
     window().set_focus(Eigen::Vector3f{focus_x->value(), focus_y->value(), focus_z->value()});
     window().updateGL();
-  } catch (Exception) {
+  } catch (Exception &e) {
+    WARN("Error parsing requested focus point: " + e[0]);
   }
 }
 
@@ -599,7 +600,8 @@ void View::onSetVoxel() {
     focus = window().image()->voxel2scanner() * focus;
     window().set_focus(focus);
     window().updateGL();
-  } catch (Exception) {
+  } catch (Exception &e) {
+    WARN("Error parsing requested voxel position: " + e[0]);
   }
 }
 
@@ -610,7 +612,7 @@ void View::onSetVolumeIndex() {
 
     for (int i = 0; i < volume_index_layout->count(); ++i) {
       auto *box = dynamic_cast<SpinBox *>(volume_index_layout->itemAt(i)->widget());
-      if (image.ndim() <= static_cast<size_t>(i + 3))
+      if (image.ndim() <= static_cast<size_t>(i) + 3)
         break;
       window().set_image_volume(i + 3, box->value());
     }

--- a/cpp/gui/mrview/tool/view.cpp
+++ b/cpp/gui/mrview/tool/view.cpp
@@ -17,6 +17,7 @@
 #include "mrview/tool/view.h"
 
 #include <cstdint>
+#include <sys/types.h>
 
 #include "exception.h"
 #include "math/math.h"

--- a/cpp/gui/mrview/tool/view.cpp
+++ b/cpp/gui/mrview/tool/view.cpp
@@ -488,7 +488,7 @@ void View::onVolumeIndexChanged() {
   for (int i = 0; i < volume_index_layout->count(); ++i) {
     auto *box = dynamic_cast<SpinBox *>(volume_index_layout->itemAt(i)->widget());
     box->setValue(image.ndim() > static_cast<size_t>(i) + 3 ? static_cast<int>(image.index(static_cast<ssize_t>(i) + 3))
-                                                            : int(0));
+                                                            : 0);
   }
 }
 

--- a/cpp/gui/mrview/volume.h
+++ b/cpp/gui/mrview/volume.h
@@ -165,11 +165,11 @@ protected:
       vertex_array_object.bind();
 
       gl::EnableVertexAttribArray(0);
-      gl::VertexAttribPointer(0, 3, gl::FLOAT, gl::FALSE_, 2 * sizeof(Eigen::Vector3f), (void *)0);
+      gl::VertexAttribPointer(0, 3, gl::FLOAT, gl::FALSE_, 2 * sizeof(Eigen::Vector3f), nullptr);
 
       gl::EnableVertexAttribArray(1);
       gl::VertexAttribPointer(
-          1, 3, gl::FLOAT, gl::FALSE_, 2 * sizeof(Eigen::Vector3f), (void *)(sizeof(Eigen::Vector3f)));
+          1, 3, gl::FLOAT, gl::FALSE_, 2 * sizeof(Eigen::Vector3f), reinterpret_cast<void *>(sizeof(Eigen::Vector3f)));
     } else {
       vertex_buffer.bind(gl::ARRAY_BUFFER);
       vertex_array_object.bind();

--- a/cpp/gui/mrview/window.cpp
+++ b/cpp/gui/mrview/window.cpp
@@ -177,7 +177,7 @@ void Window::GLArea::wheelEvent(QWheelEvent *event) { main->wheelEventGL(event);
 bool Window::GLArea::event(QEvent *event) {
   if (event->type() == QEvent::Gesture)
     return main->gestureEventGL(static_cast<QGestureEvent *>(event));
-  return QWidget::event(event);
+  return QOpenGLWidget::event(event);
 }
 
 // CONF option: MRViewFocusModifierKey
@@ -589,7 +589,6 @@ Window::Window()
   mode_action_group->setExclusive(true);
   connect(mode_action_group, SIGNAL(triggered(QAction *)), this, SLOT(select_mouse_mode_slot(QAction *)));
 
-  std::string modifier;
   action = toolbar->addAction(QIcon(":/select_contrast.svg"), tr("Change focus / contrast"));
   action->setToolTip(qstr("Left-click: set focus\n"
                           "Right-click: change brightness/constrast\n\n"
@@ -726,8 +725,8 @@ void Window::parse_arguments() {
       const auto last_arg_pos = MR::App::argument.back().index();
 
       const auto is_non_standard_option = [](const MR::App::ParsedOption &option) {
-        return std::none_of(MR::App::__standard_options.begin(),
-                            MR::App::__standard_options.end(),
+        return std::none_of(MR::App::_standard_options.begin(),
+                            MR::App::_standard_options.end(),
                             [&option](const auto &standard_option) { return option.opt == &standard_option; });
       };
 
@@ -745,8 +744,9 @@ void Window::parse_arguments() {
       try {
         list.push_back(std::make_unique<MR::Header>(MR::Header::open(MR::App::argument[n])));
       } catch (CancelException &e) {
-        for (const auto &msg : e.description)
+        for (const auto &msg : e.description) {
           CONSOLE(msg);
+        }
       } catch (Exception &e) {
         e.display();
       }
@@ -896,7 +896,7 @@ void Window::image_properties_slot() {
 
 void Window::select_mode_slot(QAction *action) {
   glarea->makeCurrent();
-  mode.reset(dynamic_cast<GUI::MRView::Mode::__Action__ *>(action)->create());
+  mode.reset(dynamic_cast<GUI::MRView::Mode::ActionWrapper *>(action)->create());
   mode->set_visible(!image_hide_action->isChecked());
   set_mode_features();
   emit modeChanged();
@@ -912,7 +912,7 @@ void Window::select_mouse_mode_slot(QAction *action) {
 }
 
 void Window::select_tool_slot(QAction *action) {
-  Tool::Dock *tool = dynamic_cast<Tool::__Action__ *>(action)->dock;
+  Tool::Dock *tool = dynamic_cast<Tool::ActionWrapper *>(action)->dock;
   if (!tool) {
     create_tool(action, true);
     return;
@@ -928,16 +928,16 @@ void Window::select_tool_slot(QAction *action) {
 }
 
 void Window::create_tool(QAction *action, bool show) {
-  if (dynamic_cast<Tool::__Action__ *>(action)->dock)
+  if (dynamic_cast<Tool::ActionWrapper *>(action)->dock)
     return;
 
-  Tool::Dock *tool = dynamic_cast<Tool::__Action__ *>(action)->create(tools_floating);
+  Tool::Dock *tool = dynamic_cast<Tool::ActionWrapper *>(action)->create(tools_floating);
   connect(tool, SIGNAL(visibilityChanged(bool)), action, SLOT(visibility_slot(bool)));
 
   if (!tools_floating) {
 
     for (int i = 0; i < tool_group->actions().size(); ++i) {
-      Tool::Dock *other_tool = dynamic_cast<Tool::__Action__ *>(tool_group->actions()[i])->dock;
+      Tool::Dock *other_tool = dynamic_cast<Tool::ActionWrapper *>(tool_group->actions()[i])->dock;
       if (other_tool && other_tool != tool) {
         QList<QDockWidget *> list = QMainWindow::tabifiedDockWidgets(other_tool);
         if (!list.empty())
@@ -1045,7 +1045,7 @@ void Window::reset_view_slot() {
     mode->reset_event();
     QList<QAction *> tools = tool_group->actions();
     for (QAction *action : tools) {
-      Tool::Dock *dock = dynamic_cast<Tool::__Action__ *>(action)->dock;
+      Tool::Dock *dock = dynamic_cast<Tool::ActionWrapper *>(action)->dock;
       if (dock)
         dock->tool->reset_event();
     }
@@ -1192,7 +1192,7 @@ void Window::toggle_annotations_slot() {
     show_colourbar_action->setChecked(false);
   } else {
     if (!annotations)
-      annotations = 0xFFFFFFFF;
+      annotations = 0xFFFFFFFFU;
     show_crosshairs_action->setChecked(annotations & 0x00000001);
     show_comments_action->setChecked(annotations & 0x00000002);
     show_voxel_info_action->setChecked(annotations & 0x00000004);
@@ -1425,7 +1425,7 @@ void Window::initGL() {
   // CONF The default image background colour in the main MRView window.
   background_colour = File::Config::get_RGB("MRViewImageBackgroundColour", {0.0F, 0.0F, 0.0F});
   gl::ClearColor(background_colour[0], background_colour[1], background_colour[2], 1.0);
-  mode.reset(dynamic_cast<Mode::__Action__ *>(mode_group->actions()[0])->create());
+  mode.reset(dynamic_cast<Mode::ActionWrapper *>(mode_group->actions()[0])->create());
   set_mode_features();
 
   GL::assert_context_is_current();
@@ -1650,7 +1650,8 @@ void Window::process_commandline_option() {
   stub = lowercase(#classname ".");                                                                                    \
   if (stub.compare(0, stub.size(), std::string(opt.opt->id), 0, stub.size()) == 0) {                                   \
     create_tool(tool_group->actions()[tool_id], false);                                                                \
-    if (dynamic_cast<Tool::__Action__ *>(tool_group->actions()[tool_id])->dock->tool->process_commandline_option(opt)) \
+    if (dynamic_cast<Tool::ActionWrapper *>(tool_group->actions()[tool_id])                                            \
+            ->dock->tool->process_commandline_option(opt))                                                             \
       return;                                                                                                          \
   }                                                                                                                    \
   ++tool_id;

--- a/cpp/gui/mrview/window.cpp
+++ b/cpp/gui/mrview/window.cpp
@@ -13,6 +13,12 @@
  *
  * For more details, see http://www.mrtrix.org/.
  */
+
+#include <QDebug>
+#include <algorithm>
+#include <qopenglwidget.h>
+#include <unordered_map>
+
 #include "algo/copy.h"
 #include "app.h"
 #include "dialog/dialog.h"
@@ -30,8 +36,6 @@
 #include "opengl/glutils.h"
 #include "opengl/lighting.h"
 #include "timer.h"
-#include <QDebug>
-#include <unordered_map>
 
 namespace MR::GUI::MRView {
 using namespace App;
@@ -928,7 +932,7 @@ void Window::select_tool_slot(QAction *action) {
 }
 
 void Window::create_tool(QAction *action, bool show) {
-  if (dynamic_cast<Tool::ActionWrapper *>(action)->dock)
+  if (dynamic_cast<Tool::ActionWrapper *>(action)->dock != nullptr)
     return;
 
   Tool::Dock *tool = dynamic_cast<Tool::ActionWrapper *>(action)->create(tools_floating);
@@ -1192,7 +1196,7 @@ void Window::toggle_annotations_slot() {
     show_colourbar_action->setChecked(false);
   } else {
     if (!annotations)
-      annotations = 0xFFFFFFFFU;
+      annotations = 0xFFFFFFFF;
     show_crosshairs_action->setChecked(annotations & 0x00000001);
     show_comments_action->setChecked(annotations & 0x00000002);
     show_voxel_info_action->setChecked(annotations & 0x00000004);

--- a/cpp/gui/mrview/window.h
+++ b/cpp/gui/mrview/window.h
@@ -31,7 +31,6 @@ class Lighting;
 
 namespace MR::GUI::MRView::Mode {
 class Base;
-class __Entry__;
 } // namespace MR::GUI::MRView::Mode
 
 namespace MR::GUI::MRView::Tool {

--- a/cpp/gui/opengl/font.cpp
+++ b/cpp/gui/opengl/font.cpp
@@ -156,11 +156,11 @@ void Font::initGL(bool with_shadow) {
 
   vertex_buffer[0].bind(gl::ARRAY_BUFFER);
   gl::EnableVertexAttribArray(0);
-  gl::VertexAttribPointer(0, 2, gl::FLOAT, gl::FALSE_, 0, (void *)0);
+  gl::VertexAttribPointer(0, 2, gl::FLOAT, gl::FALSE_, 0, nullptr);
 
   vertex_buffer[1].bind(gl::ARRAY_BUFFER);
   gl::EnableVertexAttribArray(1);
-  gl::VertexAttribPointer(1, 2, gl::FLOAT, gl::FALSE_, 0, (void *)0);
+  gl::VertexAttribPointer(1, 2, gl::FLOAT, gl::FALSE_, 0, nullptr);
 
   GL::Shader::Vertex vertex_shader(vertex_shader_source.c_str());
   GL::Shader::Fragment fragment_shader(fragment_shader_source.c_str());

--- a/cpp/gui/opengl/font.cpp
+++ b/cpp/gui/opengl/font.cpp
@@ -189,7 +189,7 @@ void Font::render(std::string_view text, int x, int y) const {
   for (size_t n = 0; n < text.size(); ++n) {
     starts[n] = 4 * n;
     counts[n] = 4;
-    const int c = text[n];
+    const size_t c = static_cast<size_t>(static_cast<unsigned char>(text[n]));
     GLfloat *pos = &screen_pos[8 * n];
     pos[0] = x;
     pos[1] = y;

--- a/cpp/gui/opengl/glutils.cpp
+++ b/cpp/gui/opengl/glutils.cpp
@@ -25,10 +25,10 @@ namespace MR::GUI::GL {
 Area *glwidget = nullptr;
 
 #ifndef NDEBUG
-void __assert_context_is_current(QWidget *glarea) {
-  auto __current_context = Context::current();
-  auto __expected_context = Context::get(glarea ? glarea : glwidget);
-  assert(__current_context == __expected_context);
+void _assert_context_is_current(QWidget *glarea) {
+  auto _current_context = Context::current();
+  auto _expected_context = Context::get(glarea ? glarea : glwidget);
+  assert(_current_context == _expected_context);
 }
 #endif
 

--- a/cpp/gui/opengl/glutils.h
+++ b/cpp/gui/opengl/glutils.h
@@ -88,8 +88,8 @@ inline void check_error(const char *filename, int line) { // check_syntax off (i
 }
 
 #ifndef NDEBUG
-void __assert_context_is_current(QWidget *glarea);
-inline void assert_context_is_current(QWidget *glarea = nullptr) { __assert_context_is_current(glarea); }
+void _assert_context_is_current(QWidget *glarea);
+inline void assert_context_is_current(QWidget *glarea = nullptr) { _assert_context_is_current(glarea); }
 #else
 inline void assert_context_is_current(QWidget * = nullptr) {}
 #endif

--- a/cpp/gui/shapes/halfsphere.cpp
+++ b/cpp/gui/shapes/halfsphere.cpp
@@ -120,8 +120,8 @@ void HalfSphere::LOD(const size_t level_of_detail) {
       GLuint index1, index2, index3;
 
       Edge E(indices[n][0], indices[n][1]);
-      std::map<Edge, GLuint>::const_iterator iter;
-      if ((iter = edges.find(E)) == edges.end()) {
+      std::map<Edge, GLuint>::const_iterator iter = edges.find(E);
+      if (iter == edges.end()) {
         index1 = vertices.size();
         edges.insert(std::make_pair(E, index1));
         vertices.push_back(Vertex(vertices, indices[n][0], indices[n][1]));
@@ -129,7 +129,8 @@ void HalfSphere::LOD(const size_t level_of_detail) {
         index1 = iter->second;
 
       E.set(indices[n][1], indices[n][2]);
-      if ((iter = edges.find(E)) == edges.end()) {
+      iter = edges.find(E);
+      if (iter == edges.end()) {
         index2 = vertices.size();
         edges.insert(std::make_pair(E, index2));
         vertices.push_back(Vertex(vertices, indices[n][1], indices[n][2]));
@@ -137,7 +138,8 @@ void HalfSphere::LOD(const size_t level_of_detail) {
         index2 = iter->second;
 
       E.set(indices[n][2], indices[n][0]);
-      if ((iter = edges.find(E)) == edges.end()) {
+      iter = edges.find(E);
+      if (iter == edges.end()) {
         index3 = vertices.size();
         edges.insert(std::make_pair(E, index3));
         vertices.push_back(Vertex(vertices, indices[n][2], indices[n][0]));

--- a/cpp/gui/shapes/sphere.cpp
+++ b/cpp/gui/shapes/sphere.cpp
@@ -142,7 +142,8 @@ void Sphere::LOD(const size_t level_of_detail) {
 
       Edge E(indices[n][0], indices[n][1]);
       std::map<Edge, GLuint>::const_iterator iter;
-      if ((iter = edges.find(E)) == edges.end()) {
+      iter = edges.find(E);
+      if (iter == edges.end()) {
         index1 = vertices.size();
         edges.insert(std::make_pair(E, index1));
         vertices.push_back(Vertex(vertices, indices[n][0], indices[n][1]));
@@ -150,7 +151,8 @@ void Sphere::LOD(const size_t level_of_detail) {
         index1 = iter->second;
 
       E.set(indices[n][1], indices[n][2]);
-      if ((iter = edges.find(E)) == edges.end()) {
+      iter = edges.find(E);
+      if (iter == edges.end()) {
         index2 = vertices.size();
         edges.insert(std::make_pair(E, index2));
         vertices.push_back(Vertex(vertices, indices[n][1], indices[n][2]));
@@ -158,7 +160,8 @@ void Sphere::LOD(const size_t level_of_detail) {
         index2 = iter->second;
 
       E.set(indices[n][2], indices[n][0]);
-      if ((iter = edges.find(E)) == edges.end()) {
+      iter = edges.find(E);
+      if (iter == edges.end()) {
         index3 = vertices.size();
         edges.insert(std::make_pair(E, index3));
         vertices.push_back(Vertex(vertices, indices[n][2], indices[n][0]));

--- a/docs/reference/config_file_options.rst
+++ b/docs/reference/config_file_options.rst
@@ -651,6 +651,12 @@ List of MRtrix3 configuration file options
 
      Linear registration: estimated spatial coherence length in voxels.
 
+.. option:: RegGdConvergenceBufferLen
+
+    *default: 4*
+
+     Linear registration: gradient descent convergence buffer length.
+
 .. option:: RegGdConvergenceDataSmooth
 
     *default: 0.8*


### PR DESCRIPTION
Supersedes #3349.
Closes #2862.

#3349 collected far too many commits due to not being able to replicate the CI Action behaviour locally. This alternative branch did a mass rebase, grouping the commits into a few basic categories and collapsing each category into a single commit, to make the history vastly cleaner.

There may be other checks for which it could be beneficial to introduce into the enforcement check, with corresponding rebasing of the repository (shouldn't preclude addition of a bad pattern if there's precedent for that pattern), but I think for now I'd prefer to get this completed and merged in so I can get on to dealing with the myriad conflicts.