### PR TITLE
Make build checks show all compile errors

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -55,7 +55,7 @@ jobs:
         -D CMAKE_CXX_COMPILER=clang++
 
     - name: build
-      run: cmake --build build
+      run: cmake --build build -k 0
 
     - name: interface tests
       run: cd build && ctest -L cli --output-on-failure
@@ -120,7 +120,7 @@ jobs:
         -D MRTRIX_WARNINGS_AS_ERRORS=ON
 
     - name: build
-      run: cmake --build build
+      run: cmake --build build -k 0
 
     - name: interface tests
       run: cd build && ctest -L cli --output-on-failure
@@ -181,7 +181,7 @@ jobs:
         -D MRTRIX_WARNINGS_AS_ERRORS=ON
 
     - name: build
-      run: cmake --build build
+      run: cmake --build build -k 0
 
     - name: interface tests
       run: cd build && ctest -L cli --output-on-failure
@@ -260,7 +260,7 @@ jobs:
             -D CMAKE_CXX_COMPILER_LAUNCHER=${{env.SCCACHE_UNIX_PATH}} .
 
       - name: build
-        run: cmake --build build
+        run: cmake --build build -k 0
 
       - name: interface tests
         run: cd build && ctest -L cli --output-on-failure

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -55,7 +55,7 @@ jobs:
         -D CMAKE_CXX_COMPILER=clang++
 
     - name: build
-      run: cmake --build build -k 0
+      run: cmake --build build -- -k 0
 
     - name: interface tests
       run: cd build && ctest -L cli --output-on-failure
@@ -120,7 +120,7 @@ jobs:
         -D MRTRIX_WARNINGS_AS_ERRORS=ON
 
     - name: build
-      run: cmake --build build -k 0
+      run: cmake --build build -- -k 0
 
     - name: interface tests
       run: cd build && ctest -L cli --output-on-failure
@@ -181,7 +181,7 @@ jobs:
         -D MRTRIX_WARNINGS_AS_ERRORS=ON
 
     - name: build
-      run: cmake --build build -k 0
+      run: cmake --build build -- -k 0
 
     - name: interface tests
       run: cd build && ctest -L cli --output-on-failure
@@ -260,7 +260,7 @@ jobs:
             -D CMAKE_CXX_COMPILER_LAUNCHER=${{env.SCCACHE_UNIX_PATH}} .
 
       - name: build
-        run: cmake --build build -k 0
+        run: cmake --build build -- -k 0
 
       - name: interface tests
         run: cd build && ctest -L cli --output-on-failure


### PR DESCRIPTION
In 3.0.x we have `./build -persistent`, which repeatedly re-runs the build process until no processing thread succeeds with a single job. This enables accessing as many compiler error messages from each CI Action as possible, which can be handy when fixing compilation issues that only manifest on specific systems.

For 3.1.0 it looks like something very similar can be achieved with Ninja using `-k 0`.
