### PR TITLE
mrview: add option to colour streamlines relative to camera 

### DIFF
--- a/src/gui/mrview/tool/tractography/tractogram.cpp
+++ b/src/gui/mrview/tool/tractography/tractogram.cpp
@@ -223,8 +223,12 @@ namespace MR
           std::string source =
             "uniform float lower, upper;\n"
             "uniform vec3 colourmap_colour;\n"
-            "uniform mat4 MV;\n"
-            "out vec3 colour;\n";
+            "uniform mat4 MV;\n";
+
+          if (color_type == TrackColourType::Direction && colour_relative_to_projection)
+            source += "uniform mat4 rotation;\n";
+
+          source += "out vec3 colour;\n";
 
           if (color_type == TrackColourType::ScalarFile || color_type == TrackColourType::Ends)
             source += using_geom ? "in vec3 fColour;\n" : "in vec3 v_colour;\n";
@@ -272,8 +276,13 @@ namespace MR
 
           switch (color_type) {
             case TrackColourType::Direction:
-              source += using_geom ? "  colour = abs (normalize (g_tangent));\n"
-                                   : "  colour = abs (normalize (v_tangent));\n";
+              {
+                std::string col = using_geom ? "g_tangent" : "v_tangent";
+                if (colour_relative_to_projection)
+                  col = "mat3(rotation) * " + col;
+
+                source += "  colour = abs (normalize (" + col + "));\n";
+              }
               break;
             case TrackColourType::ScalarFile:
               source += using_geom ? "  colour = fColour;\n"
@@ -330,6 +339,8 @@ namespace MR
             return true;
           if (color_type != tractogram.color_type)
             return true;
+          if (colour_relative_to_projection != tractogram.tractography_tool.colour_relative_to_projection())
+            return true;
           if (threshold_type != tractogram.threshold_type)
             return true;
           if (use_lighting != tractogram.tractography_tool.use_lighting)
@@ -348,6 +359,7 @@ namespace MR
           const Tractogram& tractogram (dynamic_cast<const Tractogram&> (object));
           do_crop_to_slab = tractogram.tractography_tool.crop_to_slab();
           use_lighting = tractogram.tractography_tool.use_lighting;
+          colour_relative_to_projection = tractogram.tractography_tool.colour_relative_to_projection();
           color_type = tractogram.color_type;
           threshold_type = tractogram.threshold_type;
           geometry_type = tractogram.geometry_type;
@@ -448,6 +460,11 @@ namespace MR
             gl::Uniform1f (gl::GetUniformLocation (track_shader, "diffuse"), tractography_tool.lighting->diffuse);
             gl::Uniform1f (gl::GetUniformLocation (track_shader, "specular"), tractography_tool.lighting->specular);
             gl::Uniform1f (gl::GetUniformLocation (track_shader, "shine"), tractography_tool.lighting->shine);
+          }
+
+          if (tractography_tool.colour_relative_to_projection()) {
+            GL::mat4 rot = GL::inv (GL::mat4 (window().orientation()));
+            gl::UniformMatrix4fv (gl::GetUniformLocation (track_shader, "rotation"), 1, gl::FALSE_, rot);
           }
 
           if (!std::isfinite (original_fov)) {

--- a/src/gui/mrview/tool/tractography/tractogram.h
+++ b/src/gui/mrview/tool/tractography/tractogram.h
@@ -98,6 +98,7 @@ namespace MR
                 Shader () :
                     do_crop_to_slab (false),
                     use_lighting (false),
+                    colour_relative_to_projection (false),
                     color_type (TrackColourType::Direction),
                     threshold_type (TrackThresholdType::None),
                     geometry_type (Tractogram::default_tract_geom) { }
@@ -107,7 +108,7 @@ namespace MR
                 virtual bool need_update (const Displayable&) const override;
                 virtual void update (const Displayable&) override;
               protected:
-                bool do_crop_to_slab, use_lighting;
+                bool do_crop_to_slab, use_lighting, colour_relative_to_projection;
                 TrackColourType color_type;
                 TrackThresholdType threshold_type;
                 TrackGeometryType geometry_type;

--- a/src/gui/mrview/tool/tractography/tractography.cpp
+++ b/src/gui/mrview/tool/tractography/tractography.cpp
@@ -201,6 +201,7 @@ namespace MR
 
             main_box->addLayout (hlayout);
 
+
             hlayout = new HBoxLayout;
             hlayout->setContentsMargins (0, 0, 0, 0);
             hlayout->setSpacing (0);
@@ -236,7 +237,7 @@ namespace MR
             slab_group_box = new QGroupBox (tr("crop to slab"));
             slab_group_box->setCheckable (true);
             slab_group_box->setChecked (true);
-            general_opt_grid->addWidget (slab_group_box, 4, 0, 1, 2);
+            general_opt_grid->addWidget (slab_group_box, 1, 0, 1, 2);
 
             connect (slab_group_box, SIGNAL (clicked (bool)), this, SLOT (on_crop_to_slab_slot (bool)));
 
@@ -248,6 +249,13 @@ namespace MR
             slab_entry->setMin (0.0);
             connect (slab_entry, SIGNAL (valueChanged()), this, SLOT (on_slab_thickness_slot()));
             slab_layout->addWidget (slab_entry, 0, 1);
+
+            colour_relative_to_projection_box = new QCheckBox ("colour by camera");
+            colour_relative_to_projection_box->setToolTip (tr ("Colour streamlines according their direction relative to the camera,\nrather than relative to the scanner coordinate system"));
+            colour_relative_to_projection_box->setChecked (false);
+            general_opt_grid->addWidget (colour_relative_to_projection_box, 2, 0, 1, 2);
+
+            connect (colour_relative_to_projection_box, SIGNAL (stateChanged(int)), this, SLOT (updateGL()));
 
             lighting_group_box = new QGroupBox (tr("use lighting"));
             lighting_group_box->setCheckable (true);
@@ -780,6 +788,12 @@ namespace MR
           thickness_slider->blockSignals (false);
         }
 
+
+        void Tractography::updateGL ()
+        {
+          if (!hide_all_button->isChecked())
+            window().updateGL();
+        }
 
 
         void Tractography::update_scalar_options()

--- a/src/gui/mrview/tool/tractography/tractography.h
+++ b/src/gui/mrview/tool/tractography/tractography.h
@@ -57,6 +57,7 @@ namespace MR
             void draw_colourbars () override;
             size_t visible_number_colourbars () override;
             bool crop_to_slab () const { return (do_crop_to_slab && not_3D); }
+            bool colour_relative_to_projection () const { return colour_relative_to_projection_box->isChecked(); }
 
             static void add_commandline_options (MR::App::OptionList& options);
             virtual bool process_commandline_option (const MR::App::ParsedOption& opt) override;
@@ -95,6 +96,7 @@ namespace MR
             void colour_button_slot();
             void geom_type_selection_slot (int);
             void selection_changed_slot (const QItemSelection &, const QItemSelection &);
+            void updateGL ();
 
           protected:
             AdjustButton* slab_entry;
@@ -114,6 +116,7 @@ namespace MR
             QGroupBox* slab_group_box;
             QGroupBox* lighting_group_box;
             QPushButton* lighting_button;
+            QCheckBox* colour_relative_to_projection_box;
 
             QSlider* opacity_slider;
 


### PR DESCRIPTION
This PR adds a check box to colour streamlines by direction _relative to the current camera projection_, rather than relative to the scanner coordinate system (the current default). This mirrors the equivalent functionality in the ODF tool, and is useful when looking at images acquired along non-scanner axes (notably fetal data).