### PR TITLE
Replace sccache with ccache across CI workflows and build system

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,8 +18,11 @@ jobs:
 
     env:
       QT_SELECT: qt6
-      SCCACHE_GHA_ENABLED: "true"
-      SCCACHE_CACHE_SIZE: "2G"
+      CCACHE_SLOPPINESS: pch_defines,time_macros
+      CCACHE_DEPEND: "true"
+      CCACHE_BASEDIR: ${{ github.workspace }}
+      CCACHE_COMPILERCHECK: content
+      CCACHE_MAXSIZE: 2G
 
     steps:
     - uses: actions/checkout@v1
@@ -31,8 +34,12 @@ jobs:
          sudo apt-get update
          sudo apt-get install clang qt6-base-dev libglvnd-dev zlib1g-dev libfftw3-dev ninja-build python3-numpy libpng-dev mesa-vulkan-drivers
 
-    - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.9
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ${{ github.workflow }}-${{ github.job }}
+        max-size: 2G
+        verbose: 1
 
     - name: Get CMake
       uses: lukka/get-cmake@latest
@@ -85,8 +92,11 @@ jobs:
 
     env:
       QT_SELECT: qt6
-      SCCACHE_GHA_ENABLED: "true"
-      SCCACHE_CACHE_SIZE: "2G"
+      CCACHE_SLOPPINESS: pch_defines,time_macros
+      CCACHE_DEPEND: "true"
+      CCACHE_BASEDIR: ${{ github.workspace }}
+      CCACHE_COMPILERCHECK: content
+      CCACHE_MAXSIZE: 2G
 
     steps:
     - uses: actions/checkout@v1
@@ -98,8 +108,12 @@ jobs:
          sudo apt-get update
          sudo apt-get install g++-9 qt6-base-dev libglvnd-dev zlib1g-dev libfftw3-dev ninja-build python3-numpy libpng-dev mesa-vulkan-drivers
 
-    - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.9
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ${{ github.workflow }}-${{ github.job }}
+        max-size: 2G
+        verbose: 1
 
     - name: Get CMake
       uses: lukka/get-cmake@latest
@@ -142,8 +156,11 @@ jobs:
     runs-on: macos-latest
 
     env:
-      SCCACHE_GHA_ENABLED: "true"
-      SCCACHE_CACHE_SIZE: "2G"
+      CCACHE_SLOPPINESS: pch_defines,time_macros
+      CCACHE_DEPEND: "true"
+      CCACHE_BASEDIR: ${{ github.workspace }}
+      CCACHE_COMPILERCHECK: content
+      CCACHE_MAXSIZE: 2G
 
     steps:
     - uses: actions/checkout@v1
@@ -156,8 +173,12 @@ jobs:
          brew link --force qt
          brew install numpy
 
-    - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.9
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ${{ github.workflow }}-${{ github.job }}
+        max-size: 2G
+        verbose: 1
 
     - name: Get CMake
       uses: lukka/get-cmake@latest
@@ -177,7 +198,6 @@ jobs:
         -D CMAKE_FIND_FRAMEWORK=LAST
         -D MRTRIX_BUILD_TESTS=ON
         -D MRTRIX_STL_DEBUGGING=ON
-        -D MRTRIX_USE_PCH=OFF
         -D MRTRIX_WARNINGS_AS_ERRORS=ON
 
     - name: build
@@ -212,9 +232,12 @@ jobs:
     env:
       CHERE_INVOKING: enabled_from_arguments
       MINGW_PACKAGE_PREFIX: mingw-w64-ucrt-x86_64
-      SCCACHE_GHA_ENABLED: "true"
-      SCCACHE_CACHE_SIZE: "2G"
-      SCCACHE_DIR: ${{ github.workspace }}/.sccache
+      CCACHE_SLOPPINESS: pch_defines,time_macros
+      CCACHE_DEPEND: "true"
+      CCACHE_BASEDIR: ${{ github.workspace }}
+      CCACHE_COMPILERCHECK: content
+      CCACHE_MAXSIZE: 2G
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
 
     steps:
       - uses: actions/checkout@v1
@@ -229,6 +252,7 @@ jobs:
             git
             python
             ${{env.MINGW_PACKAGE_PREFIX}}-bc
+            ${{env.MINGW_PACKAGE_PREFIX}}-ccache
             ${{env.MINGW_PACKAGE_PREFIX}}-cmake
             ${{env.MINGW_PACKAGE_PREFIX}}-diffutils
             ${{env.MINGW_PACKAGE_PREFIX}}-fftw
