### PR TITLE
dwifslpreproc: Engage FSL multi-threading

### DIFF
--- a/.claude
+++ b/.claude
@@ -1,0 +1,1 @@
+/home/unimelb.edu.au/robertes/OneDrive/claude/

--- a/bin/dwifslpreproc
+++ b/bin/dwifslpreproc
@@ -815,7 +815,10 @@ def execute(): #pylint: disable=unused-variable
     topup_manual_options = ''
     if app.ARGS.topup_options:
       topup_manual_options = ' ' + app.ARGS.topup_options.strip()
-    topup_output = run.command(topup_cmd + ' --imain=topup_in.nii --datain=topup_datain.txt --out=field --fout=field_map' + fsl_suffix + ' --config=' + topup_config_path + ' --verbose' + topup_manual_options)
+    # Where supported by the installed FSL version, request multi-threaded execution from topup
+    #   consistent with the number of threads requested for this script
+    topup_nthr_option = fsl.nthr_option(topup_cmd, app.ARGS.topup_options)
+    topup_output = run.command(topup_cmd + ' --imain=topup_in.nii --datain=topup_datain.txt --out=field --fout=field_map' + fsl_suffix + ' --config=' + topup_config_path + ' --verbose' + topup_manual_options + topup_nthr_option)
     with open('topup_output.txt', 'wb') as topup_output_file:
       topup_output_file.write((topup_output.stdout + '\n' + topup_output.stderr + '\n').encode('utf-8', errors='replace'))
     if app.VERBOSITY > 1:
@@ -955,6 +958,10 @@ def execute(): #pylint: disable=unused-variable
   eddy_all_options = '--imain=eddy_in.nii --mask=eddy_mask.nii --acqp=eddy_config.txt --index=eddy_indices.txt --bvecs=bvecs --bvals=bvals' + eddy_in_topup_option + eddy_manual_options + ' --out=dwi_post_eddy --verbose'
   eddy_cuda_cmd = fsl.eddy_binary(True)
   eddy_openmp_cmd = fsl.eddy_binary(False)
+  # Where supported by the installed FSL version, request multi-threaded execution from the CPU version
+  #   of eddy consistent with the number of threads requested for this script; the CUDA version of eddy
+  #   does not provide this option, hence this multi-threading control is applied to the CPU invocation only
+  eddy_openmp_nthr_option = fsl.nthr_option(eddy_openmp_cmd, app.ARGS.eddy_options) if eddy_openmp_cmd else ''
   if eddy_cuda_cmd:
     # If running CUDA version, but OpenMP version is also available, don't stop the script if the CUDA version fails
     try:
@@ -966,7 +973,7 @@ def execute(): #pylint: disable=unused-variable
         eddy_output_file.write(str(exception_cuda).encode('utf-8', errors='replace'))
       app.console('CUDA version of \'eddy\' was not successful; attempting OpenMP version')
       try:
-        eddy_output = run.command(eddy_openmp_cmd + ' ' + eddy_all_options)
+        eddy_output = run.command(eddy_openmp_cmd + ' ' + eddy_all_options + eddy_openmp_nthr_option)
       except run.MRtrixCmdError as exception_openmp:
         with open('eddy_openmp_failure_output.txt', 'wb') as eddy_output_file:
           eddy_output_file.write(str(exception_openmp).encode('utf-8', errors='replace'))
@@ -1001,7 +1008,7 @@ def execute(): #pylint: disable=unused-variable
                                  exception_stderr)
 
   else:
-    eddy_output = run.command(eddy_openmp_cmd + ' ' + eddy_all_options)
+    eddy_output = run.command(eddy_openmp_cmd + ' ' + eddy_all_options + eddy_openmp_nthr_option)
   with open('eddy_output.txt', 'wb') as eddy_output_file:
     eddy_output_file.write((eddy_output.stdout + '\n' + eddy_output.stderr + '\n').encode('utf-8', errors='replace'))
   if app.VERBOSITY > 1:

--- a/lib/mrtrix3/fsl.py
+++ b/lib/mrtrix3/fsl.py
@@ -146,28 +146,6 @@ def eddy_binary(cuda): #pylint: disable=unused-variable
 
 
 
