### PR TITLE
Trigger CI Actions on dev

### DIFF
--- a/testing/binaries/tests/dwirecon/combinepairs_pequad
+++ b/testing/binaries/tests/dwirecon/combinepairs_pequad
@@ -14,4 +14,4 @@ mrcat \
 dwirecon - combine_pairs \
     -field dwirecon/field.mif \
     - | \
-testing_diff_image - dwirecon/combine_pairs/pequad.mif -frac 1e-5
+testing_diff_image - dwirecon/combine_pairs/pequad.mif -frac 1e-4


### PR DESCRIPTION
#3374 has a lot of test failures; some look like bugs that I need to look into, others look like floating-point imprecision. Purpose of this PR is to see if failures in the CI environment are wholly independent of the changes on #3374.

I think I saw somewhere that one of the two major compilers has changed with one of their major version updates the default floating-point precision flag, which has a chance of being supra-threshold for some of our tests (though I'd have expected the Mac CI tests to have already triggered them; maybe x86 has a different low-precision mode to ARM?)