@@ -241,13 +265,13 @@ jobs:
             ${{env.MINGW_PACKAGE_PREFIX}}-qt6-svg
             ${{env.MINGW_PACKAGE_PREFIX}}-zlib
 
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
-
-      - name: export sccache to msys2 shell
-        run: |
-          export SCCACHE_UNIX_PATH=$(cygpath -u "$SCCACHE_PATH")
-          echo "SCCACHE_UNIX_PATH=$SCCACHE_UNIX_PATH" >> $GITHUB_ENV
+      - name: Restore ccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.ccache
+          key: ${{ github.workflow }}-windows-ccache-${{ github.run_id }}
+          restore-keys: |
+            ${{ github.workflow }}-windows-ccache-
 
       - name: configure
         run: >
@@ -258,8 +282,7 @@ jobs:
             -D MRTRIX_BUILD_TESTS=ON
             -D MRTRIX_STL_DEBUGGING=ON
             -D MRTRIX_WARNINGS_AS_ERRORS=ON
-            -D MRTRIX_ENABLE_GPU=OFF
-            -D CMAKE_CXX_COMPILER_LAUNCHER=${{env.SCCACHE_UNIX_PATH}} .
+            -D MRTRIX_ENABLE_GPU=OFF .
 
       - name: build
         run: cmake --build build -- -k 0

--- a/.github/workflows/weekly_sanitizers.yml
+++ b/.github/workflows/weekly_sanitizers.yml
@@ -11,8 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      SCCACHE_GHA_ENABLED: "true"
-      SCCACHE_CACHE_SIZE: "2G"
+      CCACHE_SLOPPINESS: pch_defines,time_macros
+      CCACHE_DEPEND: "true"
+      CCACHE_BASEDIR: ${{ github.workspace }}
+      CCACHE_COMPILERCHECK: content
+      CCACHE_MAXSIZE: 2G
 
     strategy:
         fail-fast: false
@@ -30,8 +33,12 @@ jobs:
          sudo apt-get update
          sudo apt-get install clang llvm qt6-base-dev libglvnd-dev libeigen3-dev zlib1g-dev libfftw3-dev libpng-dev ninja-build python3-numpy
 
-    - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.9
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.sanitizer }}
+        max-size: 2G
+        verbose: 1
 
     - name: Get CMake
       uses: lukka/get-cmake@latest

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can address all *MRtrix3*-related queries there, using your GitHub or Google
         $ cmake --build build
         $ cmake --install build
     
-    It's **highly** recommended, that you use [Ninja](https://ninja-build.org/) and a compiler caching tool like [ccache](https://ccache.dev/) or [sccache](https://github.com/mozilla/sccache) to speed up compilation time. You can install these tools using your package manager (e.g. `apt install ninja-build ccache` or `brew install ninja ccache`). Then, add `-GNinja` to the third step above or set the environment variable `CMAKE_GENERATOR` variable to `Ninja`.
+    It's **highly** recommended, that you use [Ninja](https://ninja-build.org/) and a compiler caching tool like [ccache](https://ccache.dev/) to speed up compilation time. You can install these tools using your package manager (e.g. `apt install ninja-build ccache` or `brew install ninja ccache`). Then, add `-GNinja` to the third step above or set the environment variable `CMAKE_GENERATOR` variable to `Ninja`.
     
     NOTE: by default MRtrix3 will build using Qt 6, but if you wish to use Qt 5
     you can specify this by passing `-DMRTRIX_USE_QT5=ON` when configuring the build.

--- a/cmake/CompilerCache.cmake
+++ b/cmake/CompilerCache.cmake
@@ -18,7 +18,9 @@ function(use_compiler_cache)
     )
   endif()
 