-# Determine whether the version of a given FSL command that is installed on the system provides the
-#   "--nthr" command-line option, which controls the number of threads used for multi-threaded execution.
-# The presence of this option depends on the version of FSL installed, and in the case of "eddy" also on
-#   whether the CPU or CUDA version of the command is being interrogated; it is therefore established by
-#   inspecting the help page of the specific executable that is to be invoked.
-def supports_nthr(exe): #pylint: disable=unused-variable
-  from mrtrix3 import app #pylint: disable=import-outside-toplevel
-  try:
-    with subprocess.Popen([exe, '--help'],
-                          stdout=subprocess.PIPE,
-                          stderr=subprocess.PIPE) as proc:
-      (stdout, stderr) = proc.communicate()
-  except OSError:
-    app.debug('Unable to execute FSL command \"' + exe + '\" to query support for \"--nthr\" option')
-    return False
-  help_text = stdout.decode('utf-8', errors='replace') + stderr.decode('utf-8', errors='replace')
-  result = '--nthr' in help_text
-  app.debug('FSL command \"' + exe + '\"' + (' provides' if result else ' does not provide') + ' \"--nthr\" option')
-  return result
-
-
-
 # Construct the "--nthr" command-line option to be appended to an invocation of an FSL command
 #   (specifically "topup", or the CPU version of "eddy") so that its multi-threaded execution is
 #   consistent with the number of threads requested for the MRtrix3 script.
@@ -185,22 +163,36 @@ def supports_nthr(exe): #pylint: disable=unused-variable
 #   as the raw string provided at the command-line (or None if not provided)
 # @return: String to be appended to the FSL command invocation; empty if the "--nthr" option
 #   is unavailable or should not be applied
-def nthr_option(exe, manual_options): #pylint: disable=unused-variable
+def nthr_option(exe, manual_options=None): #pylint: disable=unused-variable
   from mrtrix3 import app, run #pylint: disable=import-outside-toplevel
   if manual_options and any(entry == '--nthr' or entry.startswith('--nthr=') for entry in manual_options.split()):
-    app.debug('\"--nthr\" manually specified for FSL command \"' + exe + '\"; automated multi-threading control disabled')
+    app.debug('\"--nthr\" manually specified by user for FSL command \"' + exe + '\";'
+              ' automated multi-threading control disabled')
     return ''
-  if not supports_nthr(exe):
+  try:
+    with subprocess.Popen([exe, '--help'],
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE) as proc:
+      (stdout, stderr) = proc.communicate()
+  except OSError:
+    app.debug('Unable to execute FSL command \"' + exe + '\" to query support for \"--nthr\" option')
     return ''
-  num_threads = run.shared.get_num_threads()
-  if num_threads is None:
-    # No explicit user instruction regarding multi-threading;
-    #   default MRtrix3 behaviour is to utilise all threads available on the system
+  if not any(line.lstrip().startswith('--nthr') \
+             for line in \
+             (stdout.decode('utf-8', errors='replace') + stderr.decode('utf-8', errors='replace')).splitlines()):
+    app.debug('FSL command \"' + exe + '\" does not provide \"--nthr\" option')
+    return ''
+  # Default MRtrix3 behaviour is to utilise all threads available on the system if no explicit user instruction
+  if run.shared.get_num_threads() is None:
     num_threads = multiprocessing.cpu_count()
+    app.debug('FSL command \"' + exe + '\":'
+              ' requesting max hardware ' + str(num_threads) + ' thread(s) via \"--nthr\" option')
   else:
     # A request for either zero or one thread(s) disables multi-threading
-    num_threads = max(1, num_threads)
-  app.debug('FSL command \"' + exe + '\": requesting ' + str(num_threads) + ' thread(s) via \"--nthr\" option')
+    num_threads = max(1, run.shared.get_num_threads())
+    app.debug('FSL command \"' + exe + '\":'
+              ' requesting ' + str(num_threads) + ' thread(s) via \"--nthr\" option'
+              ' as per user request')
   return ' --nthr=' + str(num_threads)
 
 

--- a/lib/mrtrix3/fsl.py
+++ b/lib/mrtrix3/fsl.py
@@ -13,6 +13,7 @@
 #
 # For more details, see http://www.mrtrix.org/.
 
+import multiprocessing
 import os
 import subprocess
 try:
