### PR TITLE
Add Perl engine to check_syntax for line-numbered reporting

### DIFF
--- a/.github/workflows/clang-tidy-enforce.yml
+++ b/.github/workflows/clang-tidy-enforce.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Run clang-tidy on changed C++ files
       run: |
         BASE=${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
-        CHANGED=$(git diff --name-only "${BASE}...HEAD" | grep -E '\.(cpp|cxx|cc|h|hpp|hxx)$' | grep -vE 'cpp/core/eigen_plugins/|cpp/gui/opengl/gl_core_3_3' || true)
+        CHANGED=$(git diff --name-only "${BASE}...HEAD" | grep -E '\.(cpp|cxx|cc|h|hpp|hxx)$' | grep -vE 'cpp/core/eigen_plugins/|cpp/gui/opengl/gl_core_3_3|(^|/)testing/data/' || true)
         if [ -z "${CHANGED}" ]; then
           echo "No C++ files changed; nothing to check."
           exit 0

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -22,6 +22,9 @@ jobs:
         apt_packages: g++,qt6-base-dev,libqt6opengl6-dev,libglvnd-dev,zlib1g-dev,libfftw3-dev,ninja-build
         config_file: .clang-tidy-review
         clang_tidy_version: 19
+        # Exclude intentionally non-conforming fixtures under testing/data/
+        # (e.g. the check_syntax offenders fixture) from review.
+        exclude: "testing/data/*"
 
     - uses: ZedThree/clang-tidy-review/upload@v0.21.0
       id: upload-review

--- a/check_syntax
+++ b/check_syntax
@@ -15,213 +15,59 @@
 #
 # For more details, see http://www.mrtrix.org/.
 
+# Thin front-end for the C++ house-style checks.  File discovery (whole-tree),
+# an explicit command-line file list, and staged-diff extraction live here; the
+# per-file pattern checks and the reporting of offending line numbers are
+# delegated to the Perl engine check_syntax_engine.pl (invoked via "perl", so it
+# needs no execute bit).  The engine matches the project's PCRE patterns and
+# reports each offending line (or line range), so neither the BSD gnu-grep
+# workaround nor any in-band diff-hunk sentinel is required here.
+#
+# Usage:
+#   check_syntax                 check every C++ source file under cpp/
+#   check_syntax FILE [FILE ...] check only the explicitly listed files
+#   check_syntax --diff          check the staged changes only
+
 DIFF_MODE=0
+FILES=()
 while [[ $# -gt 0 ]]; do
   case $1 in
     --diff)
       DIFF_MODE=1
       shift
       ;;
-    *)
+    -*)
       echo "Unknown option: $1" >&2
       exit 1
       ;;
+    *)
+      FILES+=("$1")
+      shift
+      ;;
   esac
 done
