### PR TITLE
fmtlib adoption extension

### DIFF
--- a/cpp/cmd/5ttedit.cpp
+++ b/cpp/cmd/5ttedit.cpp
@@ -200,7 +200,7 @@ bool Modifier::operator()(const Iterator &pos) {
           std::cerr << "User modification values: ";
           for (size_t tissue = 0; tissue != 5; ++tissue) {
             if (buffers[tissue].valid()) {
-              std::cerr << str<float>(buffers[tissue].value()) << " ";
+              std::cerr << fmt::format("{}", static_cast<float>(buffers[tissue].value())) << " ";
             } else {
               std::cerr << "<> ";
             }
@@ -210,8 +210,10 @@ bool Modifier::operator()(const Iterator &pos) {
           for (auto i = Loop(3)(v_out); i; ++i)
             std::cerr << str(v_out.value()) << " ";
           std::cerr << "\n";
-          std::cerr << "sum_user=" << str<float>(sum_user) << "; sum_unmodified=" << str<float>(sum_unmodified)
-                    << "; multiplier=" << str<float>(multiplier) << "\n";
+          std::cerr << fmt::format("sum_user={}; sum_unmodified={}; multiplier={}\n",
+                                   static_cast<float>(sum_user),
+                                   static_cast<float>(sum_unmodified),
+                                   static_cast<float>(multiplier));
         }
 #endif
       }

--- a/cpp/cmd/5ttedit.cpp
+++ b/cpp/cmd/5ttedit.cpp
@@ -192,10 +192,11 @@ bool Modifier::operator()(const Iterator &pos) {
         for (auto i = Loop(3)(v_out); i; ++i)
           sum_result += v_out.value();
         if (MR::abs(sum_result - 1.0) > 1e-5) {
-          std::cerr << "[" << str(pos.index(0)) << "," << str(pos.index(1)) << "," << str(pos.index(2)) << "]\n";
+          std::cerr << "[" << fmt::format("{}", pos.index(0)) << "," << fmt::format("{}", pos.index(1)) << ","
+                    << fmt::format("{}", pos.index(2)) << "]\n";
           std::cerr << "Input image values: ";
           for (auto i = Loop(3)(v_in); i; ++i)
-            std::cerr << str(v_in.value()) << " ";
+            std::cerr << fmt::format("{}", v_in.value()) << " ";
           std::cerr << "\n";
           std::cerr << "User modification values: ";
           for (size_t tissue = 0; tissue != 5; ++tissue) {
@@ -208,7 +209,7 @@ bool Modifier::operator()(const Iterator &pos) {
           std::cerr << "\n";
           std::cerr << "Output image values: ";
           for (auto i = Loop(3)(v_out); i; ++i)
-            std::cerr << str(v_out.value()) << " ";
+            std::cerr << fmt::format("{}", v_out.value()) << " ";
           std::cerr << "\n";
           std::cerr << fmt::format("sum_user={}; sum_unmodified={}; multiplier={}\n",
                                    static_cast<float>(sum_user),

--- a/cpp/cmd/amp2response.cpp
+++ b/cpp/cmd/amp2response.cpp
@@ -379,7 +379,7 @@ void run() {
 
   KeyValues keyvals;
   if (shells) {
-    std::string line = str(static_cast<size_t>(std::round((*shells)[0].get_mean())));
+    std::string line = fmt::format("{}", static_cast<size_t>(std::round((*shells)[0].get_mean())));
     for (size_t i = 1; i != (*shells).count(); ++i)
       line += fmt::format(",{}", static_cast<size_t>(std::round((*shells)[i].get_mean())));
     keyvals["Shells"] = line;

--- a/cpp/cmd/fixelcfestats.cpp
+++ b/cpp/cmd/fixelcfestats.cpp
@@ -351,11 +351,11 @@ void run() {
   }
 
   Header output_header(dynamic_cast<SubjectFixelImport *>(importer[0].get())->header());
-  output_header.keyval()["cfe_dh"] = str(cfe_dh);
-  output_header.keyval()["cfe_e"] = str(cfe_e);
-  output_header.keyval()["cfe_h"] = str(cfe_h);
-  output_header.keyval()["cfe_c"] = str(cfe_c);
-  output_header.keyval()["cfe_legacy"] = str(cfe_legacy);
+  output_header.keyval()["cfe_dh"] = fmt::format("{}", cfe_dh);
+  output_header.keyval()["cfe_e"] = fmt::format("{}", cfe_e);
+  output_header.keyval()["cfe_h"] = fmt::format("{}", cfe_h);
+  output_header.keyval()["cfe_c"] = fmt::format("{}", cfe_c);
+  output_header.keyval()["cfe_legacy"] = fmt::format("{}", cfe_legacy);
 
   measurements_matrix_type data(importer.size(), num_fixels);
   {
@@ -468,14 +468,14 @@ void run() {
   matrix_type empirical_cfe_statistic;
   if (do_nonstationarity_adjustment) {
     Stats::PermTest::precompute_empirical_stat(glm_test, cfe_integrator, empirical_skew, empirical_cfe_statistic);
-    output_header.keyval()["nonstationarity_adjustment"] = str(true);
+    output_header.keyval()["nonstationarity_adjustment"] = fmt::format("{}", true);
     for (Math::Stats::index_type i = 0; i != num_hypotheses; ++i)
       write_fixel_output(output_fixel_directory / fmt::format("cfe_empirical{}.mif", postfix(i)),
                          empirical_cfe_statistic.col(i),
                          mask_processing_image,
                          output_header);
   } else {
-    output_header.keyval()["nonstationarity_adjustment"] = str(false);
+    output_header.keyval()["nonstationarity_adjustment"] = fmt::format("{}", false);
   }
 
   // Precompute default statistic and CFE statistic

--- a/cpp/cmd/fixelcrop.cpp
+++ b/cpp/cmd/fixelcrop.cpp
@@ -77,7 +77,7 @@ void run() {
       total_nfixels--;
   }
 
-  out_index_header.keyval()[Fixel::n_fixels_key] = str(total_nfixels);
+  out_index_header.keyval()[Fixel::n_fixels_key] = fmt::format("{}", total_nfixels);
   auto out_index_image =
       Image<index_type>::create(out_fixel_directory / in_index_header.path().filename(), out_index_header);
 

--- a/cpp/cmd/fixeltransform.cpp
+++ b/cpp/cmd/fixeltransform.cpp
@@ -162,7 +162,7 @@ void run() {
   // Ready to construct output images
   Header output_index_header(warp_header);
   output_index_header.size(3) = 2;
-  output_index_header.keyval()[Fixel::n_fixels_key] = str(nfixels_out);
+  output_index_header.keyval()[Fixel::n_fixels_key] = fmt::format("{}", nfixels_out);
   Image<index_type> output_index_image =                  //
       Image<index_type>::create(output_dir / "index.mif", //
                                 output_index_header);     //

--- a/cpp/cmd/fod2fixel.cpp
+++ b/cpp/cmd/fod2fixel.cpp
@@ -181,7 +181,7 @@ void Segmented_FOD_receiver::commit() {
   std::unique_ptr<DataImage> skew_image;
 
   auto index_header(H);
-  index_header.keyval()[Fixel::n_fixels_key] = str(fixel_count);
+  index_header.keyval()[Fixel::n_fixels_key] = fmt::format("{}", fixel_count);
   index_header.ndim() = 4;
   index_header.size(3) = 2;
   index_header.datatype() = DataType::from<index_type>();

--- a/cpp/cmd/label2colour.cpp
+++ b/cpp/cmd/label2colour.cpp
@@ -88,7 +88,7 @@ void run() {
         colour[1] = dist(rng);
         colour[2] = dist(rng);
       } while (colour.sum() < 100);
-      lut.insert(std::make_pair(i, LUT_node(str(i), colour)));
+      lut.insert(std::make_pair(i, LUT_node(fmt::format("{}", i), colour)));
     }
   }
 

--- a/cpp/cmd/label2mesh.cpp
+++ b/cpp/cmd/label2mesh.cpp
@@ -107,7 +107,7 @@ void run() {
   if (!missing_nodes.empty()) {
     WARN("The following labels are absent from the parcellation image "
          "and so will have an empty mesh in the output file: " +
-         join(missing_nodes, ", "));
+         fmt::format("{}", fmt::join(missing_nodes, ", ")));
   }
 
   {

--- a/cpp/cmd/label2mesh.cpp
+++ b/cpp/cmd/label2mesh.cpp
@@ -120,7 +120,7 @@ void run() {
     };
 
     auto worker = [&](const size_t &in) {
-      meshes[in].set_name(str(in));
+      meshes[in].set_name(fmt::format("{}", in));
       std::vector<int> from, dimensions;
       for (size_t axis = 0; axis != 3; ++axis) {
         from.push_back(lower_corners[in][axis]);

--- a/cpp/cmd/labelvalidate.cpp
+++ b/cpp/cmd/labelvalidate.cpp
@@ -104,7 +104,7 @@ void run() {
     for (size_t i = 0; i < std::min(ngaps, max_listed); ++i) {
       if (i > 0U)
         missing_str += ", ";
-      missing_str += str(result.missing_indices[i]);
+      missing_str += fmt::format("{}", result.missing_indices[i]);
     }
     if (ngaps > max_listed)
       missing_str += fmt::format(", ... (and {} more)", ngaps - max_listed);

--- a/cpp/cmd/mraverageheader.cpp
+++ b/cpp/cmd/mraverageheader.cpp
@@ -66,7 +66,7 @@ void usage() {
                         " (see Description)."
                         " Valid options are: {};"
                         " default = {}",
-                        join(avgspace_voxspacing_choices, ","),
+                        fmt::join(avgspace_voxspacing_choices, ","),
                         SPACING_DEFAULT_STRING))
     + Argument("type").type_choice(avgspace_voxspacing_choices)
   + Option ("fill", "set the intensity in the first volume of the average space to 1")

--- a/cpp/cmd/mrcalc.cpp
+++ b/cpp/cmd/mrcalc.cpp
@@ -664,7 +664,7 @@ std::string operation_string(const StackEntry &entry) {
       replace(s, n, operation_string(entry.evaluator->operands[n]));
     return s;
   } else
-    return str(entry.value);
+    return fmt::format("{}", entry.value);
 }
 
 template <class Operation> class UnaryEvaluator : public Evaluator {

--- a/cpp/cmd/mrclusterstats.cpp
+++ b/cpp/cmd/mrclusterstats.cpp
@@ -320,14 +320,14 @@ void run() {
   Header output_header(mask_header);
   output_header.datatype() = DataType::Float32;
   // output_header.keyval()["num permutations"] = str(num_perms);
-  output_header.keyval()["26 connectivity"] = str(do_26_connectivity);
-  output_header.keyval()["nonstationary adjustment"] = str(do_nonstationarity_adjustment);
+  output_header.keyval()["26 connectivity"] = fmt::format("{}", do_26_connectivity);
+  output_header.keyval()["nonstationary adjustment"] = fmt::format("{}", do_nonstationarity_adjustment);
   if (use_tfce) {
-    output_header.keyval()["tfce_dh"] = str(tfce_dh);
-    output_header.keyval()["tfce_e"] = str(tfce_E);
-    output_header.keyval()["tfce_h"] = str(tfce_H);
+    output_header.keyval()["tfce_dh"] = fmt::format("{}", tfce_dh);
+    output_header.keyval()["tfce_e"] = fmt::format("{}", tfce_E);
+    output_header.keyval()["tfce_h"] = fmt::format("{}", tfce_H);
   } else {
-    output_header.keyval()["threshold"] = str(cluster_forming_threshold);
+    output_header.keyval()["threshold"] = fmt::format("{}", cluster_forming_threshold);
   }
 
   const std::filesystem::path output_dir = argument[3];

--- a/cpp/cmd/mrcolour.cpp
+++ b/cpp/cmd/mrcolour.cpp
@@ -59,7 +59,7 @@ void usage() {
 
   ARGUMENTS
   + Argument ("input",  "the input image").type_image_in()
-  + Argument ("map",    fmt::format("the colourmap to apply; choices are: {}", join(colourmap_choices, ","))).type_choice (colourmap_choices)
+  + Argument ("map",    fmt::format("the colourmap to apply; choices are: {}", fmt::join(colourmap_choices, ","))).type_choice (colourmap_choices)
   + Argument ("output", "the output image").type_image_out();
 
   OPTIONS

--- a/cpp/cmd/mrconvert.cpp
+++ b/cpp/cmd/mrconvert.cpp
@@ -410,7 +410,7 @@ void run() {
   opt = get_options("copy_properties");
   if (!opt.empty()) {
     header_out.keyval().clear();
-    if (str(opt[0][0]) != "NULL") {
+    if (std::string(opt[0][0]) != "NULL") {
       try {
         const Header source = Header::open(opt[0][0]);
         header_out.keyval() = source.keyval();
@@ -426,7 +426,7 @@ void run() {
 
   opt = get_options("clear_property");
   for (size_t n = 0; n < opt.size(); ++n) {
-    if (str(opt[n][0]) == "command_history")
+    if (std::string(opt[n][0]) == "command_history")
       add_to_command_history = false;
     auto entry = header_out.keyval().find(opt[n][0]);
     if (entry == header_out.keyval().end()) {
@@ -440,14 +440,14 @@ void run() {
 
   opt = get_options("set_property");
   for (size_t n = 0; n < opt.size(); ++n) {
-    if (str(opt[n][0]) == "command_history")
+    if (std::string(opt[n][0]) == "command_history")
       add_to_command_history = false;
     header_out.keyval()[std::string(opt[n][0])] = std::string(opt[n][1]);
   }
 
   opt = get_options("append_property");
   for (size_t n = 0; n < opt.size(); ++n) {
-    if (str(opt[n][0]) == "command_history")
+    if (std::string(opt[n][0]) == "command_history")
       add_to_command_history = false;
     add_line(header_out.keyval()[std::string(opt[n][0])], std::string(opt[n][1]));
   }

--- a/cpp/cmd/mrgrid.cpp
+++ b/cpp/cmd/mrgrid.cpp
@@ -423,7 +423,7 @@ void run() {
       const size_t axis = opt[i][0];
       if (axis >= input_header.ndim())
         throw Exception("-axis {} larger than image dimensions ({})", axis, input_header.ndim());
-      std::string spec = str(opt[i][1]);
+      std::string spec = std::string(opt[i][1]);
       std::string::size_type start = 0, end;
       end = spec.find_first_of(":", start);
       if (end == std::string::npos) { // spec = delta_lower,delta_upper

--- a/cpp/cmd/mrhistmatch.cpp
+++ b/cpp/cmd/mrhistmatch.cpp
@@ -135,10 +135,10 @@ void match_linear(Image<float> &input,
   Header H(input);
   H.datatype() = DataType::Float32;
   H.datatype().set_byte_order_native();
-  H.keyval()["mrhistmatch_scale"] = str<float>(parameters[0]);
+  H.keyval()["mrhistmatch_scale"] = fmt::format("{}", static_cast<float>(parameters[0]));
   if (estimate_intercept) {
     CONSOLE("Estimated linear transform is: {}x + {}", parameters[0], parameters[1]);
-    H.keyval()["mrhistmatch_offset"] = str<float>(parameters[1]);
+    H.keyval()["mrhistmatch_offset"] = fmt::format("{}", static_cast<float>(parameters[1]));
     auto output = Image<float>::create(output_path, H);
     for (auto l = Loop("Writing output image data", input)(input, output); l; ++l) {
       if (std::isfinite(static_cast<float>(input.value()))) {

--- a/cpp/cmd/mrinfo.cpp
+++ b/cpp/cmd/mrinfo.cpp
@@ -171,7 +171,7 @@ void print_dimensions(const Header &header) {
   for (size_t i = 0; i < header.ndim(); ++i) {
     if (i)
       buffer += " ";
-    buffer += str(header.size(i));
+    buffer += fmt::format("{}", header.size(i));
   }
   std::cout << buffer << "\n";
 }
@@ -181,7 +181,7 @@ void print_spacing(const Header &header) {
   for (size_t i = 0; i < header.ndim(); ++i) {
     if (i)
       buffer += " ";
-    buffer += str(header.spacing(i));
+    buffer += fmt::format("{}", header.spacing(i));
   }
   std::cout << buffer << "\n";
 }
@@ -193,7 +193,7 @@ void print_strides(const Header &header) {
   for (size_t i = 0; i < header.ndim(); ++i) {
     if (i)
       buffer += " ";
-    buffer += strides[i] == 0 ? "?" : str(strides[i]);
+    buffer += strides[i] == 0 ? "?" : fmt::format("{}", strides[i]);
   }
   std::cout << buffer << "\n";
 }

--- a/cpp/cmd/mrinfo.cpp
+++ b/cpp/cmd/mrinfo.cpp
@@ -215,7 +215,7 @@ void print_shells(const Eigen::MatrixXd &grad,
   }
   if (shell_indices) {
     for (size_t i = 0; i < dwshells.count(); i++)
-      std::cout << join(dwshells[i].get_volumes(), ",") + " ";
+      std::cout << fmt::format("{}", fmt::join(dwshells[i].get_volumes(), ",")) + " ";
     std::cout << "\n";
   }
 }

--- a/cpp/cmd/mrmetric.cpp
+++ b/cpp/cmd/mrmetric.cpp
@@ -486,9 +486,9 @@ void run() {
 
   if (normalisation)
     sos.array() /= static_cast<value_type>(n_voxels);
-  std::cout << str(sos.transpose());
+  std::cout << fmt::format("{}", sos.transpose());
 
   if (!get_options("overlap").empty())
-    std::cout << " " << str(n_voxels);
+    std::cout << " " << fmt::format("{}", n_voxels);
   std::cout << std::endl;
 }

--- a/cpp/cmd/mrstats.cpp
+++ b/cpp/cmd/mrstats.cpp
@@ -53,9 +53,9 @@ void usage() {
 using value_type = Stats::value_type;
 using complex_type = Stats::complex_type;
 
-class Volume_loop {
+template <typename T> class Volume_loop {
 public:
-  Volume_loop(Image<complex_type> &in) : image(in), is_4D(in.ndim() == 4), status(true) {
+  Volume_loop(Image<T> &in) : image(in), is_4D(in.ndim() == 4), status(true) {
     if (is_4D)
       image.index(3) = 0;
   }
@@ -76,12 +76,12 @@ public:
   }
 
 private:
-  Image<complex_type> &image;
+  Image<T> &image;
   const bool is_4D;
   bool status;
 };
 
-void run_volume(Stats::Stats &stats, Image<complex_type> &data, Image<bool> &mask) {
+template <typename T> void run_volume(Stats::Stats<T> &stats, Image<T> &data, Image<bool> &mask) {
   if (mask.valid()) {
     for (auto l = Loop(0, 3)(data, mask); l; ++l) {
       if (mask.value())
@@ -93,12 +93,8 @@ void run_volume(Stats::Stats &stats, Image<complex_type> &data, Image<bool> &mas
   }
 }
 
-void run() {
-  auto header = Header::open(argument[0]);
-  if (header.ndim() > 4)
-    throw Exception("mrstats is not designed to handle images greater than 4D");
-  const bool is_complex = header.datatype().is_complex();
-  auto data = header.get_image<complex_type>();
+template <typename T> void run_impl(Header &header) {
+  auto data = header.get_image<T>();
   const bool ignorezero = !get_options("ignorezero").empty();
 
   auto opt = get_options("mask");
@@ -114,18 +110,28 @@ void run() {
     fields.push_back(opt[n][0]);
 
   if (App::log_level && fields.empty())
-    Stats::print_header(is_complex);
+    Stats::print_header<T>();
 
   if (get_options("allvolumes").empty()) {
-    for (auto i = Volume_loop(data); i; ++i) {
-      Stats::Stats stats(is_complex, ignorezero);
-      run_volume(stats, data, mask);
+    for (auto i = Volume_loop<T>(data); i; ++i) {
+      Stats::Stats<T> stats(ignorezero);
+      run_volume<T>(stats, data, mask);
       stats.print(data, fields);
     }
   } else {
-    Stats::Stats stats(is_complex, ignorezero);
-    for (auto i = Volume_loop(data); i; ++i)
-      run_volume(stats, data, mask);
+    Stats::Stats<T> stats(ignorezero);
+    for (auto i = Volume_loop<T>(data); i; ++i)
+      run_volume<T>(stats, data, mask);
     stats.print(data, fields);
   }
+}
+
+void run() {
+  auto header = Header::open(argument[0]);
+  if (header.ndim() > 4)
+    throw Exception("mrstats is not designed to handle images greater than 4D");
+  if (header.datatype().is_complex())
+    run_impl<complex_type>(header);
+  else
+    run_impl<value_type>(header);
 }

--- a/cpp/cmd/mtnormalise.cpp
+++ b/cpp/cmd/mtnormalise.cpp
@@ -454,9 +454,9 @@ void write_output(const std::filesystem::path &original,
   auto in = ImageType::open(original);
   Header header(in);
   header.datatype() = DataType::Float32;
-  header.keyval()["lognorm_scale"] = str(lognorm_scale);
+  header.keyval()["lognorm_scale"] = fmt::format("{}", lognorm_scale);
   if (output_balanced)
-    header.keyval()["lognorm_balance"] = str(balance_factor);
+    header.keyval()["lognorm_balance"] = fmt::format("{}", balance_factor);
   else
     balance_factor = 1.0;
   auto out = ImageType::create(corrected, header);

--- a/cpp/cmd/peaks2fixel.cpp
+++ b/cpp/cmd/peaks2fixel.cpp
@@ -110,7 +110,7 @@ void run() {
   index_header.datatype() = DataType::UInt32;
   index_header.datatype().set_byte_order_native();
   index_header.size(3) = 2;
-  index_header.keyval()[Fixel::n_fixels_key] = str(nfixels);
+  index_header.keyval()[Fixel::n_fixels_key] = fmt::format("{}", nfixels);
   auto index_image = Image<uint32_t>::create(index_path, index_header);
 
   Header directions_header = Fixel::directions_header_from_index(index_header);

--- a/cpp/cmd/tckconvert.cpp
+++ b/cpp/cmd/tckconvert.cpp
@@ -190,7 +190,7 @@ public:
 
       // write back total number of points:
       VTKout.seekp(offset_num_points);
-      std::string num_points(str(current_index));
+      std::string num_points(fmt::format("{}", current_index));
       num_points.resize(10, ' ');
       VTKout.write(num_points.c_str(), 10);
 

--- a/cpp/cmd/tckdfc.cpp
+++ b/cpp/cmd/tckdfc.cpp
@@ -121,7 +121,7 @@ void usage () {
       fmt::format("define the statistic for choosing the final voxel intensities"
                   " for a given contrast type given the individual values"
                   " from the tracks passing through each voxel;"
-                  " options are: {} (default: mean)", join(voxel_statistics, ", ")))
+                  " options are: {} (default: mean)", fmt::join(voxel_statistics, ", ")))
     + Argument ("type").type_choice(voxel_statistics)
 
   + OptionGroup ("Other options for affecting the streamline sampling & mapping behaviour")

--- a/cpp/cmd/tckgen.cpp
+++ b/cpp/cmd/tckgen.cpp
@@ -276,12 +276,12 @@ void run() {
     if (!properties["max_num_tracks"].empty())
       WARN("Overriding -select option (desired number of successful streamline selections), as seeds can only provide "
            "a finite number");
-    properties["max_num_tracks"] = str(properties.seeds.get_total_count());
+    properties["max_num_tracks"] = fmt::format("{}", properties.seeds.get_total_count());
 
     if (!properties["max_num_seeds"].empty())
       WARN("Overriding -seeds option (maximum number of seeds that will be attempted to track from), as seeds can only "
            "provide a finite number");
-    properties["max_num_seeds"] = str(properties.seeds.get_total_count());
+    properties["max_num_seeds"] = fmt::format("{}", properties.seeds.get_total_count());
   }
 
   switch (algorithm) {

--- a/cpp/cmd/tckmap.cpp
+++ b/cpp/cmd/tckmap.cpp
@@ -77,7 +77,7 @@ const OptionGroup OutputDimOption = OptionGroup ("Options for the dimensionality
 const OptionGroup TWIOption = OptionGroup ("Options for the TWI image contrast properties")
   + Option ("contrast",
       fmt::format("define the desired form of contrast for the output image;"
-                  " options are: {} (default: tdi)", join(contrasts, ", ")))
+                  " options are: {} (default: tdi)", fmt::join(contrasts, ", ")))
     + Argument ("type").type_choice(contrasts)
   + Option ("image",
       "provide the scalar image map for generating images with 'scalar_map' / 'scalar_map_count' contrast,"
@@ -89,13 +89,13 @@ const OptionGroup TWIOption = OptionGroup ("Options for the TWI image contrast p
   + Option ("stat_vox",
       fmt::format("define the statistic for choosing the final voxel intensities for a given contrast type"
                   " given the individual values from the tracks passing through each voxel."
-                  " Options are: {} (default: sum)", join(voxel_statistics, ", ")))
+                  " Options are: {} (default: sum)", fmt::join(voxel_statistics, ", ")))
     + Argument ("type").type_choice(voxel_statistics)
   + Option ("stat_tck",
       fmt::format("define the statistic for choosing the contribution to be made by each streamline"
                   " as a function of the samples taken along their lengths."
                   " Only has an effect for 'scalar_map', 'fod_amp' and 'curvature' contrast types."
-                  " Options are: {} (default: mean)", join(track_statistics, ", ")))
+                  " Options are: {} (default: mean)", fmt::join(track_statistics, ", ")))
     + Argument ("type").type_choice(track_statistics)
   + Option ("fwhm_tck",
       "when using gaussian-smoothed per-track statistic,"

--- a/cpp/cmd/tckstats.cpp
+++ b/cpp/cmd/tckstats.cpp
@@ -242,7 +242,7 @@ void run() {
     } else {
       out << "Length,Count\n";
       for (size_t i = 0; i != histogram.size(); ++i)
-        out << str(i * step_size) << "," << str<size_t>(histogram[i]) << "\n";
+        out << str(i * step_size) << "," << fmt::format("{}", static_cast<size_t>(histogram[i])) << "\n";
     }
     out << "\n";
   }

--- a/cpp/cmd/tckstats.cpp
+++ b/cpp/cmd/tckstats.cpp
@@ -198,15 +198,15 @@ void run() {
 
     for (size_t n = 0; n < fields.size(); ++n) {
       if (fields[n] == FieldChoice::MEAN)
-        std::cout << str(mean_length) << " ";
+        std::cout << fmt::format("{}", mean_length) << " ";
       else if (fields[n] == FieldChoice::MEDIAN)
-        std::cout << str(median_length) << " ";
+        std::cout << fmt::format("{}", median_length) << " ";
       else if (fields[n] == FieldChoice::STD)
-        std::cout << str(stdev) << " ";
+        std::cout << fmt::format("{}", stdev) << " ";
       else if (fields[n] == FieldChoice::MIN)
-        std::cout << str(min_length) << " ";
+        std::cout << fmt::format("{}", min_length) << " ";
       else if (fields[n] == FieldChoice::MAX)
-        std::cout << str(max_length) << " ";
+        std::cout << fmt::format("{}", max_length) << " ";
       else if (fields[n] == FieldChoice::COUNT)
         std::cout << count << " ";
     }
@@ -238,11 +238,11 @@ void run() {
     if (weights_provided) {
       out << "Length,Sum_weights\n";
       for (size_t i = 0; i != histogram.size(); ++i)
-        out << str(i * step_size) << "," << str(histogram[i]) << "\n";
+        out << fmt::format("{}", i * step_size) << "," << fmt::format("{}", histogram[i]) << "\n";
     } else {
       out << "Length,Count\n";
       for (size_t i = 0; i != histogram.size(); ++i)
-        out << str(i * step_size) << "," << fmt::format("{}", static_cast<size_t>(histogram[i])) << "\n";
+        out << fmt::format("{}", i * step_size) << "," << fmt::format("{}", static_cast<size_t>(histogram[i])) << "\n";
     }
     out << "\n";
   }

--- a/cpp/cmd/transformcalc.cpp
+++ b/cpp/cmd/transformcalc.cpp
@@ -321,7 +321,7 @@ void run() {
     out << "S: " << S.row(0).format(fmt);
     out << "S: " << S.row(1).format(fmt);
     out << "S: " << S.row(2).format(fmt);
-    out << "jacobian_det: " << str(transform.linear().topLeftCorner<3, 3>().determinant()) << "\n";
+    out << "jacobian_det: " << fmt::format("{}", transform.linear().topLeftCorner<3, 3>().determinant()) << "\n";
 
     break;
   }

--- a/cpp/cmd/warpvalidate.cpp
+++ b/cpp/cmd/warpvalidate.cpp
@@ -96,5 +96,6 @@ void run() {
           result.format == WarpFormat::Simple ? "simple (displacement or deformation) field" : "full warp field");
 
   CONSOLE("Fill value: {}",
-          result.fill_value.has_value() ? str(result.fill_value.value()) : "not auto-detected from input data");
+          result.fill_value.has_value() ? fmt::format("{}", result.fill_value.value())
+                                        : "not auto-detected from input data");
 }

--- a/cpp/core/CMakeLists.txt
+++ b/cpp/core/CMakeLists.txt
@@ -1,4 +1,5 @@
 include(CheckSymbolExists)
+include(CheckCXXSourceCompiles)
 find_package(ZLIB REQUIRED)
 find_package(FFTW REQUIRED)
 find_package(Git QUIET)
@@ -17,6 +18,53 @@ list(REMOVE_AT CMAKE_REQUIRED_DEFINITIONS -1)
 
 if(NOT MRTRIX_HAVE_LGAMMA_R)
     message(STATUS "No lgamma_r() function found; statistical inference may have poorer multi-threading performance")
+endif()
+
+# Check support for std::from_chars across every type MR::to<T>() is instantiated with.
+# Integer support has been ubiquitous since C++17; floating-point support landed late in
+# libc++ and in some libstdc++ versions, so probe both paths separately. When either probe
+# fails, MR::to<>() falls back to the historical std::istringstream implementation for the
+# unsupported family.
+set(CMAKE_REQUIRED_FLAGS "${CMAKE_CXX17_STANDARD_COMPILE_OPTION}")
+check_cxx_source_compiles("
+#include <charconv>
+#include <cstddef>
+int main() {
+    const char* s = \"42\";
+    int i = 0;
+    auto r1 = std::from_chars(s, s + 2, i);
+    long l = 0;
+    auto r2 = std::from_chars(s, s + 2, l);
+    long long ll = 0;
+    auto r3 = std::from_chars(s, s + 2, ll);
+    unsigned u = 0;
+    auto r4 = std::from_chars(s, s + 2, u);
+    unsigned long ul = 0;
+    auto r5 = std::from_chars(s, s + 2, ul);
+    unsigned long long ull = 0;
+    auto r6 = std::from_chars(s, s + 2, ull);
+    return r1.ec == std::errc{} && r2.ec == std::errc{} && r3.ec == std::errc{} &&
+           r4.ec == std::errc{} && r5.ec == std::errc{} && r6.ec == std::errc{} ? 0 : 1;
+}
+" MRTRIX_HAVE_FROM_CHARS_INT)
+check_cxx_source_compiles("
+#include <charconv>
+int main() {
+    const char* s = \"1.5\";
+    float f = 0;
+    auto r1 = std::from_chars(s, s + 3, f);
+    double d = 0;
+    auto r2 = std::from_chars(s, s + 3, d);
+    return r1.ec == std::errc{} && r2.ec == std::errc{} ? 0 : 1;
+}
+" MRTRIX_HAVE_FROM_CHARS_FP)
+unset(CMAKE_REQUIRED_FLAGS)
+
+if(NOT MRTRIX_HAVE_FROM_CHARS_INT)
+    message(STATUS "std::from_chars not available for integer types; MR::to<int>() will use std::istringstream fallback")
+endif()
+if(NOT MRTRIX_HAVE_FROM_CHARS_FP)
+    message(STATUS "std::from_chars not available for floating-point types; MR::to<float|double>() will use std::istringstream fallback")
 endif()
 
 file(GLOB_RECURSE HEADLESS_SOURCES *.h *.cpp)
@@ -104,6 +152,8 @@ endif()
 target_compile_definitions(mrtrix-core PUBLIC
     MRTRIX_BASE_VERSION="${MRTRIX_BASE_VERSION}"
     $<$<BOOL:${MRTRIX_HAVE_LGAMMA_R}>:MRTRIX_HAVE_LGAMMA_R>
+    $<$<BOOL:${MRTRIX_HAVE_FROM_CHARS_INT}>:MRTRIX_HAVE_FROM_CHARS_INT>
+    $<$<BOOL:${MRTRIX_HAVE_FROM_CHARS_FP}>:MRTRIX_HAVE_FROM_CHARS_FP>
 )
 
 if(APPLE AND MRTRIX_HAVE_LGAMMA_R)

--- a/cpp/core/app.cpp
+++ b/cpp/core/app.cpp
@@ -986,7 +986,7 @@ void parse() {
         }
       }
       if (!potential_options.empty())
-        e.push_back("(Did you mean {}?)", join(potential_options, " or "));
+        e.push_back("(Did you mean {}?)", fmt::join(potential_options, " or "));
     }
     throw e;
   }
@@ -1305,7 +1305,7 @@ int64_t App::ParsedArgument::as_int() const {
         msg += fmt::format("argument \"{}", arg->id);
       msg += "\" ";
       as_choice_msg = fmt::format("received \"{}\"; ", p);
-      as_choice_msg += fmt::format("valid choices are: {}", join(arg->choices, ", "));
+      as_choice_msg += fmt::format("valid choices are: {}", fmt::join(arg->choices, ", "));
       msg += fmt::format("({})", as_choice_msg);
       if (!arg->types[ArgTypeFlags::Integer])
         throw Exception(msg);

--- a/cpp/core/datatype.cpp
+++ b/cpp/core/datatype.cpp
@@ -254,7 +254,7 @@ const std::unordered_map<uint8_t, DataType::Strings> DataType::dt2str{
 App::OptionGroup DataType::options() {
   using namespace App;
   return OptionGroup("Data type options")
-         + Option("datatype", fmt::format("specify output image data type. Valid choices are: {}.", join(identifiers, ", ")))
+         + Option("datatype", fmt::format("specify output image data type. Valid choices are: {}.", fmt::join(identifiers, ", ")))
           + Argument("spec").type_choice(identifiers);
 }
 // clang-format on

--- a/cpp/core/debug.h
+++ b/cpp/core/debug.h
@@ -49,7 +49,7 @@ extern std::string NAME;
   {                                                                                                                    \
     std::cerr << MR::App::NAME << " [" << __FILE__ << ": " << __LINE__ << "]: " << #variable << " = ";                 \
     for (ssize_t i = 0; i < variable.size(); ++i) {                                                                    \
-      std::cerr << str(variable(i)) << " ";                                                                            \
+      std::cerr << fmt::format("{}", variable(i)) << " ";                                                              \
     }                                                                                                                  \
     std::cerr << std::endl;                                                                                            \
   }

--- a/cpp/core/doc/newcommand.md
+++ b/cpp/core/doc/newcommand.md
@@ -178,8 +178,7 @@ void read_file (const std::string& filename, int64_t offset)
 
   in.seekg (offset);
   if (!in.good())
-    throw Exception ("error seeking to offset " + str(offset)
-       + " in file \"" + filename + "\": " + strerror (errno));
+    throw Exception ("error seeking to offset {} in file \"{}\": {}", offset, filename, strerror (errno));
   ...
   // do something useful
   ...

--- a/cpp/core/dwi/tractography/SIFT/output.h
+++ b/cpp/core/dwi/tractography/SIFT/output.h
@@ -209,8 +209,8 @@ template <class Fixel> void ModelBase<Fixel>::output_scatterplot(const std::file
   out << "#Fibre density,Track density (unscaled),Track density (scaled),Weight,\n";
   typename std::vector<Fixel>::const_iterator i = fixels.begin(); // Skip first null fixel in DWI::Fixel_map<>
   for (++i; i != fixels.end(); ++i)
-    out << str(i->get_FOD()) << "," << str(i->get_TD()) << "," << str(i->get_TD() * current_mu) << ","
-        << str(i->get_weight()) << ",\n";
+    out << fmt::format("{}", i->get_FOD()) << "," << fmt::format("{}", i->get_TD()) << ","
+        << fmt::format("{}", i->get_TD() * current_mu) << "," << fmt::format("{}", i->get_weight()) << ",\n";
   out.close();
 }
 

--- a/cpp/core/dwi/tractography/SIFT/sifter.cpp
+++ b/cpp/core/dwi/tractography/SIFT/sifter.cpp
@@ -89,11 +89,11 @@ void SIFTer::perform_filtering() {
   }
 
   auto display_func = [&]() {
-    return printf(" %6u      %7u     %9u       %.2f%%",
-                  iteration,
-                  removed_this_iteration,
-                  tracks_remaining,
-                  100.0 * cf_end_iteration / init_cf);
+    return fmt::format(" {:6}      {:7}     {:9}       {:.2f}%",
+                       iteration,
+                       removed_this_iteration,
+                       tracks_remaining,
+                       100.0 * cf_end_iteration / init_cf);
   };
   CONSOLE("       Iteration     Removed     Remaining     Cost fn");
   ProgressBar progress("");

--- a/cpp/core/dwi/tractography/SIFT/sifter.cpp
+++ b/cpp/core/dwi/tractography/SIFT/sifter.cpp
@@ -84,8 +84,8 @@ void SIFTer::perform_filtering() {
     File::OFStream csv_out(csv_path, std::ios_base::out | std::ios_base::trunc);
     csv_out << "# " << App::command_history_string << "\n";
     csv_out << "#Iteration,Removed this iteration,Total removed,Remaining,Cost,TD,Mu,Recalculation,\n";
-    csv_out << "0,0,0," << str(tracks_remaining) << "," << str(init_cf) << "," << str(TD_sum) << "," << str(mu())
-            << ",Start,\n";
+    csv_out << "0,0,0," << fmt::format("{}", tracks_remaining) << "," << fmt::format("{}", init_cf) << ","
+            << fmt::format("{}", TD_sum) << "," << fmt::format("{}", mu()) << ",Start,\n";
   }
 
   auto display_func = [&]() {
@@ -140,7 +140,7 @@ void SIFTer::perform_filtering() {
     do {
 
       if (!output_at_counts.empty() && (tracks_remaining == output_at_counts.back())) {
-        const std::string prefix = str(tracks_remaining);
+        const std::string prefix = fmt::format("{}", tracks_remaining);
         if (App::log_level)
           fprintf(stderr, "\n");
         output_filtered_tracks(tck_file_path, prefix + "_tracks.tck");
@@ -283,9 +283,10 @@ void SIFTer::perform_filtering() {
 
     if (!csv_path.empty()) {
       File::OFStream csv_out(csv_path, std::ios_base::out | std::ios_base::app | std::ios_base::ate);
-      csv_out << str(iteration) << "," << str(removed_this_iteration) << "," << str(num_tracks() - tracks_remaining)
-              << "," << str(tracks_remaining) << "," << str(cf_end_iteration) << "," << str(TD_sum) << "," << str(mu())
-              << ",";
+      csv_out << fmt::format("{}", iteration) << "," << fmt::format("{}", removed_this_iteration) << ","
+              << fmt::format("{}", num_tracks() - tracks_remaining) << "," << fmt::format("{}", tracks_remaining) << ","
+              << fmt::format("{}", cf_end_iteration) << "," << fmt::format("{}", TD_sum) << ","
+              << fmt::format("{}", mu()) << ",";
       switch (recalculate) {
       case UNDEFINED:
         throw Exception("Encountered undefined recalculation at end of iteration!");
@@ -349,7 +350,7 @@ void SIFTer::output_filtered_tracks(const std::filesystem::path &input_path,
                                     const std::filesystem::path &output_path) const {
   Tractography::Properties p;
   Tractography::Reader<float> reader(input_path, p);
-  p["SIFT_mu"] = str(mu());
+  p["SIFT_mu"] = fmt::format("{}", mu());
   Tractography::Writer<float> writer(output_path, p);
   track_t tck_counter = 0;
   Tractography::Streamline<> tck;

--- a/cpp/core/dwi/tractography/SIFT2/tckfactor.cpp
+++ b/cpp/core/dwi/tractography/SIFT2/tckfactor.cpp
@@ -206,11 +206,11 @@ void TckFactor::estimate_factors() {
   unsigned int iter = 0;
 
   auto display_func = [&]() {
-    return printf("    %5u        %3.3f%%         %2.3f%%        %u",
-                  iter,
-                  100.0 * cf_data / init_cf,
-                  100.0 * cf_reg / init_cf,
-                  nonzero_streamlines);
+    return fmt::format("    {:5}        {:3.3f}%         {:2.3f}%        {}",
+                       iter,
+                       100.0 * cf_data / init_cf,
+                       100.0 * cf_reg / init_cf,
+                       nonzero_streamlines);
   };
   CONSOLE("         Iteration     CF (data)       CF (reg)    Streamlines");
   ProgressBar progress("");

--- a/cpp/core/dwi/tractography/SIFT2/tckfactor.cpp
+++ b/cpp/core/dwi/tractography/SIFT2/tckfactor.cpp
@@ -117,7 +117,7 @@ void TckFactor::test_streamline_length_scaling() {
   for (int i = -1000; i != 1000; ++i) {
     const double factor = std::pow(10.0, static_cast<double>(i) / 1000.0);
     TD_sum = factor * actual_TD_sum;
-    out << str(factor) << "," << str(calc_cost_function()) << "\n";
+    out << fmt::format("{}", factor) << "," << fmt::format("{}", calc_cost_function()) << "\n";
   }
   out << "\n";
   out.close();
@@ -311,14 +311,18 @@ void TckFactor::estimate_factors() {
     new_cf = cf_data + cf_reg;
 
     if (!csv_path.empty()) {
-      (*csv_out) << str(iter) << "," << str(cf_data) << "," << str(cf_reg_tik) << "," << str(cf_reg_tv) << ","
-                 << str(cf_reg) << "," << str(new_cf) << "," << str(nonzero_streamlines) << "," << str(total_excluded)
-                 << "," << str(step_stats.get_min()) << "," << str(step_stats.get_mean()) << ","
-                 << str(step_stats.get_mean_abs()) << "," << str(step_stats.get_var()) << ","
-                 << str(step_stats.get_max()) << "," << str(coefficient_stats.get_min()) << ","
-                 << str(coefficient_stats.get_mean()) << "," << str(coefficient_stats.get_mean_abs()) << ","
-                 << str(coefficient_stats.get_var()) << "," << str(coefficient_stats.get_max()) << ","
-                 << str(coefficient_stats.get_var() * (num_tracks() - 1)) << ",\n";
+      (*csv_out) << fmt::format("{}", iter) << "," << fmt::format("{}", cf_data) << "," << fmt::format("{}", cf_reg_tik)
+                 << "," << fmt::format("{}", cf_reg_tv) << "," << fmt::format("{}", cf_reg) << ","
+                 << fmt::format("{}", new_cf) << "," << fmt::format("{}", nonzero_streamlines) << ","
+                 << fmt::format("{}", total_excluded) << "," << fmt::format("{}", step_stats.get_min()) << ","
+                 << fmt::format("{}", step_stats.get_mean()) << "," << fmt::format("{}", step_stats.get_mean_abs())
+                 << "," << fmt::format("{}", step_stats.get_var()) << "," << fmt::format("{}", step_stats.get_max())
+                 << "," << fmt::format("{}", coefficient_stats.get_min()) << ","
+                 << fmt::format("{}", coefficient_stats.get_mean()) << ","
+                 << fmt::format("{}", coefficient_stats.get_mean_abs()) << ","
+                 << fmt::format("{}", coefficient_stats.get_var()) << ","
+                 << fmt::format("{}", coefficient_stats.get_max()) << ","
+                 << fmt::format("{}", coefficient_stats.get_var() * (num_tracks() - 1)) << ",\n";
       csv_out->flush();
     }
 

--- a/cpp/core/dwi/tractography/algorithms/iFOD1.cpp
+++ b/cpp/core/dwi/tractography/algorithms/iFOD1.cpp
@@ -31,7 +31,7 @@ const OptionGroup iFODOptions =
 void load_iFOD_options(Tractography::Properties &properties) {
   auto opt = get_options("power");
   if (!opt.empty())
-    properties["fod_power"] = str<float>(opt[0][0]);
+    properties["fod_power"] = fmt::format("{}", static_cast<float>(opt[0][0]));
 }
 
 } // namespace MR::DWI::Tractography::Algorithms

--- a/cpp/core/dwi/tractography/algorithms/iFOD2.cpp
+++ b/cpp/core/dwi/tractography/algorithms/iFOD2.cpp
@@ -32,7 +32,7 @@ const OptionGroup iFOD2Options =
 void load_iFOD2_options(Tractography::Properties &properties) {
   auto opt = get_options("samples");
   if (!opt.empty())
-    properties["samples_per_step"] = str<unsigned int>(opt[0][0]);
+    properties["samples_per_step"] = fmt::format("{}", static_cast<unsigned int>(opt[0][0]));
 }
 
 } // namespace MR::DWI::Tractography::Algorithms

--- a/cpp/core/dwi/tractography/connectome/extract.cpp
+++ b/cpp/core/dwi/tractography/connectome/extract.cpp
@@ -132,7 +132,7 @@ void WriterExemplars::write(const node_t one,
                             const std::filesystem::path &path,
                             const std::optional<std::filesystem::path> &weights_path = std::nullopt) {
   Tractography::Properties properties;
-  properties["step_size"] = str(step_size);
+  properties["step_size"] = fmt::format("{}", step_size);
   Tractography::WriterUnbuffered<float> writer(path, properties);
   for (size_t i = 0; i != exemplars.size(); ++i) {
     if (selectors[i](one, two))
@@ -144,7 +144,7 @@ void WriterExemplars::write(const node_t one,
     File::OFStream output(weights_path.value());
     for (size_t i = 0; i != exemplars.size(); ++i) {
       if (selectors[i](one, two))
-        output << str(exemplars[i].get_weight()) << "\n";
+        output << fmt::format("{}", exemplars[i].get_weight()) << "\n";
     }
   }
 }
@@ -153,7 +153,7 @@ void WriterExemplars::write(const node_t node,
                             const std::filesystem::path &path,
                             const std::optional<std::filesystem::path> &weights_path = std::nullopt) {
   Tractography::Properties properties;
-  properties["step_size"] = str(step_size);
+  properties["step_size"] = fmt::format("{}", step_size);
   Tractography::Writer<float> writer(path, properties);
   for (size_t i = 0; i != exemplars.size(); ++i) {
     if (selectors[i](node))
@@ -165,7 +165,7 @@ void WriterExemplars::write(const node_t node,
     File::OFStream output(weights_path.value());
     for (size_t i = 0; i != exemplars.size(); ++i) {
       if (selectors[i](node))
-        output << str(exemplars[i].get_weight()) << "\n";
+        output << fmt::format("{}", exemplars[i].get_weight()) << "\n";
     }
   }
 }
@@ -173,14 +173,14 @@ void WriterExemplars::write(const node_t node,
 void WriterExemplars::write(const std::filesystem::path &path,
                             const std::optional<std::filesystem::path> &weights_path = std::nullopt) {
   Tractography::Properties properties;
-  properties["step_size"] = str(step_size);
+  properties["step_size"] = fmt::format("{}", step_size);
   Tractography::Writer<float> writer(path, properties);
   for (std::vector<Exemplar>::const_iterator i = exemplars.begin(); i != exemplars.end(); ++i)
     writer(i->get());
   if (weights_path.has_value()) {
     File::OFStream output(weights_path.value());
     for (std::vector<Exemplar>::const_iterator i = exemplars.begin(); i != exemplars.end(); ++i)
-      output << str(i->get_weight()) << "\n";
+      output << fmt::format("{}", i->get_weight()) << "\n";
   }
 }
 

--- a/cpp/core/dwi/tractography/connectome/matrix.cpp
+++ b/cpp/core/dwi/tractography/connectome/matrix.cpp
@@ -160,7 +160,7 @@ template <typename T> void Matrix<T>::error_check(const std::vector<node_t> &mis
   std::vector<std::string> empty_nodes;
   for (node_t i = 1; i != visited.size(); ++i) {
     if (!visited[i] && std::find(missing_nodes.begin(), missing_nodes.end(), i) == missing_nodes.end())
-      empty_nodes.push_back(str(i));
+      empty_nodes.push_back(fmt::format("{}", i));
   }
   if (!empty_nodes.empty()) {
     WARN("The following nodes present in the parcellation do not have any streamlines assigned:");
@@ -175,14 +175,14 @@ template <typename T> void Matrix<T>::write_assignments(const std::filesystem::p
   File::OFStream stream(path);
   stream << "# " << App::command_history_string << "\n";
   for (auto i = assignments_single.begin(); i != assignments_single.end(); ++i)
-    stream << str(*i) << "\n";
+    stream << fmt::format("{}", *i) << "\n";
   for (auto i = assignments_pairs.begin(); i != assignments_pairs.end(); ++i)
-    stream << str(i->first) << " " << str(i->second) << "\n";
+    stream << fmt::format("{}", i->first) << " " << fmt::format("{}", i->second) << "\n";
   for (auto i = assignments_lists.begin(); i != assignments_lists.end(); ++i) {
     assert(i->size());
-    stream << str((*i)[0]);
+    stream << fmt::format("{}", (*i)[0]);
     for (size_t j = 1; j != i->size(); ++j)
-      stream << " " << str((*i)[j]);
+      stream << " " << fmt::format("{}", (*i)[j]);
     stream << "\n";
   }
 }

--- a/cpp/core/dwi/tractography/connectome/matrix.cpp
+++ b/cpp/core/dwi/tractography/connectome/matrix.cpp
@@ -31,7 +31,7 @@ const App::Option EdgeStatisticOption
                   "statistic for combining the values from all streamlines in an edge "
                   "into a single scale value for that edge "
                   "(options are: " +
-                      join(statistics, ",") + "; default=sum)") +
+                      fmt::format("{}", fmt::join(statistics, ",")) + "; default=sum)") +
       App::Argument("statistic").type_choice(statistics);
 
 template <typename T> bool Matrix<T>::operator()(const Mapped_track_nodepair &in) {
@@ -164,7 +164,7 @@ template <typename T> void Matrix<T>::error_check(const std::vector<node_t> &mis
   }
   if (!empty_nodes.empty()) {
     WARN("The following nodes present in the parcellation do not have any streamlines assigned:");
-    WARN(join(empty_nodes, ", "));
+    WARN("{}", fmt::join(empty_nodes, ", "));
     WARN("(This may indicate a poor registration)");
   }
 }

--- a/cpp/core/dwi/tractography/editing/editing.cpp
+++ b/cpp/core/dwi/tractography/editing/editing.cpp
@@ -59,7 +59,7 @@ void load_properties(Tractography::Properties &properties) {
     } else {
       try {
         const float maxlength = std::min(static_cast<float>(opt[0][0]), to<float>(properties["max_dist"]));
-        properties["max_dist"] = str(maxlength);
+        properties["max_dist"] = fmt::format("{}", maxlength);
       } catch (...) {
         properties["max_dist"] = static_cast<std::string>(opt[0][0]);
       }
@@ -72,7 +72,7 @@ void load_properties(Tractography::Properties &properties) {
     } else {
       try {
         const float minlength = std::max(static_cast<float>(opt[0][0]), to<float>(properties["min_dist"]));
-        properties["min_dist"] = str(minlength);
+        properties["min_dist"] = fmt::format("{}", minlength);
       } catch (...) {
         properties["min_dist"] = static_cast<std::string>(opt[0][0]);
       }

--- a/cpp/core/dwi/tractography/editing/receiver.cpp
+++ b/cpp/core/dwi/tractography/editing/receiver.cpp
@@ -20,8 +20,8 @@ namespace MR::DWI::Tractography::Editing {
 
 bool Receiver::operator()(const Streamline<> &in) {
   auto display_func = [&]() {
-    return (printf("%8" PRIu64 " read, %8" PRIu64 " written", total_count, count) +
-            (crop ? printf(", %8" PRIu64 " segments", segments) : ""));
+    return (fmt::format("{:8} read, {:8} written", total_count, count) +
+            (crop ? fmt::format(", {:8} segments", segments) : ""));
   };
 
   if (number && (count == number))

--- a/cpp/core/dwi/tractography/editing/receiver.h
+++ b/cpp/core/dwi/tractography/editing/receiver.h
@@ -45,8 +45,8 @@ public:
 
   ~Receiver() {
     // Use set_text() rather than update() here to force update of the text before progress goes out of scope
-    progress.set_text(std::string(printf("%8" PRIu64 " read, %8" PRIu64 " written", total_count, count)) +
-                      (crop ? printf(", %8" PRIu64 " segments", segments) : ""));
+    progress.set_text(fmt::format("{:8} read, {:8} written", total_count, count) +
+                      (crop ? fmt::format(", {:8} segments", segments) : ""));
     if (number && (count != number))
       WARN("User requested {} streamlines, but only {} were written to file", number, count);
   }

--- a/cpp/core/dwi/tractography/properties.cpp
+++ b/cpp/core/dwi/tractography/properties.cpp
@@ -19,7 +19,9 @@
 
 namespace MR::DWI::Tractography {
 
-void Properties::set_timestamp() { (*this)["timestamp"] = str(Timer::current_time(), file_timestamp_precision); }
+void Properties::set_timestamp() {
+  (*this)["timestamp"] = fmt::format("{:.{}g}", Timer::current_time(), file_timestamp_precision);
+}
 
 void Properties::set_version_info() {
   (*this)["mrtrix_version"] = App::mrtrix_version;

--- a/cpp/core/dwi/tractography/properties.h
+++ b/cpp/core/dwi/tractography/properties.h
@@ -39,7 +39,7 @@ public:
   template <typename T> void set(T &variable, std::string_view name) {
     const std::string key(name);
     if ((*this)[key].empty())
-      (*this)[key] = str(variable);
+      (*this)[key] = fmt::format("{}", variable);
     else
       variable = to<T>((*this)[key]);
   }

--- a/cpp/core/dwi/tractography/seeding/seeding.cpp
+++ b/cpp/core/dwi/tractography/seeding/seeding.cpp
@@ -221,11 +221,11 @@ void load_seed_mechanisms(Properties &properties) {
 void load_seed_parameters(Properties &properties) {
   auto opt = get_options("seeds");
   if (!opt.empty())
-    properties["max_num_seeds"] = str<unsigned int>(opt[0][0]);
+    properties["max_num_seeds"] = fmt::format("{}", static_cast<unsigned int>(opt[0][0]));
 
   opt = get_options("max_attempts_per_seed");
   if (!opt.empty())
-    properties["max_seed_attempts"] = str<unsigned int>(opt[0][0]);
+    properties["max_seed_attempts"] = fmt::format("{}", static_cast<unsigned int>(opt[0][0]));
 
   opt = get_options("seed_cutoff");
   if (!opt.empty())

--- a/cpp/core/dwi/tractography/tracking/generated_track.h
+++ b/cpp/core/dwi/tractography/tracking/generated_track.h
@@ -64,7 +64,8 @@ public:
   }
 
   friend inline std::ostream &operator<<(std::ostream &stream, GeneratedTrack &tck) {
-    stream << str(tck.size()) << " vertices, seed index " << str(tck.seed_index) << ", status ";
+    stream << fmt::format("{}", tck.size()) << " vertices, seed index " << fmt::format("{}", tck.seed_index)
+           << ", status ";
     switch (tck.status) {
     case status_t::INVALID:
       stream << "INVALID";

--- a/cpp/core/dwi/tractography/tracking/tractography.cpp
+++ b/cpp/core/dwi/tractography/tracking/tractography.cpp
@@ -126,7 +126,7 @@ void load_streamline_properties_and_rois(Properties &properties) {
 
   auto opt = get_options("select");
   if (!opt.empty())
-    properties["max_num_tracks"] = str<unsigned int>(opt[0][0]);
+    properties["max_num_tracks"] = fmt::format("{}", static_cast<unsigned int>(opt[0][0]));
 
   opt = get_options("step");
   if (!opt.empty())
@@ -150,7 +150,7 @@ void load_streamline_properties_and_rois(Properties &properties) {
 
   opt = get_options("trials");
   if (!opt.empty())
-    properties["max_trials"] = str<unsigned int>(opt[0][0]);
+    properties["max_trials"] = fmt::format("{}", static_cast<unsigned int>(opt[0][0]));
 
   opt = get_options("noprecomputed");
   if (!opt.empty())
@@ -172,7 +172,7 @@ void load_streamline_properties_and_rois(Properties &properties) {
 
   opt = get_options("downsample");
   if (!opt.empty())
-    properties["downsample_factor"] = str<unsigned int>(opt[0][0]);
+    properties["downsample_factor"] = fmt::format("{}", static_cast<unsigned int>(opt[0][0]));
 
   opt = get_options("grad");
   if (!opt.empty())

--- a/cpp/core/dwi/tractography/tracking/write_kernel.cpp
+++ b/cpp/core/dwi/tractography/tracking/write_kernel.cpp
@@ -48,10 +48,7 @@ bool WriteKernel::operator()(const GeneratedTrack &tck) {
     break;
   }
   progress.update(
-      [&]() {
-        return printf(
-            "%8" PRIu64 " seeds, %8" PRIu64 " streamlines, %8" PRIu64 " selected", seeds, streamlines, selected);
-      },
+      [&]() { return fmt::format("{:8} seeds, {:8} streamlines, {:8} selected", seeds, streamlines, selected); },
       always_increment ? true : tck.size());
   if (early_exit(seeds, selected)) {
     WARN("Track generation terminating prematurely:"

--- a/cpp/core/dwi/tractography/tracking/write_kernel.cpp
+++ b/cpp/core/dwi/tractography/tracking/write_kernel.cpp
@@ -24,8 +24,9 @@ bool WriteKernel::operator()(const GeneratedTrack &tck) {
     return false;
   if (!tck.empty() && output_seeds) {
     const auto &p = tck[tck.get_seed_index()];
-    (*output_seeds) << str(writer.count) << "," << str(tck.get_seed_index()) << "," << str(p[0]) << "," << str(p[1])
-                    << "," << str(p[2]) << ",\n";
+    (*output_seeds) << fmt::format("{}", writer.count) << "," << fmt::format("{}", tck.get_seed_index()) << ","
+                    << fmt::format("{}", p[0]) << "," << fmt::format("{}", p[1]) << "," << fmt::format("{}", p[2])
+                    << ",\n";
   }
   switch (tck.get_status()) {
   case GeneratedTrack::status_t::INVALID:

--- a/cpp/core/dwi/tractography/tracking/write_kernel.h
+++ b/cpp/core/dwi/tractography/tracking/write_kernel.h
@@ -48,7 +48,7 @@ public:
         seeds(0),
         streamlines(0),
         selected(0),
-        progress(printf("       0 seeds,        0 streamlines,        0 selected", 0, 0),
+        progress("       0 seeds,        0 streamlines,        0 selected",
                  always_increment ? S.max_num_seeds : S.max_num_tracks),
         early_exit(shared) {
     const auto p = properties.find("seed_output");
@@ -64,8 +64,7 @@ public:
 
   ~WriteKernel() {
     // Use set_text() rather than update() here to force update of the text before progress goes out of scope
-    progress.set_text(
-        printf("%8" PRIu64 " seeds, %8" PRIu64 " streamlines, %8" PRIu64 " selected", seeds, streamlines, selected));
+    progress.set_text(fmt::format("{:8} seeds, {:8} streamlines, {:8} selected", seeds, streamlines, selected));
     if (warn_on_max_seeds && writer.total_count == S.max_num_seeds && S.max_num_tracks &&
         writer.count < S.max_num_tracks) {
       WARN("less than desired streamline number due to implicit maximum number of seeds; set -seeds 0 to override");

--- a/cpp/core/exception.cpp
+++ b/cpp/core/exception.cpp
@@ -39,11 +39,11 @@ bool __need_newline = false;
 
 void cmdline_report_to_user_func(std::string_view msg, int type) {
 
-  static const std::unordered_map<int, std::string> colour_format_strings{{-1, "%s: %s%s\n"},
-                                                                          {0, "%s: \033[01;31m%s%s\033[0m\n"},
-                                                                          {1, "%s: \033[00;31m%s%s\033[0m\n"},
-                                                                          {2, "%s: \033[00;32m%s%s\033[0m\n"},
-                                                                          {3, "%s: \033[00;34m%s%s\033[0m\n"}};
+  static const std::unordered_map<int, std::string> colour_format_strings{{-1, "{}: {}{}\n"},
+                                                                          {0, "{}: \033[01;31m{}{}\033[0m\n"},
+                                                                          {1, "{}: \033[00;31m{}{}\033[0m\n"},
+                                                                          {2, "{}: \033[00;32m{}{}\033[0m\n"},
+                                                                          {3, "{}: \033[00;34m{}{}\033[0m\n"}};
 
   static const std::unordered_map<int, std::string> console_prefixes{
       {-1, ""}, {0, "[ERROR] "}, {1, "[WARNING] "}, {2, "[INFO] "}, {3, "[DEBUG] "}};
@@ -59,10 +59,10 @@ void cmdline_report_to_user_func(std::string_view msg, int type) {
     return t + 1;
   };
 
-  __print_stderr(printf(colour_format_strings.at(App::terminal_use_colour ? type : -1).c_str(),
-                        App::NAME.c_str(),
-                        console_prefixes.at(type).c_str(),
-                        std::string(msg).c_str()));
+  __print_stderr(fmt::format(fmt::runtime(colour_format_strings.at(App::terminal_use_colour ? type : -1)),
+                             App::NAME,
+                             console_prefixes.at(type),
+                             msg));
   if (type == 1 && App::fail_on_warn)
     throw Exception("terminating due to request to fail on warning");
 }

--- a/cpp/core/file/dicom/csa_entry.h
+++ b/cpp/core/file/dicom/csa_entry.h
@@ -170,3 +170,8 @@ protected:
 };
 
 } // namespace MR::File::Dicom
+
+namespace fmt {
+//! Render a CSAEntry via its ostream insertion operator.
+template <> struct formatter<MR::File::Dicom::CSAEntry> : ostream_formatter {};
+} // namespace fmt

--- a/cpp/core/file/dicom/element.cpp
+++ b/cpp/core/file/dicom/element.cpp
@@ -33,7 +33,7 @@ std::ostream &operator<<(std::ostream &stream, const Time &item) {
   stream << std::setfill('0') << std::setw(2) << item.hour << ":" << std::setfill('0') << std::setw(2) << item.minute
          << ":" << std::setfill('0') << std::setw(2) << item.second;
   if (item.fraction)
-    stream << str(item.fraction, 6).substr(1);
+    stream << fmt::format("{:.6g}", item.fraction).substr(1);
   return stream;
 }
 

--- a/cpp/core/file/dicom/element.cpp
+++ b/cpp/core/file/dicom/element.cpp
@@ -383,9 +383,9 @@ std::string Element::as_string() const {
         out << x << " ";
       return out.str();
     case Element::DATE:
-      return str(get_date());
+      return fmt::format("{}", get_date());
     case Element::TIME:
-      return str(get_time());
+      return fmt::format("{}", get_time());
     case Element::DATETIME:
       return fmt::format("{} {}", get_datetime().first, get_datetime().second);
     case Element::STRING:

--- a/cpp/core/file/dicom/element.cpp
+++ b/cpp/core/file/dicom/element.cpp
@@ -358,7 +358,7 @@ std::pair<Date, Time> Element::get_datetime() const {
 
 std::vector<std::string> Element::get_string() const {
   if (VR == VR_AT)
-    return {printf("%04X %04X", Raw::fetch_<uint16_t>(data, is_BE), Raw::fetch_<uint16_t>(data + 2, is_BE))};
+    return {fmt::format("{:04X} {:04X}", Raw::fetch_<uint16_t>(data, is_BE), Raw::fetch_<uint16_t>(data + 2, is_BE))};
 
   auto strings = split(std::string(reinterpret_cast<const char *>(data), size), "\\", false);
   for (auto &entry : strings)
@@ -448,13 +448,13 @@ std::ostream &operator<<(std::ostream &stream, const Element &item) {
   // return "TYPE  GROUP ELEMENT VR  SIZE  OFFSET  NAME                               CONTENTS";
 
   const std::string name(item.tag_name());
-  stream << printf("[DCM] %04X %04X %c%c % 8u % 8llu ",
-                   item.group,
-                   item.element,
-                   reinterpret_cast<const char *>(&item.VR)[1],
-                   reinterpret_cast<const char *>(&item.VR)[0],
-                   (item.size == undefined_length ? uint32_t(0) : item.size),
-                   item.offset(item.start));
+  stream << fmt::format("[DCM] {:04X} {:04X} {}{} {:8} {:8} ",
+                        item.group,
+                        item.element,
+                        reinterpret_cast<const char *>(&item.VR)[1],
+                        reinterpret_cast<const char *>(&item.VR)[0],
+                        (item.size == undefined_length ? uint32_t(0) : item.size),
+                        item.offset(item.start));
 
   std::string tmp;
   size_t indent = item.level() - (item.VR == VR_SQ ? 1 : 0);

--- a/cpp/core/file/dicom/element.h
+++ b/cpp/core/file/dicom/element.h
@@ -219,4 +219,5 @@ namespace fmt {
 //! Render via the type's ostream insertion operator while honouring any standard format specification.
 template <> struct formatter<MR::File::Dicom::Date> : ostream_formatter {};
 template <> struct formatter<MR::File::Dicom::Time> : ostream_formatter {};
+template <> struct formatter<MR::File::Dicom::Element> : ostream_formatter {};
 } // namespace fmt

--- a/cpp/core/file/dicom/image.cpp
+++ b/cpp/core/file/dicom/image.cpp
@@ -304,7 +304,7 @@ void Image::read() {
       try {
         parse_item(item);
       } catch (Exception &E) {
-        DEBUG(printf("error reading tag (%04X,%04X):", item.group, item.element));
+        DEBUG("error reading tag ({:04X},{:04X}):", item.group, item.element);
         E.display(3);
       }
     }

--- a/cpp/core/file/dicom/image.cpp
+++ b/cpp/core/file/dicom/image.cpp
@@ -37,7 +37,7 @@ void Image::parse_item(Element &item) {
       manufacturer = item.get_string()[0];
       return;
     case 0x0008U:
-      image_type = join(item.get_string(), " ");
+      image_type = fmt::format("{}", fmt::join(item.get_string(), " "));
       return;
     case 0x0032U:
       acquisition_time = item.get_time();

--- a/cpp/core/file/dicom/mapper.cpp
+++ b/cpp/core/file/dicom/mapper.cpp
@@ -142,7 +142,7 @@ std::unique_ptr<MR::ImageIO::Base> dicom_to_mapper(MR::Header &H, std::vector<st
       const default_type value = functor(f);
       if (!std::isfinite(value))
         return;
-      const std::string value_string = str(multiplier * value, 6);
+      const std::string value_string = fmt::format("{}", multiplier * value);
       if (values.empty() || value_string != values.back())
         values.push_back(value_string);
     }

--- a/cpp/core/file/dicom/mapper.cpp
+++ b/cpp/core/file/dicom/mapper.cpp
@@ -147,7 +147,7 @@ std::unique_ptr<MR::ImageIO::Base> dicom_to_mapper(MR::Header &H, std::vector<st
         values.push_back(value_string);
     }
     if (!values.empty())
-      H.keyval()[key] = join(values, ",");
+      H.keyval()[key] = fmt::format("{}", fmt::join(values, ","));
   };
   import_parameter(
       "EchoTime", [](Frame *f) -> default_type { return f->echo_time; }, 0.001);
@@ -198,7 +198,7 @@ std::unique_ptr<MR::ImageIO::Base> dicom_to_mapper(MR::Header &H, std::vector<st
       }
     }
     if (!all_equal)
-      H.keyval()["FlipAngle"] = join(frame.flip_angles, ",");
+      H.keyval()["FlipAngle"] = fmt::format("{}", fmt::join(frame.flip_angles, ","));
   }
 
   size_t nchannels = image.samples_per_pixel;
@@ -343,8 +343,8 @@ std::unique_ptr<MR::ImageIO::Base> dicom_to_mapper(MR::Header &H, std::vector<st
   if (!slices_timing_float.empty()) {
     const size_t slices_acquired_at_zero = std::count(slices_timing_float.begin(), slices_timing_float.end(), 0.0f);
     if (slices_acquired_at_zero < (image.images_in_mosaic ? image.images_in_mosaic : dim[1])) {
-      H.keyval()["SliceTiming"] =
-          !slices_timing_str.empty() ? join(slices_timing_str, ",") : join(slices_timing_float, ",");
+      H.keyval()["SliceTiming"] = !slices_timing_str.empty() ? fmt::format("{}", fmt::join(slices_timing_str, ","))
+                                                             : fmt::format("{}", fmt::join(slices_timing_float, ","));
       H.keyval()["MultibandAccelerationFactor"] = str(slices_acquired_at_zero);
       H.keyval()["SliceEncodingDirection"] = "k";
     } else {

--- a/cpp/core/file/dicom/mapper.cpp
+++ b/cpp/core/file/dicom/mapper.cpp
@@ -313,7 +313,7 @@ std::unique_ptr<MR::ImageIO::Base> dicom_to_mapper(MR::Header &H, std::vector<st
       //   base-10 scaling
       for (size_t n = 0; n < image.images_in_mosaic; ++n) {
         slices_timing_float.push_back(0.001 * image.mosaic_slices_timing[n]);
-        std::string temp = str(static_cast<int>(std::floor(10.0 * image.mosaic_slices_timing[n])));
+        std::string temp = fmt::format("{}", static_cast<int>(std::floor(10.0 * image.mosaic_slices_timing[n])));
         const bool neg = image.mosaic_slices_timing[n] < 0.0;
         if (neg)
           temp.erase(temp.begin());
@@ -345,7 +345,7 @@ std::unique_ptr<MR::ImageIO::Base> dicom_to_mapper(MR::Header &H, std::vector<st
     if (slices_acquired_at_zero < (image.images_in_mosaic ? image.images_in_mosaic : dim[1])) {
       H.keyval()["SliceTiming"] = !slices_timing_str.empty() ? fmt::format("{}", fmt::join(slices_timing_str, ","))
                                                              : fmt::format("{}", fmt::join(slices_timing_float, ","));
-      H.keyval()["MultibandAccelerationFactor"] = str(slices_acquired_at_zero);
+      H.keyval()["MultibandAccelerationFactor"] = fmt::format("{}", slices_acquired_at_zero);
       H.keyval()["SliceEncodingDirection"] = "k";
     } else {
       DEBUG("All slices acquired at same time; not writing slice encoding information");

--- a/cpp/core/file/dicom/quick_scan.cpp
+++ b/cpp/core/file/dicom/quick_scan.cpp
@@ -109,7 +109,7 @@ bool QuickScan::read(const std::filesystem::path &file_path,
         }
 
         if (print_DICOM_fields)
-          print(str(item));
+          print(fmt::format("{}", item));
 
         if ((print_CSA_fields || print_Phoenix) && item.group == 0x0029U) {
           if (item.element == 0x1010U || item.element == 0x1020U || item.element == 0x1110U ||
@@ -119,7 +119,7 @@ bool QuickScan::read(const std::filesystem::path &file_path,
               const bool is_phoenix = entry.key() == "MrPhoenixProtocol";
               if ((print_Phoenix && is_phoenix) || (print_CSA_fields && !is_phoenix)) {
                 if (print_CSA_fields) {
-                  print(str(entry));
+                  print(fmt::format("{}", entry));
                 } else {
                   const auto data = entry.get_string();
                   for (const auto &entry : data)

--- a/cpp/core/file/dicom/quick_scan.cpp
+++ b/cpp/core/file/dicom/quick_scan.cpp
@@ -57,7 +57,7 @@ bool QuickScan::read(const std::filesystem::path &file_path,
         if (!item.ignore_when_parsing()) {
 
           if (item.is(0x0008U, 0x0008U))
-            current_image_type = join(item.get_string(), " ");
+            current_image_type = fmt::format("{}", fmt::join(item.get_string(), " "));
           else if (item.is(0x0008U, 0x0020U))
             study_date = item.get_string(0);
           else if (item.is(0x0008U, 0x0021U))

--- a/cpp/core/file/json_utils.cpp
+++ b/cpp/core/file/json_utils.cpp
@@ -89,7 +89,7 @@ KeyValues read(const nlohmann::json &json) {
         } else if (all_numeric) {
           std::vector<std::string> line;
           for (const auto &k : *i)
-            line.push_back(str(k));
+            line.push_back(k.dump());
           result.insert(std::make_pair(i.key(), fmt::format("{}", fmt::join(line, ","))));
         } else {
           throw Exception("JSON entry \"{}\" is array but contains mixed data types", i.key());
@@ -99,7 +99,7 @@ KeyValues read(const nlohmann::json &json) {
         for (const auto &j : *i) {
           std::vector<std::string> line;
           for (const auto &k : j)
-            line.push_back(unquote(str(k)));
+            line.push_back(unquote(k.dump()));
           s.push_back(fmt::format("{}", fmt::join(line, ",")));
         }
         result.insert(std::make_pair(i.key(), fmt::format("{}", fmt::join(s, "\n"))));

--- a/cpp/core/file/json_utils.cpp
+++ b/cpp/core/file/json_utils.cpp
@@ -85,12 +85,12 @@ KeyValues read(const nlohmann::json &json) {
           std::vector<std::string> lines;
           for (const auto &k : *i)
             lines.push_back(unquote(std::string(k)));
-          result.insert(std::make_pair(i.key(), join(lines, "\n")));
+          result.insert(std::make_pair(i.key(), fmt::format("{}", fmt::join(lines, "\n"))));
         } else if (all_numeric) {
           std::vector<std::string> line;
           for (const auto &k : *i)
             line.push_back(str(k));
-          result.insert(std::make_pair(i.key(), join(line, ",")));
+          result.insert(std::make_pair(i.key(), fmt::format("{}", fmt::join(line, ","))));
         } else {
           throw Exception("JSON entry \"{}\" is array but contains mixed data types", i.key());
         }
@@ -100,9 +100,9 @@ KeyValues read(const nlohmann::json &json) {
           std::vector<std::string> line;
           for (const auto &k : j)
             line.push_back(unquote(str(k)));
-          s.push_back(join(line, ","));
+          s.push_back(fmt::format("{}", fmt::join(line, ",")));
         }
-        result.insert(std::make_pair(i.key(), join(s, "\n")));
+        result.insert(std::make_pair(i.key(), fmt::format("{}", fmt::join(s, "\n"))));
       } else
         throw Exception("JSON entry \"{}\" contains mixture of elements and arrays", i.key());
     }
@@ -141,7 +141,7 @@ void read(const nlohmann::json &json, Header &header) {
       const std::string msg1 = "JSON metadata for image \"" + header.name() + "\"" +      //
                                " was reoriented on import to match MRtrix3's realignment" //
                                " of the corresponding image axes";                        //
-      const std::string msg2 = "  (affected fields: " + join(modified_fields, ", ") + ")";
+      const std::string msg2 = fmt::format("  (affected fields: {})", fmt::join(modified_fields, ", "));
       if (File::Config::get_bool("RealignmentVerbose", true)) {
         CONSOLE(msg1);
         CONSOLE(msg2);

--- a/cpp/core/file/matrix.h
+++ b/cpp/core/file/matrix.h
@@ -134,8 +134,8 @@ void save_vector_text(const VectorType &V,
   File::KeyValue::write(out, keyvals, "# ", add_to_command_history);
   const char d(delimiter(filename));
   for (decltype(V.size()) i = 0; i < V.size() - 1; i++)
-    out << str(V[i], 10) << d;
-  out << str(V[V.size() - 1], 10) << "\n";
+    out << fmt::format("{}", V[i]) << d;
+  out << fmt::format("{}", V[V.size() - 1]) << "\n";
 }
 
 } // namespace

--- a/cpp/core/file/mgh.h
+++ b/cpp/core/file/mgh.h
@@ -472,10 +472,10 @@ template <class Input> void read_other(Header &H, Input &in) {
   // Start the function read_other() proper
   try {
     // fetch() will throw an int(1) straight away if these data don't exist
-    H.keyval()["MGH_TR"] = str(fetch<float32>(in), 6);
-    H.keyval()["MGH_flip"] = str(fetch<float32>(in) * 180.0 / Math::pi, 6); // Radians in MGHO -> degrees in header
-    H.keyval()["MGH_TE"] = str(fetch<float32>(in), 6);
-    H.keyval()["MGH_TI"] = str(fetch<float32>(in), 6);
+    H.keyval()["MGH_TR"] = fmt::format("{}", fetch<float32>(in));
+    H.keyval()["MGH_flip"] = fmt::format("{}", fetch<float32>(in) * 180.0 / Math::pi); // Radians in MGHO -> degrees
+    H.keyval()["MGH_TE"] = fmt::format("{}", fetch<float32>(in));
+    H.keyval()["MGH_TI"] = fmt::format("{}", fetch<float32>(in));
     fetch<float32>(in); // fov - ignored
 
     do {

--- a/cpp/core/file/mgh.h
+++ b/cpp/core/file/mgh.h
@@ -543,7 +543,7 @@ template <class Input> void read_other(Header &H, Input &in) {
 #ifndef MRTRIX_IS_BIG_ENDIAN
         ByteOrder::swap(field_strength);
 #endif
-        H.keyval()[tag_ID_to_string(id)] = str(field_strength);
+        H.keyval()[tag_ID_to_string(id)] = fmt::format("{}", field_strength);
       } break;
       default: // FreeSurfer doesn't actually perform any import of any other fields
         in.read(&content[0], size);

--- a/cpp/core/file/name_parser.cpp
+++ b/cpp/core/file/name_parser.cpp
@@ -169,7 +169,7 @@ std::filesystem::path NameParser::name(const std::vector<uint32_t> &indices) {
     if (array[i].is_string())
       str += array[i].string();
     else {
-      str += printf("%*.*d", array[i].size(), array[i].size(), array[i].sequence()[indices[n]]);
+      str += fmt::format("{:0{}}", array[i].sequence()[indices[n]], array[i].size());
       n--;
     }
   }

--- a/cpp/core/file/npy.cpp
+++ b/cpp/core/file/npy.cpp
@@ -162,7 +162,7 @@ std::string datatype2descr(const DataType data_type) {
     descr.push_back('?');
     return descr;
   }
-  descr.append(str(data_type.bytes()));
+  descr.append(fmt::format("{}", data_type.bytes()));
   return descr;
 }
 

--- a/cpp/core/file/png.cpp
+++ b/cpp/core/file/png.cpp
@@ -49,7 +49,7 @@ Reader::Reader(const std::filesystem::path &filepath)
     fclose(infile);
     std::stringstream s;
     for (size_t i = 0; i != 8; ++i) {
-      s << str(static_cast<int>(sig[i])) << " ";
+      s << fmt::format("{}", static_cast<int>(sig[i])) << " ";
     }
     Exception e("Bad PNG signature in file \"{}\"", filepath);
     e.push_back("File signature: {}", s.str());

--- a/cpp/core/fixel/matrix.cpp
+++ b/cpp/core/fixel/matrix.cpp
@@ -277,7 +277,7 @@ template <class MatrixType> void Writer<MatrixType>::save(const std::filesystem:
   index_header.spacing(0) = index_header.spacing(1) = index_header.spacing(2) = 1.0;
   index_header.transform() = transform_type::Identity();
   index_header.keyval() = keyvals;
-  index_header.keyval()["nfixels"] = str(matrix.size());
+  index_header.keyval()["nfixels"] = fmt::format("{}", matrix.size());
   index_header.datatype() = DataType::from<index_image_type>();
   index_header.datatype().set_byte_order_native();
 
@@ -307,7 +307,7 @@ template <class MatrixType> void Writer<MatrixType>::save(const std::filesystem:
   fixel_header.spacing(0) = fixel_header.spacing(1) = fixel_header.spacing(2) = 1.0;
   fixel_header.transform() = transform_type::Identity();
   fixel_header.keyval() = keyvals;
-  fixel_header.keyval()["nfixels"] = str(matrix.size());
+  fixel_header.keyval()["nfixels"] = fmt::format("{}", matrix.size());
   fixel_header.datatype() = DataType::from<index_type>();
   fixel_header.datatype().set_byte_order_native();
 

--- a/cpp/core/half.h
+++ b/cpp/core/half.h
@@ -16,9 +16,14 @@
 
 #pragma once
 
+#include <fmt/ostream.h>
+
 namespace std {
 template <> struct is_fundamental<Eigen::half> : std::true_type {};
 template <> struct is_floating_point<Eigen::half> : std::true_type {};
 template <> struct is_arithmetic<Eigen::half> : std::true_type {};
 template <> struct is_integral<Eigen::half> : std::false_type {};
 } // namespace std
+
+//! fmtlib bridge for Eigen::half (no native fmt formatter; delegates to its ostream operator<<).
+template <> struct fmt::formatter<Eigen::half> : fmt::ostream_formatter {};

--- a/cpp/core/header.cpp
+++ b/cpp/core/header.cpp
@@ -130,8 +130,8 @@ std::string short_description(const Header &H) {
     vox.push_back(str(H.spacing(n)));
 
   return fmt::format(" with dimensions {}, voxel spacing {}, datatype {}", //
-                     join(dims, "x"),                                      //
-                     join(vox, "x"),                                       //
+                     fmt::join(dims, "x"),                                 //
+                     fmt::join(vox, "x"),                                  //
                      H.datatype().specifier());                            //
 }
 } // namespace
@@ -752,7 +752,7 @@ void Header::realign_transform() {
   }
   std::string msg = "Image \"" + name() + "\" axes realigned to approximate RAS";
   if (!modified_fields.empty())
-    msg += "; reoriented metadata: " + join(modified_fields, ", ");
+    msg += fmt::format("; reoriented metadata: {}", fmt::join(modified_fields, ", "));
   if (File::Config::get_bool("RealignmentVerbose", true)) {
     CONSOLE(msg);
     CONSOLE("  (mrinfo -realignment / -ondisk for details;"

--- a/cpp/core/header.cpp
+++ b/cpp/core/header.cpp
@@ -124,10 +124,10 @@ namespace {
 std::string short_description(const Header &H) {
   std::vector<std::string> dims;
   for (size_t n = 0; n < H.ndim(); ++n)
-    dims.push_back(str(H.size(n)));
+    dims.push_back(fmt::format("{}", H.size(n)));
   std::vector<std::string> vox;
   for (size_t n = 0; n < H.ndim(); ++n)
-    vox.push_back(str(H.spacing(n)));
+    vox.push_back(fmt::format("{}", H.spacing(n)));
 
   return fmt::format(" with dimensions {}, voxel spacing {}, datatype {}", //
                      fmt::join(dims, "x"),                                 //
@@ -491,7 +491,7 @@ std::string Header::description(bool print_all) const {
   for (i = 0; i < ndim(); i++) {
     if (i)
       desc += " x ";
-    desc += str(size(i));
+    desc += fmt::format("{}", size(i));
   }
 
   desc += "\n  Voxel size:        ";
@@ -996,9 +996,9 @@ std::vector<std::string> Header::Realignment::describe_axis_mapping() const {
   lines.reserve(3);
   for (size_t output = 0; output != 3; ++output) {
     const size_t source_axis = shuffle_.permutations[output];
-    lines.push_back("output axis " + str(output) + " (~" + std::string(output_labels.at(output)) + ")" //
-                    + " <- source axis " + str(source_axis)                                            //
-                    + ", sign " + (shuffle_.flips[source_axis] ? "reversed" : "preserved"));           //
+    lines.push_back("output axis " + fmt::format("{}", output) + " (~" + std::string(output_labels.at(output)) + ")" //
+                    + " <- source axis " + fmt::format("{}", source_axis)                                            //
+                    + ", sign " + (shuffle_.flips[source_axis] ? "reversed" : "preserved"));                         //
   }
   return lines;
 }

--- a/cpp/core/header.cpp
+++ b/cpp/core/header.cpp
@@ -498,7 +498,7 @@ std::string Header::description(bool print_all) const {
   for (i = 0; i < ndim(); i++) {
     if (i)
       desc += " x ";
-    desc += std::isnan(spacing(i)) ? "?" : str(spacing(i), 6);
+    desc += std::isnan(spacing(i)) ? "?" : fmt::format("{}", spacing(i));
   }
   desc += "\n";
 

--- a/cpp/core/image_helpers.h
+++ b/cpp/core/image_helpers.h
@@ -360,7 +360,7 @@ inline bool dimensions_match(const HeaderType1 &in1, const HeaderType2 &in2, con
 
 namespace {
 template <class HeaderType> std::string dim2str(const HeaderType &in) {
-  std::string msg = str(in.size(0));
+  std::string msg = fmt::format("{}", in.size(0));
   for (size_t axis = 1; axis != in.ndim(); ++axis)
     msg += fmt::format(",{}", in.size(axis));
   return msg;

--- a/cpp/core/image_helpers.h
+++ b/cpp/core/image_helpers.h
@@ -395,7 +395,7 @@ inline void check_dimensions(const HeaderType1 &in1, const HeaderType2 &in2, con
     throw Exception("dimension mismatch between \"{}\" and \"{}\" for axes [{}] ({} vs. {})",
                     in1.name(),
                     in2.name(),
-                    join(axes, ","),
+                    fmt::join(axes, ","),
                     dim2str(in1),
                     dim2str(in2));
 }

--- a/cpp/core/image_io/base.h
+++ b/cpp/core/image_io/base.h
@@ -86,8 +86,8 @@ public:
   }
 
   friend std::ostream &operator<<(std::ostream &stream, const Base &B) {
-    stream << str(B.files.size()) << " files, segsize " << str(B.segsize) << ", is " << (B.is_new ? "" : "NOT ")
-           << "new, " << (B.writable ? "read/write" : "read-only");
+    stream << fmt::format("{}", B.files.size()) << " files, segsize " << fmt::format("{}", B.segsize) << ", is "
+           << (B.is_new ? "" : "NOT ") << "new, " << (B.writable ? "read/write" : "read-only");
     return stream;
   }
 

--- a/cpp/core/math/check_gradient.h
+++ b/cpp/core/math/check_gradient.h
@@ -39,13 +39,13 @@ check_function_gradient(Function &function,
           DataType::from<value_type>().specifier());                           //
   value_type step_size = function.init(g);
   CONSOLE("cost function suggests initial step size = {}", step_size);
-  CONSOLE("cost function suggests initial position at [ {} ]", g);
+  CONSOLE("cost function suggests initial position at [ {:T} ]", g);
 
-  CONSOLE("checking gradient at position [ {}]:", x);
+  CONSOLE("checking gradient at position [ {:T}]:", x);
   Eigen::Matrix<value_type, Eigen::Dynamic, 1> g0(N);
   value_type f0 = function(x, g0);
   CONSOLE("  cost function = {}", f0);
-  CONSOLE("  gradient from cost function         = [ {}]", g0);
+  CONSOLE("  gradient from cost function         = [ {:T}]", g0);
 
   Eigen::Matrix<value_type, Eigen::Dynamic, 1> g_fd(N);
   Eigen::Matrix<value_type, Eigen::Dynamic, Eigen::Dynamic> hessian;
@@ -85,7 +85,7 @@ check_function_gradient(Function &function,
     }
   }
 
-  CONSOLE("gradient by central finite difference = [ {} ]", g_fd);
+  CONSOLE("gradient by central finite difference = [ {:T} ]", g_fd);
   CONSOLE("normalised dot product = {}", g_fd.dot(g0) / g_fd.squaredNorm());
 
   if (show_hessian) {

--- a/cpp/core/math/gradient_descent.h
+++ b/cpp/core/math/gradient_descent.h
@@ -144,12 +144,12 @@ public:
     assert(std::isfinite(normg));
     assert(!std::isnan(normg));
     if (log_os) {
-      log_os << niter << delim << nfeval << delim << str(f) << delim << str(dt);
+      log_os << niter << delim << nfeval << delim << fmt::format("{}", f) << delim << fmt::format("{}", dt);
       for (ssize_t i = 0; i < x.size(); ++i) {
-        log_os << delim << str(x(i));
+        log_os << delim << fmt::format("{}", x(i));
       }
       for (ssize_t i = 0; i < x.size(); ++i) {
-        log_os << delim << str(g(i));
+        log_os << delim << fmt::format("{}", g(i));
       }
       log_os << std::endl;
     }
@@ -187,12 +187,12 @@ public:
         x.swap(x2);
         g.swap(g2);
         if (log_os) {
-          log_os << niter << delim << nfeval << delim << str(f) << delim << str(dt);
+          log_os << niter << delim << nfeval << delim << fmt::format("{}", f) << delim << fmt::format("{}", dt);
           for (ssize_t i = 0; i < x.size(); ++i) {
-            log_os << delim << str(x(i));
+            log_os << delim << fmt::format("{}", x(i));
           }
           for (ssize_t i = 0; i < x.size(); ++i) {
-            log_os << delim << str(g(i));
+            log_os << delim << fmt::format("{}", g(i));
           }
           log_os << std::endl;
         }

--- a/cpp/core/math/gradient_descent_bb.h
+++ b/cpp/core/math/gradient_descent_bb.h
@@ -134,12 +134,12 @@ public:
       CONSOLE("            x = [ {} ]", x1);
     }
     if (log_os) {
-      log_os << niter << delim << nfeval << delim << str(f) << delim << str(dt);
+      log_os << niter << delim << nfeval << delim << fmt::format("{}", f) << delim << fmt::format("{}", dt);
       for (ssize_t i = 0; i < x2.size(); ++i) {
-        log_os << delim << str(x1(i));
+        log_os << delim << fmt::format("{}", x1(i));
       }
       for (ssize_t i = 0; i < x2.size(); ++i) {
-        log_os << delim << str(g1(i));
+        log_os << delim << fmt::format("{}", g1(i));
       }
       log_os << std::endl;
     }
@@ -161,12 +161,12 @@ public:
     assert(std::isfinite(normg));
     assert(!std::isnan(normg));
     if (log_os) {
-      log_os << niter << delim << nfeval << delim << str(f) << delim << str(dt);
+      log_os << niter << delim << nfeval << delim << fmt::format("{}", f) << delim << fmt::format("{}", dt);
       for (ssize_t i = 0; i < x2.size(); ++i) {
-        log_os << delim << str(x2(i));
+        log_os << delim << fmt::format("{}", x2(i));
       }
       for (ssize_t i = 0; i < x2.size(); ++i) {
-        log_os << delim << str(g2(i));
+        log_os << delim << fmt::format("{}", g2(i));
       }
       log_os << std::endl;
     }
@@ -193,12 +193,12 @@ public:
     g1.swap(g3);
     ++niter;
     if (log_os) {
-      log_os << niter << delim << nfeval << delim << str(f) << delim << str(dt);
+      log_os << niter << delim << nfeval << delim << fmt::format("{}", f) << delim << fmt::format("{}", dt);
       for (ssize_t i = 0; i < x2.size(); ++i) {
-        log_os << delim << str(x2(i));
+        log_os << delim << fmt::format("{}", x2(i));
       }
       for (ssize_t i = 0; i < x2.size(); ++i) {
-        log_os << delim << str(g2(i));
+        log_os << delim << fmt::format("{}", g2(i));
       }
       log_os << std::endl;
     }

--- a/cpp/core/math/gradient_descent_bb.h
+++ b/cpp/core/math/gradient_descent_bb.h
@@ -95,7 +95,7 @@ public:
       DEBUG("Gradient descent iteration: {}; cost: {}", niter, f);
       if (verbose) {
         CONSOLE("iteration {}: f = {}, |g| = {}:", niter, f, normg);
-        CONSOLE("  x  = [ {} ]", x2);
+        CONSOLE("  x  = [ {:T} ]", x2);
       }
 
       if (normg < gradient_tolerance) {
@@ -131,7 +131,7 @@ public:
     dt /= normg;
     if (verbose) {
       CONSOLE("initialise: f = {}, |g| = {}, step = {}:", f, normg, dt);
-      CONSOLE("            x = [ {} ]", x1);
+      CONSOLE("            x = [ {:T} ]", x1);
     }
     if (log_os) {
       log_os << niter << delim << nfeval << delim << fmt::format("{}", f) << delim << fmt::format("{}", dt);
@@ -225,8 +225,8 @@ protected:
       throw Exception("cost function is NaN or Inf!");
     if (verbose) {
       CONSOLE("      << eval {}, f = {} >>", nfeval, cost);
-      CONSOLE("      << newx = [ {} ]", newx);
-      CONSOLE("      << newg = [ {} ]", newg);
+      CONSOLE("      << newx = [ {:T} ]", newx);
+      CONSOLE("      << newg = [ {:T} ]", newg);
     }
     return cost;
   }

--- a/cpp/core/math/quadratic_line_search.h
+++ b/cpp/core/math/quadratic_line_search.h
@@ -191,8 +191,10 @@ public:
     ValueType fl = functor(l), fm = functor(m), fu = functor(u);
     std::cerr << "Initialising quadratic line search\n";
     std::cerr << "        Lower        Mid         Upper\n";
-    std::cerr << "Pos     " << str(l) << "           " << str(m) << "        " << str(u) << "\n";
-    std::cerr << "Value   " << str(fl) << "           " << str(fm) << "        " << str(fu) << "\n";
+    std::cerr << "Pos     " << fmt::format("{}", l) << "           " << fmt::format("{}", m) << "        "
+              << fmt::format("{}", u) << "\n";
+    std::cerr << "Value   " << fmt::format("{}", fl) << "           " << fmt::format("{}", fm) << "        "
+              << fmt::format("{}", fu) << "\n";
     size_t iters = 0;
 
     while (iters++ < max_iters) {
@@ -215,7 +217,7 @@ public:
 
       const ValueType fn = functor(n);
 
-      std::cerr << "  New point " << str(n) << ", value " << str(fn) << "\n";
+      std::cerr << "  New point " << fmt::format("{}", n) << ", value " << fmt::format("{}", fn) << "\n";
 
       if (n < l) {
         if (exit_outside_bounds) {
@@ -264,8 +266,10 @@ public:
       }
 
       std::cerr << "\n";
-      std::cerr << "Pos     " << str(l) << "           " << str(m) << "        " << str(u) << "\n";
-      std::cerr << "Value   " << str(fl) << "           " << str(fm) << "        " << str(fu) << "\n";
+      std::cerr << "Pos     " << fmt::format("{}", l) << "           " << fmt::format("{}", m) << "        "
+                << fmt::format("{}", u) << "\n";
+      std::cerr << "Value   " << fmt::format("{}", fl) << "           " << fmt::format("{}", fm) << "        "
+                << fmt::format("{}", fu) << "\n";
 
       if ((u - l) < value_tolerance) {
         status = SUCCESS;

--- a/cpp/core/metadata/phase_encoding.cpp
+++ b/cpp/core/metadata/phase_encoding.cpp
@@ -122,7 +122,7 @@ void set_scheme(KeyValues &keyval, const scheme_type &PE) {
     const Metadata::BIDS::axis_vector_type dir(PE.block<1, 3>(0, 0).cast<Metadata::BIDS::axis_vector_type::Scalar>());
     keyval["PhaseEncodingDirection"] = Metadata::BIDS::vector2axisid(dir);
     if (PE.cols() >= 4)
-      keyval["TotalReadoutTime"] = str(PE(0, 3), 3);
+      keyval["TotalReadoutTime"] = fmt::format("{}", PE(0, 3));
     else
       erase(keyval, "TotalReadoutTime");
   }

--- a/cpp/core/metadata/slice_encoding.cpp
+++ b/cpp/core/metadata/slice_encoding.cpp
@@ -70,7 +70,7 @@ void transform_for_image_load(KeyValues &keyval, const Header &header) {
     } else if ((new_dir * -1).dot(orig_dir) == 1) {
       auto slice_timing = parse_floats(slice_timing_it->second);
       std::reverse(slice_timing.begin(), slice_timing.end());
-      slice_timing_it->second = join(slice_timing, ",");
+      slice_timing_it->second = fmt::format("{}", fmt::join(slice_timing, ","));
       INFO("Slice timing vector reversed"                                 //
            " to conform to MRtrix3 internal transform realignment"        //
            " of image \"{}\""                                             //
@@ -114,7 +114,7 @@ void transform_for_nifti_write(KeyValues &keyval, const Header &H) {
   } else if ((new_dir * -1).dot(orig_dir) == 1) {
     auto slice_timing = parse_floats(slice_timing_it->second);
     std::reverse(slice_timing.begin(), slice_timing.end());
-    slice_timing_it->second = join(slice_timing, ",");
+    slice_timing_it->second = fmt::format("{}", fmt::join(slice_timing, ","));
     INFO("Slice timing vector reversed to conform to output NIfTI strides");
   } else {
     keyval["SliceEncodingDirection"] = Metadata::BIDS::vector2axisid(new_dir);

--- a/cpp/core/misc/voxel2vector.h
+++ b/cpp/core/misc/voxel2vector.h
@@ -51,7 +51,7 @@ public:
     }
     DEBUG("Voxel2vector class for image \"{}\" of size {} initialised with {} elements",
           header.name(),
-          join(pos(), "x"),
+          fmt::join(pos(), "x"),
           reverse.size());
   }
 
@@ -104,7 +104,7 @@ Voxel2Vector::Voxel2Vector(MaskType &mask, const Header &data)
   }
   DEBUG("Voxel2vector class for image \"{}\" of size {} initialised with {} elements",
         data.name(),
-        join(pos(), "x"),
+        fmt::join(pos(), "x"),
         reverse.size());
 }
 

--- a/cpp/core/mrtrix.cpp
+++ b/cpp/core/mrtrix.cpp
@@ -285,28 +285,4 @@ std::string without_leading_dash(std::string_view arg) {
   return result;
 }
 
-std::string join(const std::vector<std::string> &V, std::string_view delimiter) {
-  std::string ret;
-  if (V.empty())
-    return ret;
-  ret = V[0];
-  for (std::vector<std::string>::const_iterator i = V.begin() + 1; i != V.end(); ++i) {
-    ret += delimiter;
-    ret += *i;
-  }
-  return ret;
-}
-
-std::string join(const char *const *null_terminated_array, std::string_view delimiter) { // check_syntax off
-  std::string ret;
-  if (!null_terminated_array)
-    return ret;
-  ret = null_terminated_array[0];
-  for (const char *const *p = null_terminated_array + 1; *p; ++p) { // check_syntax off
-    ret += delimiter;
-    ret += *p;
-  }
-  return ret;
-}
-
 } // namespace MR

--- a/cpp/core/mrtrix.h
+++ b/cpp/core/mrtrix.h
@@ -126,18 +126,6 @@ bool starts_with_dash(std::string_view arg);
 //! returns string without leading dashes
 std::string without_leading_dash(std::string_view arg);
 
-template <class T> inline std::string str(const T &value, int precision = 0) {
-  std::ostringstream stream;
-  if (precision)
-    stream.precision(precision);
-  else if (max_digits<T>::value())
-    stream.precision(max_digits<T>::value());
-  stream << value;
-  if (stream.fail())
-    throw Exception("error converting type \"{}\" value to string", typeid(T).name());
-  return stream.str();
-}
-
 template <class T> inline T to(std::string_view string) {
   const std::string stripped(strip(string));
   std::istringstream stream(stripped);

--- a/cpp/core/mrtrix.h
+++ b/cpp/core/mrtrix.h
@@ -171,18 +171,6 @@ template <> inline bool to<bool>(std::string_view string) {
   return to<int>(string);
 }
 
-template <> inline std::string str<cfloat>(const cfloat &value, int precision) {
-  std::ostringstream stream;
-  if (precision > 0)
-    stream.precision(precision);
-  stream << value.real();
-  if (value.imag())
-    stream << std::showpos << value.imag() << "i";
-  if (stream.fail())
-    throw Exception("error converting complex float value to string");
-  return stream.str();
-}
-
 template <> inline cfloat to<cfloat>(std::string_view string) {
   if (string.empty())
     throw Exception("cannot convert empty string to complex float");
@@ -226,18 +214,6 @@ template <> inline cfloat to<cfloat>(std::string_view string) {
       throw Exception("error converting string \"{}\" to complex float (ambiguity in imaginary component)", string);
   }
   return candidates[0];
-}
-
-template <> inline std::string str<cdouble>(const cdouble &value, int precision) {
-  std::ostringstream stream;
-  if (precision > 0)
-    stream.precision(precision);
-  stream << value.real();
-  if (value.imag() != 0)
-    stream << std::showpos << value.imag() << "i";
-  if (stream.fail())
-    throw Exception("error converting complex double value to string");
-  return stream.str();
 }
 
 template <> inline cdouble to<cdouble>(std::string_view string) {

--- a/cpp/core/mrtrix.h
+++ b/cpp/core/mrtrix.h
@@ -76,16 +76,6 @@ std::string lowercase(std::string_view string);
 //! return uppercase version of string
 std::string uppercase(std::string_view string);
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-security"
-template <typename... Args> std::string printf(const std::string format, Args... args) {
-  const int len = std::snprintf(nullptr, 0, format.c_str(), args...) + 1;
-  VLA(buf, char, len);
-  std::snprintf(buf, len, format.c_str(), args...);
-  return std::string(buf);
-}
-#pragma GCC diagnostic pop
-
 std::string strip(std::string_view string, std::string_view ws = {" \0\t\r\n", 5}, bool left = true, bool right = true);
 
 //! Remove quotation marks only if surrounding entire string

--- a/cpp/core/mrtrix.h
+++ b/cpp/core/mrtrix.h
@@ -17,6 +17,9 @@
 #pragma once
 
 #include <array>
+#if defined(MRTRIX_HAVE_FROM_CHARS_INT) || defined(MRTRIX_HAVE_FROM_CHARS_FP)
+#include <charconv>
+#endif
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -29,6 +32,8 @@
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <system_error>
+#include <type_traits>
 
 #include "exception.h"
 #include "types.h"
@@ -116,28 +121,86 @@ bool starts_with_dash(std::string_view arg);
 //! returns string without leading dashes
 std::string without_leading_dash(std::string_view arg);
 
-template <class T> inline T to(std::string_view string) {
-  const std::string stripped(strip(string));
-  std::istringstream stream(stripped);
+namespace detail {
+
+//! Floating-point keyword fallback (covers "nan", "-nan", "inf", "-inf"). Both implementations
+//! defer to this so the lexical form is recognised uniformly across the from_chars and
+//! istringstream paths.
+template <class T> inline std::optional<T> floating_point_keyword(std::string_view stripped) {
+  static_assert(std::is_floating_point<T>::value, "floating_point_keyword<T> requires floating-point T");
+  const std::string lstring = lowercase(stripped);
+  if (lstring == "nan")
+    return std::numeric_limits<T>::quiet_NaN();
+  if (lstring == "-nan")
+    return -std::numeric_limits<T>::quiet_NaN();
+  if (lstring == "inf")
+    return std::numeric_limits<T>::infinity();
+  if (lstring == "-inf")
+    return -std::numeric_limits<T>::infinity();
+  return std::nullopt;
+}
+
+//! Historical stream-based conversion. Retained as the fallback whenever std::from_chars
+//! support for the relevant family is unavailable in the standard library in use.
+template <class T> inline T to_via_istringstream(std::string_view string, std::string_view stripped) {
+  std::istringstream stream{std::string(stripped)};
   T value;
   stream >> value;
   if (stream.fail()) {
-    if (std::is_floating_point<T>::value) {
-      const std::string lstring = lowercase(stripped);
-      if (lstring == "nan")
-        return std::numeric_limits<T>::quiet_NaN();
-      else if (lstring == "-nan")
-        return -std::numeric_limits<T>::quiet_NaN();
-      else if (lstring == "inf")
-        return std::numeric_limits<T>::infinity();
-      else if (lstring == "-inf")
-        return -std::numeric_limits<T>::infinity();
+    if constexpr (std::is_floating_point<T>::value) {
+      if (auto kw = floating_point_keyword<T>(stripped); kw.has_value())
+        return *kw;
     }
     throw Exception("error converting string \"{}\" to type \"{}\"", string, typeid(T).name());
   } else if (!stream.eof()) {
     throw Exception("incomplete use of string \"{}\" in conversion to type \"{}\"", string, typeid(T).name());
   }
   return value;
+}
+
+#if defined(MRTRIX_HAVE_FROM_CHARS_INT) || defined(MRTRIX_HAVE_FROM_CHARS_FP)
+//! std::from_chars-based conversion. Returns a typed value or throws. Distinguishes overflow
+//! (errc::result_out_of_range) from generic parse failure (errc::invalid_argument), and enforces
+//! the same "all of the input must be consumed" invariant as the historical implementation by
+//! comparing the returned ptr against the end of the input range.
+template <class T> inline T to_via_from_chars(std::string_view string, std::string_view stripped) {
+  T value{};
+  const auto result = std::from_chars(stripped.data(), stripped.data() + stripped.size(), value);
+  if (result.ec == std::errc::result_out_of_range)
+    throw Exception("value in string \"{}\" out of range for type \"{}\"", string, typeid(T).name());
+  if (result.ec != std::errc{}) {
+    if constexpr (std::is_floating_point<T>::value) {
+      if (auto kw = floating_point_keyword<T>(stripped); kw.has_value())
+        return *kw;
+    }
+    throw Exception("error converting string \"{}\" to type \"{}\"", string, typeid(T).name());
+  }
+  if (result.ptr != stripped.data() + stripped.size())
+    throw Exception("incomplete use of string \"{}\" in conversion to type \"{}\"", string, typeid(T).name());
+  return value;
+}
+#endif
+
+//! Selects between from_chars and the istringstream fallback at compile time per T, based on
+//! which feature macros the CMake configure step exposed. Non-arithmetic specialisations
+//! (bool, complex) are handled outside this dispatch.
+template <class T> inline T to_dispatch(std::string_view string, std::string_view stripped) {
+#if defined(MRTRIX_HAVE_FROM_CHARS_INT)
+  if constexpr (std::is_integral_v<T> && !std::is_same_v<T, bool>)
+    return to_via_from_chars<T>(string, stripped);
+#endif
+#if defined(MRTRIX_HAVE_FROM_CHARS_FP)
+  if constexpr (std::is_floating_point_v<T>)
+    return to_via_from_chars<T>(string, stripped);
+#endif
+  return to_via_istringstream<T>(string, stripped);
+}
+
+} // namespace detail
+
+template <class T> inline T to(std::string_view string) {
+  const std::string stripped(strip(string));
+  return detail::to_dispatch<T>(string, stripped);
 }
 
 template <> inline bool to<bool>(std::string_view string) {

--- a/cpp/core/mrtrix.h
+++ b/cpp/core/mrtrix.h
@@ -175,7 +175,13 @@ template <> inline cfloat to<cfloat>(std::string_view string) {
   if (string.empty())
     throw Exception("cannot convert empty string to complex float");
 
-  const std::string stripped = strip(string);
+  std::string stripped = strip(string);
+  // Accept fmtlib's parenthesised complex form "(a+bi)" in addition to the bare "a+bi".
+  if (stripped.size() >= 2 && stripped.front() == '(' && stripped.back() == ')') {
+    const std::string inner = strip(stripped.substr(1, stripped.size() - 2));
+    if (!inner.empty())
+      stripped = inner;
+  }
   std::vector<cfloat> candidates;
   for (ssize_t i = -1; i <= static_cast<ssize_t>(stripped.size()); ++i) {
     std::string first, second;
@@ -220,7 +226,13 @@ template <> inline cdouble to<cdouble>(std::string_view string) {
   if (string.empty())
     throw Exception("cannot convert empty string to complex double");
 
-  const std::string stripped = strip(string);
+  std::string stripped = strip(string);
+  // Accept fmtlib's parenthesised complex form "(a+bi)" in addition to the bare "a+bi".
+  if (stripped.size() >= 2 && stripped.front() == '(' && stripped.back() == ')') {
+    const std::string inner = strip(stripped.substr(1, stripped.size() - 2));
+    if (!inner.empty())
+      stripped = inner;
+  }
   std::vector<cdouble> candidates;
   for (ssize_t i = -1; i <= static_cast<ssize_t>(stripped.size()); ++i) {
     std::string first, second;

--- a/cpp/core/mrtrix.h
+++ b/cpp/core/mrtrix.h
@@ -358,25 +358,4 @@ Eigen::Matrix<ValueType, Eigen::Dynamic, Eigen::Dynamic> parse_matrix(std::strin
   return M;
 }
 
-std::string join(const std::vector<std::string> &V, std::string_view delimiter);
-
-template <size_t N> inline std::string join(const std::array<std::string, N> &array, std::string_view delimiter) {
-  const auto v = std::vector<std::string>(array.begin(), array.end());
-  return join(v, delimiter);
-}
-
-template <typename T> inline std::string join(const std::vector<T> &V, std::string_view delimiter) {
-  std::string ret;
-  if (V.empty())
-    return ret;
-  ret = str(V[0]);
-  for (typename std::vector<T>::const_iterator i = V.begin() + 1; i != V.end(); ++i) {
-    ret += delimiter;
-    ret += str(*i);
-  }
-  return ret;
-}
-
-std::string join(const char *const *null_terminated_array, std::string_view delimiter); // check_syntax off
-
 } // namespace MR

--- a/cpp/core/progressbar.cpp
+++ b/cpp/core/progressbar.cpp
@@ -44,24 +44,24 @@ void display_func_multithreaded(const ProgressBar &p) {
 void display_func_terminal(const ProgressBar &p) {
   __need_newline = true;
   if (p.show_percent())
-    __print_stderr(printf(WRAP_OFF_CODE "\r%s: [%3" PRI_SIZET "%%] %s%s" CLEAR_LINE_CODE WRAP_ON_CODE,
-                          App::NAME.c_str(),
-                          p.value(),
-                          p.text_cstr(),
-                          p.ellipsis_cstr()));
+    __print_stderr(fmt::format(WRAP_OFF_CODE "\r{}: [{:3}%] {}{}" CLEAR_LINE_CODE WRAP_ON_CODE,
+                               App::NAME,
+                               p.value(),
+                               p.text_cstr(),
+                               p.ellipsis_cstr()));
   else
-    __print_stderr(printf(WRAP_OFF_CODE "\r%s: [%s] %s%s" CLEAR_LINE_CODE WRAP_ON_CODE,
-                          App::NAME.c_str(),
-                          busy[p.value() % busy.size()].c_str(),
-                          p.text_cstr(),
-                          p.ellipsis_cstr()));
+    __print_stderr(fmt::format(WRAP_OFF_CODE "\r{}: [{}] {}{}" CLEAR_LINE_CODE WRAP_ON_CODE,
+                               App::NAME,
+                               busy[p.value() % busy.size()],
+                               p.text_cstr(),
+                               p.ellipsis_cstr()));
 }
 
 void done_func_terminal(const ProgressBar &p) {
   if (p.show_percent())
-    __print_stderr(printf("\r%s: [100%%] %s" CLEAR_LINE_CODE "\n", App::NAME.c_str(), p.text_cstr()));
+    __print_stderr(fmt::format("\r{}: [100%] {}" CLEAR_LINE_CODE "\n", App::NAME, p.text_cstr()));
   else
-    __print_stderr(printf("\r%s: [done] %s" CLEAR_LINE_CODE "\n", App::NAME.c_str(), p.text_cstr()));
+    __print_stderr(fmt::format("\r{}: [done] {}" CLEAR_LINE_CODE "\n", App::NAME, p.text_cstr()));
   __need_newline = false;
 }
 
@@ -75,15 +75,11 @@ void display_func_redirect(const ProgressBar &p) {
       count = next_update_at = 0;
     if (count++ == next_update_at) {
       if (p.show_percent()) {
-        __print_stderr(
-            printf("%s: [%3" PRI_SIZET "%%] %s%s\n", App::NAME.c_str(), p.value(), p.text_cstr(), p.ellipsis_cstr()));
+        __print_stderr(fmt::format("{}: [{:3}%] {}{}\n", App::NAME, p.value(), p.text_cstr(), p.ellipsis_cstr()));
         ;
       } else {
-        __print_stderr(printf("%s: [%s] %s%s\n",
-                              App::NAME.c_str(),
-                              busy[p.value() % busy.size()].c_str(),
-                              p.text_cstr(),
-                              p.ellipsis_cstr()));
+        __print_stderr(
+            fmt::format("{}: [{}] {}{}\n", App::NAME, busy[p.value() % busy.size()], p.text_cstr(), p.ellipsis_cstr()));
       }
       if (next_update_at)
         next_update_at *= 2;
@@ -97,16 +93,16 @@ void display_func_redirect(const ProgressBar &p) {
     if (p.show_percent()) {
       if (p.first_time) {
         p.first_time = false;
-        __print_stderr(printf("%s: %s%s [", App::NAME.c_str(), p.text_cstr(), p.ellipsis_cstr()));
+        __print_stderr(fmt::format("{}: {}{} [", App::NAME, p.text_cstr(), p.ellipsis_cstr()));
         ;
       } else
         while (p.last_value < p.value()) {
-          __print_stderr(printf("="));
+          __print_stderr("=");
           p.last_value += 2;
         }
     } else {
       if (p.value() == 0) {
-        __print_stderr(printf("%s: %s%s ", App::NAME.c_str(), p.text_cstr(), p.ellipsis_cstr()));
+        __print_stderr(fmt::format("{}: {}{} ", App::NAME, p.text_cstr(), p.ellipsis_cstr()));
         ;
       } else if (!(p.value() & (p.value() - 1))) {
         __print_stderr(".");
@@ -118,16 +114,16 @@ void display_func_redirect(const ProgressBar &p) {
 void done_func_redirect(const ProgressBar &p) {
   if (p.text_has_been_modified()) {
     if (p.show_percent()) {
-      __print_stderr(printf("%s: [100%%] %s\n", App::NAME.c_str(), p.text_cstr()));
+      __print_stderr(fmt::format("{}: [100%] {}\n", App::NAME, p.text_cstr()));
       ;
     } else {
-      __print_stderr(printf("%s: [done] %s\n", App::NAME.c_str(), p.text_cstr()));
+      __print_stderr(fmt::format("{}: [done] {}\n", App::NAME, p.text_cstr()));
     }
   } else {
     if (p.show_percent())
-      __print_stderr(printf("]\n"));
+      __print_stderr("]\n");
     else
-      __print_stderr(printf("done\n"));
+      __print_stderr("done\n");
   }
   __need_newline = false;
 }

--- a/cpp/core/registration/metric/evaluate.h
+++ b/cpp/core/registration/metric/evaluate.h
@@ -126,9 +126,9 @@ public:
       }
     }
     iteration++;
-    DEBUG("Metric evaluate iteration: {}, cost: {}", iteration, overall_cost_function);
-    DEBUG("  x: {}", x);
-    DEBUG("  gradient: {}", gradient);
+    DEBUG("Metric evaluate iteration: {}, cost: {:T}", iteration, overall_cost_function);
+    DEBUG("  x: {:T}", x);
+    DEBUG("  gradient: {:T}", gradient);
     DEBUG("  norm(gradient): {}", gradient.norm());
     DEBUG("  overlapping voxels: {}", overlap_count);
     return overall_cost_function(0);

--- a/cpp/core/registration/metric/params.h
+++ b/cpp/core/registration/metric/params.h
@@ -148,9 +148,9 @@ public:
     auto trafo1 = transformation.get_transform_half();
     auto trafo2 = transformation.get_transform_half_inverse();
 
-    header.keyval()["control_points"] = str(control_points);
-    header.keyval()["trafo1"] = str(trafo1.matrix());
-    header.keyval()["trafo2"] = str(trafo2.matrix());
+    header.keyval()["control_points"] = fmt::format("{}", control_points);
+    header.keyval()["trafo1"] = fmt::format("{}", trafo1.matrix());
+    header.keyval()["trafo2"] = fmt::format("{}", trafo2.matrix());
     auto check = Image<default_type>::create(image_path, header);
 
     std::vector<uint32_t> no_oversampling(3, 1);

--- a/cpp/core/registration/nonlinear.h
+++ b/cpp/core/registration/nonlinear.h
@@ -476,19 +476,19 @@ public:
   }
 
   void write_linear_to_header(Header &output_header) const {
-    output_header.keyval()["linear1"] = str(im1_to_mid_linear.matrix());
-    output_header.keyval()["linear2"] = str(im2_to_mid_linear.matrix());
+    output_header.keyval()["linear1"] = fmt::format("{}", im1_to_mid_linear.matrix());
+    output_header.keyval()["linear2"] = fmt::format("{}", im2_to_mid_linear.matrix());
   }
 
   void write_params_to_header(Header &output_header) const {
-    output_header.keyval()["nl_scale"] = str(scale_factor);
-    output_header.keyval()["nl_niter"] = str(max_iter);
-    output_header.keyval()["nl_update_smooth"] = str(update_smoothing);
-    output_header.keyval()["nl_disp_smooth"] = str(disp_smoothing);
-    output_header.keyval()["nl_gradient_step"] = str(gradient_step);
-    output_header.keyval()["fod_reorientation"] = str(do_reorientation);
+    output_header.keyval()["nl_scale"] = fmt::format("{}", scale_factor);
+    output_header.keyval()["nl_niter"] = fmt::format("{}", max_iter);
+    output_header.keyval()["nl_update_smooth"] = fmt::format("{}", update_smoothing);
+    output_header.keyval()["nl_disp_smooth"] = fmt::format("{}", disp_smoothing);
+    output_header.keyval()["nl_gradient_step"] = fmt::format("{}", gradient_step);
+    output_header.keyval()["fod_reorientation"] = fmt::format("{}", do_reorientation);
     if (do_reorientation)
-      output_header.keyval()["nl_lmax"] = str(fod_lmax);
+      output_header.keyval()["nl_lmax"] = fmt::format("{}", fod_lmax);
   }
 
   template <class OutputType> void get_output_warps(OutputType &output_warps) {

--- a/cpp/core/registration/transform/initialiser.cpp
+++ b/cpp/core/registration/transform/initialiser.cpp
@@ -42,7 +42,7 @@ void set_centre_via_mass(Image<default_type> &im1,
   transform.transform_half(im2_centre_mass_transformed, im2_centre_mass);
 
   const Eigen::Vector3d centre = (im1_centre_mass + im2_centre_mass) * 0.5;
-  DEBUG("centre: {}", centre);
+  DEBUG("centre: {:T}", centre);
   transform.set_centre_without_transform_update(centre);
 }
 
@@ -61,7 +61,7 @@ void set_centre_via_image_centres(const Image<default_type> &im1,
   get_geometric_centre(im2, im2_centre_scanner);
 
   Eigen::Vector3d centre = (im1_centre_scanner + im2_centre_scanner) / 2.0;
-  DEBUG("centre: {}", centre);
+  DEBUG("centre: {:T}", centre);
   transform.set_centre_without_transform_update(centre);
 }
 

--- a/cpp/core/registration/transform/initialiser_helpers.cpp
+++ b/cpp/core/registration/transform/initialiser_helpers.cpp
@@ -292,7 +292,7 @@ void get_centre_of_mass(Image<default_type> &im,
   if (mass == 0.0)
     throw Exception("centre of mass initialisation not possible for empty image");
   centre_of_mass /= mass;
-  DEBUG("centre of mass of {}: {}", im.name(), centre_of_mass);
+  DEBUG("centre of mass of {}: {:T}", im.name(), centre_of_mass);
 }
 
 void initialise_using_rotation_search(Image<default_type> &im1,

--- a/cpp/core/stats.cpp
+++ b/cpp/core/stats.cpp
@@ -43,39 +43,43 @@ const OptionGroup Options =
              "ignore zero values during statistics calculation");
 // clang-format on
 
-void Stats::operator()(complex_type val) {
-  if (std::isfinite(val.real()) && std::isfinite(val.imag()) &&
-      (!ignore_zero || val.real() != 0.0 || val.imag() != 0.0)) {
-    if (min.real() > val.real())
-      min = complex_type(val.real(), min.imag());
-    if (min.imag() > val.imag())
-      min = complex_type(min.real(), val.imag());
-    if (max.real() < val.real())
-      max = complex_type(val.real(), max.imag());
-    if (max.imag() < val.imag())
-      max = complex_type(max.real(), val.imag());
-    count++;
-    // Welford's online algorithm for variance calculation:
-    delta = val - mean;
-    mean += cdouble{delta.real() / static_cast<double>(count), delta.imag() / static_cast<double>(count)};
-    delta2 = val - mean;
-    m2 += cdouble{delta.real() * delta2.real(), delta.imag() * delta2.imag()};
-    if (!is_complex)
-      values.push_back(static_cast<value_type>(val.real()));
+template <typename T> void Stats<T>::operator()(T val) {
+  if constexpr (is_complex<T>::value) {
+    if (std::isfinite(val.real()) && std::isfinite(val.imag()) &&
+        (!ignore_zero || val.real() != 0.0 || val.imag() != 0.0)) {
+      if (min.real() > val.real())
+        min = T(val.real(), min.imag());
+      if (min.imag() > val.imag())
+        min = T(min.real(), val.imag());
+      if (max.real() < val.real())
+        max = T(val.real(), max.imag());
+      if (max.imag() < val.imag())
+        max = T(max.real(), val.imag());
+      count++;
+      // Welford's online algorithm for variance calculation:
+      delta = val - mean;
+      mean += T{delta.real() / static_cast<double>(count), delta.imag() / static_cast<double>(count)};
+      delta2 = val - mean;
+      m2 += T{delta.real() * delta2.real(), delta.imag() * delta2.imag()};
+    }
+  } else {
+    if (std::isfinite(val) && (!ignore_zero || val != 0.0)) {
+      if (min > val)
+        min = val;
+      if (max < val)
+        max = val;
+      count++;
+      // Welford's online algorithm for variance calculation:
+      delta = val - mean;
+      mean += delta / static_cast<double>(count);
+      delta2 = val - mean;
+      m2 += delta * delta2;
+      values.push_back(static_cast<value_type>(val));
+    }
   }
 }
 
-void print_header(bool is_complex) {
-  const int width = is_complex ? 20 : 10;
-  std::cout << std::setw(12) << std::right << "volume"
-            << " " << std::setw(width) << std::right << "mean";
-  if (!is_complex)
-    std::cout << " " << std::setw(width) << std::right << "median";
-  std::cout << " " << std::setw(width) << std::right << "std"
-            << " " << std::setw(width) << std::right << "min"
-            << " " << std::setw(width) << std::right << "max"
-            << " " << std::setw(10) << std::right << "count"
-            << "\n";
-}
+template class Stats<value_type>;
+template class Stats<complex_type>;
 
 } // namespace MR::Stats

--- a/cpp/core/stats.cpp
+++ b/cpp/core/stats.cpp
@@ -34,7 +34,7 @@ const OptionGroup Options =
                          " For complex data, min, max and std are calculated separately for real and imaginary parts,"
                          " std_rv is based on the real valued variance"
                          " (equals sqrt of sum of variances of imaginary and real parts).",
-                         join(field_choices, ", "))).allow_multiple()
+                         fmt::join(field_choices, ", "))).allow_multiple()
       + Argument("field").type_choice(field_choices)
     + Option("mask",
              "only perform computation within the specified binary mask image.")

--- a/cpp/core/stats.h
+++ b/cpp/core/stats.h
@@ -66,20 +66,20 @@ public:
       }
       for (size_t n = 0; n < fields.size(); ++n) {
         if (fields[n] == "mean")
-          std::cout << str(mean) << " ";
+          std::cout << fmt::format("{}", mean) << " ";
         else if (fields[n] == "median")
           std::cout << (!values.empty() ? str(Math::median(values)) : "N/A") << " ";
         else if (fields[n] == "std")
-          std::cout << (count > 1 ? str(std) : "N/A") << " ";
+          std::cout << (count > 1 ? fmt::format("{}", std) : "N/A") << " ";
         else if (fields[n] == "std_rv")
-          std::cout << (count > 1 ? str(std_rv) : "N/A") << " ";
+          std::cout << (count > 1 ? fmt::format("{}", std_rv) : "N/A") << " ";
         else if (fields[n] == "iqr")
           std::cout << (!values.empty() ? str(Math::quantile(values, 0.75) - Math::quantile(values, 0.25)) : "N/A")
                     << " ";
         else if (fields[n] == "min")
-          std::cout << str(min) << " ";
+          std::cout << fmt::format("{}", min) << " ";
         else if (fields[n] == "max")
-          std::cout << str(max) << " ";
+          std::cout << fmt::format("{}", max) << " ";
         else if (fields[n] == "count")
           std::cout << count << " ";
         else
@@ -100,7 +100,7 @@ public:
       int width = is_complex ? 20 : 10;
       std::cout << std::setw(12) << std::right << s << " ";
 
-      std::cout << std::setw(width) << std::right << (count ? str(mean) : "N/A");
+      std::cout << std::setw(width) << std::right << (count ? fmt::format("{}", mean) : "N/A");
 
       if (!is_complex) {
         std::cout << " " << std::setw(width) << std::right;
@@ -109,9 +109,10 @@ public:
         else
           std::cout << "N/A";
       }
-      std::cout << " " << std::setw(width) << std::right << (count > 1 ? str(std) : "N/A") << " " << std::setw(width)
-                << std::right << (count ? str(min) : "N/A") << " " << std::setw(width) << std::right
-                << (count ? str(max) : "N/A") << " " << std::setw(10) << std::right << count << "\n";
+      std::cout << " " << std::setw(width) << std::right << (count > 1 ? fmt::format("{}", std) : "N/A") << " "
+                << std::setw(width) << std::right << (count ? fmt::format("{}", min) : "N/A") << " " << std::setw(width)
+                << std::right << (count ? fmt::format("{}", max) : "N/A") << " " << std::setw(10) << std::right << count
+                << "\n";
     }
   }
 

--- a/cpp/core/stats.h
+++ b/cpp/core/stats.h
@@ -30,29 +30,38 @@ extern const App::OptionGroup Options;
 using value_type = default_type;
 using complex_type = cdouble;
 
-class Stats {
+//! Online image statistics accumulator.
+/*! \a T selects the storage/formatting domain at compile time: \c default_type for
+ *  guaranteed-real data (so the complex formatter is never engaged) and \c cdouble for
+ *  complex data, where min/max/std are tracked separately for real and imaginary parts. */
+template <typename T> class Stats {
 public:
-  Stats(const bool is_complex = false, const bool ignorezero = false)
-      : mean(0.0, 0.0),
-        delta(0.0, 0.0),
-        delta2(0.0, 0.0),
-        m2(0.0, 0.0),
-        std(0.0, 0.0),
-        std_rv(0.0, 0.0),
-        min(Inf, Inf),
-        max(-Inf, -Inf),
-        count(0),
-        is_complex(is_complex),
-        ignore_zero(ignorezero) {}
+  Stats(const bool ignorezero = false) : count(0), ignore_zero(ignorezero) {
+    if constexpr (is_complex<T>::value) {
+      mean = delta = delta2 = m2 = std = T(0.0, 0.0);
+      min = T(Inf, Inf);
+      max = T(-Inf, -Inf);
+    } else {
+      mean = delta = delta2 = m2 = std = T(0);
+      min = Inf;
+      max = -Inf;
+    }
+    std_rv = value_type(0);
+  }
 
-  void operator()(complex_type val);
+  void operator()(T val);
 
   template <class ImageType> void print(ImageType &ima, const std::vector<std::string> &fields) {
 
     if (count > 1) {
-      std = complex_type(sqrt(m2.real() / static_cast<value_type>(count - 1)),
-                         sqrt(m2.imag() / static_cast<value_type>(count - 1)));
-      std_rv = complex_type(sqrt((m2.real() + m2.imag()) / static_cast<value_type>(count - 1)));
+      if constexpr (is_complex<T>::value) {
+        std = T(sqrt(m2.real() / static_cast<value_type>(count - 1)),
+                sqrt(m2.imag() / static_cast<value_type>(count - 1)));
+        std_rv = sqrt((m2.real() + m2.imag()) / static_cast<value_type>(count - 1));
+      } else {
+        std = std::sqrt(m2 / static_cast<value_type>(count - 1));
+        std_rv = std;
+      }
       std::sort(values.begin(), values.end());
     }
     if (!fields.empty()) {
@@ -68,13 +77,14 @@ public:
         if (fields[n] == "mean")
           std::cout << fmt::format("{}", mean) << " ";
         else if (fields[n] == "median")
-          std::cout << (!values.empty() ? str(Math::median(values)) : "N/A") << " ";
+          std::cout << (!values.empty() ? fmt::format("{}", Math::median(values)) : "N/A") << " ";
         else if (fields[n] == "std")
           std::cout << (count > 1 ? fmt::format("{}", std) : "N/A") << " ";
         else if (fields[n] == "std_rv")
           std::cout << (count > 1 ? fmt::format("{}", std_rv) : "N/A") << " ";
         else if (fields[n] == "iqr")
-          std::cout << (!values.empty() ? str(Math::quantile(values, 0.75) - Math::quantile(values, 0.25)) : "N/A")
+          std::cout << (!values.empty() ? fmt::format("{}", Math::quantile(values, 0.75) - Math::quantile(values, 0.25))
+                                        : "N/A")
                     << " ";
         else if (fields[n] == "min")
           std::cout << fmt::format("{}", min) << " ";
@@ -97,15 +107,15 @@ public:
         s += "0 ";
       s += "]";
 
-      int width = is_complex ? 20 : 10;
+      constexpr int width = is_complex<T>::value ? 20 : 10;
       std::cout << std::setw(12) << std::right << s << " ";
 
       std::cout << std::setw(width) << std::right << (count ? fmt::format("{}", mean) : "N/A");
 
-      if (!is_complex) {
+      if constexpr (!is_complex<T>::value) {
         std::cout << " " << std::setw(width) << std::right;
         if (count)
-          std::cout << Math::median(values);
+          std::cout << fmt::format("{}", Math::median(values));
         else
           std::cout << "N/A";
       }
@@ -117,12 +127,24 @@ public:
   }
 
 private:
-  complex_type mean, delta, delta2, m2, std, std_rv, min, max;
+  T mean, delta, delta2, m2, std, min, max;
+  value_type std_rv;
   size_t count;
-  const bool is_complex, ignore_zero;
+  const bool ignore_zero;
   std::vector<float> values;
 };
 
-void print_header(bool is_complex);
+template <typename T> void print_header() {
+  constexpr int width = is_complex<T>::value ? 20 : 10;
+  std::cout << std::setw(12) << std::right << "volume"
+            << " " << std::setw(width) << std::right << "mean";
+  if constexpr (!is_complex<T>::value)
+    std::cout << " " << std::setw(width) << std::right << "median";
+  std::cout << " " << std::setw(width) << std::right << "std"
+            << " " << std::setw(width) << std::right << "min"
+            << " " << std::setw(width) << std::right << "max"
+            << " " << std::setw(10) << std::right << "count"
+            << "\n";
+}
 
 } // namespace MR::Stats

--- a/cpp/core/surface/mesh.cpp
+++ b/cpp/core/surface/mesh.cpp
@@ -730,7 +730,7 @@ void Mesh::save_vtk(const std::filesystem::path &path, const bool binary) const 
 
   } else {
 
-    out << "POINTS " << str(vertices.size()) << " float\n";
+    out << "POINTS " << fmt::format("{}", vertices.size()) << " float\n";
     for (const auto &v : vertices) {
       out << fmt::format("{} {} {}\n", static_cast<float>(v[0]), static_cast<float>(v[1]), static_cast<float>(v[2]));
       ++progress;
@@ -739,11 +739,13 @@ void Mesh::save_vtk(const std::filesystem::path &path, const bool binary) const 
                        triangles.size() + quads.size(),          //
                        4 * triangles.size() + 5 * quads.size()); //
     for (const auto &t : triangles) {
-      out << "3 " << str(t[0]) << " " << str(t[1]) << " " << str(t[2]) << "\n";
+      out << "3 " << fmt::format("{}", t[0]) << " " << fmt::format("{}", t[1]) << " " << fmt::format("{}", t[2])
+          << "\n";
       ++progress;
     }
     for (const auto &q : quads) {
-      out << "4 " << str(q[0]) << " " << str(q[1]) << " " << str(q[2]) << " " << str(q[3]) << "\n";
+      out << "4 " << fmt::format("{}", q[0]) << " " << fmt::format("{}", q[1]) << " " << fmt::format("{}", q[2]) << " "
+          << fmt::format("{}", q[3]) << "\n";
       ++progress;
     }
   }
@@ -784,11 +786,13 @@ void Mesh::save_stl(const std::filesystem::path &path, const bool binary) const 
     out << "solid \n";
     for (TriangleList::const_iterator i = triangles.begin(); i != triangles.end(); ++i) {
       const Eigen::Vector3d n(normal(*this, *i));
-      out << "facet normal " << str(n[0]) << " " << str(n[1]) << " " << str(n[2]) << "\n";
+      out << "facet normal " << fmt::format("{}", n[0]) << " " << fmt::format("{}", n[1]) << " "
+          << fmt::format("{}", n[2]) << "\n";
       out << "    outer loop\n";
       for (size_t v = 0; v != 3; ++v) {
         const Vertex p(vertices[(*i)[v]]);
-        out << "        vertex " << str(p[0]) << " " << str(p[1]) << " " << str(p[2]) << "\n";
+        out << "        vertex " << fmt::format("{}", p[0]) << " " << fmt::format("{}", p[1]) << " "
+            << fmt::format("{}", p[2]) << "\n";
       }
       out << "    endloop\n";
       out << "endfacet\n";
@@ -803,12 +807,14 @@ void Mesh::save_obj(const std::filesystem::path &path) const {
   out << "# " << App::command_history_string << "\n";
   out << "o " << name << "\n";
   for (VertexList::const_iterator v = vertices.begin(); v != vertices.end(); ++v)
-    out << "v " << str((*v)[0]) << " " << str((*v)[1]) << " " << str((*v)[2]) << " 1.0\n";
+    out << "v " << fmt::format("{}", (*v)[0]) << " " << fmt::format("{}", (*v)[1]) << " " << fmt::format("{}", (*v)[2])
+        << " 1.0\n";
   for (TriangleList::const_iterator t = triangles.begin(); t != triangles.end(); ++t)
-    out << "f " << str((*t)[0] + 1) << " " << str((*t)[1] + 1) << " " << str((*t)[2] + 1) << "\n";
+    out << "f " << fmt::format("{}", (*t)[0] + 1) << " " << fmt::format("{}", (*t)[1] + 1) << " "
+        << fmt::format("{}", (*t)[2] + 1) << "\n";
   for (QuadList::const_iterator q = quads.begin(); q != quads.end(); ++q)
-    out << "f " << str((*q)[0] + 1) << " " << str((*q)[1] + 1) << " " << str((*q)[2] + 1) << " " << str((*q)[3] + 1)
-        << "\n";
+    out << "f " << fmt::format("{}", (*q)[0] + 1) << " " << fmt::format("{}", (*q)[1] + 1) << " "
+        << fmt::format("{}", (*q)[2] + 1) << " " << fmt::format("{}", (*q)[3] + 1) << "\n";
 }
 
 void Mesh::load_triangle_vertices(VertexList &output, const size_t index) const {

--- a/cpp/core/surface/mesh.cpp
+++ b/cpp/core/surface/mesh.cpp
@@ -732,7 +732,7 @@ void Mesh::save_vtk(const std::filesystem::path &path, const bool binary) const 
 
     out << "POINTS " << str(vertices.size()) << " float\n";
     for (const auto &v : vertices) {
-      out << str<float>(v[0]) << " " << str<float>(v[1]) << " " << str<float>(v[2]) << "\n";
+      out << fmt::format("{} {} {}\n", static_cast<float>(v[0]), static_cast<float>(v[1]), static_cast<float>(v[2]));
       ++progress;
     }
     out << fmt::format("POLYGONS {} {}\n",                       //

--- a/cpp/core/surface/mesh_multi.cpp
+++ b/cpp/core/surface/mesh_multi.cpp
@@ -132,7 +132,7 @@ void MeshMulti::load(const std::filesystem::path &path) {
         vertex_index_offset += vertices.size();
         Mesh temp;
         temp.load(std::move(vertices), std::move(triangles), std::move(quads));
-        temp.set_name(!object.empty() ? object : str(index - 1));
+        temp.set_name(!object.empty() ? object : fmt::format("{}", index - 1));
         push_back(temp);
       }
       object = data;
@@ -157,12 +157,14 @@ void MeshMulti::save(const std::filesystem::path &path) const {
   for (const_iterator i = begin(); i != end(); ++i) {
     out << "o " << i->get_name() << "\n";
     for (VertexList::const_iterator v = i->vertices.begin(); v != i->vertices.end(); ++v)
-      out << "v " << str((*v)[0]) << " " << str((*v)[1]) << " " << str((*v)[2]) << " 1.0\n";
+      out << "v " << fmt::format("{}", (*v)[0]) << " " << fmt::format("{}", (*v)[1]) << " "
+          << fmt::format("{}", (*v)[2]) << " 1.0\n";
     for (TriangleList::const_iterator t = i->triangles.begin(); t != i->triangles.end(); ++t)
-      out << "f " << str((*t)[0] + offset) << " " << str((*t)[1] + offset) << " " << str((*t)[2] + offset) << "\n";
+      out << "f " << fmt::format("{}", (*t)[0] + offset) << " " << fmt::format("{}", (*t)[1] + offset) << " "
+          << fmt::format("{}", (*t)[2] + offset) << "\n";
     for (QuadList::const_iterator q = i->quads.begin(); q != i->quads.end(); ++q)
-      out << "f " << str((*q)[0] + offset) << " " << str((*q)[1] + offset) << " " << str((*q)[2] + offset) << " "
-          << str((*q)[3] + offset) << "\n";
+      out << "f " << fmt::format("{}", (*q)[0] + offset) << " " << fmt::format("{}", (*q)[1] + offset) << " "
+          << fmt::format("{}", (*q)[2] + offset) << " " << fmt::format("{}", (*q)[3] + offset) << "\n";
     offset += i->vertices.size();
   }
 }

--- a/cpp/core/types.h
+++ b/cpp/core/types.h
@@ -22,6 +22,7 @@
 #include <deque>
 #include <fmt/format.h>
 #include <fmt/ostream.h>
+#include <fmt/ranges.h>
 #include <iostream>
 #include <map>
 #include <memory>
@@ -242,34 +243,25 @@ template <class T, std::size_t N> inline ostream &operator<<(ostream &stream, co
 } // namespace std
 
 namespace fmt {
-template <class T> struct formatter<std::vector<T>> {
-  //! Per-element formatter; receives any format specification so it propagates to each entry.
-  formatter<T> value_formatter;
-  constexpr auto parse(format_parse_context &ctx) { return value_formatter.parse(ctx); }
-  template <typename FormatContext> auto format(const std::vector<T> &v, FormatContext &ctx) const {
-    auto out = format_to(ctx.out(), "[ ");
-    for (size_t i = 0; i != v.size(); ++i) {
-      ctx.advance_to(out);
-      out = value_formatter.format(v[i], ctx);
-      out = format_to(out, " ");
-    }
-    return format_to(out, "]");
-  }
-};
-template <class T, std::size_t N> struct formatter<std::array<T, N>> {
-  //! Per-element formatter; receives any format specification so it propagates to each entry.
-  formatter<T> value_formatter;
-  constexpr auto parse(format_parse_context &ctx) { return value_formatter.parse(ctx); }
-  template <typename FormatContext> auto format(const std::array<T, N> &v, FormatContext &ctx) const {
-    auto out = format_to(ctx.out(), "[ ");
-    for (size_t i = 0; i != N; ++i) {
-      ctx.advance_to(out);
-      out = value_formatter.format(v[i], ctx);
-      out = format_to(out, " ");
-    }
-    return format_to(out, "]");
-  }
-};
+// std::vector and std::array are formatted by fmtlib's native range formatter (<fmt/ranges.h>),
+// yielding "[1, 2, 3]".
+
+//! Disable fmtlib's native range formatter for Eigen matrix/array expressions, so the dedicated
+//! formatter below (which mirrors Eigen's own layout) applies unambiguously rather than colliding
+//! with the generic range formatter that would otherwise treat an Eigen object as a range.
+template <typename Derived>
+struct range_format_kind<
+    Derived,
+    char,
+    std::enable_if_t<
+        MR::is_eigen_type<std::remove_cv_t<Derived>>::value &&
+        (std::is_same_v<typename Eigen::internal::traits<std::remove_cv_t<Derived>>::XprKind, Eigen::MatrixXpr> ||
+         std::is_same_v<typename Eigen::internal::traits<std::remove_cv_t<Derived>>::XprKind, Eigen::ArrayXpr>)>>
+    : std::integral_constant<range_format, range_format::disabled> {};
+
+//! Format an Eigen matrix/array by delegating to Eigen's own ostream insertion operator.
+//! A column vector is emitted transposed onto a single line with a trailing "^T" (the transpose
+//! is performed inside the formatter, so call sites need not transpose explicitly).
 template <typename Derived>
 struct formatter<
     Derived,
@@ -278,40 +270,11 @@ struct formatter<
         MR::is_eigen_type<std::remove_cv_t<Derived>>::value &&
         (std::is_same_v<typename Eigen::internal::traits<std::remove_cv_t<Derived>>::XprKind, Eigen::MatrixXpr> ||
          std::is_same_v<typename Eigen::internal::traits<std::remove_cv_t<Derived>>::XprKind, Eigen::ArrayXpr>)>> {
-  //! Per-coefficient formatter; receives any format specification so it propagates to each coefficient.
-  formatter<typename std::remove_cv_t<Derived>::Scalar> value_formatter;
-  constexpr auto parse(format_parse_context &ctx) { return value_formatter.parse(ctx); }
+  constexpr auto parse(format_parse_context &ctx) { return ctx.begin(); }
   template <typename FormatContext> auto format(const Derived &m, FormatContext &ctx) const {
-    auto out = ctx.out();
-    if (m.rows() == 1) {
-      out = format_to(out, "[ ");
-      for (Eigen::Index i = 0; i < m.cols(); ++i) {
-        ctx.advance_to(out);
-        out = value_formatter.format(m.coeff(0, i), ctx);
-        out = format_to(out, " ");
-      }
-      return format_to(out, "]");
-    } else if (m.cols() == 1) {
-      out = format_to(out, "[ ");
-      for (Eigen::Index i = 0; i < m.rows(); ++i) {
-        ctx.advance_to(out);
-        out = value_formatter.format(m.coeff(i, 0), ctx);
-        out = format_to(out, " ");
-      }
-      return format_to(out, "]^T");
-    } else {
-      out = format_to(out, "\n[ ");
-      for (Eigen::Index i = 0; i < m.rows(); ++i) {
-        if (i > 0)
-          out = format_to(out, "\n");
-        for (Eigen::Index j = 0; j < m.cols(); ++j) {
-          ctx.advance_to(out);
-          out = value_formatter.format(m.coeff(i, j), ctx);
-          out = format_to(out, " ");
-        }
-      }
-      return format_to(out, "]");
-    }
+    if (m.cols() == 1 && m.rows() > 1)
+      return fmt::format_to(ctx.out(), "{}^T", fmt::streamed(m.transpose()));
+    return fmt::format_to(ctx.out(), "{}", fmt::streamed(m));
   }
 };
 template <typename T> struct formatter<Eigen::Transform<T, 3, Eigen::AffineCompact>> {

--- a/cpp/core/types.h
+++ b/cpp/core/types.h
@@ -260,8 +260,12 @@ struct range_format_kind<
     : std::integral_constant<range_format, range_format::disabled> {};
 
 //! Format an Eigen matrix/array by delegating to Eigen's own ostream insertion operator.
-//! A column vector is emitted transposed onto a single line with a trailing "^T" (the transpose
-//! is performed inside the formatter, so call sites need not transpose explicitly).
+//! Spec grammar: an optional single 'T' selects "display the transpose": the expression is
+//! transposed before being emitted and a trailing "^T" suffix is appended. Without the spec
+//! the expression is emitted as-is (a column vector therefore renders multi-line, matching
+//! Eigen's native ostream layout); the spec is the only way to obtain the transposed
+//! single-line form. No other spec characters are accepted (use Eigen::IOFormat for richer
+//! control via Eigen::WithFormat).
 template <typename Derived>
 struct formatter<
     Derived,
@@ -270,9 +274,20 @@ struct formatter<
         MR::is_eigen_type<std::remove_cv_t<Derived>>::value &&
         (std::is_same_v<typename Eigen::internal::traits<std::remove_cv_t<Derived>>::XprKind, Eigen::MatrixXpr> ||
          std::is_same_v<typename Eigen::internal::traits<std::remove_cv_t<Derived>>::XprKind, Eigen::ArrayXpr>)>> {
-  constexpr auto parse(format_parse_context &ctx) { return ctx.begin(); }
+  bool transpose = false;
+  constexpr auto parse(format_parse_context &ctx) {
+    auto it = ctx.begin();
+    const auto end = ctx.end();
+    if (it != end && *it == 'T') {
+      transpose = true;
+      ++it;
+    }
+    if (it != end && *it != '}')
+      throw format_error("invalid format spec for Eigen matrix/array (expected optional 'T' then '}')");
+    return it;
+  }
   template <typename FormatContext> auto format(const Derived &m, FormatContext &ctx) const {
-    if (m.cols() == 1 && m.rows() > 1)
+    if (transpose)
       return fmt::format_to(ctx.out(), "{}^T", fmt::streamed(m.transpose()));
     return fmt::format_to(ctx.out(), "{}", fmt::streamed(m));
   }

--- a/cpp/gui/dialog/file.cpp
+++ b/cpp/gui/dialog/file.cpp
@@ -30,7 +30,8 @@
 
 namespace MR::GUI::Dialog::File {
 
-const std::string image_filter_string = "Medical Images (*" + join(MR::Formats::known_extensions, " *") + ")";
+const std::string image_filter_string =
+    "Medical Images (*" + fmt::format("{}", fmt::join(MR::Formats::known_extensions, " *")) + ")";
 
 const FileDialogReturn
 input_dirpath(QWidget *parent, std::string_view caption, std::optional<std::filesystem::path> start_directory) {

--- a/cpp/gui/dialog/image_properties.cpp
+++ b/cpp/gui/dialog/image_properties.cpp
@@ -54,12 +54,12 @@ ImageProperties::ImageProperties(QWidget *parent, const MR::Header &header)
   }
 
   std::string text;
-  text = str(H.size(0));
+  text = fmt::format("{}", H.size(0));
   for (size_t n = 1; n < H.ndim(); ++n)
     text += fmt::format(" x {}", H.size(n));
   root->appendChild(new TreeItem("Dimensions", text, root));
 
-  text = str(H.spacing(0));
+  text = fmt::format("{}", H.spacing(0));
   for (size_t n = 1; n < H.ndim(); ++n)
     text += fmt::format(" x {}", H.spacing(n));
   root->appendChild(new TreeItem("Voxel size", text, root));
@@ -67,7 +67,7 @@ ImageProperties::ImageProperties(QWidget *parent, const MR::Header &header)
   root->appendChild(new TreeItem("Data type", H.datatype().description(), root));
 
   MR::Stride::List strides = MR::Stride::get_symbolic(H);
-  text = str(strides[0]);
+  text = fmt::format("{}", strides[0]);
   for (size_t n = 1; n != strides.size(); ++n)
     text += fmt::format(", {}", strides[n]);
   root->appendChild(new TreeItem("Strides", text, root));

--- a/cpp/gui/dialog/opengl.cpp
+++ b/cpp/gui/dialog/opengl.cpp
@@ -39,12 +39,12 @@ OpenGL::OpenGL(QWidget *parent, const GL::Format &format) : QDialog(parent) {
   TreeItem *bit_depths = new TreeItem("Bit depths", std::string(), root);
   root->appendChild(bit_depths);
 
-  bit_depths->appendChild(new TreeItem("red", str(format.redBufferSize()), bit_depths));
-  bit_depths->appendChild(new TreeItem("green", str(format.greenBufferSize()), bit_depths));
-  bit_depths->appendChild(new TreeItem("blue", str(format.blueBufferSize()), bit_depths));
-  bit_depths->appendChild(new TreeItem("alpha", str(format.alphaBufferSize()), bit_depths));
-  bit_depths->appendChild(new TreeItem("depth", str(format.depthBufferSize()), bit_depths));
-  bit_depths->appendChild(new TreeItem("stencil", str(format.stencilBufferSize()), bit_depths));
+  bit_depths->appendChild(new TreeItem("red", fmt::format("{}", format.redBufferSize()), bit_depths));
+  bit_depths->appendChild(new TreeItem("green", fmt::format("{}", format.greenBufferSize()), bit_depths));
+  bit_depths->appendChild(new TreeItem("blue", fmt::format("{}", format.blueBufferSize()), bit_depths));
+  bit_depths->appendChild(new TreeItem("alpha", fmt::format("{}", format.alphaBufferSize()), bit_depths));
+  bit_depths->appendChild(new TreeItem("depth", fmt::format("{}", format.depthBufferSize()), bit_depths));
+  bit_depths->appendChild(new TreeItem("stencil", fmt::format("{}", format.stencilBufferSize()), bit_depths));
 
   root->appendChild(new TreeItem("Buffering",
                                  format.swapBehavior() == QSurfaceFormat::SingleBuffer
@@ -52,16 +52,16 @@ OpenGL::OpenGL(QWidget *parent, const GL::Format &format) : QDialog(parent) {
                                      : (format.swapBehavior() == QSurfaceFormat::DoubleBuffer ? "double" : "triple"),
                                  root));
   root->appendChild(new TreeItem("VSync", format.swapInterval() ? "on" : "off", root));
-  root->appendChild(
-      new TreeItem("Multisample anti-aliasing", format.samples() ? str(format.samples()).c_str() : "off", root));
+  root->appendChild(new TreeItem(
+      "Multisample anti-aliasing", format.samples() ? fmt::format("{}", format.samples()).c_str() : "off", root));
 
   GLint max_2d_texture_size;
   gl::GetIntegerv(gl::MAX_TEXTURE_SIZE, &max_2d_texture_size);
-  root->appendChild(new TreeItem("Maximum 2D texture size", str(max_2d_texture_size), root));
+  root->appendChild(new TreeItem("Maximum 2D texture size", fmt::format("{}", max_2d_texture_size), root));
 
   GLint max_3D_texture_size;
   gl::GetIntegerv(gl::MAX_3D_TEXTURE_SIZE, &max_3D_texture_size);
-  root->appendChild(new TreeItem("Maximum 3D texture size", str(max_3D_texture_size), root));
+  root->appendChild(new TreeItem("Maximum 3D texture size", fmt::format("{}", max_3D_texture_size), root));
 
   QTreeView *view = new QTreeView;
   view->setModel(model);

--- a/cpp/gui/mrview/adjust_button.h
+++ b/cpp/gui/mrview/adjust_button.h
@@ -45,15 +45,15 @@ public:
   void setValue(float val) {
     if (std::isfinite(val)) {
       if (val >= max) {
-        setText(str(max).c_str());
+        setText(fmt::format("{}", max).c_str());
         is_min = false;
         is_max = true;
       } else if (val <= min) {
-        setText(str(min).c_str());
+        setText(fmt::format("{}", min).c_str());
         is_min = true;
         is_max = false;
       } else {
-        setText(str(val).c_str());
+        setText(fmt::format("{}", val).c_str());
         is_min = is_max = false;
       }
     } else {

--- a/cpp/gui/mrview/colourbars.cpp
+++ b/cpp/gui/mrview/colourbars.cpp
@@ -208,8 +208,8 @@ void ColourBars::render(size_t colourmap,
 
   current_projection->setup_render_text();
   int x = halign > 0 ? data[0] - text_offset : data[6] + text_offset;
-  current_projection->render_text_align(x, data[1], str(local_min_value), halign, 0);
-  current_projection->render_text_align(x, data[4], str(local_max_value), halign, 0);
+  current_projection->render_text_align(x, data[1], fmt::format("{}", local_min_value), halign, 0);
+  current_projection->render_text_align(x, data[4], fmt::format("{}", local_max_value), halign, 0);
   current_projection->done_render_text();
 
   gl::DepthMask(gl::TRUE_);

--- a/cpp/gui/mrview/gui_image.cpp
+++ b/cpp/gui/mrview/gui_image.cpp
@@ -586,11 +586,11 @@ std::string Image::describe_value(const Eigen::Vector3f &focus) const {
       value_str += "rgb"[n];
       value_str += ": ";
       const ssize_t v = n + image.index(3);
-      value_str += std::isfinite(MR::abs(values[v])) ? str(values[v]) : "?";
+      value_str += std::isfinite(MR::abs(values[v])) ? fmt::format("{}", values[v]) : "?";
     }
   } else { // show single value
     const cfloat value = interpolate() ? trilinear_value(focus) : nearest_neighbour_value(focus);
-    value_str += " value: " + (std::isfinite(MR::abs(value)) ? str(value) : "?");
+    value_str += " value: " + (std::isfinite(MR::abs(value)) ? fmt::format("{}", value) : "?");
   }
   return value_str;
 }

--- a/cpp/gui/mrview/mode/base.cpp
+++ b/cpp/gui/mrview/mode/base.cpp
@@ -59,12 +59,12 @@ void Base::paintGL() {
       const Eigen::Vector3f voxel(image()->scanner2voxel() * focus());
       const Eigen::Matrix<ssize_t, 3, 1> vox(voxel.array().round().cast<ssize_t>());
 
-      std::string vox_str = printf("voxel index: [ %d %d %d ", vox[0], vox[1], vox[2]);
+      std::string vox_str = fmt::format("voxel index: [ {} {} {} ", vox[0], vox[1], vox[2]);
       for (size_t n = 3; n < image()->header().ndim(); ++n)
         vox_str += fmt::format("{}", image()->image.index(n)) + " ";
       vox_str += "]";
 
-      projection.render_text(printf("position: [ %.4g %.4g %.4g ] mm", focus()[0], focus()[1], focus()[2]),
+      projection.render_text(fmt::format("position: [ {:.4g} {:.4g} {:.4g} ] mm", focus()[0], focus()[1], focus()[2]),
                              LeftEdge | BottomEdge);
       projection.render_text(vox_str, LeftEdge | BottomEdge, 1);
       projection.render_text(image()->describe_value(window().focus()), LeftEdge | BottomEdge, 2);

--- a/cpp/gui/mrview/mode/base.cpp
+++ b/cpp/gui/mrview/mode/base.cpp
@@ -61,7 +61,7 @@ void Base::paintGL() {
 
       std::string vox_str = printf("voxel index: [ %d %d %d ", vox[0], vox[1], vox[2]);
       for (size_t n = 3; n < image()->header().ndim(); ++n)
-        vox_str += str(image()->image.index(n)) + " ";
+        vox_str += fmt::format("{}", image()->image.index(n)) + " ";
       vox_str += "]";
 
       projection.render_text(printf("position: [ %.4g %.4g %.4g ] mm", focus()[0], focus()[1], focus()[2]),

--- a/cpp/gui/mrview/tool/connectome/node_list.cpp
+++ b/cpp/gui/mrview/tool/connectome/node_list.cpp
@@ -43,7 +43,7 @@ QVariant Node_list_model::data(const QModelIndex &index, int role) const {
     }
   }
   if (index.column() == 0 && role == Qt::DisplayRole)
-    return qstr(str(index.row()));
+    return qstr(fmt::format("{}", index.row()));
   else if (index.column() == 1 && role == Qt::DecorationRole)
     return connectome.nodes[index.row()].get_pixmap();
   else if (index.column() == 2 && role == Qt::DisplayRole)

--- a/cpp/gui/mrview/tool/odf/odf.cpp
+++ b/cpp/gui/mrview/tool/odf/odf.cpp
@@ -429,8 +429,8 @@ void ODF::setup_ODFtype_UI(const ODF_Item *image) {
   if (image->odf_type == odf_type_t::DIXEL && image->dixel->shells) {
     for (size_t i = 0; i != image->dixel->shells->count(); ++i) {
       if (!(*image->dixel->shells)[i].is_bzero())
-        shell_selector->addItem(
-            QString::fromStdString(str(static_cast<size_t>(std::round((*image->dixel->shells)[i].get_mean())))));
+        shell_selector->addItem(QString::fromStdString(
+            fmt::format("{}", static_cast<size_t>(std::round((*image->dixel->shells)[i].get_mean())))));
     }
     if (shell_selector->count() && image->dixel->dir_type == ODF_Item::DixelPlugin::dir_t::DW_SCHEME)
       shell_selector->setCurrentIndex(image->dixel->shell_index -

--- a/cpp/gui/mrview/tool/screen_capture.cpp
+++ b/cpp/gui/mrview/tool/screen_capture.cpp
@@ -328,7 +328,7 @@ void Capture::run(bool with_capture) {
       break;
 
     if (with_capture)
-      win.captureGL(current_folder / (prefix + printf("%04d.png", i)));
+      win.captureGL(current_folder / (prefix + fmt::format("{:04d}.png", i)));
 
     // Rotation
     Eigen::Quaternionf orientation(win.orientation());

--- a/cpp/gui/mrview/tool/tractography/tractography.cpp
+++ b/cpp/gui/mrview/tool/tractography/tractography.cpp
@@ -56,7 +56,7 @@ size_t geometry_string2index(std::string type_str) {
     return std::distance(list.begin(), it);
 
   throw Exception(
-      "Unrecognised value for tractogram geometry \"{}\" (options are: {}); ignoring", type_str, join(list, ", "));
+      "Unrecognised value for tractogram geometry \"{}\" (options are: {}); ignoring", type_str, fmt::join(list, ", "));
   return 0;
 }
 
@@ -785,7 +785,7 @@ void Tractography::add_commandline_options(MR::App::OptionList &options) {
 
       + Option("tractography.geometry",
                "The geometry type to use when rendering tractograms"
-               " (options are: " + join(tractogram_geometry_types, ", ") + ")").allow_multiple()
+               " (options are: " + fmt::format("{}", fmt::join(tractogram_geometry_types, ", ")) + ")").allow_multiple()
         + Argument("value").type_choice(tractogram_geometry_types)
 
       + Option("tractography.opacity",

--- a/cpp/gui/mrview/tool/view.cpp
+++ b/cpp/gui/mrview/tool/view.cpp
@@ -549,7 +549,7 @@ void View::copy_focus_slot() {
   std::cout << focus.transpose().format(fmt) << "\n";
 
   QClipboard *clip = QApplication::clipboard();
-  QString input = QString::fromStdString(str(focus.transpose().format(fmt)));
+  QString input = QString::fromStdString(::fmt::format("{}", focus.transpose().format(fmt)));
   clip->setText(input);
 }
 
@@ -562,7 +562,7 @@ void View::copy_voxel_slot() {
   std::cout << focus.transpose().format(fmt) << "\n";
 
   QClipboard *clip = QApplication::clipboard();
-  QString input = QString::fromStdString(str(focus.transpose().format(fmt)));
+  QString input = QString::fromStdString(::fmt::format("{}", focus.transpose().format(fmt)));
   clip->setText(input);
 }
 

--- a/cpp/gui/mrview/window.cpp
+++ b/cpp/gui/mrview/window.cpp
@@ -1382,7 +1382,7 @@ void Window::paintGL() {
 
     if (render_times.size() == 10) {
       FPS = (render_times.size() - 1.0) / (render_times.back() - render_times.front());
-      FPS_string = str(FPS, 4);
+      FPS_string = fmt::format("{:.4g}", FPS);
       if (!std::isfinite(best_FPS) || FPS > best_FPS) {
         best_FPS = FPS;
         best_FPS_time = render_times.back();
@@ -1391,7 +1391,7 @@ void Window::paintGL() {
       best_FPS = NaN;
 
     if (std::isfinite(best_FPS))
-      FPS_best_string = str(best_FPS, 4);
+      FPS_best_string = fmt::format("{:.4g}", best_FPS);
     mode->projection.setup_render_text(0.0, 1.0, 0.0);
     mode->projection.render_text("max FPS: " + FPS_best_string, RightEdge | TopEdge);
     mode->projection.render_text("FPS: " + FPS_string, RightEdge | TopEdge, 1);

--- a/cpp/gui/mrview/window.cpp
+++ b/cpp/gui/mrview/window.cpp
@@ -1346,7 +1346,7 @@ void Window::about_slot() {
   const std::string version = "debug";
 #endif
   message += fmt::format("<em>{} bit {} version, built {}</em><p>", 8 * sizeof(size_t), version, MR::App::build_date);
-  message += fmt::format("<h4>Authors:</h4>{}<p>", MR::join(MR::split(MR::App::AUTHOR, ",;&\n", true), "<br>"));
+  message += fmt::format("<h4>Authors:</h4>{}<p>", fmt::join(MR::split(MR::App::AUTHOR, ",;&\n", true), "<br>"));
   message += fmt::format("<em>{}</em>", MR::App::COPYRIGHT);
 
   QMessageBox::about(this, tr("About MRView"), qstr(message));

--- a/testing/binaries/tests/dirrotate/default
+++ b/testing/binaries/tests/dirrotate/default
@@ -11,14 +11,14 @@ dirgen 30 tmp1.txt -force -cartesian -restarts 1
 rm -f tmp1_stats.txt
 dirstat tmp1.txt | \
 grep 'condition numbers for lmax' | \
-awk '{ print $10,$11,$12 }' > tmp1_stats.txt
+sed 's/.*: //; s/[][]//g; s/,/ /g' > tmp1_stats.txt
 
 dirrotate tmp1.txt tmp2.txt -force -cartesian -number 1M
 
 rm -f tmp2_stats.txt
 dirstat tmp2.txt | \
 grep 'condition numbers for lmax' | \
-awk '{ print $10,$11,$12 }' > tmp2_stats.txt
+sed 's/.*: //; s/[][]//g; s/,/ /g' > tmp2_stats.txt
 
 testing_diff_matrix tmp1_stats.txt tmp2_stats.txt
 

--- a/testing/binaries/tests/dirrotate/onerotation
+++ b/testing/binaries/tests/dirrotate/onerotation
@@ -10,12 +10,12 @@ dirgen 30 tmp1.txt -force -cartesian -restarts 1
 
 dirstat tmp1.txt | \
 grep 'condition numbers for lmax' | \
-awk '{ print $10,$11,$12 }' > tmp1_stats.txt
+sed 's/.*: //; s/[][]//g; s/,/ /g' > tmp1_stats.txt
 
 dirrotate tmp1.txt tmp2.txt -force -cartesian -number 1
 
 dirstat tmp2.txt | \
 grep 'condition numbers for lmax' | \
-awk '{ print $10,$11,$12 }' > tmp2_stats.txt
+sed 's/.*: //; s/[][]//g; s/,/ /g' > tmp2_stats.txt
 
 testing_diff_matrix tmp1_stats.txt tmp2_stats.txt

--- a/testing/binaries/tests/labelvalidate/non_spatially_contiguous
+++ b/testing/binaries/tests/labelvalidate/non_spatially_contiguous
@@ -5,4 +5,4 @@
 rm -f tmp.txt
 mredit labelconvert/out_fs.mif.gz -voxel 62,67,63 2 - | \
    labelvalidate - 2>&1 | tee tmp.txt
-grep -E "labels are spatially disconnected: .+ 2 .+" tmp.txt
+grep -E "labels are spatially disconnected:.*\b2\b" tmp.txt

--- a/testing/binaries/tests/mrstats/complex
+++ b/testing/binaries/tests/mrstats/complex
@@ -4,9 +4,11 @@
 #   by mapping mean DWI image to real axis and estimated noise level to imaginary axis;
 #   this image has no meaning,
 #   but is just used to ensure successful command execution
-# Outcome is compared to that generated using a prior software version
+# Outcome is compared to that generated using a prior software version,
+#   with a fractional tolerance to accommodate fmtlib's shortest-round-trip number formatting
+#   (which prints more significant figures than the reference, and a parenthesised complex form)
 rm -f tmp.txt
 mrcalc dwi_mean.mif noise.mif -complex - | \
 mrstats - -output mean -output std -output std_rv -output min -output max -output count > tmp.txt
 
-testing_diff_matrix tmp.txt mrstats/complex.txt
+testing_diff_matrix tmp.txt mrstats/complex.txt -frac 1e-5

--- a/testing/tools/testing_cpp_cli.cpp
+++ b/testing/tools/testing_cpp_cli.cpp
@@ -181,6 +181,6 @@ void run() {
     std::vector<std::string> specs;
     for (size_t i = 0; i != opt.size(); ++i)
       specs.push_back(fmt::format("\"{}\"", opt[i][0]));
-    CONSOLE("-multiple: [" + join(specs, " ") + "]");
+    CONSOLE("-multiple: [{}]", fmt::join(specs, " "));
   }
 }

--- a/testing/unit_tests/parse_axes_tests.cpp
+++ b/testing/unit_tests/parse_axes_tests.cpp
@@ -37,7 +37,7 @@ struct ParseAxesParam {
   ExceptionPolicy exception_policy = ExceptionPolicy::NotExpected;
 
   friend std::ostream &operator<<(std::ostream &os, const ParseAxesParam &p) {
-    os << "InputStr: \"" << p.input_str << "\", ExpectedValues: " << MR::str(p.expected_values);
+    os << "InputStr: \"" << p.input_str << "\", ExpectedValues: " << fmt::format("{}", p.expected_values);
     return os;
   }
 };
@@ -70,10 +70,11 @@ TEST_F(ParseAxesTest, HandlesVariousFormats) {
       EXPECT_NO_THROW(actual_values = MR::Formats::parse_axes(param.ndim, input))
           << "Input string: \"" << input << "\" with " << param.ndim << " dimensions should not throw an exception.";
     }
-    EXPECT_EQ(actual_values, param.expected_values) << "Input string: \"" << input << "\""
-                                                    << " with " << param.ndim << " dimensions\n"
-                                                    << "  Expected: " << MR::str(param.expected_values) << "\n"
-                                                    << "  Actual:   " << MR::str(actual_values);
+    EXPECT_EQ(actual_values, param.expected_values)
+        << "Input string: \"" << input << "\""
+        << " with " << param.ndim << " dimensions\n"
+        << "  Expected: " << fmt::format("{}", param.expected_values) << "\n"
+        << "  Actual:   " << fmt::format("{}", actual_values);
   };
 
   for (const auto &param : parse_axes_test_cases) {

--- a/testing/unit_tests/parse_ints_tests.cpp
+++ b/testing/unit_tests/parse_ints_tests.cpp
@@ -35,7 +35,7 @@ struct ParseIntsParam {
   ExceptionPolicy exception_policy = ExceptionPolicy::NotExpected;
 
   friend std::ostream &operator<<(std::ostream &os, const ParseIntsParam &p) {
-    os << "InputStr: \"" << p.input_str << "\", ExpectedValues: " << MR::str(p.expected_values);
+    os << "InputStr: \"" << p.input_str << "\", ExpectedValues: " << fmt::format("{}", p.expected_values);
     return os;
   }
 };
@@ -77,8 +77,8 @@ TEST_F(ParseIntsTest, HandlesVariousFormats) {
           << "Input string: \"" << input << "\" should not throw an exception.";
     }
     EXPECT_EQ(actual_values, param.expected_values)
-        << "Input string: \"" << input << "\"\n  Expected: " << MR::str(param.expected_values)
-        << "\n  Actual:   " << MR::str(actual_values);
+        << "Input string: \"" << input << "\"\n  Expected: " << fmt::format("{}", param.expected_values)
+        << "\n  Actual:   " << fmt::format("{}", actual_values);
   };
 
   for (const auto &param : parse_ints_test_cases) {

--- a/testing/unit_tests/to_tests.cpp
+++ b/testing/unit_tests/to_tests.cpp
@@ -21,6 +21,8 @@
 
 #include <complex>
 #include <cstddef>
+#include <cstdint>
+#include <fmt/format.h>
 #include <string>
 #include <vector>
 
@@ -210,6 +212,11 @@ const std::vector<bool> expectedIntResults = {
     false  // "()"
 };
 
+// Note: the expected results below include "infinity"/"-infinity" as true, whereas the
+// historical std::istringstream-based implementation rejected them (istream consumed "inf"
+// then failed the trailing "inity"). std::from_chars accepts the full "infinity" keyword
+// per the C++17 specification, and that more standard-conformant behaviour is now reflected
+// here. The short forms "inf"/"-inf" remain accepted, as do "nan"/"-nan".
 const std::vector<bool> expectedFloatResults = {
     true,  // "0"
     true,  // "1"
@@ -242,9 +249,9 @@ const std::vector<bool> expectedFloatResults = {
     false, // "1e-1a"
     true,  // "inf"
     true,  // "INF"
-    false, // "infinity"
+    true,  // "infinity"
     true,  // "-inf"
-    false, // "-infinity"
+    true,  // "-infinity"
     true,  // "nan"
     true,  // "NAN"
     false, // "nana"
@@ -303,9 +310,9 @@ const std::vector<bool> expectedComplexResults = {
     false, // "1e-1a"
     true,  // "inf"
     true,  // "INF"
-    false, // "infinity"
+    true,  // "infinity"
     true,  // "-inf"
-    false, // "-infinity"
+    true,  // "-infinity"
     true,  // "nan"
     true,  // "NAN"
     false, // "nana"
@@ -409,4 +416,105 @@ TEST_F(ToComplexFloatTest, ParenthesisedComplexRoundTrip) {
   EXPECT_EQ(MR::to<std::complex<double>>("(1.5+2.5i)"), std::complex<double>(1.5, 2.5));
   EXPECT_EQ(MR::to<std::complex<double>>("(1.5+2.5i)"), MR::to<std::complex<double>>("1.5+2.5i"));
   EXPECT_EQ(MR::to<std::complex<double>>("(-1-2i)"), std::complex<double>(-1.0, -2.0));
+}
+
+// Drive the complex specialisation directly off fmtlib's complex formatter output rather than
+// hard-coded literals, so the test pins the actual fmtlib<->MR::to<>() contract. fmtlib elides
+// a zero real/imag component (so {3,0} renders as "3+0i" without the outer brackets, and {0,-7.25}
+// as "-7.25i"); MR::to<>() must accept both the parenthesised form and any shorter form fmtlib
+// chooses to emit.
+TEST_F(ToComplexFloatTest, FmtlibFormatRoundTrip) {
+  const std::vector<std::complex<float>> cf_values = {
+      {0.0f, 0.0f},
+      {1.5f, 2.5f},
+      {-1.5f, -2.5f},
+      {3.0f, 0.0f},
+      {0.0f, -7.25f},
+  };
+  for (const auto &value : cf_values) {
+    const std::string formatted = fmt::format("{}", value);
+    ASSERT_FALSE(formatted.empty()) << "fmt::format produced empty string";
+    EXPECT_EQ(MR::to<std::complex<float>>(formatted), value)
+        << "round-trip failed for fmt-formatted complex \"" << formatted << "\"";
+  }
+
+  const std::vector<std::complex<double>> cd_values = {
+      {0.0, 0.0},
+      {1.5, 2.5},
+      {-1.5, -2.5},
+      {3.0, 0.0},
+  };
+  for (const auto &value : cd_values) {
+    const std::string formatted = fmt::format("{}", value);
+    EXPECT_EQ(MR::to<std::complex<double>>(formatted), value)
+        << "round-trip failed for fmt-formatted complex \"" << formatted << "\"";
+  }
+}
+
+// fmtlib's parenthesised form is meaningful only for complex types; real-valued conversions
+// must reject the brackets so that a real-valued spec accidentally fed a complex literal
+// fails loudly rather than silently truncating to the real component.
+TEST(ToRealParenthesesRejection, ParenthesesRejectedForReal) {
+  const std::vector<std::string> inputs = {
+      "(1)",   // integer
+      "(1.0)", // floating
+      "(1.5+2.5i)",
+      "(-1-2i)",
+      "(0)",
+      "()",
+  };
+  for (const auto &input : inputs) {
+    EXPECT_THROW(MR::to<int>(input), MR::Exception)
+        << "Parenthesised input \"" << input << "\" must be rejected by MR::to<int>()";
+    EXPECT_THROW(MR::to<float>(input), MR::Exception)
+        << "Parenthesised input \"" << input << "\" must be rejected by MR::to<float>()";
+    EXPECT_THROW(MR::to<double>(input), MR::Exception)
+        << "Parenthesised input \"" << input << "\" must be rejected by MR::to<double>()";
+  }
+}
+
+// std::from_chars exposes overflow as std::errc::result_out_of_range; MR::to<>() must surface
+// that distinct condition as an Exception rather than silently saturating or wrapping. The
+// istringstream fallback yields the same observable behaviour (failbit set, value clamped to
+// numeric_limits<T>::max()), so this test pins the user-facing contract independent of which
+// backend was selected at configure time.
+template <typename T> std::string overflow_above_max() {
+  // Multiply numeric_limits::max() by 10 by appending a digit: cheap, portable, and avoids any
+  // arithmetic on the integer type itself (which would itself overflow).
+  return fmt::format("{}0", std::numeric_limits<T>::max());
+}
+
+template <typename T> std::string overflow_below_min() { return fmt::format("{}0", std::numeric_limits<T>::min()); }
+
+TEST(ToOverflow, IntegerOverflowThrows) {
+  EXPECT_THROW(MR::to<int8_t>(overflow_above_max<int8_t>()), MR::Exception);
+  EXPECT_THROW(MR::to<int8_t>(overflow_below_min<int8_t>()), MR::Exception);
+  EXPECT_THROW(MR::to<int16_t>(overflow_above_max<int16_t>()), MR::Exception);
+  EXPECT_THROW(MR::to<int16_t>(overflow_below_min<int16_t>()), MR::Exception);
+  EXPECT_THROW(MR::to<int32_t>(overflow_above_max<int32_t>()), MR::Exception);
+  EXPECT_THROW(MR::to<int32_t>(overflow_below_min<int32_t>()), MR::Exception);
+  EXPECT_THROW(MR::to<int64_t>(overflow_above_max<int64_t>()), MR::Exception);
+  EXPECT_THROW(MR::to<int64_t>(overflow_below_min<int64_t>()), MR::Exception);
+
+  EXPECT_THROW(MR::to<uint8_t>(overflow_above_max<uint8_t>()), MR::Exception);
+  EXPECT_THROW(MR::to<uint16_t>(overflow_above_max<uint16_t>()), MR::Exception);
+  EXPECT_THROW(MR::to<uint32_t>(overflow_above_max<uint32_t>()), MR::Exception);
+  EXPECT_THROW(MR::to<uint64_t>(overflow_above_max<uint64_t>()), MR::Exception);
+
+  // Boundary: numeric_limits::max() itself must round-trip cleanly.
+  EXPECT_EQ(MR::to<int32_t>(fmt::format("{}", std::numeric_limits<int32_t>::max())),
+            std::numeric_limits<int32_t>::max());
+  EXPECT_EQ(MR::to<int32_t>(fmt::format("{}", std::numeric_limits<int32_t>::min())),
+            std::numeric_limits<int32_t>::min());
+}
+
+TEST(ToOverflow, FloatOverflowThrows) {
+  // 1e400 is well beyond either float or double's representable range.
+  EXPECT_THROW(MR::to<float>("1e400"), MR::Exception);
+  EXPECT_THROW(MR::to<float>("-1e400"), MR::Exception);
+  EXPECT_THROW(MR::to<double>("1e400"), MR::Exception);
+  EXPECT_THROW(MR::to<double>("-1e400"), MR::Exception);
+  // A value beyond float range but within double range must be accepted as double.
+  EXPECT_THROW(MR::to<float>("1e40"), MR::Exception);
+  EXPECT_NO_THROW(MR::to<double>("1e40"));
 }

--- a/testing/unit_tests/to_tests.cpp
+++ b/testing/unit_tests/to_tests.cpp
@@ -28,11 +28,65 @@ using namespace MR;
 
 namespace {
 const std::vector<std::string> kInputStrings = {
-    "0",         "1",     "2",     "0 ",   " 1",     "0 0",   "0a",       "a0",          "true", "TRUE",     "tru",
-    "truee",     "false", "FALSE", "fals", "falsee", "true ", "yes",      "YES",         "yeah", "yess",     "no",
-    "NO",        "nope",  "na",    "0.0",  "1e",     "1e-1",  "1e-1a",    "inf",         "INF",  "infinity", "-inf",
-    "-infinity", "nan",   "NAN",   "nana", "-nan",   "i",     "I",        "j",           "J",    "-i",       "1i",
-    "1i0",       "1+i",   "1+ii",  "a1+i", "1+1+i",  "-1-i",  "inf+infi", " -inf+-nani "};
+    "0",
+    "1",
+    "2",
+    "0 ",
+    " 1",
+    "0 0",
+    "0a",
+    "a0",
+    "true",
+    "TRUE",
+    "tru",
+    "truee",
+    "false",
+    "FALSE",
+    "fals",
+    "falsee",
+    "true ",
+    "yes",
+    "YES",
+    "yeah",
+    "yess",
+    "no",
+    "NO",
+    "nope",
+    "na",
+    "0.0",
+    "1e",
+    "1e-1",
+    "1e-1a",
+    "inf",
+    "INF",
+    "infinity",
+    "-inf",
+    "-infinity",
+    "nan",
+    "NAN",
+    "nana",
+    "-nan",
+    "i",
+    "I",
+    "j",
+    "J",
+    "-i",
+    "1i",
+    "1i0",
+    "1+i",
+    "1+ii",
+    "a1+i",
+    "1+1+i",
+    "-1-i",
+    "inf+infi",
+    " -inf+-nani ",
+    // fmtlib's parenthesised complex form "(a+bi)" and malformed parenthesised inputs
+    "(1+2i)",
+    "(0+0i)",
+    "(-1.5-2.5i)",
+    "(3+0i)",
+    "(1+ii)",
+    "()"};
 
 const std::vector<bool> expectedBoolResults = {
     true,  // "0"
@@ -86,7 +140,13 @@ const std::vector<bool> expectedBoolResults = {
     false, // "1+1+i"
     false, // "-1-i"
     false, // "inf+infi"
-    false  // " -inf+-nani "
+    false, // " -inf+-nani "
+    false, // "(1+2i)"
+    false, // "(0+0i)"
+    false, // "(-1.5-2.5i)"
+    false, // "(3+0i)"
+    false, // "(1+ii)"
+    false  // "()"
 };
 
 const std::vector<bool> expectedIntResults = {
@@ -141,7 +201,13 @@ const std::vector<bool> expectedIntResults = {
     false, // "1+1+i"
     false, // "-1-i"
     false, // "inf+infi"
-    false  // " -inf+-nani "
+    false, // " -inf+-nani "
+    false, // "(1+2i)"
+    false, // "(0+0i)"
+    false, // "(-1.5-2.5i)"
+    false, // "(3+0i)"
+    false, // "(1+ii)"
+    false  // "()"
 };
 
 const std::vector<bool> expectedFloatResults = {
@@ -196,7 +262,13 @@ const std::vector<bool> expectedFloatResults = {
     false, // "1+1+i"
     false, // "-1-i"
     false, // "inf+infi"
-    false  // " -inf+-nani "
+    false, // " -inf+-nani "
+    false, // "(1+2i)"
+    false, // "(0+0i)"
+    false, // "(-1.5-2.5i)"
+    false, // "(3+0i)"
+    false, // "(1+ii)"
+    false  // "()"
 };
 
 const std::vector<bool> expectedComplexResults = {
@@ -251,7 +323,13 @@ const std::vector<bool> expectedComplexResults = {
     false, // "1+1+i"
     true,  // "-1-i"
     true,  // "inf+infi"
-    true   //" -inf+-nani "
+    true,  //" -inf+-nani "
+    true,  // "(1+2i)"
+    true,  // "(0+0i)"
+    true,  // "(-1.5-2.5i)"
+    true,  // "(3+0i)"
+    false, // "(1+ii)"
+    false  // "()"
 };
 
 } // namespace
@@ -318,4 +396,17 @@ TEST_F(ToComplexFloatTest, StringToComplexFloatConversion) {
           << "Input: \"" << input_string << "\" to std::complex<float> should fail.";
     }
   }
+}
+
+// fmtlib formats complex values as "(a+bi)"; verify the parenthesised form round-trips back
+// through MR::to<>() to the same value as the equivalent bare "a+bi" form.
+TEST_F(ToComplexFloatTest, ParenthesisedComplexRoundTrip) {
+  EXPECT_EQ(MR::to<std::complex<float>>("(1.5+2.5i)"), std::complex<float>(1.5f, 2.5f));
+  EXPECT_EQ(MR::to<std::complex<float>>("(1.5+2.5i)"), MR::to<std::complex<float>>("1.5+2.5i"));
+  EXPECT_EQ(MR::to<std::complex<float>>("(-1-2i)"), std::complex<float>(-1.0f, -2.0f));
+  EXPECT_EQ(MR::to<std::complex<float>>("(3+0i)"), std::complex<float>(3.0f, 0.0f));
+
+  EXPECT_EQ(MR::to<std::complex<double>>("(1.5+2.5i)"), std::complex<double>(1.5, 2.5));
+  EXPECT_EQ(MR::to<std::complex<double>>("(1.5+2.5i)"), MR::to<std::complex<double>>("1.5+2.5i"));
+  EXPECT_EQ(MR::to<std::complex<double>>("(-1-2i)"), std::complex<double>(-1.0, -2.0));
 }


### PR DESCRIPTION
Potential extension of #3339.
Using that branch as the base here to evaluate changes given I've already gone to the effort of manually code-reviewing #3339 in its current form.
Draft for now; deferring to a better time for me to review manually.

Had a go at further reducing redundancies between legacy MRtrix string-handling functions and `fmtlib` capabilities. 

- [ ] Consider re-introduction of `MR::str()` function, but it just wraps `fmt::format("{}", item)`.
- [ ] Where stream `<<` operators are involved, collapse the whole operation into a single `fmt::format()` call.
- [ ] Remove unnecessary `static_cast<>` calls on `MR::Helper::Index` and `MR::Helper::Value`.
- [ ] Manually check string outputs for any points of concern (thinking `MR::printf()` usages, confirm column vector transposition display)
