### PR TITLE
Temporarily disable GPU in Windows CI build

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -257,6 +257,7 @@ jobs:
             -D MRTRIX_BUILD_TESTS=ON
             -D MRTRIX_STL_DEBUGGING=ON
             -D MRTRIX_WARNINGS_AS_ERRORS=ON
+            -D MRTRIX_ENABLE_GPU=OFF
             -D CMAKE_CXX_COMPILER_LAUNCHER=${{env.SCCACHE_UNIX_PATH}} .
 
       - name: build


### PR DESCRIPTION
The Windows build CI check is currently broken with the following message:

```text
FAILED: [code=1] bin/libmrtrix-core.dll cpp/core/libmrtrix-core.dll.a 
C:\Windows\system32\cmd.exe /C "cd . && C:\msys64\ucrt64\bin\c++.exe -O3 -DNDEBUG  -shared -o bin\libmrtrix-core.dll -Wl,--out-implib,cpp\core\libmrtrix-core.dll.a -Wl,--major-image-version,0,--minor-image-version,0 @CMakeFiles\mrtrix-core.rsp && C:\Windows\system32\cmd.exe /C "cd /D D:\a\mrtrix3\mrtrix3\build\cpp\core && C:\msys64\ucrt64\bin\cmake.exe -E copy_if_different D:/a/mrtrix3/mrtrix3/build/_deps/dawn-src/lib/libwebgpu_dawn.a D:/a/mrtrix3/mrtrix3/build/_deps/slang-src/bin/slang-compiler.dll D:/a/mrtrix3/mrtrix3/build/bin""
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: _deps/dawn-src/lib/libwebgpu_dawn.a(EventManager.cpp.obj):EventManager.cpp:(.rdata$.refptr.__emutls_v._ZSt11__once_call[.refptr.__emutls_v._ZSt11__once_call]+0x0): undefined reference to `__emutls_v._ZSt11__once_call'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/16.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: _deps/dawn-src/lib/libwebgpu_dawn.a(EventManager.cpp.obj):EventManager.cpp:(.rdata$.refptr.__emutls_v._ZSt15__once_callable[.refptr.__emutls_v._ZSt15__once_callable]+0x0): undefined reference to `__emutls_v._ZSt15__once_callable'
collect2.exe: error: ld returned 1 exit status
```

This occurs due to a change from GCC15 to GCC16. Specifically the TLS implementation in libstdc++ changes from emulated to native. However the pre-compiled Dawn library does not reflect this. It therefore can't be rectified using the `-fno-emulated-tls` compiler flag.

Here the proposal is to temporarily disable the building of GPU capabilities in the Windows CI check, in order for merges to `dev` to pass checks. In time I think we will need to build and package this library a second time for this different compiler version, and have `cmake` appropriately choose which of them is the correct download. This might take a moment to get right.