### PR TITLE
run_pylint: parallelism, pre-commit hook, and lint fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@
 .__tmp.log
 .check_syntax.tmp
 .check_syntax2.tmp
+.run_pylint_tmp*
 build*/
 CMakeLists.txt.user
 CMakeUserPresets.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,11 @@ repos:
         language: system
         pass_filenames: false
         types_or: [c++]
+      - id: run-pylint
+        name: run-pylint
+        entry: ./run_pylint --precommit
+        language: system
+        types_or: [python]
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v16.0.4
     hooks:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,6 +3,11 @@
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+# Sphinx reads these module-level names by convention; their lower-case naming
+#   and apparent non-use (they are consumed by Sphinx, not this module) are
+#   inherent to the configuration format.
+# pylint: disable=invalid-name,redefined-builtin,unused-variable
+
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
@@ -33,4 +38,3 @@ rst_prolog = """
 
   <br/>
 """
-

--- a/generate_bash_completion.py
+++ b/generate_bash_completion.py
@@ -26,16 +26,16 @@
 import getopt, sys, os, re, subprocess, locale
 
 def usage():
-  print ('''
-Usage:  %s -m [dir_path] -c [file_path]\n
+  print (f'''
+Usage:  {sys.argv[0]} -m [dir_path] -c [file_path]\n
         -m, --mrtrix_commands_dir [dir path]: The directory where the mrtrix executable commands reside.
         -c, --completion_path [file path]: The generated bash completion file path.
-''' % (sys.argv[0]))
+''')
 
 
 def main(argv):
   try:
-    opts, args = getopt.getopt(argv, "m:c:", ["mrtrix_commands_dir=", "completion_path="])
+    opts, _ = getopt.getopt(argv, "m:c:", ["mrtrix_commands_dir=", "completion_path="])
     if not opts or len(opts) != 2:
       raise getopt.GetoptError('Incorrect number of arguments')
   except getopt.GetoptError:
@@ -74,7 +74,9 @@ def main(argv):
 
 def parse_commands (commands_dir, completion_path, commands):
 
-  completion_file = open (completion_path, 'w+')
+  # Handle is referenced throughout the nested helper closures below and the
+  #   verbatim shell here-strings, so a 'with' block is not used here.
+  completion_file = open (completion_path, 'w+', encoding='utf-8') # pylint: disable=consider-using-with
 
 ###########################################################################
 #                         INNER PARSE FUNCTIONS
@@ -88,21 +90,23 @@ def parse_commands (commands_dir, completion_path, commands):
 
   def flush_option_arg ():
     if not current_option:
-      print ('\t_%s_arg_%s()' % (command, current_num_of_option_args), file = completion_file)
+      print (f'\t_{command}_arg_{current_num_of_option_args}()', file = completion_file)
     else:
-      print ('\t_%s_%s_arg_%s()' % (command, current_option, current_num_of_option_args), file = completion_file)
+      print (f'\t_{command}_{current_option}_arg_{current_num_of_option_args}()', file = completion_file)
 
     print ('\t{ echo "%s"; }\n' % (current_arg_choices) , file = completion_file)
 
-  def flush_option_arg_allows_multiple ():
+  def flush_option_arg_multiple ():
     if not current_option:
-      print ('\t_%s_arg_%s_allows_multiple()' %  (command, current_num_of_option_args), file = completion_file)
+      print (f'\t_{command}_arg_{current_num_of_option_args}_allows_multiple()', file = completion_file)
     else:
-      print ('\t_%s_%s_arg_%s_allows_multiple()' % (command, current_option, current_num_of_option_args), file = completion_file)
+      print (f'\t_{command}_{current_option}_arg_{current_num_of_option_args}_allows_multiple()', file = completion_file)
 
     print ('\t{ echo %s; }\n' % (current_arg_allows_multiple), file = completion_file)
 
-  def parse_option_arg_choices (arg_type, choices = []):
+  def parse_option_arg_choices (arg_type, choices = None):
+    if choices is None:
+      choices = []
     arg_choices = ""
 
     if arg_type == 'CHOICE':
@@ -111,13 +115,12 @@ def parse_commands (commands_dir, completion_path, commands):
         # End of choice lists are generally delimited by -1
         # however tckgen choices are delimited by 2 (?)
         if choice in ['-1', '2']:
