### PR TITLE
Enable Eigen 5.0 compatibility with C++14 support

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -75,6 +75,47 @@ jobs:
 
 
 
+  # Compilation test exercising Eigen 5.0.0 rather than the system Eigen3
+  # package. Eigen >= 5.0 mandates at least C++14; 'configure' detects this
+  # requirement from the Eigen headers (located via the EIGEN_CFLAGS include
+  # path) and selects the C++14 language standard accordingly. The Eigen 5.0.0
+  # headers are fetched from the upstream GitLab source archive and exposed
+  # exclusively through EIGEN_CFLAGS, so the system 'libeigen3-dev' package is
+  # deliberately not installed. As with the other Linux builds, 'CFLAGS:
+  # -Werror' promotes any compiler warning to an error, so that a warning
+  # causes the build (and therefore CI) to fail.
+  linux-eigen5-build:
+
+    runs-on: ubuntu-latest
+
+    env:
+      CFLAGS: -Werror
+      QT_SELECT: qt5
+      EIGEN_CFLAGS: "-isystem ${{ github.workspace }}/eigen-5.0.0"
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: install dependencies
+      run: |
+         sudo apt-get update
+         sudo apt-get install clang libqt5opengl5-dev libqt5svg5-dev libglvnd-dev zlib1g-dev libfftw3-dev libpng-dev
+
+    - name: fetch Eigen 5.0.0
+      run: |
+         mkdir -p "${{ github.workspace }}/eigen-5.0.0"
+         curl -sSL https://gitlab.com/libeigen/eigen/-/archive/5.0.0/eigen-5.0.0.tar.gz | tar xz --strip-components=1 -C "${{ github.workspace }}/eigen-5.0.0"
+
+    - name: configure
+      run: ./configure -assert || { cat configure.log; false; }
+
+    - name: build
+      run: ./build -nowarnings -persistent -nopaginate || { cat build.log; false; }
+
+
+
+
+
 
   macos-build:
 

--- a/cmd/tckconvert.cpp
+++ b/cmd/tckconvert.cpp
@@ -387,7 +387,13 @@ class PLYWriter: public WriterInterface<float> { MEMALIGN(PLYWriter)
 
       // we only need the left-singular matrix here
       //  http://math.stackexchange.com/questions/99299/best-fitting-plane-given-a-set-of-points
+      // Eigen 5 (EIGEN_MAJOR_VERSION >= 5) deprecated the runtime-argument
+      // overload of jacobiSvd() in favour of template-parameter options.
+#if EIGEN_MAJOR_VERSION >= 5
+      auto svd = coord.jacobiSvd<Eigen::ComputeThinU | Eigen::ComputeThinV>();
+#else
       auto svd = coord.jacobiSvd(Eigen::ComputeThinU | Eigen::ComputeThinV);
+#endif
       Eigen::Vector3f plane_normal = svd.matrixU().rightCols<1>();
       return plane_normal;
     }

--- a/configure
+++ b/configure
@@ -836,6 +836,72 @@ else:
 
 
 
+# Determine the C++ language standard required for compilation.
+#
+# MRtrix3 has historically targeted C++11, and the compliance check above is
+# performed against that standard. However, Eigen version 5.0 and later mandate
+# at least C++14. The Eigen include path is provided to 'configure' via the
+# EIGEN_CFLAGS environment variable, so as soon as a working compiler has been
+# identified we attempt to compile a minimal program that includes an Eigen
+# header using the C++11 standard. If Eigen signals (via a preprocessor #error)
+# that C++14 is required, the language standard flag is switched from
+# '-std=c++11' to '-std=c++14', and a fresh compliance check is performed
+# against C++14 (additionally verifying availability of std::make_unique()).
+# All subsequent compilation checks performed by this script then proceed using
+# the selected language standard.
+
+cxx_standard = 'c++11'
+eigen_cflags = get_flags ([ '-isystem', '/usr/include/eigen3' ], 'EIGEN_CFLAGS', '--cflags eigen3')
+
+report ('Checking C++ standard required by Eigen: ')
+try:
+  compile ('''
+#include <Eigen/Core>
+int main() { return 0; }
+''', cpp_flags + eigen_cflags, ld_flags)
+  report (cxx_standard + '\n')
+except CompileError as eigen_std_probe:
+  if 'error: #error Eigen requires at least c++14 support.' in str (eigen_std_probe):
+    report ('c++14\n')
+    cpp_flags = [ '-std=c++14' if flag == '-std=c++11' else flag for flag in cpp_flags ]
+    cxx_standard = 'c++14'
+    if not compile_test ('C++14 compliance', cpp_flags, ld_flags, '''
+#include <cstddef>
+#include <memory>
+struct Base {
+    Base (int) { }
+};
+struct Derived : Base {
+    using Base::Base;
+};
+
+int main() {
+  Derived D (int); // check for contructor inheritance
+  auto ptr = std::make_unique<Derived> (0); // check for std::make_unique() (requires C++14)
+  return ptr ? 0 : 1;
+}
+''', on_failure='test failed (see configure.log for details)\n'):
+      error ('''C++14 compliance test failed!
+
+  The Eigen library detected via the EIGEN_CFLAGS environment variable requires
+  at least C++14 support, but the selected compiler was unable to compile a
+  C++14 test program.'''
+          + compiler_hint ('compiler', 'CXX', '/usr/bin/g++-5.5', 'CXX_ARGS', '"-c CFLAGS SRC -o OBJECT"')
+          + configure_log_hint)
+  else:
+    # Compilation failed for some unrelated reason (e.g. the Eigen headers
+    # could not be found); leave the standard at C++11 and let the dedicated
+    # Eigen dependency check below report the problem with appropriate hints.
+    report ('unable to determine; assuming c++11\n')
+except Exception:
+  # A linking or runtime failure here is not informative for the purpose of
+  # language standard selection; the dedicated Eigen dependency check below
+  # will report any genuine problems.
+  report ('unable to determine; assuming c++11\n')
+
+
+
+
 # shared library generation:
 if not noshared:
   report ('Checking shared library generation: ')