+
+if [[ $DIFF_MODE -eq 1 && ${#FILES[@]} -gt 0 ]]; then
+  echo "Cannot combine --diff with an explicit file list" >&2
+  exit 1
+fi
+
+ENGINE="$(dirname "$0")/check_syntax_engine.pl"
 
 LOG=syntax.log
 echo -n "Checking syntax... "
 echo "Checking syntax..." > $LOG
 echo "" >> $LOG
 
-grep=grep
-v=`grep --version`
-if [[ "$OSTYPE" == darwin* ]] && [[ $v == *"BSD"* ]]; then
-  if ! hash ggrep 2>/dev/null; then
-    echo 'Aborting, this script requires gnu-grep which you can install for instance via "brew install grep"'
-    exit 1
-  else
-    grep=ggrep
-  fi
-fi
-
 retval=0
-
-rm -f .check_syntax1.tmp .check_syntax2.tmp .check_syntax3.tmp .check_syntax4.tmp
-
-# Run all syntax checks on content already written to .check_syntax1.tmp.
-# Argument: $1 = filename (for log reporting and special-case handling).
-# Cleans up all .check_syntax*.tmp files on exit.
-run_checks() {
-  local f="$1"
-  local res=""
-
-# Check for use of #define for constants
-# Intended to catch integers, floats, scientific notation, hexadecimal, bitwise, and strings
-  res=$(
-    cat .check_syntax1.tmp | \
-    $grep -Po '^#define\s+[a-zA-Z_][a-zA-Z0-9_]*\s+(0x[\dA-F]+|0b[01]+|\".*\"|[-+]?(?:[0-9]+\.?[0-9]*|\.[0-9]+)(?:[eE][-+]?[0-9]+)?)'
-  )
-
-# detect deprecated use of "#ifdef __headerpath__"
-  res="$res"$(
-    cat .check_syntax1.tmp | \
-    perl -pe 's|//.*$||' | \
-    tr '\n' ' ' | \
-    perl -pe 's|\s+| |g' | \
-    perl -pe 's|/\*.*?\*/||g' |
-    $grep -Po '\#ifndef\s+__.*__\s+\#define\s+__.*__'
-  )
-
-# detect the inclusion of Eigen headers without eigen_plugins/eigen_plugins.h appearing upstream;
-#   this can cause issues with compilation on some systems
-  if [[ ! "$f" -ef "cpp/core/eigen_plugins/eigen_plugins.h" ]]; then
-    res="$res"$(
-      cat .check_syntax1.tmp | \
-      $grep -Po '^#include .*' | \
-      tr '\n' ' ' | \
-      $grep -Po '.*#include <(unsupported\/)?Eigen\/[\w\/]+>' | \
-      $grep -Pv '#include "eigen_plugins\/eigen_plugins\.h"'
-    )
-  fi
-
-#############################################################
-# Process the file to strip macros and single-line comments #
-#############################################################
-  cat .check_syntax1.tmp | \
-  $grep -v '^#' | \
-  perl -pe 's|//.*$||' > .check_syntax2.tmp
-
-# Identify any uses of std::string_view as a function return
-  res="$res"$(
-    cat .check_syntax2.tmp | \
-    $grep -Po '^\s*(const\s+|)std::string_view\s?\&?([a-zA-Z_][a-zA-Z0-9_]*|operator.*)\s?\(.*\)'
-  )
-
-######################################
-# Further processing of file content #
-######################################
-  cat .check_syntax2.tmp | \
-# remove all newlines to make file one long line:
-  tr '\n' ' ' | \
-# remove any duplicate spaces:
-  perl -pe 's|\s+| |g' | \
-# remove C-style comments:
-  perl -pe 's|/\*.*?\*/||g' | \
-# split diff hunks across lines
-  perl -pe 's|\s?\@\@\@HUNK_BREAK\@\@\@\s?|\n|g' > .check_syntax3.tmp
-
-# detect any instances of %zu in a print() call (not supported on MSYS2):
-  res="$res"$(
-    cat .check_syntax3.tmp | \
-# match for the parts we're interested in and output just the bits that match:
-    $grep -Po '\w*print\w*.*?%\d?zu\b' |
-    $grep -Po '\w*print(?!.*?print).*?$'
-  )
-
-# Detect any instances of definition of C-style arrays
-# Note: Need to use version without removal of quoted strings
-#   so that keyval["key"] isn't a hit
-  res="$res"$(
-    cat .check_syntax3.tmp | \
-    $grep -Po '\b\w+(::\w+)*(?<!\breturn)(?<!\bnew)\s\w+(\[\d*\])+\s*[=;,]'
-  )
-
-#########################
-# Remove quoted strings #
-#########################
-  cat .check_syntax3.tmp | \
-  perl -pe 's/(")(\\"|.)*?"//g' > .check_syntax4.tmp
-
-# - Detect any instances of char* or char item[],
-#   which does not look like a cast for compatibility with external code
-  res="$res"$(
-    cat .check_syntax4.tmp | \
-    $grep -Po '(const\s+|)char(\s?\*(\s?const|)\s?(?![>\(\)])|\s+[a-zA-Z_][a-zA-Z0-9_]*\[(\d*\]|))'
-  )
-
-# - Detect any instances of C-style string manipulation functions,
-#   including direct strerror() calls (use MR::C_strerror() instead)
-  res="$res"$(
-    cat .check_syntax4.tmp | \
-    $grep -Po '\b(strcpy|strncpy|strcat|strncat|strxfrm|strlen|strcmp|strncmp|strcoll|strchr|strrchr|strspn|strcspn|strpbrk|strstr|strtok|wcscpy|wcsncpy|wcscat|wcsncat|wcsxfrm|wcslen|wcscmp|wcsncmp|wcscoll|wcschr|wcsrchr|wcsspn|wcscspn|wcspbrk|wcsstr|wcstok|strerror)\s*\('
-  )
-
-# - Detect direct calls to std::getenv() or getenv() (use MR::get_env() instead)
-  res="$res"$(
-    cat .check_syntax4.tmp | \
-    $grep -Po '\bgetenv\s*\('
-  )
-
-# - Detect any instances of C rand() or srand() (use <random> STL instead)
-  res="$res"$(
-    cat .check_syntax4.tmp | \
-    $grep -Po '\b(srand|rand)\s*\('
-  )
-
-# - Detect instances of const std::string &
-#   most can be changed to std::string_view,
-#   others would be safer to return a copy
-  res="$res"$(
-    cat .check_syntax4.tmp | \
-    $grep -Po '\bconst\sstd::string\s?\&'
-  )
-
-# - Detect namespaces that could have been nested
-  res="$res"$(
-    cat .check_syntax4.tmp | \
-    $grep -Po '\bnamespace [\w\:]+\s*\{(\s*namespace [\w\:]+\s*\{)+'
-  )
-
-# - Detect any instances of "using namespace std;":
-  res="$res"$(
-    cat .check_syntax4.tmp | \
-    $grep -Po '\busing\snamespace\sstd\s?;'
-  )
-
-# - Detect any instances of C-style casts
-  res="$res"$(
-    cat .check_syntax4.tmp | \
-    $grep -Po '(\((?!void\))[a-zA-Z][a-zA-Z0-9_]*\)[a-zA-Z][a-zA-Z0-9_]*|\([a-zA-Z][a-zA-Z0-9_]*\s?\*(\s?const)?\)[a-zA-Z][a-zA-Z0-9_]*|\(\s?void\s?\*(\s?const)?\)[\w&(]|(?<!\bstd::function<)\b(GLint|GLfloat|c?float|c?double|(default|value|index)_type|[^\w_](unsigned\s+)?int|u?int(8|16|32|64)_t|s?size_t|ValueType|(?<!Scalar)::Scalar)\(\(*\**(?![\d\-\.]*\)))'
-  )
-
-# - Detect any instances of macros NULL (nullptr is better), NAN, INFINITY
-  res="$res"$(
-    cat .check_syntax4.tmp | \
-    $grep -Po '\b(NAN|INFINITY|NULL)\b'
-  )
-
-# detect any instances of std::abs() or non-disambiguated abs() (outside of the SFINAE call in core/types.h):
-  if [[ ! "$f" -ef "cpp/core/types.h" ]]; then
-    res="$res"$(
-      cat .check_syntax4.tmp | \
-      $grep -Po '((?<!::)std::|)(?<!MR::)(?<!\.)\babs\s?\('
-    )
-  fi
-
-# detect use of std::visit with a lambda function
-  res="$res"$(
-    cat .check_syntax4.tmp | \
-    $grep -Po 'std::visit\s?\(\s?\[\s?(&?\w+(,\s?&?\w+)*)?\]\s?\('
-  )
-
-  rm -f .check_syntax1.tmp .check_syntax2.tmp .check_syntax3.tmp .check_syntax4.tmp
-
-# if anything is left after that, show it:
-  if [[ ! -z $res ]]; then
-    echo "################################### $f" >> $LOG
-    echo "$res" >> $LOG
-    retval=1
-  fi
-}
 
 if [[ $DIFF_MODE -eq 1 ]]; then
 
   staged_cpp_files=$(git diff --cached --name-only | \
-    $grep -E '\.(h|cpp)$' | \
-    $grep -v '_moc\.cpp' | \
-    $grep -v 'gl_core_3_3' | \
-    $grep '^cpp/')
+    grep -E '\.(h|cpp)$' | \
+    grep -v '_moc\.cpp' | \
+    grep -v 'gl_core_3_3' | \
+    grep '^cpp/')
 
   if [[ -z "$staged_cpp_files" ]]; then
     echo "OK"
@@ -233,27 +79,48 @@ if [[ $DIFF_MODE -eq 1 ]]; then
   git diff --cached > "$diff_tmp"
 
   for f in $staged_cpp_files; do
-    awk -v target="b/$f" '
-      /^diff --git / { in_file = ($4 == target); hunk_started = 0 }
+    # Emit one "<new-file-line>\t<content>" record per added/context line, and a
+    # bare "--" line between hunks so the engine treats each hunk as a separate
+    # segment (preventing matches that span non-contiguous blocks of code).
+    res=$(awk -v target="b/$f" '
+      /^diff --git / { in_file = ($4 == target); started = 0 }
       in_file && /^\+\+\+ / { next }
-      in_file && /^@@ / { if (hunk_started) print "@@@HUNK_BREAK@@@"; hunk_started = 1; next }
-      in_file && /^[+ ]/ { print substr($0, 2) }
+      in_file && /^@@ / {
+        if (match($0, /\+[0-9]+/)) newline = substr($0, RSTART + 1, RLENGTH - 1) + 0
+        if (started) print "--"
+        started = 1
+        next
+      }
+      in_file && /^[+ ]/ { print newline "\t" substr($0, 2); newline++ }
     ' "$diff_tmp" | \
-    $grep -v '\/\/.*\bcheck_syntax\soff' > .check_syntax1.tmp
+    perl "$ENGINE" --diff --label "$f")
 
-    run_checks "$f"
+    if [[ -n "$res" ]]; then
+      echo "$res" >> $LOG
+      retval=1
+    fi
   done
 
   rm -f "$diff_tmp"
 
 else
 
-  for f in $(find cpp -type f -name '*.h' -o -name '*.cpp' | $grep -v '_moc.cpp' | $grep -v 'gl_core_3_3' | sort); do
-    cat $f | \
-    $grep -v '\/\/.*\bcheck_syntax\soff' > .check_syntax1.tmp
+  if [[ ${#FILES[@]} -gt 0 ]]; then
+    # Explicit command-line file list: check exactly the files requested.
+    cpp_files=("${FILES[@]}")
+  else
+    # Whole-tree discovery of every C++ source file under cpp/.
+    mapfile -t cpp_files < <(find cpp -type f \( -name '*.h' -o -name '*.cpp' \) | \
+      grep -v '_moc.cpp' | \
+      grep -v 'gl_core_3_3' | \
+      sort)
+  fi
 
-    run_checks "$f"
-  done
+  res=$(perl "$ENGINE" "${cpp_files[@]}")
+  if [[ -n "$res" ]]; then
+    echo "$res" >> $LOG
+    retval=1
+  fi
 
 fi
 

--- a/check_syntax
+++ b/check_syntax
@@ -67,6 +67,7 @@ if [[ $DIFF_MODE -eq 1 ]]; then
     grep -E '\.(h|cpp)$' | \
     grep -v '_moc\.cpp' | \
     grep -v 'gl_core_3_3' | \
+    grep -v -E '(^|/)testing/data/' | \
     grep '^cpp/')
 
   if [[ -z "$staged_cpp_files" ]]; then
@@ -116,7 +117,23 @@ else
       sort)
   fi
 
-  res=$(perl "$ENGINE" "${cpp_files[@]}")
+  # Exclude all content under testing/data/ (e.g. intentionally non-conforming
+  # fixtures such as the check_syntax unit-test offenders file) from checking,
+  # however the file list was assembled.
+  filtered=()
+  for f in "${cpp_files[@]}"; do
+    if [[ "$f" =~ (^|/)testing/data/ ]]; then
+      continue
+    fi
+    filtered+=("$f")
+  done
+  cpp_files=("${filtered[@]}")
+
+  if [[ ${#cpp_files[@]} -eq 0 ]]; then
+    res=""
+  else
+    res=$(perl "$ENGINE" "${cpp_files[@]}")
+  fi
   if [[ -n "$res" ]]; then
     echo "$res" >> $LOG
     retval=1

--- a/check_syntax_engine.pl
+++ b/check_syntax_engine.pl
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-#
+
 # Copyright (c) 2008-2026 the MRtrix3 contributors.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public

--- a/check_syntax_engine.pl
+++ b/check_syntax_engine.pl
@@ -1,0 +1,440 @@
+#!/usr/bin/perl
+#
+# Copyright (c) 2008-2026 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
+# Heavy-lifting engine for the repository's `check_syntax` script.
+#
+# Both are handled by a single mechanism, the char -> source-line interval map:
+# every transform the original performed (drop `^#` lines, blank `//`, join,
+# collapse `\s+`, strip `/*...*/`, remove strings) is reproduced while a
+# parallel array @map is kept in lockstep, so @map[i] is the source line of the
+# i-th character of the working buffer.  A match at byte offset [ms,me) maps to
+# source lines @map[ms] .. @map[me-1] -- an exact line, or a line range for a
+# genuinely multi-line match.  The bytes the regexes see are pristine (no
+# in-band markers), so matching behaviour is identical to the original.
+#
+# Diff-mode block separation: the engine processes a LIST OF SEGMENTS.  Each
+# diff hunk is a separate segment; every line-joining transform operates within
+# a single segment, so a match can never span two non-contiguous blocks.  The
+# boundary is therefore structural -- it never enters any buffer the regexes
+# inspect, and there is no token to strip or to accidentally match.
+#
+# Usage:
+#   check_syntax_engine.pl [--format human|tsv] FILE [FILE ...]
+#       Non-diff: read each file directly, treat it as one segment, tagging
+#       lines by their source number and dropping `// ... check_syntax off`.
+#   check_syntax_engine.pl --diff --label REL/PATH [--format human|tsv]
+#       Diff: read a tagged stream on stdin -- one "<line>\t<content>" record
+#       per line, a bare "--" line separating segments (hunks).
+#
+# Exit status: 1 if any offending line was reported, 0 otherwise.
+
+use strict;
+use warnings;
+
+# ---------------------------------------------------------------------------
+# Arguments
+# ---------------------------------------------------------------------------
+my @files;
+my $diff = 0;
+my $label = '';
+my $format = 'human';
+while (@ARGV) {
+  my $a = shift @ARGV;
+  if    ($a eq '--diff')   { $diff = 1; }
+  elsif ($a eq '--label')  { $label = shift @ARGV; }
+  elsif ($a eq '--format') { $format = shift @ARGV; }
+  elsif ($a eq '--file')   { push @files, shift @ARGV; }
+  elsif ($a =~ /^-/)       { die "unknown argument: $a\n"; }
+  else                     { push @files, $a; }
+}
+die "unknown --format '$format'\n" unless $format eq 'human' || $format eq 'tsv';
+
+# ---------------------------------------------------------------------------
+# In-house syntax-check regular expressions.
+#
+# Each pattern encodes one house-style rule.  They are collected here, away from
+# the scanning logic, so the rule set can be reviewed and amended in one place.
+# For every pattern the comment names the check performed and the working buffer
+# the pattern is matched against (see check_file() for how each buffer is built
+# from a segment's records):
+#   raw     : source lines verbatim (suppressed `check_syntax off` lines removed)
+#   guard   : per-segment; // blanked, whitespace collapsed, C comments stripped
+#   buffer2 : per-segment; `^#` lines dropped and trailing // comments blanked
+#   buffer3 : buffer2 joined into one string, whitespace collapsed, and
+#             C-style /*...*/ comments stripped
+#   buffer4 : buffer3 with quoted string literals removed
+# ---------------------------------------------------------------------------
+
+# A: #define of a numeric/string constant -- applied per line to the raw buffer.
+my $RE_define_constant =
+  qr/^#define\s+[a-zA-Z_][a-zA-Z0-9_]*\s+(0x[\dA-F]+|0b[01]+|".*"|[-+]?(?:[0-9]+\.?[0-9]*|\.[0-9]+)(?:[eE][-+]?[0-9]+)?)/;
+
+# B: deprecated `#ifndef __X__ / #define __X__` include guard -- guard buffer.
+my $RE_include_guard = qr/\#ifndef\s+__.*__\s+\#define\s+__.*__/;
+
+# C: Eigen header included before eigen_plugins/eigen_plugins.h -- applied per
+# #include line of the raw buffer (the order check is stateful; see check_file).
+my $RE_include_any     = qr/^#include /;
+my $RE_include_plugins = qr/#include "eigen_plugins\/eigen_plugins\.h"/;
+my $RE_include_eigen   = qr/(#include <(?:unsupported\/)?Eigen\/[\w\/]+>)/;
+
+# D: std::string_view used as a function return type -- per line to buffer2.
+my $RE_string_view_return =
+  qr/^\s*(const\s+|)std::string_view\s?\&?([a-zA-Z_][a-zA-Z0-9_]*|operator.*)\s?\(.*\)/;
+
+# E: %zu inside a print() call -- applied to buffer3 (two-stage; see postfilter).
+my $RE_print_zu = qr/\w*print\w*.*?%\d?zu\b/;
+# E (stage 2): isolate the innermost print(...) call wrapping the %zu, for the report.
+my $RE_print_zu_call = qr/(\w*print(?!.*?print).*?$)/;
+
+# F: C-style array declaration -- applied to buffer3.
+my $RE_c_array = qr/\b\w+(::\w+)*(?<!\breturn)(?<!\bnew)\s\w+(\[\d*\])+\s*[=;,]/;
+
+# G: char* / char item[] -- applied to buffer4.
+my $RE_c_char =
+  qr/(const\s+|)char(\s?\*(\s?const|)\s?(?![>\(\)])|\s+[a-zA-Z_][a-zA-Z0-9_]*\[(\d*\]|))/;
+
+# H: C-style string-manipulation functions (incl. strerror) -- applied to buffer4.
+my $RE_c_string_fn =
+  qr/\b(strcpy|strncpy|strcat|strncat|strxfrm|strlen|strcmp|strncmp|strcoll|strchr|strrchr|strspn|strcspn|strpbrk|strstr|strtok|wcscpy|wcsncpy|wcscat|wcsncat|wcsxfrm|wcslen|wcscmp|wcsncmp|wcscoll|wcschr|wcsrchr|wcsspn|wcscspn|wcspbrk|wcsstr|wcstok|strerror)\s*\(/;
+
+# I: getenv() -- applied to buffer4.
+my $RE_getenv = qr/\bgetenv\s*\(/;
+
+# J: rand()/srand() -- applied to buffer4.
+my $RE_rand = qr/\b(srand|rand)\s*\(/;
+
+# K: const std::string & function argument -- applied to buffer4.
+my $RE_const_string_ref = qr/\bconst\sstd::string\s?\&/;
+
+# L: sequential namespaces that could be nested -- applied to buffer4.
+my $RE_nested_namespace = qr/\bnamespace [\w\:]+\s*\{(\s*namespace [\w\:]+\s*\{)+/;
+
+# M: using namespace std; -- applied to buffer4.
+my $RE_using_namespace_std = qr/\busing\snamespace\sstd\s?;/;
+
+# N: C-style casts -- applied to buffer4.
+my $RE_c_cast =
+  qr/(\((?!void\))[a-zA-Z][a-zA-Z0-9_]*\)[a-zA-Z][a-zA-Z0-9_]*|\([a-zA-Z][a-zA-Z0-9_]*\s?\*(\s?const)?\)[a-zA-Z][a-zA-Z0-9_]*|\(\s?void\s?\*(\s?const)?\)[\w&(]|(?<!\bstd::function<)\b(GLint|GLfloat|c?float|c?double|(default|value|index)_type|[^\w_](unsigned\s+)?int|u?int(8|16|32|64)_t|s?size_t|ValueType|(?<!Scalar)::Scalar)\(\(*\**(?![\d\-\.]*\)))/;
+
+# O: NULL / NAN / INFINITY macros -- applied to buffer4.
+my $RE_macro_null_nan = qr/\b(NAN|INFINITY|NULL)\b/;
+
+# P: std::abs() or naked abs() -- applied to buffer4 (skipped in cpp/core/types.h).
+my $RE_abs = qr/((?<!::)std::|)(?<!MR::)(?<!\.)\babs\s?\(/;
+
+# Q: std::visit() with a lambda -- applied to buffer4.
+my $RE_visit_lambda = qr/std::visit\s?\(\s?\[\s?(&?\w+(,\s?&?\w+)*)?\]\s?\(/;
+
+# ---------------------------------------------------------------------------
+# Transform / scan primitives that keep (string, @map) in lockstep.
+# A "segment" is an arrayref of [line_number, text] records (text without its
+# trailing newline).  @map entries are source line numbers.
+# ---------------------------------------------------------------------------
+
+# Drop a `// ... check_syntax off` line (mirror of the original `grep -v`).
+sub is_suppressed { return $_[0] =~ m{//.*\bcheck_syntax\soff}; }
+
+# Blank a trailing // comment on one line (mirror of perl -pe 's|//.*$||').
+sub blank_line_comment {
+  my ($t) = @_;
+  $t =~ s{//.*$}{};
+  return $t;
+}
+
+# Join a segment's records into ($string, \@map); each terminating newline
+# becomes a single space (mirror of `tr '\n' ' '`).  Optionally blank //.
+sub join_records {
+  my ($recs, $blank_comments) = @_;
+  my $s = '';
+  my @map;
+  for my $r (@$recs) {
+    my ($ln, $txt) = @$r;
+    $txt = blank_line_comment($txt) if $blank_comments;
+    my $len = length $txt;
+    for (my $i = 0; $i < $len; $i++) {
+      $s .= substr($txt, $i, 1);
+      push @map, $ln;
+    }
+    $s .= ' ';        # the line's terminating newline -> space
+    push @map, $ln;
+  }
+  return ($s, \@map);
+}
+
+# Collapse runs of whitespace to a single space (mirror of s|\s+| |g).  The
+# surviving space inherits the line of the LAST whitespace character in the run
+# (the indent abutting the next token), so a leading-\s match begins on the
+# token's own line.
+sub collapse_ws {
+  my ($s, $map) = @_;
+  my $ns = '';
+  my @nm;
+  my $len = length $s;
+  my $i = 0;
+  while ($i < $len) {
+    if (substr($s, $i, 1) =~ /\s/) {
+      my $j = $i;
+      $j++ while ($j < $len && substr($s, $j, 1) =~ /\s/);
+      $ns .= ' ';
+      push @nm, $map->[$j - 1];
+      $i = $j;
+    } else {
+      $ns .= substr($s, $i, 1);
+      push @nm, $map->[$i];
+      $i++;
+    }
+  }
+  return ($ns, \@nm);
+}
+
+# Remove every non-overlapping match of $re from ($string, @map), splicing both
+# in lockstep (used for C-style comments and for quoted strings).
+sub remove_matches {
+  my ($s, $map, $re) = @_;
+  my $ns = '';
+  my @nm;
+  my $prev = 0;
+  while ($s =~ /$re/g) {
+    my $ms = $-[0];
+    my $me = $+[0];
+    if ($me == $ms) { pos($s) = $ms + 1; next; }   # guard against zero-width
+    $ns .= substr($s, $prev, $ms - $prev);
+    push @nm, @{$map}[$prev .. $ms - 1] if $ms > $prev;
+    $prev = $me;
+  }
+  $ns .= substr($s, $prev);
+  push @nm, @{$map}[$prev .. $#$map] if $prev <= $#$map;
+  return ($ns, \@nm);
+}
+
+# ---------------------------------------------------------------------------
+# Hit collection
+# ---------------------------------------------------------------------------
+my @hits;   # each: { l1 => start_line, l2 => end_line, rule => '...', text => '...' }
+
+sub add_hit {
+  my ($l1, $l2, $rule, $text) = @_;
+  push @hits, { l1 => $l1, l2 => (defined $l2 ? $l2 : $l1), rule => $rule, text => $text };
+}
+
+# Scan a joined ($string, @map) for $re, recording each match's line range.
+# Optional $postfilter rewrites the reported text (used for the two-stage %zu
+# check); returning undef drops the hit.
+sub scan {
+  my ($s, $map, $re, $rule, $postfilter) = @_;
+  while ($s =~ /$re/g) {
+    my $ms = $-[0];
+    my $me = $+[0];
+    if ($me == $ms) { pos($s) = $ms + 1; next; }
+    my $text = substr($s, $ms, $me - $ms);
+    if ($postfilter) { $text = $postfilter->($text); next unless defined $text; }
+    add_hit($map->[$ms], $map->[$me - 1], $rule, $text);
+  }
+}
+
+# Scan line-anchored checks per record (the P1 regime: ^-anchored, single line).
+sub scan_lines {
+  my ($recs, $re, $rule) = @_;
+  for my $r (@$recs) {
+    my ($ln, $txt) = @$r;
+    while ($txt =~ /$re/g) {
+      my $ms = $-[0];
+      my $me = $+[0];
+      if ($me == $ms) { pos($txt) = $ms + 1; next; }
+      add_hit($ln, $ln, $rule, substr($txt, $ms, $me - $ms));
+    }
+  }
+}
+
+# ===========================================================================
+# The check suite, applied to one file's segments.
+# ===========================================================================
+sub check_file {
+  my ($segments, $path) = @_;
+  @hits = ();
+
+  my $is_types_h       = ($path =~ m{(?:^|/)cpp/core/types\.h$});
+  my $is_eigen_plugins = ($path =~ m{(?:^|/)cpp/core/eigen_plugins/eigen_plugins\.h$});
+
+  # All records in file order (for the per-line and whole-file structural checks).
+  my @all = map { @$_ } @$segments;
+
+  # --- whole-file / per-line checks (segment boundaries irrelevant) ---------
+
+  # A: #define numeric/string constants (raw buffer, line-anchored).
+  scan_lines(\@all, $RE_define_constant, 'define-constant');
+
+  # C: Eigen header included before eigen_plugins/eigen_plugins.h.  Stateful in
+  # include order across the whole file; reported at the offending #include.
+  unless ($is_eigen_plugins) {
+    my $plugin_seen = 0;
+    for my $r (@all) {
+      my ($ln, $txt) = @$r;
+      next unless $txt =~ /$RE_include_any/;
+      if ($txt =~ /$RE_include_plugins/) { $plugin_seen = 1; }
+      elsif (!$plugin_seen && $txt =~ /$RE_include_eigen/) {
+        add_hit($ln, $ln, 'eigen-plugin-order', $1);
+      }
+    }
+  }
+
+  # --- per-segment joined checks (a match can never cross a segment) ---------
+  for my $seg (@$segments) {
+
+    # B: deprecated #ifndef __X__ / #define __X__ include guard (guard buffer).
+    {
+      my ($s, $m) = join_records($seg, 1);
+      ($s, $m) = collapse_ws($s, $m);
+      ($s, $m) = remove_matches($s, $m, qr{/\*.*?\*/});
+      scan($s, $m, $RE_include_guard, 'include-guard');
+    }
+
+    # buffer2: drop ^# lines, blank // comments.
+    my @b2 = map { [ $_->[0], blank_line_comment($_->[1]) ] }
+             grep { $_->[1] !~ /^#/ } @$seg;
+
+    # D: std::string_view as a function return type (buffer2, line-anchored).
+    scan_lines(\@b2, $RE_string_view_return, 'string_view-return');
+
+    # buffer3: join, collapse, strip C-style comments.
+    my ($s3, $m3) = join_records(\@b2, 0);
+    ($s3, $m3) = collapse_ws($s3, $m3);
+    ($s3, $m3) = remove_matches($s3, $m3, qr{/\*.*?\*/});
+
+    # E: %zu inside a print() call (buffer3, two-stage like the original).
+    scan($s3, $m3, $RE_print_zu, 'print-zu', sub {
+      my ($t) = @_;
+      return ($t =~ /$RE_print_zu_call/) ? $1 : $t;
+    });
+
+    # F: C-style array declarations (buffer3).
+    scan($s3, $m3, $RE_c_array, 'c-array');
+
+    # buffer4: remove quoted strings.
+    my ($s4, $m4) = remove_matches($s3, $m3, qr/(")(\\"|.)*?"/);
+
+    # G: char* / char item[] (buffer4).
+    scan($s4, $m4, $RE_c_char, 'c-char');
+
+    # H: C-style string manipulation functions, incl. strerror (buffer4).
+    scan($s4, $m4, $RE_c_string_fn, 'c-string-fn');
+
+    # I: getenv() (buffer4).
+    scan($s4, $m4, $RE_getenv, 'getenv');
+
+    # J: rand()/srand() (buffer4).
+    scan($s4, $m4, $RE_rand, 'rand');
+
+    # K: const std::string & (buffer4).
+    scan($s4, $m4, $RE_const_string_ref, 'const-string-ref');
+
+    # L: namespaces that could be nested (buffer4).
+    scan($s4, $m4, $RE_nested_namespace, 'nested-namespace');
+
+    # M: using namespace std; (buffer4).
+    scan($s4, $m4, $RE_using_namespace_std, 'using-namespace-std');
+
+    # N: C-style casts (buffer4).
+    scan($s4, $m4, $RE_c_cast, 'c-cast');
+
+    # O: NULL / NAN / INFINITY macros (buffer4).
+    scan($s4, $m4, $RE_macro_null_nan, 'macro-null-nan');
+
+    # P: std::abs() or naked abs(), buffer4 (skipped in cpp/core/types.h).
+    unless ($is_types_h) {
+      scan($s4, $m4, $RE_abs, 'abs');
+    }
+
+    # Q: std::visit() with a lambda (buffer4).
+    scan($s4, $m4, $RE_visit_lambda, 'visit-lambda');
+  }
+
+  return [ @hits ];
+}
+
+# ---------------------------------------------------------------------------
+# Input readers -> list of segments
+# ---------------------------------------------------------------------------
+
+# Non-diff: one segment containing every (non-suppressed) line of the file.
+sub read_file_segments {
+  my ($path) = @_;
+  open(my $fh, '<', $path) or die "cannot open $path: $!\n";
+  my @seg;
+  while (my $line = <$fh>) {
+    chomp $line;
+    next if is_suppressed($line);
+    push @seg, [ $., $line ];
+  }
+  close $fh;
+  return [ [ @seg ] ];   # one segment containing every record
+}
+
+# Diff: "<line>\t<content>" records, a bare "--" line starting a new segment.
+sub read_tagged_segments {
+  my @segments = ([]);
+  while (my $row = <STDIN>) {
+    chomp $row;
+    if ($row eq '--') { push @segments, []; next; }
+    my ($ln, $txt) = split(/\t/, $row, 2);
+    $txt = '' unless defined $txt;
+    next if is_suppressed($txt);
+    push @{$segments[-1]}, [ $ln + 0, $txt ];
+  }
+  return [ grep { @$_ } @segments ];
+}
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+sub emit {
+  my ($path, $file_hits) = @_;
+  return 0 unless @$file_hits;
+  my @sorted = sort {
+    $a->{l1} <=> $b->{l1} || $a->{l2} <=> $b->{l2} || $a->{rule} cmp $b->{rule}
+  } @$file_hits;
+
+  if ($format eq 'tsv') {
+    for my $h (@sorted) {
+      print join("\t", $path, $h->{l1}, $h->{l2}, $h->{rule}, $h->{text}), "\n";
+    }
+  } else {
+    print "################################### $path\n";
+    for my $h (@sorted) {
+      my $loc = ($h->{l1} == $h->{l2}) ? $h->{l1} : "$h->{l1}-$h->{l2}";
+      printf "%s:%s: %-22s %s\n", $path, $loc, "[$h->{rule}]", $h->{text};
+    }
+  }
+  return 1;
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+my $any = 0;
+if ($diff) {
+  my $segments = read_tagged_segments();
+  $any = emit($label, check_file($segments, $label)) || $any;
+} else {
+  die "no input files\n" unless @files;
+  for my $f (@files) {
+    my $segments = read_file_segments($f);
+    $any = emit($f, check_file($segments, $f)) || $any;
+  }
+}
+exit($any ? 1 : 0);

--- a/run_pylint
+++ b/run_pylint
@@ -135,6 +135,17 @@ if [[ ${#files[@]} -eq 0 ]]; then
   done < <(git ls-files '*.py')
 fi
 
+# Exclude all content under testing/data/ (e.g. intentionally non-conforming
+#   fixtures) from linting, however the file list was assembled.
+filtered=()
+for f in "${files[@]}"; do
+  if [[ "$f" =~ (^|/)testing/data/ ]]; then
+    continue
+  fi
+  filtered+=("$f")
+done
+files=("${filtered[@]}")
+
 LOGFILE=pylint.log
 echo logging to \""$LOGFILE"\"
 

--- a/testing/data/check_syntax/offenders.cpp
+++ b/testing/data/check_syntax/offenders.cpp
@@ -1,0 +1,215 @@
+// Regression fixture for the check_syntax engine (testing/tools/check_syntax_engine.pl).
+//
+// Every line that the engine MUST flag carries a trailing "EXPECT:" marker
+// naming the rule(s) it triggers, e.g.   some_code();   EXPECT: rule-a, rule-b
+// placed on the START line of the match (matches may span two lines).  Any line
+// without an EXPECT marker MUST NOT be flagged; most such lines are deliberate
+// near-misses chosen to catch a regex that is not careful about word
+// boundaries, required punctuation, or surrounding context.
+//
+// Comments are stripped before the pattern checks run, so the markers
+// themselves never trigger a rule.  This file is parsed only by check_syntax;
+// no build target compiles it, so it need not be valid C++.
+//
+// clang-format is disabled below: reformatting would alter the exact spacing
+// (pointer placement, cast layout, ...) that several checks key off, changing
+// which lines match.
+// clang-format off
+
+#ifndef __OFFENDERS_H__   // EXPECT: include-guard
+#define __OFFENDERS_H__
+
+// =====================================================================
+// define-constant : #define of a literal constant (use constexpr instead)
+// =====================================================================
+#define DC_INT 42                 // EXPECT: define-constant
+#define DC_NEG -7                 // EXPECT: define-constant
+#define DC_PLUS +5                // EXPECT: define-constant
+#define DC_FLOAT 3.14             // EXPECT: define-constant
+#define DC_SCI 6.022e23           // EXPECT: define-constant
+#define DC_HEX 0xFF               // EXPECT: define-constant
+#define DC_BIN 0b1010             // EXPECT: define-constant
+#define DC_STR "literal"          // EXPECT: define-constant
+// near-misses (must stay clean):
+#define DC_FUNC(x) ((x) + 1)
+#define DC_EXPR alpha + beta
+#define DC_EMPTY
+#define DC_CALL compute()
+#define DC_CONCAT a ## b
+
+// =====================================================================
+// macro-null-nan : NULL / NAN / INFINITY macros
+// =====================================================================
+ptr = NULL;                       // EXPECT: macro-null-nan
+flt = NAN;                        // EXPECT: macro-null-nan
+inf = INFINITY;                   // EXPECT: macro-null-nan
+// near-misses:
+nullable = MY_NULL;
+prefixed = NULLABLE;
+lower = nan;
+camel = NaN;
+
+// =====================================================================
+// abs : std::abs() or naked abs() (only MR::abs() is allowed)
+// =====================================================================
+a0 = abs(x);                      // EXPECT: abs
+a1 = std::abs(x);                 // EXPECT: abs
+a2 = abs (x);                     // EXPECT: abs
+// near-misses:
+a3 = MR::abs(x);
+a4 = obj.abs(x);
+a5 = fabs(x);
+a6 = std::fabs(x);
+
+// =====================================================================
+// getenv : getenv() / std::getenv()
+// =====================================================================
+g0 = getenv("HOME");              // EXPECT: getenv
+g1 = std::getenv("HOME");         // EXPECT: getenv
+// near-misses:
+g2 = my_getenv("HOME");
+g3 = getenvironment();
+
+// =====================================================================
+// rand : rand() / srand()
+// =====================================================================
+r0 = rand();                      // EXPECT: rand
+r1 = srand(1);                    // EXPECT: rand
+// near-misses:
+r2 = my_rand();
+r3 = random();
+r4 = operand(x);
+
+// =====================================================================
+// c-string-fn : C string-manipulation functions
+// =====================================================================
+s0 = strlen(p);                   // EXPECT: c-string-fn
+s1 = strcpy(a, b);                // EXPECT: c-string-fn
+s2 = strerror(e);                 // EXPECT: c-string-fn
+s3 = wcslen(w);                   // EXPECT: c-string-fn
+// near-misses:
+s4 = my_strlen(p);
+s5 = strlength(p);
+
+// =====================================================================
+// c-char : char* and char arrays (not casts)
+// =====================================================================
+char* cc0;                        // EXPECT: c-char
+char *cc1;                        // EXPECT: c-char
+char * cc2;                       // EXPECT: c-char
+const char* cc3;                  // EXPECT: c-char
+char cc4[10];                     // EXPECT: c-char, c-array
+char cc5[];                       // EXPECT: c-char, c-array
+// near-misses:
+character_count = 5;
+char_type cc6;
+std::vector<char> cc7;
+
+// =====================================================================
+// using-namespace-std
+// =====================================================================
+using namespace std;              // EXPECT: using-namespace-std
+// near-misses:
+using namespace other;
+using std::string;
+using namespace std::chrono;
+
+// =====================================================================
+// const-string-ref : const std::string& (prefer std::string_view arg)
+// =====================================================================
+void k0(const std::string& s);    // EXPECT: const-string-ref
+void k1(const std::string &s);    // EXPECT: const-string-ref
+// near-misses:
+void k2(const std::string s);
+void k3(const std::string_view& s);
+void k4(std::string& s);
+
+// =====================================================================
+// string_view-return : std::string_view as a return type
+// =====================================================================
+std::string_view sv0();           // EXPECT: string_view-return
+const std::string_view sv1();     // EXPECT: string_view-return
+std::string_view &sv2();          // EXPECT: string_view-return
+// near-misses:
+void sv3(std::string_view s);
+std::string_view sv4 = source();
+using sv5 = std::string_view;
+
+// =====================================================================
+// c-cast : C-style casts
+// =====================================================================
+n0 = (int)x;                      // EXPECT: c-cast
+n1 = (MyType)y;                   // EXPECT: c-cast
+n2 = (char*)p;                    // EXPECT: c-cast
+n3 = (char* const)q;              // EXPECT: c-cast, c-char
+n4 = (void*)addr;                 // EXPECT: c-cast
+n5 = (void *)&ref;                // EXPECT: c-cast
+n6 = (unsigned)q;                 // EXPECT: c-cast
+n7 = float(val);                  // EXPECT: c-cast
+n8 = size_t(count);               // EXPECT: c-cast
+n9 = uint32_t(m);                 // EXPECT: c-cast
+n10 = value_type(v);              // EXPECT: c-cast
+n11 = Foo::Scalar(z);             // EXPECT: c-cast
+// near-misses:
+n12 = (void)expr;
+n13 = float(3.14);
+n14 = int(42);
+n15 = double(-1.0);
+std::function<double(double)> n16;
+n17 = compute(arg);
+if (cond) n18 = 1;
+n19 = Scalar::Scalar(z);
+
+// =====================================================================
+// visit-lambda : std::visit() with a lambda
+// =====================================================================
+q0 = std::visit([](auto v){}, x); // EXPECT: visit-lambda
+q1 = std::visit([&y](auto v){}, x); // EXPECT: visit-lambda
+q2 = std::visit([a, b](auto v){}, x); // EXPECT: visit-lambda
+// near-misses:
+q3 = std::visit(visitor, x);
+q4 = boost::visit([](auto v){}, x);
+
+// =====================================================================
+// eigen-plugin-order : Eigen header before eigen_plugins/eigen_plugins.h
+// =====================================================================
+#include <Eigen/Core>             // EXPECT: eigen-plugin-order
+#include "eigen_plugins/eigen_plugins.h"
+#include <Eigen/Dense>
+
+// =====================================================================
+// nested-namespace : sequentially-defined namespaces (use nested form)
+// =====================================================================
+namespace NsA { namespace NsB {   // EXPECT: nested-namespace
+} }
+namespace NsSolo { int solo_x; }
+
+// =====================================================================
+// c-array : C-style array declarations
+// =====================================================================
+int ca0[3];                       // EXPECT: c-array
+float ca1[] = {};                 // EXPECT: c-array
+int ca2[2][3];                    // EXPECT: c-array
+long                              // EXPECT: c-array
+ca3[5];
+// near-misses:
+data[idx] = 5;
+values = matrix[i];
+new_buffer = new int[n];
+
+// =====================================================================
+// check_syntax off : suppression must drop the whole line
+// =====================================================================
+suppressed = strlen(p); // check_syntax off
+
+// =====================================================================
+// print-zu : %zu in a print() call (kept LAST; see note below)
+// Ordered so each print is consumed by its own %zu and no stray %zu
+// follows the final no-%zu print, avoiding whole-file-join artefacts.
+// =====================================================================
+z0 = print("x = %zu", a);         // EXPECT: print-zu
+z1_decoy = "%zu";
+z2 = myprintf("n = %3zu", b);     // EXPECT: print-zu
+z3 = printf("%d", c);
+
+#endif

--- a/testing/unit_tests/CMakeLists.txt
+++ b/testing/unit_tests/CMakeLists.txt
@@ -89,3 +89,6 @@ function (add_bash_unit_test FILE_SRC)
         ${no_filesystem_lock}
     )
 endfunction()
+
+# Reads the check_syntax fixture and runs the Perl engine; never writes to disk.
+add_bash_unit_test(check_syntax_engine.sh NO_FILESYSTEM_LOCK)

--- a/testing/unit_tests/CMakeLists.txt
+++ b/testing/unit_tests/CMakeLists.txt
@@ -90,5 +90,21 @@ function (add_bash_unit_test FILE_SRC)
     )
 endfunction()
 
+# The check_syntax engine unit test consumes two repository artifacts: the Perl
+# engine under test (repository root) and the offenders fixture (testing/data/).
+# Copy both into the build tree so the test runs entirely against build-directory
+# content; configure_file(COPYONLY) refreshes each copy whenever its source
+# changes (re-running CMake configuration to do so).
+set(CHECK_SYNTAX_ENGINE_BUILD ${CMAKE_CURRENT_BINARY_DIR}/check_syntax_engine.pl)
+set(CHECK_SYNTAX_FIXTURE_BUILD ${CMAKE_CURRENT_BINARY_DIR}/data/check_syntax/offenders.cpp)
+configure_file(${PROJECT_SOURCE_DIR}/check_syntax_engine.pl ${CHECK_SYNTAX_ENGINE_BUILD} COPYONLY)
+configure_file(${DATA_DIR}/check_syntax/offenders.cpp ${CHECK_SYNTAX_FIXTURE_BUILD} COPYONLY)
+
 # Reads the check_syntax fixture and runs the Perl engine; never writes to disk.
 add_bash_unit_test(check_syntax_engine.sh NO_FILESYSTEM_LOCK)
+
+# Point the test at the build-tree copies (see configure_file calls above).
+set_property(TEST unittest_check_syntax_engine APPEND PROPERTY ENVIRONMENT
+    "CHECK_SYNTAX_ENGINE=${CHECK_SYNTAX_ENGINE_BUILD}"
+    "CHECK_SYNTAX_FIXTURE=${CHECK_SYNTAX_FIXTURE_BUILD}"
+)

--- a/testing/unit_tests/check_syntax_engine.sh
+++ b/testing/unit_tests/check_syntax_engine.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Unit test for the check_syntax engine (check_syntax_engine.pl at the repo root).
+#
+# The fixture testing/data/check_syntax/offenders.cpp annotates every line the
+# engine must flag with a trailing "// EXPECT: <rule>[, <rule> ...]" marker (on
+# the START line of a multi-line match).  This test parses those markers as
+# ground truth and asserts that the set of (line, rule) pairs the engine reports
+# is exactly the set the markers declare -- catching both missed detections and
+# false positives.  It also checks the diff-mode segment model in isolation.
+#
+# Any failing assertion makes the script exit non-zero, failing the test.
+set -e
+
+DIR=$(dirname "${BASH_SOURCE[0]}")
+ENGINE="$DIR/../../check_syntax_engine.pl"
+FIXTURE="$DIR/../data/check_syntax/offenders.cpp"
+
+test -f "$ENGINE"
+test -f "$FIXTURE"
+
+# Ground truth: (line<TAB>rule) for every EXPECT marker.
+expected=$(awk '
+  match($0, /\/\/ EXPECT:[ ]*/) {
+    rules = substr($0, RSTART + RLENGTH)
+    n = split(rules, arr, /,[ ]*/)
+    for (i = 1; i <= n; i++) { gsub(/[ ]+$/, "", arr[i]); if (arr[i] != "") print NR "\t" arr[i] }
+  }
+' "$FIXTURE" | LC_ALL=C sort)
+
+# Engine detections: (line<TAB>rule), de-duplicated.
+detected=$(perl "$ENGINE" --format tsv "$FIXTURE" \
+  | awk -F'\t' '{print $2 "\t" $4}' | LC_ALL=C sort -u)
+
+echo "expected $(printf '%s\n' "$expected" | grep -c .) (line, rule) pairs; detected $(printf '%s\n' "$detected" | grep -c .)"
+
+if ! diff <(printf '%s\n' "$expected") <(printf '%s\n' "$detected"); then
+  echo "FAIL: engine detections do not match EXPECT markers" >&2
+  echo "  '<' = expected but not detected (missed); '>' = detected but not expected (false positive)" >&2
+  exit 1
+fi
+echo "OK: fixture detections match expectation"
+
+# The check_syntax-off suppression must drop its whole line: no detection should
+# land on the line carrying that directive.
+suppressed_line=$(grep -n 'check_syntax off' "$FIXTURE" | head -1 | cut -d: -f1)
+if perl "$ENGINE" --format tsv "$FIXTURE" | awk -F'\t' -v L="$suppressed_line" '$2 == L { found = 1 } END { exit !found }'; then
+  echo "FAIL: a 'check_syntax off' line was flagged" >&2
+  exit 1
+fi
+echo "OK: check_syntax-off line suppressed"
+
+# Diff-mode segment model: tokens that would form a c-array if merged must NOT
+# match when split across two hunks (separated by a bare "--"), but MUST match
+# (as a line range) when contiguous within one hunk.  perl exits non-zero when
+# it reports hits, so "|| true" keeps "set -e" from aborting on the within case.
+across=$(printf '10\tint\n--\n900\tbuffer[16];\n' | perl "$ENGINE" --diff --label x.cpp --format tsv || true)
+if [ -n "$across" ]; then
+  echo "FAIL: a match spanned two diff hunks: $across" >&2
+  exit 1
+fi
+echo "OK: no match spans separate hunks"
+
+within=$(printf '10\tint\n11\tbuffer[16];\n' | perl "$ENGINE" --diff --label x.cpp --format tsv || true)
+if ! printf '%s\n' "$within" | awk -F'\t' '$2 == 10 && $3 == 11 && $4 == "c-array" { f = 1 } END { exit !f }'; then
+  echo "FAIL: contiguous c-array not reported as range 10-11: $within" >&2
+  exit 1
+fi
+echo "OK: contiguous multi-line match reported as line range"

--- a/testing/unit_tests/check_syntax_engine.sh
+++ b/testing/unit_tests/check_syntax_engine.sh
@@ -11,9 +11,13 @@
 # Any failing assertion makes the script exit non-zero, failing the test.
 set -e
 
+# The engine and fixture are served from the build tree (copied there at
+# configuration time) via CHECK_SYNTAX_ENGINE / CHECK_SYNTAX_FIXTURE, set by
+# CMake when the test is run through ctest.  Fall back to the source-relative
+# locations so the script remains runnable by hand from a checkout.
 DIR=$(dirname "${BASH_SOURCE[0]}")
-ENGINE="$DIR/../../check_syntax_engine.pl"
-FIXTURE="$DIR/../data/check_syntax/offenders.cpp"
+ENGINE="${CHECK_SYNTAX_ENGINE:-$DIR/../../check_syntax_engine.pl}"
+FIXTURE="${CHECK_SYNTAX_FIXTURE:-$DIR/../data/check_syntax/offenders.cpp}"
 
 test -f "$ENGINE"
 test -f "$FIXTURE"


### PR DESCRIPTION
This ports the heavy-lifting portion of the `check_syntax` script from a Bash script with repeated `grep` calls per file to a Perl executable. The initial motivation was providing offending line numbers, to expedite instructing Claude on how to correct its own violations. As a happy side-effect, run-time when executing over the whole code base drops from a few minutes to a few seconds.

- [x] Check whether the explicit unit test for `check_syntax` needs to be removed. Neither `check_syntax` nor `check_syntax_engine.pl` are present in the build directory. It might be simpler to not have such a test, and just have an internal expectation that any modifications to `check_syntax*` will come with corresponding changes to `testing/diff/check_syntax/offenders.cpp` and will be run manually to confirm operation.

- [ ] Consider filesystem location. This is currently an additional file at repository root. When I get to #3083 I'd like to either move both of these into `cpp/`, or create a new root-level directory containing production scripts like `check_syntax`, `generate_user_docs.sh`, `run_pylint`, ...