### PR TITLE
tck2connectome: Prevent segfault on empty streamlines

### DIFF
--- a/src/dwi/tractography/connectome/tck2nodes.cpp
+++ b/src/dwi/tractography/connectome/tck2nodes.cpp
@@ -31,6 +31,8 @@ namespace Connectome {
 
 node_t Tck2nodes_end_voxels::select_node (const Tractography::Streamline<>& tck, Image<node_t>& v, const bool end) const
 {
+  if (tck.empty())
+    return 0;
   const Eigen::Vector3d p ((end ? tck.back() : tck.front()).cast<default_type>());
   const Eigen::Vector3d v_float (transform->scanner2voxel * p);
   for (size_t axis = 0; axis != 3; ++axis)
@@ -69,6 +71,8 @@ void Tck2nodes_radial::initialise_search ()
 
 node_t Tck2nodes_radial::select_node (const Tractography::Streamline<>& tck, Image<node_t>& v, const bool end) const
 {
+  if (tck.empty())
+    return 0;
   default_type min_dist = max_dist;
   node_t node = 0;
 
@@ -105,6 +109,8 @@ node_t Tck2nodes_radial::select_node (const Tractography::Streamline<>& tck, Ima
 
 node_t Tck2nodes_revsearch::select_node (const Tractography::Streamline<>& tck, Image<node_t>& v, const bool end) const
 {
+  if (tck.size() < 2)
+    return 0;
   const int midpoint_index = end ? (tck.size() / 2) : ((tck.size() + 1) / 2);
   const int start_index    = end ? (tck.size() - 1) : 0;
   const int step           = end ? -1 : 1;
@@ -134,6 +140,8 @@ node_t Tck2nodes_revsearch::select_node (const Tractography::Streamline<>& tck, 
 
 node_t Tck2nodes_forwardsearch::select_node (const Tractography::Streamline<>& tck, Image<node_t>& v, const bool end) const
 {
+  if (tck.size() < 2)
+    return 0;
   // Start by defining the endpoint and the tangent at the endpoint
   const int index = end ? (tck.size() - 1) : 0;
   const int step  = end ? -1 : 1;


### PR DESCRIPTION
Arises from applying a non-linear transformation of streamlines prior to connectome construction, where if a streamline resides entirely outside of the vollume where the deformation field is defined, it may end up with one or zero streamlines in the output tractogram. `tck2connectome` was not adequately protected against this.

I think it should be fine for such streamlines to just be assigned to "the null node". This is no different to a valid streamline that just isn't assigned to a node at either endpoint. There's an argument to be made that "streamlines" with zero or one vertex shouldn't even be assigned to *that*, they should be more explicitly "skipped", but I'm not convinced the argument is strong enough to warrant the investment.