@@ -142,6 +143,65 @@ def eddy_binary(cuda): #pylint: disable=unused-variable
       return candidate
   app.debug('No CPU version of eddy found')
   return ''
+
+
+
+# Determine whether the version of a given FSL command that is installed on the system provides the
+#   "--nthr" command-line option, which controls the number of threads used for multi-threaded execution.
+# The presence of this option depends on the version of FSL installed, and in the case of "eddy" also on
+#   whether the CPU or CUDA version of the command is being interrogated; it is therefore established by
+#   inspecting the help page of the specific executable that is to be invoked.
+def supports_nthr(exe): #pylint: disable=unused-variable
+  from mrtrix3 import app #pylint: disable=import-outside-toplevel
+  try:
+    with subprocess.Popen([exe, '--help'],
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE) as proc:
+      (stdout, stderr) = proc.communicate()
+  except OSError:
+    app.debug('Unable to execute FSL command \"' + exe + '\" to query support for \"--nthr\" option')
+    return False
+  help_text = stdout.decode('utf-8', errors='replace') + stderr.decode('utf-8', errors='replace')
+  result = '--nthr' in help_text
+  app.debug('FSL command \"' + exe + '\"' + (' provides' if result else ' does not provide') + ' \"--nthr\" option')
+  return result
+
+
+
+# Construct the "--nthr" command-line option to be appended to an invocation of an FSL command
+#   (specifically "topup", or the CPU version of "eddy") so that its multi-threaded execution is
+#   consistent with the number of threads requested for the MRtrix3 script.
+# The option is only generated if both of the following hold:
+#   - The user has not already provided "--nthr" within the options manually specified for the relevant
+#     FSL command, in which case that explicit request takes precedence and an empty string is returned;
+#   - The installed version of the relevant FSL command advertises the "--nthr" option (see supports_nthr()).
+# The value provided to the option is derived from run.shared.get_num_threads():
+#   - If None, no explicit multi-threading instruction has been provided to the script; the default MRtrix3
+#     behaviour of utilising all threads available on the system is therefore requested;
+#   - If zero or one, multi-threading is disabled by requesting a single thread;
+#   - Otherwise, the explicitly requested number of threads is provided.
+# @param exe: Name of the FSL executable that is to be invoked
+# @param manual_options: Options manually specified by the user for the relevant FSL command,
+#   as the raw string provided at the command-line (or None if not provided)
+# @return: String to be appended to the FSL command invocation; empty if the "--nthr" option
+#   is unavailable or should not be applied
+def nthr_option(exe, manual_options): #pylint: disable=unused-variable
+  from mrtrix3 import app, run #pylint: disable=import-outside-toplevel
+  if manual_options and any(entry == '--nthr' or entry.startswith('--nthr=') for entry in manual_options.split()):
+    app.debug('\"--nthr\" manually specified for FSL command \"' + exe + '\"; automated multi-threading control disabled')
+    return ''
+  if not supports_nthr(exe):
+    return ''
+  num_threads = run.shared.get_num_threads()
+  if num_threads is None:
+    # No explicit user instruction regarding multi-threading;
+    #   default MRtrix3 behaviour is to utilise all threads available on the system
+    num_threads = multiprocessing.cpu_count()
+  else:
+    # A request for either zero or one thread(s) disables multi-threading
+    num_threads = max(1, num_threads)
+  app.debug('FSL command \"' + exe + '\": requesting ' + str(num_threads) + ' thread(s) via \"--nthr\" option')
+  return ' --nthr=' + str(num_threads)
 
 
 


### PR DESCRIPTION
Closes #2254 (about 5 years late).

Turns out that for earlier versions of FSL, `eddy` checked and obeyed `OMP_NUM_THREADS`, so I set that envvar within a custom environment variable dict within the `run` module, but then in a subsequent update they started ignoring that option and instead require explicit use of `--nthr` option. It's therefore necessary to query the version of FSL being invoked to discover whether that option is present.

The same option has appeared in `topup` to enable multi-threading. Though they don't align exactly in terms of FSL software version updates, so each has to be queried independently. I don't know exactly what the multi-threading performance is like, so safest to just pass through the user request / max number and let `topup` decide what to do.

Ensures that if the user has included "`--nthr`" in their option to `dwifslpreproc -topup_options` or `-eddy_options`, this auto-fill doesn't happen.