@@ -974,9 +1040,8 @@ int main() {
 
 
 
-# Eigen3 flags:
-
-eigen_cflags = get_flags ([ '-isystem', '/usr/include/eigen3' ], 'EIGEN_CFLAGS', '--cflags eigen3')
+# Eigen library:
+# (eigen_cflags was determined above, during C++ language standard detection)
 
 compile_check ('Eigen3 library', 'Eigen3', cpp_flags + eigen_cflags, ld_flags, '''
 #include <cstddef>
@@ -1277,7 +1342,7 @@ int main() { Foo f; }
       with open (os.path.join (qt_dir.name, 'qt.cpp'), 'w') as f:
         f.write (filetext)
 
-      filetext = 'CONFIG += c++11'
+      filetext = 'CONFIG += ' + cxx_standard
       if debug:
         filetext += ' debug'
       filetext += '\nQT += core gui opengl svg network\n'

--- a/configure
+++ b/configure
@@ -861,7 +861,7 @@ int main() { return 0; }
 ''', cpp_flags + eigen_cflags, ld_flags)
   report (cxx_standard + '\n')
 except CompileError as eigen_std_probe:
-  if 'error: #error Eigen requires at least c++14 support.' in str (eigen_std_probe):
+  if 'Eigen requires at least c++14 support' in str (eigen_std_probe):
     report ('c++14\n')
     cpp_flags = [ '-std=c++14' if flag == '-std=c++11' else flag for flag in cpp_flags ]
     cxx_standard = 'c++14'

--- a/core/axes.cpp
+++ b/core/axes.cpp
@@ -16,6 +16,8 @@
 
 #include "axes.h"
 
+#include <cassert>
+
 namespace MR
 {
   namespace Axes

--- a/core/math/stats/fwe.cpp
+++ b/core/math/stats/fwe.cpp
@@ -18,6 +18,7 @@
 #include "math/stats/fwe.h"
 
 #include <algorithm>
+#include <cassert>
 #include <types.h>
 
 namespace MR

--- a/core/math/stats/glm.cpp
+++ b/core/math/stats/glm.cpp
@@ -182,7 +182,16 @@ namespace MR
 
         matrix_type solve_betas (const matrix_type& measurements, const matrix_type& design)
         {
+          // Eigen's "WORLD" version remains 3 for the Eigen3 library; the
+          // semantic-versioning major version (EIGEN_MAJOR_VERSION) became 5 as
+          // of the 5.0.0 release, which deprecated the runtime-argument overload
+          // of jacobiSvd() in favour of specifying the computation options as a
+          // template parameter.
+#if EIGEN_MAJOR_VERSION >= 5
+          return design.jacobiSvd<Eigen::ComputeThinU | Eigen::ComputeThinV>().solve (measurements);
+#else
           return design.jacobiSvd (Eigen::ComputeThinU | Eigen::ComputeThinV).solve (measurements);
+#endif
         }
 
 

--- a/core/types.h
+++ b/core/types.h
@@ -284,10 +284,17 @@ namespace MR
       return std::shared_ptr<X> (new X (std::forward<Args> (args)...));
     }
 
+#if __cplusplus >= 201402L
+  // C++14 and later (mandated by Eigen >= 5) provide std::make_unique();
+  // expose it within the MR namespace rather than defining a separate facility,
+  // so that unqualified make_unique() calls remain unambiguous.
+  using std::make_unique;
+#else
   template <typename X, typename... Args>
     inline std::unique_ptr<X> make_unique (Args&&... args) {
       return std::unique_ptr<X> (new X (std::forward<Args> (args)...));
     }
+#endif
 
 
   // required to allow use of abs() call on unsigned integers in template

--- a/src/dwi/tractography/GT/particle.h
+++ b/src/dwi/tractography/GT/particle.h
@@ -17,6 +17,8 @@
 #ifndef __gt_particle_h__
 #define __gt_particle_h__
 
+#include <cassert>
+
 #include "types.h"
 #include "spinlock.h"
 


### PR DESCRIPTION
Addresses #3402.

Rather than a Debian-specific patch, make the requisite modifications to `master` to facilitate compilation against Eigen 5.0.0. So once this gets merged in (ideally with the rest of #3373) and tagged, packaging of 3.0.9 should work on Debian without any further customisation.

This necessitates bumping to C++14 for Eigen5 compatibility. This is not a problem on `dev` given transition to C++17.

Slightly unusually, "Eigen 5" is actually "Eigen3 5.0.0", with "world" version 3 and "major" version 5.

Note that this also fixes compilation issues that have now manifested on my own local system due to absence of `#include <cassert>`.
