### PR TITLE
Fix discordances between CLI and command-lie option consumption

### DIFF
--- a/cmd/amp2response.cpp
+++ b/cmd/amp2response.cpp
@@ -68,6 +68,7 @@ void usage ()
     + Option ("directions", "provide an external text file containing the directions along which the amplitudes are sampled")
       + Argument("path").type_file_in()
 
+    + DWI::GradImportOptions()
     + DWI::ShellsOption
 
     + Option ("lmax", "specify the maximum harmonic degree of the response function to estimate "

--- a/cmd/fixelconnectivity.cpp
+++ b/cmd/fixelconnectivity.cpp
@@ -68,7 +68,7 @@ using Fixel::index_type;
 
 void run()
 {
-  const value_type connectivity_threshold = get_option_value ("connectivity", value_type(DEFAULT_CONNECTIVITY_THRESHOLD));
+  const value_type connectivity_threshold = get_option_value ("threshold", value_type(DEFAULT_CONNECTIVITY_THRESHOLD));
   const value_type angular_threshold = get_option_value ("angle", value_type(DEFAULT_ANGLE_THRESHOLD));
 
   const std::string input_fixel_directory = argument[0];

--- a/cmd/mraverageheader.cpp
+++ b/cmd/mraverageheader.cpp
@@ -48,8 +48,7 @@ void usage ()
         "Valid options are 'mean': unbiased but loss of resolution for individual images possible, "
         "and 'max': smallest voxel size of any input image defines the resolution. Default: mean")
   +   Argument ("type").type_choice (resolution_choices)
-  + Option ("fill", " set the intensity in the first volume of the average space to 1")
-  + DataType::options();
+  + Option ("fill", " set the intensity in the first volume of the average space to 1");
 }
 
 

