### PR TITLE
mrconvert: fix silent DirectIO axis misbinding in copy_permute(); dwifslpreproc: fix missing f-string in field-map crop

### DIFF
--- a/cpp/cmd/mrconvert.cpp
+++ b/cpp/cmd/mrconvert.cpp
@@ -366,7 +366,7 @@ template <class ImageType> inline std::vector<int> set_header(Header &header, co
 template <typename T, class InputType>
 void copy_permute(const InputType &in, Header &header_out, const std::filesystem::path &output_filepath) {
   const auto axes = set_header(header_out, in);
-  auto out = Image<T>::create(output_filepath, header_out, add_to_command_history);
+  auto out = Image<T>::create(output_filepath, header_out, std::nullopt, add_to_command_history);
   DWI::export_grad_commandline(out);
   Metadata::PhaseEncoding::export_commandline(out);
   auto perm = Adapter::make<Adapter::PermuteAxes>(in, axes);

--- a/python/mrtrix3/commands/dwifslpreproc.py
+++ b/python/mrtrix3/commands/dwifslpreproc.py
@@ -1364,7 +1364,7 @@ def execute(): #pylint: disable=unused-variable
         eddyqc_mask = 'eddy_mask_unpad.nii'
         progress.increment()
         field_map_image = fsl.find_image('field_map')
-        run.command('mrconvert {field_map_image} field_map_unpad.nii {dwi_post_eddy_crop_option}')
+        run.command(f'mrconvert {field_map_image} field_map_unpad.nii {dwi_post_eddy_crop_option}')
         eddyqc_fieldmap = 'field_map_unpad.nii'
         progress.increment()
         run.command(f'mrconvert {eddy_output_image_path} dwi_post_eddy_unpad.nii.gz {dwi_post_eddy_crop_option}')

--- a/testing/binaries/CMakeLists.txt
+++ b/testing/binaries/CMakeLists.txt
@@ -356,6 +356,7 @@ add_bash_binary_test(mrcolour/upperlimit NO_FILESYSTEM_LOCK)
 
 add_bash_binary_test(mrconvert/big_endian NO_FILESYSTEM_LOCK)
 add_bash_binary_test(mrconvert/coord_end)
+add_bash_binary_test(mrconvert/export_grad_fsl_roundtrip)
 add_bash_binary_test(mrconvert/format_mgh)
 add_bash_binary_test(mrconvert/format_mgz)
 add_bash_binary_test(mrconvert/format_mif_gz)

--- a/testing/binaries/tests/mrconvert/export_grad_fsl_roundtrip
+++ b/testing/binaries/tests/mrconvert/export_grad_fsl_roundtrip
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Regression test: -export_grad_fsl must export a gradient table consistent
+#   with the actual voxel-axis order of the image being written, so that a
+#   round trip through NIfTI + FSL bvecs/bvals reproduces the original
+#   gradient table exactly.
+# Regression test for a bug where copy_permute() (mrconvert.cpp) called
+#   Image<T>::create() using the pre-#3315 3-argument convention; the bool
+#   add_to_command_history silently bound to the newly-inserted direct_io
+#   parameter instead (via bool->int promotion into DirectIO(int axis)),
+#   causing every mrconvert output image to be created with an unintended
+#   DirectIO(axis=1) request. This reordered the on-disk voxel axes without
+#   a corresponding update to the exported gradient table, so re-importing
+#   the round-tripped image no longer matched the original DW-encoding.
+
+mrconvert dwi.mif tmp.nii -export_grad_fsl tmp.bvec tmp.bval -force
+mrconvert tmp.nii tmp_rt.mif -fslgrad tmp.bvec tmp.bval -force
+mrinfo dwi.mif   -export_grad_mrtrix tmp_orig.b -force
+mrinfo tmp_rt.mif -export_grad_mrtrix tmp_rt.b -force
+testing_diff_matrix tmp_orig.b tmp_rt.b -abs 1e-3


### PR DESCRIPTION
Two independent fixes:

1. Fixes #<3431>
**mrconvert: silent DirectIO axis misbinding in `copy_permute()`.**
   `Image<T>::create()` gained a new `std::optional<DirectIO> direct_io`
   parameter (#3315), inserted between `template_header` and
   `add_to_command_history`. `copy_permute()`'s call site was never updated
   for the new signature, so `add_to_command_history` (a bool, almost
   always `true`) silently binds to the new 3rd parameter (`direct_io`)
   instead of the 4th — `true` promotes to `1`, so every mrconvert output
   image silently gets `DirectIO(axis=1)`. This reorders the on-disk voxel
   layout without a corresponding update to the exported gradient table,
   producing an image/gradient-table mismatch on every NIfTI+FSL bvec
   export via `-export_grad_fsl`, independent of whether `-strides` is
   explicitly requested. Fix: pass `std::nullopt` explicitly for
   `direct_io` so `add_to_command_history` binds to its intended parameter.
   Includes a regression test.

2. **dwifslpreproc: missing f-string prefix in field-map crop command.**
   The `mrconvert` call cropping the eddy-derived field map for
   `-eddyqc_all` output was a plain string literal instead of an f-string,
   so `{field_map_image}` and `{dwi_post_eddy_crop_option}` were passed to
   `mrconvert` as literal uninterpolated text rather than the actual image
   path and crop option -- `mrconvert` then received 3 positional arguments
   instead of 2 and failed immediately ("Expected exactly 2 arguments (3
   supplied)"). Reproduces on any `-eddyqc_all` run where topup produces a
   field map, independent of vendor/scan platform. One-character fix (add
   the missing `f`), matching the pattern already used by the two identical
   sibling `mrconvert` calls immediately before and after it.