### PR TITLE
mrmetric: Restrictions on -space voxel

### DIFF
--- a/cmd/mrmetric.cpp
+++ b/cmd/mrmetric.cpp
@@ -283,7 +283,7 @@ void run ()
   Eigen::Matrix<value_type, Eigen::Dynamic, 1> sos = Eigen::Matrix<value_type, Eigen::Dynamic, 1>::Zero (volumes, 1);
   if (space==0) {
     INFO ("per-voxel");
-    check_dimensions (input1, input2);
+    check_voxel_grids_match_in_scanner_space (input1, input2);
     if (!use_mask1 and !use_mask2)
       n_voxels = input1.size(0) * input1.size(1) * input1.size(2);
     evaluate_voxelwise_msq (input1, input2, mask1, mask2, dimensions, use_mask1, use_mask2, n_voxels, sos);

--- a/cmd/mrmetric.cpp
+++ b/cmd/mrmetric.cpp
@@ -283,7 +283,13 @@ void run ()
   Eigen::Matrix<value_type, Eigen::Dynamic, 1> sos = Eigen::Matrix<value_type, Eigen::Dynamic, 1>::Zero (volumes, 1);
   if (space==0) {
     INFO ("per-voxel");
-    check_voxel_grids_match_in_scanner_space (input1, input2);
+    check_dimensions (input1, input2);
+    if (!voxel_grids_match_in_scanner_space (input1, input2)) {
+      WARN("Input images have same axis dimensions, but voxel grids reside in different spatial locations;"
+           " voxel-wise computation can proceed,"
+           " but suggest checking derivation of data "
+           " and verifying validity of voxel-wise image comparison");
+    }
     if (!use_mask1 and !use_mask2)
       n_voxels = input1.size(0) * input1.size(1) * input1.size(2);
     evaluate_voxelwise_msq (input1, input2, mask1, mask2, dimensions, use_mask1, use_mask2, n_voxels, sos);


### PR DESCRIPTION
If a voxel-wise similarity metric is to be invoked, then it is not adequate for the two input images to simply have the same number of voxels; they must share a mutual voxel grid.