-  find_program(CACHE_BINARY NAMES ${CACHE_OPTION_VALUES})
+  # Honour the requested tool only, so selection is deterministic and a stray
+  # sccache on a runner image can never be picked in preference to ccache.
+  find_program(CACHE_BINARY NAMES ${CACHE_OPTION})
   if(CACHE_BINARY)
     message(STATUS "${CACHE_BINARY} found and enabled")
     set(CMAKE_CXX_COMPILER_LAUNCHER


### PR DESCRIPTION
Hoping to catch an opinion from @daljit46.

I've had multiple PRs where I've had to wipe the whole GitHub Action cache because of compilation failures where the build cache and the precompiled headers get tangled:

<details><summary>Example CI build failure from #3414</summary>

```text
FAILED: [code=1] cpp/gui/CMakeFiles/mrtrix-gui.dir/mrview/tool/screen_capture/screen_capture.cpp.o 
/opt/hostedtoolcache/sccache/0.16.0/x64/sccache /usr/bin/c++ -DMRTRIX_BASE_VERSION=\"3.0.8\" -DMRTRIX_BUILD_TYPE=\"Release\" -DMRTRIX_HAVE_LGAMMA_R -DMRTRIX_HAVE_STRERROR_R -DMRTRIX_LINUX -DMRTRIX_PNG_SUPPORT -DQT_CORE_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_NO_DEBUG -DQT_OPENGLWIDGETS_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DSLANG_DYNAMIC -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC -I/home/runner/work/mrtrix3/mrtrix3/build/cpp/gui/mrtrix-gui_autogen/include -I/home/runner/work/mrtrix3/mrtrix3/cpp/gui -I/home/runner/work/mrtrix3/mrtrix3/cpp/core -I/home/runner/work/mrtrix3/mrtrix3/build/_deps/json-src/include -I/home/runner/work/mrtrix3/mrtrix3/build/_deps/nifti1-src -I/home/runner/work/mrtrix3/mrtrix3/build/_deps/nifti2-src -I/home/runner/work/mrtrix3/mrtrix3/build/_deps/tcb_span-src/include -I/home/runner/work/mrtrix3/mrtrix3/build/_deps/magic_enum-src/include -isystem /home/runner/work/mrtrix3/mrtrix3/build/_deps/eigen3-src -isystem /home/runner/work/mrtrix3/mrtrix3/build/_deps/dawn-src/include -isystem /home/runner/work/mrtrix3/mrtrix3/build/_deps/slang-src/include -isystem /usr/include/x86_64-linux-gnu/qt6/QtCore -isystem /usr/include/x86_64-linux-gnu/qt6 -isystem /usr/lib/x86_64-linux-gnu/qt6/mkspecs/linux-g++ -isystem /usr/include/x86_64-linux-gnu/qt6/QtGui -isystem /usr/include/x86_64-linux-gnu/qt6/QtWidgets -isystem /usr/include/x86_64-linux-gnu/qt6/QtOpenGL -isystem /usr/include/x86_64-linux-gnu/qt6/QtNetwork -isystem /usr/include/x86_64-linux-gnu/qt6/QtOpenGLWidgets -O3 -DNDEBUG -fPIC -Werror -Wno-ignored-attributes -fPIC -std=gnu++17 -Winvalid-pch -include /home/runner/work/mrtrix3/mrtrix3/build/cpp/gui/CMakeFiles/mrtrix-gui.dir/cmake_pch.hxx -MD -MT cpp/gui/CMakeFiles/mrtrix-gui.dir/mrview/tool/screen_capture/screen_capture.cpp.o -MF cpp/gui/CMakeFiles/mrtrix-gui.dir/mrview/tool/screen_capture/screen_capture.cpp.o.d -o cpp/gui/CMakeFiles/mrtrix-gui.dir/mrview/tool/screen_capture/screen_capture.cpp.o -c /home/runner/work/mrtrix3/mrtrix3/cpp/gui/mrview/tool/screen_capture/screen_capture.cpp
In file included from /home/runner/work/mrtrix3/mrtrix3/cpp/gui/dialog/file.h:20,
                 from /home/runner/work/mrtrix3/mrtrix3/cpp/gui/mrview/tool/screen_capture/screen_capture.cpp:24:
/home/runner/work/mrtrix3/mrtrix3/cpp/gui/opengl/glutils.h:82:13: error: redefinition of ‘void MR::GUI::GL::check_error(const char*, int)’
   82 | inline void check_error(const char *filename, int line) { // check_syntax off (input is __FILE__)
      |             ^~~~~~~~~~~
In file included from /home/runner/work/mrtrix3/mrtrix3/cpp/gui/gui_pch.h:19,
                 from /home/runner/work/mrtrix3/mrtrix3/build/cpp/gui/CMakeFiles/mrtrix-gui.dir/cmake_pch.hxx:5,
                 from <command-line>:
/home/runner/work/mrtrix3/mrtrix3/cpp/gui/opengl/glutils.h:82:13: note: ‘void MR::GUI::GL::check_error(const char*, int)’ previously defined here
   82 | inline void check_error(const char *filename, int line) { // check_syntax off (input is __FILE__)
      |             ^~~~~~~~~~~
```

</details>

Looking online, it seems that `sccache` does not officially support PCH, and they are known to not play together particularly well. Indeed a55d6fd466ac55d541870ddfa3b1c561ca8ad081 in #2877 disabled PCH on the Mac compilation check because this issue had already manifested in that environment.

A primary selling point of `sccache` is cloud-based synchronisation of build artifacts across machines. However if `ccache` is embedded in a dedicated GitHub Action, and we are only interested in sharing of build artifacts across CI runs, then that advantage seems to mostly disappear. `sccache` supports more than C++ but we don't need that. Finally, `sccache` stores per-compiled-object artifacts, whereas with `ccache` one is restricted to the whole tarball; it is not yet clear to me the extent to which this may be problematic, potentially to a reasonable extent when there's a large number of PRs open. Could pay for a little more Action artifact storage if it would help.

If the loss of per-compiled-object caching on GitHub is not a deal-breaker, then it would seem overall that `ccache` is a better choice than `sccache`. But curious to know if this was already factored in to the original decision process, whether I'm overlooking something, or getting the proportional weighting of priorities wrong.

Would an alternative option be to rely exclusively on `sccache` for CI Actions, disabling PCH, and use PCH exclusively as a local compilation speedup mechanism?