### PR TITLE
CMake: fix detection of commit hook when running in git worktree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,11 +86,21 @@ include(Dependencies)
 include(CompilerCache)
 use_compiler_cache()
 
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git AND NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git/hooks/pre-commit)
+execute_process(
+    COMMAND git rev-parse --git-common-dir
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_DIR_PATH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+
+if(GIT_DIR_PATH AND NOT EXISTS ${GIT_DIR_PATH}/hooks/pre-commit)
     message(WARNING
         "pre-commit git hook for clang-format not found!\n"
         "Please install pre-commit (e.g. using `apt install pre-commit` or `pip install pre-commit`) "
         "and then run `pre-commit install` from the ${CMAKE_CURRENT_SOURCE_DIR} directory.")
+else()
+    message (STATUS "pre-commit hook for clang-format already installed")
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,11 +96,11 @@ execute_process(
 
 if(GIT_DIR_PATH AND NOT EXISTS ${GIT_DIR_PATH}/hooks/pre-commit)
     message(WARNING
-        "pre-commit git hook for clang-format not found!\n"
+        "pre-commit git hooks not found!\n"
         "Please install pre-commit (e.g. using `apt install pre-commit` or `pip install pre-commit`) "
         "and then run `pre-commit install` from the ${CMAKE_CURRENT_SOURCE_DIR} directory.")
 else()
-    message (STATUS "pre-commit hook for clang-format already installed")
+    message (STATUS "pre-commit hooks already installed")
 endif()
 
 


### PR DESCRIPTION
When running in a git worktree, `.git` is a file (not a folder) containing the location of the main repo. This causes the detection of the hook to fail, which issues a warning when running cmake even if the hook is installed. This commit uses a more robust way of determining the location of the main git repo (using `git --rev-parse --git-common-dir`).