### PR TITLE
Fix clang-format comment-splitting artefacts

### DIFF
--- a/.github/workflows/clang-tidy-enforce.yml
+++ b/.github/workflows/clang-tidy-enforce.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt update
-        sudo apt install clang-tidy-19 qt6-base-dev libqt6opengl6-dev libglvnd-dev libeigen3-dev zlib1g-dev libfftw3-dev ninja-build
+        sudo apt install clang-tidy-19 qt6-base-dev libqt6opengl6-dev libglvnd-dev libeigen3-dev zlib1g-dev libfftw3-dev ninja-build libgtest-dev
 
     - name: Run CMake
       run: cmake . -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DMRTRIX_USE_PCH=OFF

--- a/cpp/cmd/dwidenoise.cpp
+++ b/cpp/cmd/dwidenoise.cpp
@@ -349,8 +349,8 @@ void run() {
   }
   INFO("selected patch size: " + str(extent[0]) + " x " + str(extent[1]) + " x " + str(extent[2]) + ".");
 
-  const Estimator estimator =
-      get_option_choice<Estimator>("estimator", Estimator::EXP2); // default: Exp2 (unbiased estimator)
+  // default: Exp2 (unbiased estimator)
+  const Estimator estimator = get_option_choice<Estimator>("estimator", Estimator::EXP2);
   const bool exp1 = estimator == Estimator::EXP1;
 
   if (std::min<uint32_t>(dwi.size(3), extent[0] * extent[1] * extent[2]) < 15) {

--- a/cpp/cmd/mrconvert.cpp
+++ b/cpp/cmd/mrconvert.cpp
@@ -267,8 +267,8 @@ void permute_DW_scheme(Header &H, const std::vector<int> &axes) {
   const Eigen::Matrix3d R = T.scanner2voxel.rotation() * permute * T.voxel2scanner.rotation();
 
   Eigen::MatrixXd out(in.rows(), in.cols());
-  out.block(0, 3, out.rows(), out.cols() - 3) =
-      in.block(0, 3, in.rows(), in.cols() - 3); // Copy b-values (and anything else stored in dw_scheme)
+  // Copy b-values (and anything else stored in dw_scheme)
+  out.block(0, 3, out.rows(), out.cols() - 3) = in.block(0, 3, in.rows(), in.cols() - 3);
   for (int row = 0; row != in.rows(); ++row)
     out.block<1, 3>(row, 0) = in.block<1, 3>(row, 0) * R;
 
@@ -285,8 +285,8 @@ void permute_PE_scheme(Header &H, const std::vector<int> &axes) {
     permute(axes[axis], axis) = 1.0;
 
   Eigen::MatrixXd out(in.rows(), in.cols());
-  out.block(0, 3, out.rows(), out.cols() - 3) =
-      in.block(0, 3, in.rows(), in.cols() - 3); // Copy total readout times (and anything else stored in pe_scheme)
+  // Copy total readout times (and anything else stored in pe_scheme)
+  out.block(0, 3, out.rows(), out.cols() - 3) = in.block(0, 3, in.rows(), in.cols() - 3);
   for (int row = 0; row != in.rows(); ++row)
     out.block<1, 3>(row, 0) = in.block<1, 3>(row, 0) * permute;
 

--- a/cpp/core/dwi/fmls.cpp
+++ b/cpp/core/dwi/fmls.cpp
@@ -238,8 +238,8 @@ bool Segmenter::operator()(const SH_coefs &in, FOD_lobes &out) const {
 
       // Revise multiple peaks if present
       for (size_t peak_index = 0; peak_index != i->num_peaks(); ++peak_index) {
-        Eigen::Vector3d newton_peak_dir =
-            i->get_peak_dir(peak_index); // to be updated by subsequent Math::SH::get_peak() call
+        // to be updated by subsequent Math::SH::get_peak() call
+        Eigen::Vector3d newton_peak_dir = i->get_peak_dir(peak_index);
         const default_type newton_peak_value = Math::SH::get_peak(in, lmax, newton_peak_dir, &(*precomputer));
         if (std::isfinite(newton_peak_value) && newton_peak_dir.allFinite()) {
 

--- a/cpp/core/dwi/tractography/GT/mhsampler.h
+++ b/cpp/core/dwi/tractography/GT/mhsampler.h
@@ -84,8 +84,8 @@ protected:
   Properties &props;
   Stats &stats;
   ParticleGrid &pGrid;
-  EnergyComputer
-      *E; // Polymorphic copy requires call to EnergyComputer::clone(), hence references or smart pointers won't do.
+  // Polymorphic copy requires call to EnergyComputer::clone(), hence references or smart pointers won't do.
+  EnergyComputer *E;
 
   Transform T;
   std::vector<size_t> dims;

--- a/cpp/core/dwi/tractography/SIFT/proc_mask.cpp
+++ b/cpp/core/dwi/tractography/SIFT/proc_mask.cpp
@@ -75,8 +75,8 @@ void initialise_processing_mask(Image<float> &in_dwi, Image<float> &out_mask, Im
       out_5tt.index(3) = 2; // Access the WM fraction
       float integral = 0.0f;
       for (auto l = Loop(out_5tt, 0, 3)(out_5tt, out_mask); l; ++l) {
-        const float value =
-            Math::pow2<float>(out_5tt.value()); // Processing mask value is the square of the WM fraction
+        // Processing mask value is the square of the WM fraction
+        const float value = Math::pow2<float>(out_5tt.value());
         if (std::isfinite(value)) {
           out_mask.value() = value;
           integral += value;

--- a/cpp/core/dwi/tractography/connectome/tck2nodes.h
+++ b/cpp/core/dwi/tractography/connectome/tck2nodes.h
@@ -150,8 +150,9 @@ private:
 class Tck2nodes_forwardsearch : public Tck2nodes_base {
 
 public:
+  // 45 degree limit
   Tck2nodes_forwardsearch(const Image<node_t> &nodes_data, const default_type length)
-      : Tck2nodes_base(nodes_data, true), max_dist(length), angle_limit(Math::pi_4) {} // 45 degree limit
+      : Tck2nodes_base(nodes_data, true), max_dist(length), angle_limit(Math::pi_4) {}
 
   Tck2nodes_forwardsearch(const Tck2nodes_forwardsearch &that)
       : Tck2nodes_base(that), max_dist(that.max_dist), angle_limit(that.angle_limit) {}

--- a/cpp/core/file/dicom/image.cpp
+++ b/cpp/core/file/dicom/image.cpp
@@ -285,8 +285,8 @@ void Image::parse_item(Element &item) {
   case 0xFFFEU:
     switch (item.element) {
     case 0xE000U:
-      if (!item.parents.empty() && item.parents.back().group == 0x5200U &&
-          item.parents.back().element == 0x9230U) { // multi-frame item
+      // multi-frame item
+      if (!item.parents.empty() && item.parents.back().group == 0x5200U && item.parents.back().element == 0x9230U) {
         if (in_frames) {
           calc_distance();
           frames.push_back(std::shared_ptr<Frame>(new Frame(*this)));

--- a/cpp/core/file/dicom/quick_scan.cpp
+++ b/cpp/core/file/dicom/quick_scan.cpp
@@ -97,8 +97,9 @@ bool QuickScan::read(const std::filesystem::path &file_path,
           else if (item.is(0x7FE0U, 0x0010U))
             data = item.offset(item.data);
           else if (item.is(0xFFFEU, 0xE000U)) {
+            // multi-frame item
             if (!item.parents.empty() && item.parents.back().group == 0x5200U &&
-                item.parents.back().element == 0x9230U) { // multi-frame item
+                item.parents.back().element == 0x9230U) {
               if (in_frames)
                 ++image_type[current_image_type];
               else

--- a/cpp/core/file/npy.cpp
+++ b/cpp/core/file/npy.cpp
@@ -388,9 +388,8 @@ prepare_ND_write(const std::filesystem::path &path, const DataType data_type, co
                      "," + (shape.size() == 2 ? (" " + str(shape[1])) : "") + "), }");
   // Pad with spaces so that, for version 1, upon adding a newline at the end, the file size (i.e. eventual offset to
   // the data) is a multiple of alignment (16)
-  uint32_t space_count =
-      alignment -
-      ((header.size() + 11) % alignment); // 11 = 6 magic number + 2 version + 2 header length + 1 newline for header
+  // 11 = 6 magic number + 2 version + 2 header length + 1 newline for header
+  uint32_t space_count = alignment - ((header.size() + 11) % alignment);
   uint32_t padded_header_length = header.size() + space_count + 1;
   File::OFStream out(path, std::ios_base::out | std::ios_base::binary);
   if (!out)
@@ -401,8 +400,8 @@ prepare_ND_write(const std::filesystem::path &path, const DataType data_type, co
     const unsigned char major_version = '\x02';
     out.write(reinterpret_cast<const char *>(&major_version), 1);
     out.write(reinterpret_cast<const char *>(&minor_version), 1);
-    space_count = alignment - ((header.size() + 13) %
-                               alignment); // 13 = 6 magic number + 2 version + 4 header length + 1 newline for header
+    // 13 = 6 magic number + 2 version + 4 header length + 1 newline for header
+    space_count = alignment - ((header.size() + 13) % alignment);
     padded_header_length = header.size() + space_count + 1;
     padded_header_length = ByteOrder::LE(padded_header_length);
     out.write(reinterpret_cast<const char *>(&padded_header_length), 4);

--- a/cpp/core/image_diff.h
+++ b/cpp/core/image_diff.h
@@ -154,8 +154,8 @@ inline void check_keyvals(const HeaderType1 &in1, const HeaderType2 &in2) {
 template <class HeaderType1, class HeaderType2> inline bool headers_match(HeaderType1 &in1, HeaderType2 &in2) {
   if (!dimensions_match(in1, in2))
     return false;
-  if (!spacings_match(
-          in1, in2, 1e-6)) // implicitly checked in voxel_grids_match_in_scanner_space but with different tolerance
+  // implicitly checked in voxel_grids_match_in_scanner_space but with different tolerance
+  if (!spacings_match(in1, in2, 1e-6))
     return false;
   if (!voxel_grids_match_in_scanner_space(in1, in2))
     return false;

--- a/cpp/core/math/average_space.cpp
+++ b/cpp/core/math/average_space.cpp
@@ -266,8 +266,8 @@ void compute_average_voxel2scanner(
     average_space_extent(1) = std::round(average_space_extent(1)) + 1;
     average_space_extent(2) = std::round(average_space_extent(2)) + 1;
 
-    Eigen::Vector3d c000 =
-        average_v2s_trafo.linear() * (bounding_box_corners_inv_min - padding).head<3>(); // voxel space min corner
+    // voxel space min corner
+    Eigen::Vector3d c000 = average_v2s_trafo.linear() * (bounding_box_corners_inv_min - padding).head<3>();
     average_v2s_trafo.matrix().col(3).template head<3>() = c000.template head<3>();
   }
 }

--- a/cpp/core/registration/linear.h
+++ b/cpp/core/registration/linear.h
@@ -319,8 +319,8 @@ public:
       Transform::Init::initialise_using_image_centres(im1_image, im2_image, im1_mask, im2_mask, transform, init);
     else if (init_translation_type == Transform::Init::set_centre_mass) // doesn't change translation or linear matrix
       Transform::Init::set_centre_via_mass(im1_image, im2_image, im1_mask, im2_mask, transform, init, contrasts);
-    else if (init_translation_type ==
-             Transform::Init::set_centre_geometric) // doesn't change translation or linear matrix
+    // doesn't change translation or linear matrix
+    else if (init_translation_type == Transform::Init::set_centre_geometric)
       Transform::Init::set_centre_via_image_centres(im1_image, im2_image, im1_mask, im2_mask, transform, init);
 
     if (init_rotation_type == Transform::Init::moments)

--- a/cpp/core/registration/metric/params.h
+++ b/cpp/core/registration/metric/params.h
@@ -191,8 +191,8 @@ public:
         transformation.transform_half_inverse(im2_point, midway_point);
         robust_estimate_score2_interp->scanner(im2_point);
         if (robust_estimate_score1_interp->value() >= 0.5 && robust_estimate_score2_interp->value() >= 0.5)
-          check.value() =
-              0.0; // 0.5 * (robust_estimate_score2_interp->value() + robust_estimate_score1_interp->value());
+          // 0.5 * (robust_estimate_score2_interp->value() + robust_estimate_score1_interp->value());
+          check.value() = 0.0;
         else
           check.value() = NaN;
       }

--- a/cpp/core/registration/metric/thread_kernel.h
+++ b/cpp/core/registration/metric/thread_kernel.h
@@ -202,8 +202,8 @@ public:
     }
 
     Eigen::Vector3d im1_point; // moving
-    params.transformation.transform_half(
-        im1_point, im2_point); // transform_half is full transformation, transform_half_inverse is identity
+    // transform_half is full transformation, transform_half_inverse is identity
+    params.transformation.transform_half(im1_point, im2_point);
     if (params.im1_mask_interp) {
       params.im1_mask_interp->scanner(im1_point);
       if (params.im1_mask_interp->value() < 0.5)

--- a/cpp/gui/mrview/tool/tractography/track_scalar_file.cpp
+++ b/cpp/gui/mrview/tool/tractography/track_scalar_file.cpp
@@ -235,10 +235,10 @@ void TrackScalarFileOptions::selected_custom_colour(const QColor &c, const Colou
   }
 }
 
+// TrackThresholdType dataSource
 void TrackScalarFileOptions::set_threshold(GUI::MRView::Tool::TrackThresholdType dataSource,
                                            default_type min,
-                                           default_type max) // TrackThresholdType dataSource
-{
+                                           default_type max) {
   if (tractogram) {
     // Source
     tractogram->set_threshold_type(dataSource);

--- a/cpp/gui/mrview/tool/view.cpp
+++ b/cpp/gui/mrview/tool/view.cpp
@@ -664,9 +664,10 @@ void View::onCheckThreshold(bool) {
 }
 
 void View::set_transparency_from_image() {
+  // reset:
   if (!std::isfinite(window().image()->transparent_intensity) || !std::isfinite(window().image()->opaque_intensity) ||
       !std::isfinite(window().image()->alpha) || !std::isfinite(window().image()->lessthan) ||
-      !std::isfinite(window().image()->greaterthan)) { // reset:
+      !std::isfinite(window().image()->greaterthan)) {
     if (!std::isfinite(window().image()->intensity_min()) || !std::isfinite(window().image()->intensity_max()))
       return;
 

--- a/testing/unit_tests/shuffle_tests.cpp
+++ b/testing/unit_tests/shuffle_tests.cpp
@@ -67,8 +67,8 @@ std::vector<ShufflerParams> GetShufflerTestParams() {
       max_num_permutations = Math::factorial(ROWS);
       max_num_signflips = size_t(1) << ROWS;
     } else if (exchange_type == Exchange::WITHIN) {
-      max_num_permutations =
-          static_cast<size_t>(Math::factorial(2)) * Math::factorial(2) * Math::factorial(2); // 2 per block
+      // 2 per block
+      max_num_permutations = static_cast<size_t>(Math::factorial(2)) * Math::factorial(2) * Math::factorial(2);
       max_num_signflips = size_t(1) << ROWS;
     } else {
       // WHOLE


### PR DESCRIPTION
Just rectifying an annoying code formatting pattern that manifested from #2652.