-          break;
-        else:
-          arg_choices +=  " " + choice
+          break
+        arg_choices +=  " " + choice
     elif arg_type == 'IMAGEIN':
       arg_choices ='`eval ls $1*.{mih,mif,nii,dcm,hdr,mgh,nii.gz,mif.gz} 2> /dev/null | tr "\n" " "``eval ls -d $1*/ 2> /dev/null | tr "\n" " "`'
     elif arg_type == 'FILEIN':
-      arg_choices ='`eval ls "$1*" 2> /dev/null | grep -E "$1*\.[^[:space:]]+"``eval ls -d $1*/ 2> /dev/null | tr "\n" " "`'
+      arg_choices ='`eval ls "$1*" 2> /dev/null | grep -E "$1*\\.[^[:space:]]+"``eval ls -d $1*/ 2> /dev/null | tr "\n" " "`'
     elif arg_type == 'TRACKSIN':
       arg_choices ='`eval ls $1*.tck 2> /dev/null | tr "\n" " "``eval ls -d $1*/ 2> /dev/null | tr "\n" " "`'
     #elif arg_type in ['FLOAT', 'INT']:
@@ -133,9 +136,9 @@ def parse_commands (commands_dir, completion_path, commands):
 ###########################################################################
   def is_script (command):
     textchars = bytearray({7,8,9,10,12,13,27} | set(range(0x20, 0x100)) - {0x7f})
-    with open(os.path.join(commands_dir, command), "rb") as f:
-      bytes = f.read(1024)
-    return not bytes.translate(None, textchars)
+    with open(os.path.join(commands_dir, command), "rb") as fileobj:
+      contents = fileobj.read(1024)
+    return not contents.translate(None, textchars)
 
 
 ###########################################################################
@@ -153,14 +156,12 @@ def parse_commands (commands_dir, completion_path, commands):
     double_dash_options = ""
     current_option = ""
     current_num_of_option_args = 0
-    current_arg = ""
-    current_arg_optional = -1
     current_arg_allows_multiple = -1
     current_arg_type = ""
     current_arg_choices = ""
 
     try:
-      process = subprocess.Popen ([ os.path.join( commands_dir, command ), '__print_full_usage__'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+      process = subprocess.Popen ([ os.path.join( commands_dir, command ), '__print_full_usage__'], stdout=subprocess.PIPE, stderr=subprocess.PIPE) # pylint: disable=consider-using-with
 
       print ('''
 _%s()
@@ -175,19 +176,16 @@ _%s()
 
         if words[0] == 'OPTION':
           flush_option_num_args ()
-          current_arg = ""
           current_arg_type = ""
           current_option = words[1]
           single_dash_options += ' -' + current_option
           double_dash_options += ' --' + current_option
           current_num_of_option_args = 0
         elif words[0] == 'ARGUMENT':
-          current_arg = words[1]
-          current_arg_optional = words[2]
           current_arg_allows_multiple = words[3]
           current_arg_type = words[4].rstrip ()
           current_arg_choices = parse_option_arg_choices (current_arg_type, words[5:])
-          flush_option_arg_allows_multiple ()
+          flush_option_arg_multiple ()
           flush_option_arg ()
           current_num_of_option_args += 1
 
@@ -203,7 +201,7 @@ _%s()
 
   COMPREPLY=();
   cur="${COMP_WORDS[COMP_CWORD]}";
-  cur_filtered=`echo "${COMP_WORDS[COMP_CWORD]}" | sed 's/\..*$//g'`;
+  cur_filtered=`echo "${COMP_WORDS[COMP_CWORD]}" | sed 's/\\..*$//g'`;
 
   if [[ "$cur" == --* ]]; then
     COMPREPLY=( $( compgen -W "%s" -- "$cur" ) );
@@ -270,7 +268,7 @@ _%s()
 }
 complete -F _%s %s \n''' % (double_dash_options, single_dash_options, command, command, command, command, command, command, command, command, command), file = completion_file)
 
-    except:
+    except Exception: # pylint: disable=broad-except
       pass
 
   completion_file.close ()

--- a/generate_bash_completion.py
+++ b/generate_bash_completion.py
@@ -145,7 +145,7 @@ def parse_commands (commands_dir, completion_path, commands):
 #                         END INTERNAL FUNCTIONS
 ###########################################################################
 
-  encoding = locale.getdefaultlocale()[1]
+  encoding = locale.getlocale()[1]
 
   for command in sorted(commands):
 

--- a/run_pylint
+++ b/run_pylint
@@ -15,23 +15,140 @@
 #
 # For more details, see http://www.mrtrix.org/.
 
+# Field separator used to pack (index, filepath) records for the parallel
+#   worker fan-out; safe because source paths never contain tabs or newlines.
+TAB=$'\t'
+
+# Reduced check set applied only when invoked with --precommit (e.g. as a
+#   pre-commit hook). These are violations that are either too slow to
+#   evaluate on a per-commit basis (duplicate-code, cyclic-import, which both
+#   require whole-codebase analysis to be meaningful), or that are acceptable
+#   to carry within an individual commit but must be rectified before a Pull
+#   Request is merged (fixme and the unused-* family). Full CI linting still
+#   enforces all of these. Kept as a single list so the set is easy to adjust.
+PRECOMMIT_DISABLE="fixme,duplicate-code,cyclic-import,unused-import,unused-variable,unused-argument"
+
+RCFILE="testing/pylint.rc"
+
+# Hidden worker mode: analyse a single file in its own process, writing its
+#   pylint output and exit status to per-file paths within the shared work
+#   directory. Re-invoking the script itself (rather than exporting a shell
+#   function) keeps the xargs fan-out portable. Configuration is inherited via
+#   the exported RP_* environment variables set up by the parent process.
+if [[ "$1" == "__worker" ]]; then
+  rec="$2"
+  idx="${rec%%"$TAB"*}"
+  file="${rec#*"$TAB"}"
+  args=(--rcfile="$RP_RCFILE")
+  if [[ -n "$RP_DISABLE" ]]; then
+    args+=(--disable="$RP_DISABLE")
+  fi
+  python3 -m pylint "${args[@]}" "$file" > "$RP_TMPDIR/$idx.log" 2>&1
+  echo $? > "$RP_TMPDIR/$idx.status"
+  exit 0
+fi
+
+usage() {
+  cat <<EOD
+Usage: run_pylint [options] [files...]
+
+Lint MRtrix3 Python code with pylint (${RCFILE}).
+With no file arguments, lints all tracked Python files in the repository;
+otherwise, lints only the files provided (as supplied by, e.g., a pre-commit
+hook via pass_filenames).
+
+Files are analysed in parallel, one single-threaded pylint process per file.
+
+Options:
+  -j, --jobs N    Number of files to analyse in parallel
+                  (default: number of available processors).
+  --precommit     Use the reduced pre-commit check set
+                  (disables: ${PRECOMMIT_DISABLE}).
+  -h, --help      Show this help and exit.
+
+Results are written to pylint.log.
+EOD
+}
+
+# --- Argument parsing -------------------------------------------------------
+PRECOMMIT=0
+JOBS=""
+files=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -j|--jobs)
+      JOBS="$2"
+      shift 2
+      ;;
+    --jobs=*)
+      JOBS="${1#*=}"
+      shift
+      ;;
+    -j*)
+      JOBS="${1#-j}"
+      shift
+      ;;
+    --precommit)
+      PRECOMMIT=1
+      shift
+      ;;
+    --)
+      shift
+      while [[ $# -gt 0 ]]; do
+        files+=("$1")
+        shift
+      done
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+    *)
+      files+=("$1")
+      shift
+      ;;
+  esac
+done
+
+# Determine parallelism: explicit --jobs, else the available processor count
+#   (getconf is portable across Linux and macOS), falling back to nproc then 1.
+if [[ -z "$JOBS" ]]; then
+  JOBS=$(getconf _NPROCESSORS_ONLN 2>/dev/null || nproc 2>/dev/null || echo 1)
+fi
+if ! [[ "$JOBS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "Invalid value for --jobs: '$JOBS' (expected a positive integer)" >&2
+  exit 1
+fi
+
+# --- File list --------------------------------------------------------------
+# With no explicit files, lint the update_copyright script plus every tracked
+#   Python file in the repository (git ls-files excludes build and untracked
+#   content; nothing vendored under python/lib is tracked).
+if [[ ${#files[@]} -eq 0 ]]; then
+  files=(update_copyright)
+  while IFS= read -r f; do
+    files+=("$f")
+  done < <(git ls-files '*.py')
+fi
+
 LOGFILE=pylint.log
 echo logging to \""$LOGFILE"\"
 
-# generate list of tests to run:
-tests="update_copyright"
-if [ $# == 0 ]; then
-  for filepath in $(find python/mrtrix3/ -name '*.py'); do
-    tests="$tests $filepath"
-  done
-else
-  tests="$@"
+if [[ ${#files[@]} -eq 0 ]]; then
+  echo "no Python files to test"
+  exit 0
 fi
+
+# --- Per-run work directory (predictable prefix; .gitignored and trap-cleaned)
+tmpdir=$(mktemp -d ./.run_pylint_tmp.XXXXXX)
+trap 'rm -rf "$tmpdir"' EXIT INT TERM
 
 success=0
 ntests=0
-
-
 
 cat > $LOGFILE <<EOD
 -------------------------------------------
@@ -50,9 +167,30 @@ cat >> $LOGFILE <<EOD
 
 EOD
 
-
+# Configuration passed to the worker processes via the environment.
 export PYTHONPATH="$(pwd)/python/lib:$PYTHONPATH"
-for file in $tests; do
+export RP_TMPDIR="$tmpdir"
+export RP_RCFILE="$RCFILE"
+if [[ $PRECOMMIT -eq 1 ]]; then
+  export RP_DISABLE="$PRECOMMIT_DISABLE"
+else
+  export RP_DISABLE=""
+fi
+
+# Fan out: one packed "(index, filepath)" record per line, up to $JOBS workers
+#   running concurrently. Each worker writes to its own index-keyed files, so
+#   results never interleave; ordering and reporting are reconstructed below.
+idx=0
+for file in "${files[@]}"; do
+  printf '%s%s%s\n' "$idx" "$TAB" "$file"
+  ((idx++))
+done | xargs -P "$JOBS" -I REC "$0" __worker REC
+
+# Aggregate per-file results in the original (deterministic) order. Live
+#   progress cannot be ordered under concurrency, so per-file status is printed
+#   here once all workers have completed.
+idx=0
+for file in "${files[@]}"; do
 
   cat >> $LOGFILE <<EOD
 -------------------------------------------
@@ -60,22 +198,20 @@ for file in $tests; do
 ## testing "${file}"...
 EOD
 
-  echo -n 'testing "'${file}'"... '
-
-  python3 -m pylint --rcfile=testing/pylint.rc ${file} > .__tmp.log 2>&1
-
-  if [[ $? -ne 0 ]]; then
-    echo 'ERROR'
+  status=$(cat "$tmpdir/$idx.status" 2>/dev/null)
+  if [[ "$status" != "0" ]]; then
+    echo "testing \"${file}\"... ERROR"
     echo " [ ERROR ]" >> $LOGFILE
   else
-    echo 'OK'
+    echo "testing \"${file}\"... OK"
     echo " [ ok ]" >> $LOGFILE
     ((success++))
   fi
 
-  cat .__tmp.log >> $LOGFILE
+  cat "$tmpdir/$idx.log" >> $LOGFILE 2>/dev/null
   echo "" >> $LOGFILE
   ((ntests++))
+  ((idx++))
 
 done
 

--- a/testing/tools/testing_check_npy.py
+++ b/testing/tools/testing_check_npy.py
@@ -4,10 +4,10 @@ import os
 import sys
 
 try:
-    import numpy as np
+  import numpy as np
 except ImportError:
-    sys.stderr.write('WARNING: Unable to import numpy module; validity of .npy files will not be checked\n')
-    sys.exit(0)
+  sys.stderr.write('WARNING: Unable to import numpy module; validity of .npy files will not be checked\n')
+  sys.exit(0)
 
 REFERENCE_1D = np.arange(0, 3)
 REFERENCE_1D_BOOL = REFERENCE_1D.astype('?')
@@ -18,23 +18,22 @@ dirname = sys.argv[1]
 
 errors = []
 
-def getreference(isboolean, is1D):
-    if isboolean:
-        return REFERENCE_1D_BOOL if is1D else REFERENCE_2D_BOOL
-    else:
-        return REFERENCE_1D if is1D else REFERENCE_2D
+def getreference(boolean, onedim):
+  if boolean:
+    return REFERENCE_1D_BOOL if onedim else REFERENCE_2D_BOOL
+  return REFERENCE_1D if onedim else REFERENCE_2D
 
 for entry in os.listdir(dirname):
-    fullpath = os.path.join(dirname, entry)
+  fullpath = os.path.join(dirname, entry)
 
-    print (entry)
-    data = np.load(fullpath)
+  print (entry)
+  data = np.load(fullpath)
 
-    isboolean = 'BOOL' in entry
-    is1D = entry.startswith('1D')
+  isboolean = 'BOOL' in entry
+  is1d = entry.startswith('1D')
 
-    if not np.array_equal(data, getreference(isboolean, is1D)):
-        errors.append(entry)
+  if not np.array_equal(data, getreference(isboolean, is1d)):
+    errors.append(entry)
 
 if errors:
-    raise Exception(str(errors.size()) + ' errors detected: ' + str(errors))
+  raise RuntimeError(f'{len(errors)} errors detected: {errors}')

--- a/testing/tools/testing_gen_npy.py
+++ b/testing/tools/testing_gen_npy.py
@@ -5,47 +5,47 @@ import sys
 
 dirname = sys.argv[1]
 if not os.path.exists(dirname):
-    os.makedirs(dirname)
+  os.makedirs(dirname)
 
 try:
-    import numpy as np
+  import numpy as np
 except ImportError:
-    sys.stderr.write('WARNING: Error importing numpy module; cannot conduct npy unit tests\n')
-    sys.exit(0)
+  sys.stderr.write('WARNING: Error importing numpy module; cannot conduct npy unit tests\n')
+  sys.exit(0)
 
 dtypes = ['?', 'b', 'B']
-for bytes in [2, 4, 8]:
-    for kind in ['i', 'u', 'f']:
-        for endianness in ['<', '>']:
-            dtypes.append(endianness + kind + str(bytes))
+for nbytes in [2, 4, 8]:
+  for kind in ['i', 'u', 'f']:
+    for endianness in ['<', '>']:
+      dtypes.append(endianness + kind + str(nbytes))
 
-def genpath(prefix, ord, dt):
-    return os.path.join(dirname, prefix + '_' + ord + '_' + dt.replace('<', 'LE').replace('>', 'BE').replace('?', 'BOOL') + '.npy')
+def genpath(prefix, order_char, datatype):
+  return os.path.join(dirname, prefix + '_' + order_char + '_' + datatype.replace('<', 'LE').replace('>', 'BE').replace('?', 'BOOL') + '.npy')
 
 for dtype in dtypes:
-    for order in ['C', 'F']:
+  for order in ['C', 'F']:
 
-        # 1D data
-        data = np.empty((3), dtype, order=order)
-        for index in range(0, 3):
-            data[index] = index
-        np.save(genpath('1D3', order, dtype), data)
+    # 1D data
+    data = np.empty((3), dtype, order=order)
+    for index in range(0, 3):
+      data[index] = index
+    np.save(genpath('1D3', order, dtype), data)
 
-        # Column vector
-        data = np.empty((3, 1), dtype, order=order)
-        for index in range(0, 3):
-            data[index, 0] = index
-        np.save(genpath('1D3x1', order, dtype), data)
+    # Column vector
+    data = np.empty((3, 1), dtype, order=order)
+    for index in range(0, 3):
+      data[index, 0] = index
+    np.save(genpath('1D3x1', order, dtype), data)
 
-        # Row vector
-        data = np.empty((1, 3), dtype, order=order)
-        for index in range(0, 3):
-            data[0, index] = index
-        np.save(genpath('1D1x3', order, dtype), data)
+    # Row vector
+    data = np.empty((1, 3), dtype, order=order)
+    for index in range(0, 3):
+      data[0, index] = index
+    np.save(genpath('1D1x3', order, dtype), data)
 
-        # 2D matrix
-        data = np.empty((3, 2), dtype, order=order)
-        for row in range(0, 3):
-            for col in range(0, 2):
-                data[row, col] = 10*row + col
-        np.save(genpath('2D3x2', order, dtype), data)
+    # 2D matrix
+    data = np.empty((3, 2), dtype, order=order)
+    for row in range(0, 3):
+      for col in range(0, 2):
+        data[row, col] = 10*row + col
+    np.save(genpath('2D3x2', order, dtype), data)

--- a/testing/tools/testing_python_cli.py
+++ b/testing/tools/testing_python_cli.py
@@ -15,19 +15,19 @@
 #
 # For more details, see http://www.mrtrix.org/.
 
-from mrtrix3 import app
+from mrtrix3 import app # pylint: disable=import-error
 
 CHOICES = ('One', 'Two', 'Three')
 
 class Custom(app.Parser.CustomTypeBase):
-    def __call__(self, input_value):
-      return input_value
-    @staticmethod
-    def _legacytypestring():
-      return 'CUSTOM'
-    @staticmethod
-    def _metavar():
-      return 'custom'
+  def __call__(self, input_value):
+    return input_value
+  @staticmethod
+  def _legacytypestring():
+    return 'CUSTOM'
+  @staticmethod
+  def _metavar():
+    return 'custom'
 
 def usage(cmdline): #pylint: disable=unused-variable
   cmdline.set_author('Robert E. Smith (robert.smith@florey.edu.au)')
@@ -53,33 +53,33 @@ def usage(cmdline): #pylint: disable=unused-variable
                         type=float,
                         help='A floating-point; built-in type')
 
-  complex = cmdline.add_argument_group('Complex interfaces; nargs, metavar, etc.')
-  complex.add_argument('-nargs_plus',
-                       nargs='+',
-                       help='A command-line option with nargs="+", no metavar')
-  complex.add_argument('-nargs_asterisk',
-                       nargs='*',
-                       help='A command-line option with nargs="*", no metavar')
-  complex.add_argument('-nargs_question',
-                       nargs='?',
-                       help='A command-line option with nargs="?", no metavar')
-  complex.add_argument('-nargs_two',
-                       nargs=2,
-                       help='A command-line option with nargs=2, no metavar')
-  complex.add_argument('-metavar_one',
-                       metavar='metavar',
-                       help='A command-line option with nargs=1 and metavar="metavar"')
-  complex.add_argument('-metavar_two',
-                       metavar='metavar',
-                       nargs=2,
-                       help='A command-line option with nargs=2 and metavar="metavar"')
-  complex.add_argument('-metavar_tuple',
-                       metavar=('metavar_one', 'metavar_two'),
-                       nargs=2,
-                       help='A command-line option with nargs=2 and metavar=("metavar_one", "metavar_two")')
-  complex.add_argument('-append',
-                       action='append',
-                       help='A command-line option with "append" action (can be specified multiple times)')
+  complex_types = cmdline.add_argument_group('Complex interfaces; nargs, metavar, etc.')
+  complex_types.add_argument('-nargs_plus',
+                             nargs='+',
+                             help='A command-line option with nargs="+", no metavar')
+  complex_types.add_argument('-nargs_asterisk',
+                             nargs='*',
+                             help='A command-line option with nargs="*", no metavar')
+  complex_types.add_argument('-nargs_question',
+                             nargs='?',
+                             help='A command-line option with nargs="?", no metavar')
+  complex_types.add_argument('-nargs_two',
+                             nargs=2,
+                             help='A command-line option with nargs=2, no metavar')
+  complex_types.add_argument('-metavar_one',
+                             metavar='metavar',
+                             help='A command-line option with nargs=1 and metavar="metavar"')
+  complex_types.add_argument('-metavar_two',
+                             metavar='metavar',
+                             nargs=2,
+                             help='A command-line option with nargs=2 and metavar="metavar"')
+  complex_types.add_argument('-metavar_tuple',
+                             metavar=('metavar_one', 'metavar_two'),
+                             nargs=2,
+                             help='A command-line option with nargs=2 and metavar=("metavar_one", "metavar_two")')
+  complex_types.add_argument('-append',
+                             action='append',
+                             help='A command-line option with "append" action (can be specified multiple times)')
 
   custom = cmdline.add_argument_group('Custom types')
   custom.add_argument('-bool',


### PR DESCRIPTION
`run_pylint` was causing some grief, and I've definitely been frustrated in the past pushing Python code changes only to have the `pylint` CI test show that the code is completely non-executable. It can take a very long time to run though, hence not always running it through before pushing code. So I thought I'd set Claude at improving its efficiency and integrating it as a pre-commit hook. It can now run only over those files modified by a commit, and multi-thread running across files.

Notably, what is run in the pre-commit hook is *not* the same comprehensive check as that of the CI. I quite often leave TODO markers in one code comment intending to fix something in a subsequent comment, and so precluding the presence of those flags in individual commits would preclude that kind of usage. Some can also take longer to execute, so skipping such checks in the pre-commit hook should be beneficial.

Claude also told me off that `run_pylint` was ignoring some Python source code files in the repo, so I let it run across those and rectify issues.