--- a/cmd/mrgrid.cpp
+++ b/cmd/mrgrid.cpp
@@ -244,7 +244,7 @@ void run () {
     if (get_options ("crop_unbound").size() && !do_crop)
       throw Exception("-crop_unbound only applies only to the crop operation");
 
-    const size_t nd = get_options ("nd").size() ? input_header.ndim() : 3;
+    const size_t all_axes = get_options ("all_axes").size() ? input_header.ndim() : 3;
 
     vector<vector<ssize_t>> bounds (input_header.ndim(), vector<ssize_t> (2));
     for (size_t axis = 0; axis < input_header.ndim(); axis++) {
@@ -311,7 +311,7 @@ void run () {
 
       Header template_header = Header::open(opt[0][0]);
 
-      for (size_t axis = 0; axis != nd; ++axis) {
+      for (size_t axis = 0; axis != all_axes; ++axis) {
         if (axis >= template_header.ndim()) {
           if (do_crop)
             bounds[axis][1] = 0;
@@ -329,7 +329,7 @@ void run () {
       ++crop_pad_option_count;
       ssize_t val = opt[0][0];
       INFO ("uniformly " + str(do_crop ? "cropping" : "padding") + " by " + str(val) + " voxels");
-      for (size_t axis = 0; axis < nd; axis++) {
+      for (size_t axis = 0; axis < all_axes; axis++) {
         bounds[axis][0] += do_crop ? val : -val;
         bounds[axis][1] += do_crop ? -val : val;
       }
@@ -398,7 +398,7 @@ void run () {
     }
 
     size_t changed_axes = 0;
-    for (size_t axis = 0; axis < nd; axis++) {
+    for (size_t axis = 0; axis < all_axes; axis++) {
       if (bounds[axis][0] != 0 || input_header.size (axis) != size[axis]) {
         changed_axes++;
         CONSOLE("changing axis " + str(axis) + " extent from 0:" + str(input_header.size (axis) - 1) +

--- a/cmd/mrtransform.cpp
+++ b/cmd/mrtransform.cpp
@@ -669,8 +669,8 @@ void run ()
   // No reslicing required, so just modify the header and do a straight copy of the data
   } else {
 
-    if (get_options ("midway").size())
-      throw Exception ("midway option given but no template image defined");
+    if (get_options ("midway_space").size())
+      throw Exception ("midway_space option given but no template image defined");
 
     INFO ("image will not be regridded");
     Eigen::MatrixXd rotation = linear_transform.linear();

--- a/cmd/sh2amp.cpp
+++ b/cmd/sh2amp.cpp
@@ -75,6 +75,7 @@ void usage ()
   OPTIONS
     + Option ("nonnegative",
               "cap all negative amplitudes to zero")
+    + DWI::ShellsOption
     + DWI::GradImportOptions()
     + Stride::Options
     + DataType::options();

--- a/cmd/tckglobal.cpp
+++ b/cmd/tckglobal.cpp
@@ -23,6 +23,7 @@
 #include "thread.h"
 #include "algo/threaded_copy.h"
 
+#include "dwi/gradient.h"
 #include "dwi/tractography/GT/particlegrid.h"
 #include "dwi/tractography/GT/gt.h"
 #include "dwi/tractography/GT/externalenergy.h"
@@ -102,15 +103,11 @@ void usage ()
   OPTIONS
   + OptionGroup("Input options")
 
-  + Option ("grad", "specify the diffusion encoding scheme (required if not supplied in the header).")
-    + Argument ("scheme").type_file_in()
-
   + Option ("mask", "only reconstruct the tractogram within the specified brain mask image.")
     + Argument ("image").type_image_in()
 
   + Option ("riso", "set one or more isotropic response functions. (multiple allowed)").allow_multiple()
     + Argument ("response").type_file_in()
-
 
   + OptionGroup("Parameters")
 
@@ -138,6 +135,7 @@ void usage ()
   + Option ("niter", "set the number of iterations of the metropolis hastings optimizer. (default = " + str(DEFAULT_NITER/1000000) + "M)")
     + Argument ("n").type_integer(0)
 
+  + DWI::GradImportOptions()
 
   + OptionGroup("Output options")
 

--- a/cmd/warpconvert.cpp
+++ b/cmd/warpconvert.cpp
@@ -90,9 +90,7 @@ void run ()
     auto deformation = Image<default_type>::open (argument[0]).with_direct_io (3);
     Registration::Warp::check_warp (deformation);
 
-    Header header (deformation);
-    header.datatype() = DataType::from_command_line (DataType::Float32);
-    Image<default_type> displacement = Image<default_type>::create (argument[2], header).with_direct_io();
+    Image<default_type> displacement = Image<default_type>::create (argument[2], deformation).with_direct_io();
     Registration::Warp::deformation2displacement (deformation, displacement);
 
   // displacement2deformation
@@ -107,9 +105,7 @@ void run ()
     if (get_options ("from").size())
       WARN ("-from option ignored with displacement2deformation conversion type");
 
-    Header header (displacement);
-    header.datatype() = DataType::from_command_line (DataType::Float32);
-    Image<default_type> deformation = Image<default_type>::create (argument[2], header).with_direct_io();
+    Image<default_type> deformation = Image<default_type>::create (argument[2], displacement).with_direct_io();
     Registration::Warp::displacement2deformation (displacement, deformation);
 
    // warpfull2deformation & warpfull2displacement
@@ -135,9 +131,7 @@ void run ()
     if (type == 3)
       Registration::Warp::deformation2displacement (warp_output, warp_output);
 
-    Header header (warp_output);
-    header.datatype() = DataType::from_command_line (DataType::Float32);
-    Image<default_type> output = Image<default_type>::create (argument[2], header);
+    Image<default_type> output = Image<default_type>::create (argument[2], warp_output);
     threaded_copy_with_progress_message ("converting warp", warp_output, output);
 
   } else {

--- a/docs/reference/commands/amp2response.rst
+++ b/docs/reference/commands/amp2response.rst
@@ -36,6 +36,13 @@ Options
 
 -  **-directions path** provide an external text file containing the directions along which the amplitudes are sampled
 
+DW gradient table import options
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  **-grad file** Provide the diffusion-weighted gradient scheme used in the acquisition in a text file. This should be supplied as a 4xN text file with each line is in the format [ X Y Z b ], where [ X Y Z ] describe the direction of the applied gradient, and b gives the b-value in units of s/mm^2. If a diffusion gradient scheme is present in the input image header, the data provided with this option will be instead used.
+
+-  **-fslgrad bvecs bvals** Provide the diffusion-weighted gradient scheme used in the acquisition in FSL bvecs/bvals format files. If a diffusion gradient scheme is present in the input image header, the data provided with this option will be instead used.
+
 DW shell selection options
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/reference/commands/mraverageheader.rst
+++ b/docs/reference/commands/mraverageheader.rst
@@ -27,11 +27,6 @@ Options
 
 -  **-fill**  set the intensity in the first volume of the average space to 1
 
-Data type options
-^^^^^^^^^^^^^^^^^
-
--  **-datatype spec** specify output image data type. Valid choices are: float32, float32le, float32be, float64, float64le, float64be, int64, uint64, int64le, uint64le, int64be, uint64be, int32, uint32, int32le, uint32le, int32be, uint32be, int16, uint16, int16le, uint16le, int16be, uint16be, cfloat32, cfloat32le, cfloat32be, cfloat64, cfloat64le, cfloat64be, int8, uint8, bit.
-
 Standard options
 ^^^^^^^^^^^^^^^^
 

--- a/docs/reference/commands/sh2amp.rst
+++ b/docs/reference/commands/sh2amp.rst
@@ -42,6 +42,12 @@ Options
 
 -  **-nonnegative** cap all negative amplitudes to zero
 
+DW shell selection options
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  **-shells b-values** specify one or more b-values to use during processing, as a comma-separated list of the desired approximate b-values (b-values are clustered to allow for small deviations). Note that some commands are incompatible with multiple b-values, and will report an error if more than one b-value is provided.  |br|
+   WARNING: note that, even though the b=0 volumes are never referred to as shells in the literature, they still have to be explicitly included in the list of b-values as provided to the -shell option! Several algorithms which include the b=0 volumes in their computations may otherwise return an undesired result.
+
 DW gradient table import options
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/reference/commands/tckglobal.rst
+++ b/docs/reference/commands/tckglobal.rst
@@ -37,8 +37,6 @@ Options
 Input options
 ^^^^^^^^^^^^^
 
--  **-grad scheme** specify the diffusion encoding scheme (required if not supplied in the header).
-
 -  **-mask image** only reconstruct the tractogram within the specified brain mask image.
 
 -  **-riso response** *(multiple uses permitted)* set one or more isotropic response functions. (multiple allowed)
@@ -61,6 +59,13 @@ Parameters
 -  **-t1 end** set the final temperature of the metropolis hastings optimizer. (default = 0.001)
 
 -  **-niter n** set the number of iterations of the metropolis hastings optimizer. (default = 10M)
+
+DW gradient table import options
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  **-grad file** Provide the diffusion-weighted gradient scheme used in the acquisition in a text file. This should be supplied as a 4xN text file with each line is in the format [ X Y Z b ], where [ X Y Z ] describe the direction of the applied gradient, and b gives the b-value in units of s/mm^2. If a diffusion gradient scheme is present in the input image header, the data provided with this option will be instead used.
+
+-  **-fslgrad bvecs bvals** Provide the diffusion-weighted gradient scheme used in the acquisition in FSL bvecs/bvals format files. If a diffusion gradient scheme is present in the input image header, the data provided with this option will be instead used.
 
 Output options
 ^^^^^^^^^^^^^^

--- a/src/dwi/tractography/seeding/list.cpp
+++ b/src/dwi/tractography/seeding/list.cpp
@@ -35,11 +35,11 @@ namespace MR
           if (seeders.size() && !(in->is_finite() == is_finite()))
             throw Exception ("Cannot use a combination of seed types where some are number-limited and some are not!");
 
-          if (!App::get_options ("max_seed_attempts").size())
+          if (!App::get_options ("max_attempts_per_seed").size())
             for (auto& i : seeders)
               if (i->get_max_attempts() != in->get_max_attempts())
                 throw Exception ("Cannot use a combination of seed types where the default maximum number "
-                    "of sampling attempts per seed is unequal, unless you use the -max_seed_attempts option.");
+                    "of sampling attempts per seed is unequal, unless you use the -max_attempts_per_seed option.");
 
           seeders.push_back (std::unique_ptr<Base> (in));
           total_volume += in->vol();

--- a/src/gui/mrview/window.cpp
+++ b/src/gui/mrview/window.cpp
@@ -758,9 +758,6 @@ namespace MR
 
       void Window::parse_arguments ()
       {
-        if (MR::App::get_options ("norealign").size())
-          Header::do_realign_transform = false;
-
         if (MR::App::argument.size()) {
           if (MR::App::option.size())  {
             // check that first non-standard option appears after last argument:


### PR DESCRIPTION
While progressively building out a project-level Claude configuration & making various components of the software more robust, I ended up cross-checking between command-line options as defined in `usage()` vs. attempts to access information from parsed options. Found a few hits: options erroneously missing from the CLI, attempting to access a command-line option via a legacy name, options deliberately removed from CLI but functionality remaining in place, that sort of thing. Since many of these are technically bugs, back-ported to `master`.