### PR TITLE
amp2response: Fix non-standard directions access

### DIFF
--- a/cmd/amp2response.cpp
+++ b/cmd/amp2response.cpp
@@ -217,7 +217,7 @@ void run ()
   auto opt = get_options ("directions");
   if (opt.size()) {
     dirs_azel.push_back (load_matrix (opt[0][0]));
-    volumes.push_back (all_volumes (dirs_azel.size()));
+    volumes.push_back (all_volumes (dirs_azel.back().rows()));
   } else {
     auto hit = header.keyval().find ("directions");
     if (hit != header.keyval().end()) {
@@ -232,7 +232,7 @@ void run ()
         directions (i/2, 1) = dir_vector[i+1];
       }
       dirs_azel.push_back (std::move (directions));
-      volumes.push_back (all_volumes (dirs_azel.size()));
+      volumes.push_back (all_volumes (dirs_azel.back().rows()));
     } else {
       auto grad = DWI::get_DW_scheme (header);
       shells.reset (new DWI::Shells (grad));


### PR DESCRIPTION
Bug not previously caught due to absent test coverage.

Probably when I first started implementing `amp2response`, I commenced with a single-shell implementation, then when I expanded it to handle multi-shell in a single run I failed to update the non-standard code paths accordingly.

Current code erroneously initialises the set of volumes to use during response function estimation to be "all volumes up to index 0", as it erroneously selects the number of unique shells as the number of volumes. There is one direction matrix per shell, so where one of these code paths applies, there is both definitionally and obviously from the preceding code only one shell, and so what is actually required is the number of rows (= # volumes) in the direction matrix of the solitary shell.